### PR TITLE
[Clouds] Modify sync script for assemblies and modules directory structure

### DIFF
--- a/bin/sync_cloud_docs.sh
+++ b/bin/sync_cloud_docs.sh
@@ -14,21 +14,21 @@ target=target
 
 # Clean the target directories.
 # rm -rf $target/titles/aap-on-aws
-rm -rf $target/aap-on-azure/aap-common
-rm -rf $target/aap-on-azure/attributes
-rm -rf $target/aap-on-azure/images
-rm -rf $target/aap-on-azure/stories
+rm -rf $target/aap-common
+rm -rf $target/attributes
+rm -rf $target/images
+rm -rf $target/stories
 rm -rf $target/aap-on-azure/stories.adoc
 
 # Copy aap-common to the target directories.
-cp -r $source/aap-common/ $target/aap-on-azure/
+cp -r $source/aap-common/ $target/
 
 # Copy attributes to the target directories.
-cp -r $source/attributes/ $target/aap-on-azure/
+cp -r $source/attributes/ $target/
 
 # Copy images to the target directories.
-cp -r $source/images/ $target/aap-on-azure/
+cp -r $source/images/ $target/
 
 # Copy user stories to the target directories.
-cp -r $source/stories/ $target/aap-on-azure/
-cp -r $source/titles/aap-on-azure/stories.adoc $target/aap-on-azure/
+cp -r $source/stories/ $target/
+cp -r $source/titles/aap-on-azure/stories.adoc $target/titles/aap-on-azure/


### PR DESCRIPTION
Fix sync script so that it pushes directories to the root directory of the production repo, rather than to the `aap-on-azure` subdirectory.