### PR TITLE
Add Jenkins job for AAP on AWS docs

### DIFF
--- a/bin/sync_cloud_docs.sh
+++ b/bin/sync_cloud_docs.sh
@@ -20,15 +20,26 @@ rm -rf $target/aap-on-azure/images
 rm -rf $target/aap-on-azure/stories
 rm -rf $target/aap-on-azure/stories.adoc
 
+rm -rf $target/aap-on-aws/aap-common
+rm -rf $target/aap-on-aws/attributes
+rm -rf $target/aap-on-aws/images
+rm -rf $target/aap-on-aws/stories
+rm -rf $target/aap-on-aws/stories.adoc
+
 # Copy aap-common to the target directories.
 cp -r $source/aap-common/ $target/aap-on-azure/
+cp -r $source/aap-common/ $target/aap-on-aws/
 
 # Copy attributes to the target directories.
 cp -r $source/attributes/ $target/aap-on-azure/
+cp -r $source/attributes/ $target/aap-on-aws/
 
 # Copy images to the target directories.
 cp -r $source/images/ $target/aap-on-azure/
+cp -r $source/images/ $target/aap-on-aws/
 
 # Copy user stories to the target directories.
 cp -r $source/stories/ $target/aap-on-azure/
 cp -r $source/titles/aap-on-azure/stories.adoc $target/aap-on-azure/
+cp -r $source/stories/ $target/aap-on-aws/
+cp -r $source/titles/aap-on-aws/stories.adoc $target/aap-on-aws/


### PR DESCRIPTION
Add a script to the `/bin` directory to sync the AAP on AWS content to the production docs repo on Gitlab. 
