### PR TITLE
Update firewall rule requirements to globally access quay.io

### DIFF
--- a/stories/topics/proc-azure-update-route-tables.adoc
+++ b/stories/topics/proc-azure-update-route-tables.adoc
@@ -57,7 +57,7 @@ If you choose not to allow all outbound traffic from  port 443, you must configu
 Add routes in the {PlatformNameShort} route table for outbound traffic from the full CIDR range of the {AAPonAzureNameShort} managed application to the following domains:
 
 ** `registry.redhat.io`
-** `quay.io`
+** `*.quay.io`
 
 * You must also allow traffic from your firewall to any other external domain or IP address that you want {PlatformNameShort} to run automation jobs against.
 Otherwise, your firewall will block connectivity between {PlatformNameShort} and destinations for automation.


### PR DESCRIPTION
Update reference to `quay.io` in firewall rules to enable all subdomains that may be used.