### PR TITLE
Add Azure PodIdentityPreview capability

### DIFF
--- a/stories/assembly-aap-azure-install.adoc
+++ b/stories/assembly-aap-azure-install.adoc
@@ -28,6 +28,8 @@ include::topics/proc-azure-resource-quotas.adoc[leveloffset=+2]
 include::topics/proc-azure-create-service-principal.adoc[leveloffset=+1]
 
 include::topics/proc-azure-deploy-aap.adoc[leveloffset=+1]
+include::topics/proc-azure-podidentity.adoc[leveloffset=+2]
+
 include::topics/proc-azure-locate-aap-marketplace.adoc[leveloffset=+2]
 include::topics/proc-azure-provisioning-aap.adoc[leveloffset=+2]
 

--- a/stories/topics/proc-azure-podidentity.adoc
+++ b/stories/topics/proc-azure-podidentity.adoc
@@ -1,0 +1,14 @@
+[id="proc-azure-podidentity_{context}"]
+
+= Enabling PodIdentityPreview capability in Azure
+
+{AAPonAzureNameShort} uses Azure features that require enablement.
+Run the following command from the Azure CLI or Cloud Console to enable those features:
+
+[source,bash]
+----
+az feature register --name EnablePodIdentityPreview --namespace Microsoft.ContainerService
+----
+
+You only need to perform this action once for each Azure subscription that you use to install {AAPonAzureNameShort}.
+


### PR DESCRIPTION
Each Ansible on Azure customer must enable the PodIdentityPreview capability in Azure in order for the AoC deployment to succeed. 

Add content to section 2.3 of the Azure doc that describes how to enable `PodIdentityPreview`