### PR TITLE
Add disclaimer for links to external websites

### DIFF
--- a/aap-common/external-site-disclaimer.adoc
+++ b/aap-common/external-site-disclaimer.adoc
@@ -1,0 +1,18 @@
+// A member of the Legal Department approved the following disclaimer.
+// When linking to external resources, include this file in your document.
+//
+// Prerequisites:
+// Add a symlink to the /downstream/aap-common directory from the directory that contains the
+// file where you plan to include the disclaimer.
+// For example, to include the disclaimer in stories.adoc for the GCP guide,
+// you must add a symlink to /downstream/aap-common in the /titles/aap-on-gcp directory:
+// $ cd titles/aap-on-gcp
+// $ ln -s ../../aap-common ./aap-common
+//
+// Note: the symlinks have already been added in /titles/aap-on-azure, /titles/aap-on-aws/, and /titles/aap-on-gcp/
+//
+// Including the file in a document
+// Add the following in the file where you want the text to be included:
+// include::aap-common/external-site-disclaimer.adoc[]
+
+*Disclaimer*: Links contained in this note to external website(s) are provided for convenience only. Red Hat has not reviewed the links and is not responsible for the content or its availability. The inclusion of any link to an external website does not imply endorsement by Red Hat of the website or their entities, products or services. You agree that Red Hat is not responsible or liable for any loss or expenses that may result due to your use of (or reliance on) the external site or content.


### PR DESCRIPTION
Add a file to the `downstream/aap-common/` directory. It contains approved text that disclaims responsibility for the content in external websites.