### PR TITLE
Add domains to outbound routing list

### DIFF
--- a/stories/topics/proc-azure-update-route-tables.adoc
+++ b/stories/topics/proc-azure-update-route-tables.adoc
@@ -59,6 +59,14 @@ Add routes in the {PlatformNameShort} route table for outbound traffic from the 
 ** `registry.redhat.io`
 ** `quay.io`
 ** `*.quay.io`
+** `*.letsencrypt.org`
+** `*.azure-dns.com`
+** `*.azure-dns.net`
+** `*.azure-dns.org`
+** `*.azure-dns.info`
+** `*.gcr.io`
+** `*.docker.com`
+** `*.docker.io`
 
 * You must also allow traffic from your firewall to any other external domain or IP address that you want {PlatformNameShort} to run automation jobs against.
 Otherwise, your firewall will block connectivity between {PlatformNameShort} and destinations for automation.


### PR DESCRIPTION
Expand the domain list in the _Outbound routing through virtual appliances_ section of the AAP on Azure docs.