### PR TITLE
Azure: Add Deployment engine docs

### DIFF
--- a/stories/assembly-aap-azure-install.adoc
+++ b/stories/assembly-aap-azure-install.adoc
@@ -6,7 +6,6 @@ ifdef::context[:parent-context: {context}]
 :context: aap-azure-install
 
 // [role="_abstract"]
-// You can use these instructions to install
 
 == Prerequisites
 
@@ -32,6 +31,8 @@ include::topics/proc-azure-podidentity.adoc[leveloffset=+2]
 
 include::topics/proc-azure-locate-aap-marketplace.adoc[leveloffset=+2]
 include::topics/proc-azure-provisioning-aap.adoc[leveloffset=+2]
+include::topics/proc-azure-monitor-deployment-engine.adoc[leveloffset=+2]
+include::topics/proc-azure-cancel-deployment.adoc[leveloffset=+2]
 
 include::topics/proc-azure-accessing-aap.adoc[leveloffset=+1]
 include::topics/proc-azure-license-association.adoc[leveloffset=+2]

--- a/stories/topics/proc-azure-cancel-deployment.adoc
+++ b/stories/topics/proc-azure-cancel-deployment.adoc
@@ -3,7 +3,7 @@
 = Canceling {AAPonAzureName} deployments
 
 [role="_abstract"]
-You can gracefully cancel an {AAPonAzureName} deployment. 
+You can gracefully cancel a {AAPonAzureName} deployment. 
 
 .Procedure
 

--- a/stories/topics/proc-azure-cancel-deployment.adoc
+++ b/stories/topics/proc-azure-cancel-deployment.adoc
@@ -1,0 +1,27 @@
+[id="azure-cancel-deployment_{context}"]
+
+= Canceling {AAPonAzureName} deployments
+
+[role="_abstract"]
+You can gracefully cancel an {AAPonAzureName} deployment. 
+
+.Procedure
+
+. Login to the deployment engine to display the progress of the deployment steps in the *Ansible Automation Platform Deployment Engine* page.
+Refer to xref:azure-monitor-deployment-engine_aap-azure-install[Monitoring deployments on the {PlatformNameShort} Deployment Engine] for information on accessing and logging into the *Ansible Automation Platform Deployment Engine* page.
+
+. To cancel the deployment, click btn:[Cancel Deployment] and confirm.
++
+This action cancels all the remaining steps in the deployment, including the currently running step. It also cancels pending steps in the deployment.
++
+The status for the steps that have not been executed updates to *Cancelled*.
+To view the deployment processes on Azure, navigate to the *Overview* page for the managed resource group in which you deployed {PlatformNameShort} and select *Deployments*.
++
+[IMPORTANT]
+====
+Cancelling the deployment does not delete the managed application from your Azure subscription.
+To avoid incurring costs for the managed application and other resources that are still running, you must delete them.
+====
+. To delete Azure resources, navigate to the resource group for your deployment in the Azure portal. Select the resources you want to delete and click btn:[Delete].
+For more information about deleting resources, refer to link:https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resources-portal[Manage Azure resources by using the Azure portal] in the Microsoft Azure documentation.
+

--- a/stories/topics/proc-azure-cancel-deployment.adoc
+++ b/stories/topics/proc-azure-cancel-deployment.adoc
@@ -14,12 +14,12 @@ Refer to xref:azure-monitor-deployment-engine_aap-azure-install[Monitoring deplo
 +
 This action cancels all the remaining steps in the deployment, including the currently running step. It also cancels pending steps in the deployment.
 +
-The status for the steps that have not been executed updates to *Cancelled*.
+The status for the steps that have not been executed updates to *Canceled*.
 To view the deployment processes on Azure, navigate to the *Overview* page for the managed resource group in which you deployed {PlatformNameShort} and select *Deployments*.
 +
 [IMPORTANT]
 ====
-Cancelling the deployment does not delete the managed application from your Azure subscription.
+Canceling the deployment does not delete the managed application from your Azure subscription.
 To avoid incurring costs for the managed application and other resources that are still running, you must delete them.
 ====
 . To delete Azure resources, navigate to the resource group for your deployment in the Azure portal. Select the resources you want to delete and click btn:[Delete].

--- a/stories/topics/proc-azure-monitor-deployment-engine.adoc
+++ b/stories/topics/proc-azure-monitor-deployment-engine.adoc
@@ -5,7 +5,7 @@
 [role="_abstract"]
 
 The deployment engine displays information about your {AAPonAzureNameShort} deployment.
-You can monitor the progress of the deployment, restart failed steps, and cancel the deployment.
+You can monitor the progress of the deployment, restart failed deployment steps, and cancel the deployment.
 
 When you begin deploying {AAPonAzureNameShort}, the Azure interface displays the *Overview* page for the deployment.
 The *Overview* page displays the deployment status.

--- a/stories/topics/proc-azure-monitor-deployment-engine.adoc
+++ b/stories/topics/proc-azure-monitor-deployment-engine.adoc
@@ -1,0 +1,32 @@
+[id="azure-monitor-deployment-engine_{context}"]
+
+= Monitoring deployments on the {PlatformNameShort} Deployment Engine
+
+[role="_abstract"]
+
+The deployment engine displays information about your {AAPonAzureNameShort} deployment.
+You can monitor the progress of the deployment and you can cancel the deployment.
+
+When you begin deploying {AAPonAzureNameShort}, the Azure interface displays the *Overview* page for the deployment.
+The *Overview* page displays the deployment status.
+
+. When the status in the *Overview* page shows "Your deployment is complete", navigate to the deployed managed application.
+. Click *Parameters and Outputs* in the *Settings* menu for the deployed managed application.
++
+Approximately 10 minutes into the deployment process, the *Outputs* section of the *Parameters and Outputs* page displays a link to the *`deploymentEngineUrl`*.
+. Copy the link and paste it in another browser tab to open the login page for the deployment engine.
+. Login to the deployment using the following credentials:
+  * *Username*: _admin_
+  * *Password*: Use the _Administrator Password_ that you chose when configuring your deployment.
+
+[discrete]
+== {PlatformNameShort} Deployment Engine interface
+
+The {PlatformNameShort} Deployment Engine displays a list of the steps in the deployment process.
+A progress bar shows how far along the deployment is.
+Icons indicate the steps that have been completed, the steps that are in progress, and steps that have failed.
+
+To view extended information about a step that failed, click on the *failed* icon for that step.
+
+To restart a failed step, click btn:[Restart Step].
+

--- a/stories/topics/proc-azure-monitor-deployment-engine.adoc
+++ b/stories/topics/proc-azure-monitor-deployment-engine.adoc
@@ -5,7 +5,7 @@
 [role="_abstract"]
 
 The deployment engine displays information about your {AAPonAzureNameShort} deployment.
-You can monitor the progress of the deployment and you can cancel the deployment.
+You can monitor the progress of the deployment, restart failed steps, and cancel the deployment.
 
 When you begin deploying {AAPonAzureNameShort}, the Azure interface displays the *Overview* page for the deployment.
 The *Overview* page displays the deployment status.

--- a/stories/topics/proc-azure-provisioning-aap.adoc
+++ b/stories/topics/proc-azure-provisioning-aap.adoc
@@ -38,6 +38,10 @@ Keep this resource group isolated from other resource groups, including the _Res
 
 The application will begin provisioning.
 
+You can use the deployment engine to view the progress of your deployment a few minutes after the Azure console displays "Your deployment is complete".
+See xref:azure-monitor-deployment-engine_aap-azure-install[Monitoring deployments on the {PlatformNameShort} Deployment Engine] for more information.
+
 It may take 30 minutes or longer for the infrastructure and software to fully provision.
 
 Once provisioning is complete, you can access and login to your new {PlatformNameShort} instance and launch {ControllerName} and {HubName}.
+


### PR DESCRIPTION
Azure:
Describe how to open the deployment engine, and use it to monitor and cancel AAP deployments.