### PR TITLE
Remove references to Automation Services Catalog

### DIFF
--- a/stories/assembly-aws-intro.adoc
+++ b/stories/assembly-aws-intro.adoc
@@ -13,7 +13,6 @@ The following {PlatformName} components are available on {AAPonAWS}:
 * {ControllerNameStart}
 * {HubNameMain}
 * {PrivateHubNameStart}
-* {CatalogNameStart}
 * Ansible Content Collections
 * {ExecEnvNameStart}
 * Ansible content tools, including access to {InsightsName}

--- a/stories/assembly-gcp-intro.adoc
+++ b/stories/assembly-gcp-intro.adoc
@@ -13,7 +13,6 @@ The following {PlatformName} components are available on {AAPonGCP}:
 * link:https://www.ansible.com/products/controller[{ControllerNameStart}]
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/getting_started_with_automation_hub/pr01[{HubNameMain}]
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/managing_containers_in_private_automation_hub/index[{PrivateHubNameStart}]
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html/getting_started_with_automation_services_catalog/index[{CatalogNameStart}]
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html-single/publishing_proprietary_content_collections_in_automation_hub/index[Ansible Content Collections]
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html-single/creating_and_consuming_execution_environments/index[{ExecEnvNameStart}]
 * link:https://www.ansible.com/products/automation-platform[Ansible content tools, including access to {InsightsName}]

--- a/stories/assembly-gcp-intro.adoc
+++ b/stories/assembly-gcp-intro.adoc
@@ -22,4 +22,4 @@ The following {PlatformName} components are available on {AAPonGCP}:
 {AutomationMeshStart} is not available on {AAPonGCP} at this time.
 =====
 
-include::topics/con-gcp-application-architecture.adoc[leveloffset+=1]
+include::topics/con-gcp-application-architecture.adoc[leveloffset=+1]

--- a/stories/topics/con-azure-about.adoc
+++ b/stories/topics/con-azure-about.adoc
@@ -12,7 +12,6 @@ The following Red Hat Automation Platform components are available on {AAPonAzur
 * Automation Controller
 * Automation Hub
 * Private Automation Hub
-* Automation Service Catalog
 * Ansible Content Collections, including the Microsoft collection for Azure
 * Automation Execution Environment
 * Ansible content tools, including access to {InsightsName}


### PR DESCRIPTION
Remove references to Automation Services Catalog in Azure, GCP, and AWS docs.