### PR TITLE
2.2.1 Modify Jenkins sync script

### DIFF
--- a/bin/sync_cloud_docs.sh
+++ b/bin/sync_cloud_docs.sh
@@ -13,12 +13,6 @@ source=source
 target=target
 
 # Clean the target directories.
-# rm -rf $target/titles/aap-on-aws
-rm -rf $target/aap-on-azure/aap-common
-rm -rf $target/aap-on-azure/attributes
-rm -rf $target/aap-on-azure/images
-rm -rf $target/aap-on-azure/stories
-rm -rf $target/aap-on-azure/stories.adoc
 
 rm -rf $target/aap-on-aws/aap-common
 rm -rf $target/aap-on-aws/attributes
@@ -33,23 +27,18 @@ rm -rf $target/aap-on-gcp/stories
 rm -rf $target/aap-on-gcp/stories.adoc
 
 # Copy aap-common to the target directories.
-cp -r $source/aap-common/ $target/aap-on-azure/
 cp -r $source/aap-common/ $target/aap-on-aws/
 cp -r $source/aap-common/ $target/aap-on-gcp/
 
 # Copy attributes to the target directories.
-cp -r $source/attributes/ $target/aap-on-azure/
 cp -r $source/attributes/ $target/aap-on-aws/
 cp -r $source/attributes/ $target/aap-on-gcp/
 
 # Copy images to the target directories.
-cp -r $source/images/ $target/aap-on-azure/
 cp -r $source/images/ $target/aap-on-aws/
 cp -r $source/images/ $target/aap-on-gcp/
 
 # Copy user stories to the target directories.
-cp -r $source/stories/ $target/aap-on-azure/
-cp -r $source/titles/aap-on-azure/stories.adoc $target/aap-on-azure/
 cp -r $source/stories/ $target/aap-on-aws/
 cp -r $source/titles/aap-on-aws/stories.adoc $target/aap-on-aws/
 cp -r $source/stories/ $target/aap-on-gcp/


### PR DESCRIPTION
Modify Jenkins script for aap-clouds-2.2.1:

- Delete references to Azure, as the 2.2.2 page on the Customer portal will only show docs for self-managed AoC.