### PR TITLE
GCP - Backup and restore updates

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,8 +23,14 @@ For local previews that include images you can do the following:
 [source,bash]
 ----
 $ git clone -b aap-clouds-latest git@github.com:ansible/aap-docs.git
-$ asciidoctor aap-docs/titles/aap-on-azure/aap-on-azure.asciidoc
-$ firefox aap-docs/titles/aap-on-azure/aap-on-azure.html
+# AWS Doc Generation
+$ asciidoctor titles/aap-on-aws/aap-on-aws.asciidoc
+$ open -a "Google Chrome" titles/aap-on-aws/aap-on-aws.html # Open in Chrome
+$ firefox titles/aap-on-aws/aap-on-aws.html # Open in Firefox
+# GCP Doc Generation
+$ asciidoctor titles/aap-on-gcp/aap-on-gcp.asciidoc
+$ open -a "Google Chrome" titles/aap-on-gcp/aap-on-gcp.html # Open in Chrome
+$ firefox titles/aap-on-gcp/aap-on-gcp.html # Open in Firefox
 ----
 
 [NOTE]

--- a/README.adoc
+++ b/README.adoc
@@ -23,14 +23,18 @@ For local previews that include images you can do the following:
 [source,bash]
 ----
 $ git clone -b aap-clouds-latest git@github.com:ansible/aap-docs.git
+# Azure Doc Generation
+$ asciidoctor titles/aap-on-azure/aap-on-azure.asciidoc
+$ open -a "Google Chrome" titles/aap-on-azure/aap-on-azure.html     # Open in Chrome
+$ firefox titles/aap-on-azure/aap-on-azure.html                     # Open in Firefox
 # AWS Doc Generation
 $ asciidoctor titles/aap-on-aws/aap-on-aws.asciidoc
-$ open -a "Google Chrome" titles/aap-on-aws/aap-on-aws.html # Open in Chrome
-$ firefox titles/aap-on-aws/aap-on-aws.html # Open in Firefox
+$ open -a "Google Chrome" titles/aap-on-aws/aap-on-aws.html         # Open in Chrome
+$ firefox titles/aap-on-aws/aap-on-aws.html                         # Open in Firefox
 # GCP Doc Generation
 $ asciidoctor titles/aap-on-gcp/aap-on-gcp.asciidoc
-$ open -a "Google Chrome" titles/aap-on-gcp/aap-on-gcp.html # Open in Chrome
-$ firefox titles/aap-on-gcp/aap-on-gcp.html # Open in Firefox
+$ open -a "Google Chrome" titles/aap-on-gcp/aap-on-gcp.html         # Open in Chrome
+$ firefox titles/aap-on-gcp/aap-on-gcp.html                         # Open in Firefox
 ----
 
 [NOTE]

--- a/stories/assembly-gcp-backup-and-restore.adoc
+++ b/stories/assembly-gcp-backup-and-restore.adoc
@@ -5,6 +5,19 @@ ifdef::context[:parent-context: {context}]
 
 :context: gcp-backup-restore
 
+[IMPORTANT]
+=====
+* You must restore with the same operational image version as the backup.
+
+* You can only restore using either a new VPC network. We do not currently support backup and restore into an existing VPC network.
+
+* You cannot delete the backed up environment before a restore because the database backups are stored in the deployment.
+Deleting your deployment therefore deletes the database backups.
+
+* Versioned or point-in-time backups are not supported by the `ansible-on-clouds-op` container.
+Only the most recent backup of a deployment is used to restore the deployment.
+=====
+
 To backup and restore your {PlatformNameShort} deployment, it is vital to have your existing {PlatformNameShort} administration secret name and value recorded somewhere safe.
 
 It is also important to take regular manual backups of the Cloud SQL database instance and filestore backups, to ensure a deployment can be restored as close as possible to its previous working state.

--- a/stories/assembly-gcp-backup-and-restore.adoc
+++ b/stories/assembly-gcp-backup-and-restore.adoc
@@ -9,7 +9,7 @@ ifdef::context[:parent-context: {context}]
 =====
 * You must restore with the same operational image version as the backup.
 
-* You can only restore using either a new VPC network. We do not currently support backup and restore into an existing VPC network.
+* You can only restore using a new VPC network. Backup and restore into an existing VPC network is not currently supported.
 
 * You cannot delete the backed up environment before a restore because the database backups are stored in the deployment.
 Deleting your deployment therefore deletes the database backups.

--- a/stories/topics/con-gcp-backup-process.adoc
+++ b/stories/topics/con-gcp-backup-process.adoc
@@ -18,7 +18,7 @@ The backup playbook requires an active {AAPonGCP} foundation deployment to be ru
 
 A bucket needs to be created in your project as restore information will be stored in that bucket.
 
-Only one backup per version will be kept in the bucket, if multiple versions of the backup need to be retain then a new bucket must be created for the new version of the backup.
+Only one backup per version is kept in the bucket, if multiple versions of the backup need to be retain then a new bucket must be created for the new version of the backup.
 
 The following procedures describe how to backup the {AAPonGCP} deployment.
 

--- a/stories/topics/con-gcp-backup-process.adoc
+++ b/stories/topics/con-gcp-backup-process.adoc
@@ -16,6 +16,10 @@ For further information, see xref:assembly-gcp-upgrade[Upgrading your deployment
 The backup process involves taking a backup of the Cloud SQL database and filestore instances at a given point in time.
 The backup playbook requires an active {AAPonGCP} foundation deployment to be running.
 
+A bucket needs to be created in your project as restore information will be stored in that bucket.
+
+Only one backup per version will be kept in the bucket, if multiple versions of the backup need to be retain then a new bucket must be created for the new version of the backup.
+
 The following procedures describe how to backup the {AAPonGCP} deployment.
 
 :context: backup

--- a/stories/topics/con-gcp-restore-process.adoc
+++ b/stories/topics/con-gcp-restore-process.adoc
@@ -8,8 +8,7 @@ The restore process deploys a new deployment, and restores the filestore and SQL
 =====
 * You must restore with the same operational image version as the backup.
 
-* You can restore using either a new VPC network or an existing one.
-You must configure additional parameters to restore on an existing VPC network.
+* You can only restore using either a new VPC network. We do not currently support backup and restore into an existing VPC network.
 
 * You cannot delete the backed up environment before a restore because the database backups are stored in the deployment.
 Deleting your deployment therefore deletes the database backups.

--- a/stories/topics/con-gcp-restore-process.adoc
+++ b/stories/topics/con-gcp-restore-process.adoc
@@ -8,7 +8,7 @@ The restore process deploys a new deployment, and restores the filestore and SQL
 =====
 * You must restore with the same operational image version which was used for the backup.
 
-* You can only restore using a new VPC network. We do not currently support backup and restore into an existing VPC network.
+* Backup and restore into an existing VPC network is not currently supported.
 
 * You cannot delete the backed up environment before a restore because the database backups are stored in the deployment.
 Deleting your deployment therefore deletes the database backups.

--- a/stories/topics/con-gcp-restore-process.adoc
+++ b/stories/topics/con-gcp-restore-process.adoc
@@ -22,6 +22,7 @@ The following procedures describe how to restore the {AAPonGCP} deployment.
 
 :context: restore
 include::proc-gcp-backup-container-image.adoc[leveloffset=+1]
+include::proc-gcp-setup-environment.adoc[leveloffset=+1]
 include::proc-gcp-generate-restore-yml-file.adoc[leveloffset=+1]
 include::ref-gcp-populate-restore-file.adoc[leveloffset=+1]
 include::proc-gcp-run-restore-command.adoc[leveloffset=+1]

--- a/stories/topics/con-gcp-restore-process.adoc
+++ b/stories/topics/con-gcp-restore-process.adoc
@@ -6,9 +6,9 @@ The restore process deploys a new deployment, and restores the filestore and SQL
 
 [IMPORTANT]
 =====
-* You must restore with the same operational image version as the backup.
+* You must restore with the same operational image version which was used for the backup.
 
-* You can only restore using either a new VPC network. We do not currently support backup and restore into an existing VPC network.
+* You can only restore using a new VPC network. We do not currently support backup and restore into an existing VPC network.
 
 * You cannot delete the backed up environment before a restore because the database backups are stored in the deployment.
 Deleting your deployment therefore deletes the database backups.

--- a/stories/topics/proc-gcp-create-data-file.adoc
+++ b/stories/topics/proc-gcp-create-data-file.adoc
@@ -30,7 +30,7 @@ https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
-$  docker run -v $(pwd)/command_generator_data/:/data --rm $IMAGE \
+$ docker run -v $(pwd)/command_generator_data/:/data --rm $IMAGE \
 command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 ----
 . After running the command, a `/tmp/backup.yml` template file is created. 

--- a/stories/topics/proc-gcp-create-data-file.adoc
+++ b/stories/topics/proc-gcp-create-data-file.adoc
@@ -5,37 +5,32 @@
 .Procedure
 . Populate the `command_generator_data` directory with the configuration file template.
 +
-[NOTE]
-====
-As `/tmp` is used, the `<local_data_file_directory>` must be set to `/tmp` unless you chose a different location for `backup.yml`.
-====
-+
-[literal, options="nowrap" subs="+quotes,attributes"]
+[source,bash]
 ----
-docker run -v /tmp:/data --rm $IMAGE command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
+docker run -v $(pwd)/command_generator_data/:/data --rm $IMAGE command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 ----
 +
 Produces the following output:
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
-docker run --rm -v <local_data_file_directory>:/data $IMAGE \
+docker run -v $(pwd)/command_generator_data/:/data --rm $IMAGE \
 command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 
 ===============================================
 Playbook: gcp_backup_deployment
-Description: This playbook is used to backup the AoC Self-managed GCP environment.
+Description: This playbook is used to backup the Ansible Automation Platform from GCP Marketplace environment.
 -----------------------------------------------
-This playbook is used to backup the AoC Self-managed GCP environment.
+This playbook is used to backup the Ansible Automation Platform from GCP Marketplace environment.
 For more information regarding backup and restore, visit our official documentation - 
-
+https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-gcp-backup-and-restore
 -----------------------------------------------
 ----
 . Run the supplied command:
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
-$ docker run --rm -v /tmp:/data $IMAGE \
+$  docker run -v $(pwd)/command_generator_data/:/data --rm $IMAGE \
 command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 ----
 . After running the command, a `/tmp/backup.yml` template file is created. 

--- a/stories/topics/proc-gcp-create-data-file.adoc
+++ b/stories/topics/proc-gcp-create-data-file.adoc
@@ -7,14 +7,14 @@
 +
 [source,bash]
 ----
-docker run -v $(pwd)/command_generator_data/:/data --rm $IMAGE command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
+docker run --rm -v $(pwd)/command_generator_data/:/data $IMAGE command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 ----
 +
 Produces the following output:
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
-docker run -v $(pwd)/command_generator_data/:/data --rm $IMAGE \
+docker run --rm -v $(pwd)/command_generator_data/:/data $IMAGE \
 command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 
 ===============================================
@@ -30,7 +30,7 @@ https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
-$ docker run -v $(pwd)/command_generator_data/:/data --rm $IMAGE \
+$ docker run --rm -v $(pwd)/command_generator_data/:/data $IMAGE \
 command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 ----
 . After running the command, a `/tmp/backup.yml` template file is created. 

--- a/stories/topics/proc-gcp-generate-restore-yml-file.adoc
+++ b/stories/topics/proc-gcp-generate-restore-yml-file.adoc
@@ -7,7 +7,7 @@
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
-docker run --rm -v /tmp:/data $IMAGE command_generator_vars gcp_restore_deployment --output-data-file /data/restore.yml
+docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE command_generator_vars gcp_restore_deployment --output-data-file /data/restore.yml
 ----
 +
 Providing the following output:
@@ -16,15 +16,15 @@ Providing the following output:
 ----
 ===============================================
 Playbook: gcp_restore_deployment
-Description: This playbook is used to restore the AoC Self-managed GCP environment.
+Description: This playbook is used to restore the Ansible Automation Platform from GCP Marketplace environment from a backup.
 -----------------------------------------------
-This playbook is used to restore the AoC Self-managed GCP environment.
+This playbook is used to restore the Ansible Automation Platform from GCP Marketplace environment from a backup.
 For more information regarding backup and restore, visit our official documentation - 
-
+https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-gcp-backup-and-restore#con-gcp-restore-process
 -----------------------------------------------
 Command generator template: 
 
-docker run --rm -v /tmp:/data $IMAGE command_generator gcp_restore_deployment --data-file /data/restore.yml
+docker run --rm -v <local_data_file_directory>:/data $IMAGE command_generator gcp_restore_deployment --data-file /data/restore.yml
 ----
 +
 The template resembles the following:

--- a/stories/topics/proc-gcp-generate-restore-yml-file.adoc
+++ b/stories/topics/proc-gcp-generate-restore-yml-file.adoc
@@ -20,7 +20,7 @@ Description: This playbook is used to restore the Ansible Automation Platform fr
 -----------------------------------------------
 This playbook is used to restore the Ansible Automation Platform from GCP Marketplace environment from a backup.
 For more information regarding backup and restore, visit our official documentation - 
-https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-gcp-backup-and-restore#con-gcp-restore-process
+https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-gcp-backup-and-restore
 -----------------------------------------------
 Command generator template: 
 

--- a/stories/topics/proc-gcp-run-backup-playbook.adoc
+++ b/stories/topics/proc-gcp-run-backup-playbook.adoc
@@ -7,7 +7,7 @@
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
-docker run --rm -v /tmp:/data $IMAGE command_generator gcp_backup_deployment --data-file /data/backup.yml
+docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE command_generator gcp_backup_deployment --data-file /data/backup.yml
 ----
 +
 Resulting in the following ouput:
@@ -17,21 +17,21 @@ Resulting in the following ouput:
 -----------------------------------------------
 Command to run playbook: 
 
-docker run --rm --env PLATFORM=GCP -v <local_credential_file>:/home/runner/.gcp/credentials:ro \
+docker run --rm --env PLATFORM=GCP -v </path/to/gcp/service-account.json>:/home/runner/.gcp/credentials:ro \
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg  $IMAGE redhat.ansible_on_clouds.gcp_backup_deployment \
 -e 'gcp_service_account_credentials_json_path=/home/runner/.gcp/credentials  \
 gcp_deployment_name=<deployment_name> gcp_compute_region=<region> \
-gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket>’
+gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket>'
 ----
 . Run the supplied backup command to trigger the backup.
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
-$ docker run --rm --env PLATFORM=GCP -v <local_credential_file>:/home/runner/.gcp/credentials:ro \
+$ docker run --rm --env PLATFORM=GCP -v </path/to/gcp/service-account.json>:/home/runner/.gcp/credentials:ro \
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg  $IMAGE redhat.ansible_on_clouds.gcp_backup_deployment \
 -e 'gcp_service_account_credentials_json_path=/home/runner/.gcp/credentials  \
 gcp_deployment_name=<deployment_name> gcp_compute_region=<region> \
-gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket>’
+gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket>'
 ----
 . When the playbook has finished running, the output resembles the following:
 +

--- a/stories/topics/proc-gcp-run-restore-command.adoc
+++ b/stories/topics/proc-gcp-run-restore-command.adoc
@@ -14,7 +14,7 @@ As `/tmp` is used, the `<local_data_file_directory>` must be set to `/tmp` unles
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
-$ docker run --rm -v /tmp:/data $IMAGE command_generator gcp_restore_deployment --data-file /data/restore.yml
+$ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE command_generator gcp_restore_deployment --data-file /data/restore.yml
 ----
 +
 This generates a new command containing all needed volumes, environment variables and parameters.

--- a/stories/topics/proc-gcp-run-restore-command.adoc
+++ b/stories/topics/proc-gcp-run-restore-command.adoc
@@ -27,7 +27,7 @@ docker run --rm --env PLATFORM=GCP -v <local_credential_file>:/home/runner/.gcp/
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg  $IMAGE redhat.ansible_on_clouds.gcp_restore_deployment \
 -e 'gcp_service_account_credentials_json_path=/home/runner/.gcp/credentials  \
 gcp_deployment_name=<former_deployment_name> gcp_restored_deployment_name=<new_deployment_name> \
-gcp_compute_region=<region> gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket> gcp_existing_vpc=True'
+gcp_compute_region=<region> gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket> gcp_existing_vpc=False'
 ----
 . Run the generated command.
 +
@@ -37,7 +37,7 @@ $ docker run --rm --env PLATFORM=GCP -v <local_credential_file>:/home/runner/.gc
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg  $IMAGE redhat.ansible_on_clouds.gcp_restore_deployment \
 -e 'gcp_service_account_credentials_json_path=/home/runner/.gcp/credentials  \
 gcp_deployment_name=<former_deployment_name> gcp_restored_deployment_name=<new_deployment_name> \
-gcp_compute_region=<region> gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket> gcp_existing_vpc=True'
+gcp_compute_region=<region> gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket> gcp_existing_vpc=False'
 ----
 . When the playbook has completed, the output resembles the following:
 +

--- a/stories/topics/ref-gcp-populate-backup-file.adoc
+++ b/stories/topics/ref-gcp-populate-backup-file.adoc
@@ -8,8 +8,8 @@ The following variables are parameters listed in the data file.
 * `cloud_credentials_path` is the path for your Google Cloud service account credentials file. 
 This must be an absolute path.
 * `gcp_deployment_name` is the name of the AAP deployment manager deployment you want to back up.
-* `gcp_bucket_backup_name` is the bucket to use for the backup.
-If the bucket does not exist, it will be automatically created.
+* `gcp_bucket_backup_name` is the bucket to use for the backup. If the bucket does not exist, it will be automatically created. 
+Only the most recent backup is stored in the bucket. Every subsequent backup to the same bucket overwrites the backup files with the latest backup.
 * `gcp_compute_region` is GCP region where the foundation deployment is deployed. 
 This can be retrieved by checking the Deployments config in Deployment Manager.
 * `gcp_compute_zone` is the GCP zone where the foundation deployment is deployed.

--- a/stories/topics/ref-gcp-populate-backup-file.adoc
+++ b/stories/topics/ref-gcp-populate-backup-file.adoc
@@ -5,10 +5,12 @@
 You must populate the data file before triggering the backup.
 The following variables are parameters listed in the data file.
 
-* `cloud_credentials_path` is the path for your credentials. 
+* `cloud_credentials_path` is the path for your Google Cloud service account credentials file. 
 This must be an absolute path.
 * `gcp_deployment_name` is the name of the deployment you want to back up.
 * `gcp_bucket_backup_name` is the bucket to use for the backup.
 If the bucket does not exist, it will be automatically created.
-* `gcp_compute_region` is GCP region where the foundation deployment is deployed.
+* `gcp_compute_region` is GCP region where the foundation deployment is deployed. 
+This can be retrieved by checking the Deployments config in Deployment Manager.
 * `gcp_compute_zone` is the GCP zone where the foundation deployment is deployed.
+This can be retrieved by checking the Deployments config in Deployment Manager.

--- a/stories/topics/ref-gcp-populate-backup-file.adoc
+++ b/stories/topics/ref-gcp-populate-backup-file.adoc
@@ -7,7 +7,7 @@ The following variables are parameters listed in the data file.
 
 * `cloud_credentials_path` is the path for your Google Cloud service account credentials file. 
 This must be an absolute path.
-* `gcp_deployment_name` is the name of the deployment you want to back up.
+* `gcp_deployment_name` is the name of the AAP deployment manager deployment you want to back up.
 * `gcp_bucket_backup_name` is the bucket to use for the backup.
 If the bucket does not exist, it will be automatically created.
 * `gcp_compute_region` is GCP region where the foundation deployment is deployed. 

--- a/stories/topics/ref-gcp-populate-backup-file.adoc
+++ b/stories/topics/ref-gcp-populate-backup-file.adoc
@@ -8,7 +8,7 @@ The following variables are parameters listed in the data file.
 * `cloud_credentials_path` is the path for your Google Cloud service account credentials file. 
 This must be an absolute path.
 * `gcp_deployment_name` is the name of the AAP deployment manager deployment you want to back up.
-* `gcp_bucket_backup_name` is the bucket to use for the backup. If the bucket does not exist, it will be automatically created. 
+* `gcp_bucket_backup_name` is the bucket that was previously created to use for the backup.
 Only the most recent backup is stored in the bucket. Every subsequent backup to the same bucket overwrites the backup files with the latest backup.
 * `gcp_compute_region` is GCP region where the foundation deployment is deployed. 
 This can be retrieved by checking the Deployments config in Deployment Manager.

--- a/stories/topics/ref-gcp-populate-restore-file.adoc
+++ b/stories/topics/ref-gcp-populate-restore-file.adoc
@@ -21,14 +21,14 @@ The following parameters must be removed:
 Provide values for the following parameters:
 
 * `gcp_existing_vpc` must be set to `false`.
-* `cloud_credentials_path` is the absolute path toward your credentials.
-* `gcp_deployment_name` is the name of the deployment you want to back up.
-* `gcp_restored_deployment_name` isthe name under which the deployment must be restored.
-* `gcp_bucket_backup_name` is the bucket you used for the backup.
-* `gcp_bucket_backup_name` is the name you used for backup.
+* `cloud_credentials_path` is the path for your Google Cloud service account credentials file.
+* `gcp_deployment_name` is the name of the AAP deployment manager deployment you want to back up.
+* `gcp_restored_deployment_name` is the name under which the deployment must be restored. A new deployment will be created with this name. A deployment must not already exist with this name.
+* `gcp_bucket_backup_name` is the bucket name you used for the backup.
 * `gcp_compute_region` is the region where the backup was taken.
+This can be retrieved by checking the Deployments config in Deployment Manager.
 * `gcp_compute_zone` is the zone where the backup was taken.
-
+This can be retrieved by checking the Deployments config in Deployment Manager.
 
 .For an existing VPC
 

--- a/stories/topics/ref-gcp-populate-restore-file.adoc
+++ b/stories/topics/ref-gcp-populate-restore-file.adoc
@@ -28,3 +28,18 @@ Provide values for the following parameters:
 This can be retrieved by checking the Deployments config in Deployment Manager.
 * `gcp_compute_zone` is the zone where the backup was taken.
 This can be retrieved by checking the Deployments config in Deployment Manager.
+
+// .For an existing VPC
+
+// If you want to restore using an existing VPC, you must set the parameters shown above.
+
+// You must also set the following additional parameters:
+
+// * `gcp_existing_vpc` is set to `true`.
+// * `gcp_filestore_ip_range` must be set to a free ip/29 range of your VPC.
+// For example: 192.168.245.0/29.
+// You must not use 192.168.243.0/29 as this the default used when deploying {AAPonGCP}.
+// * `gcp_cloud_sql_peering_network` must be set to a free `/24` subnet.
+// You must not use 192.168.241.0/24 as this is used during the original deployment.
+// * `gcp_controller_internal_ip_address` must be set to a free IP in your VPC network.
+// * `gcp_hub_internal_ip_address` must set to a free IP in your VPC network.

--- a/stories/topics/ref-gcp-populate-restore-file.adoc
+++ b/stories/topics/ref-gcp-populate-restore-file.adoc
@@ -2,8 +2,7 @@
 
 = Parameters of the restore.yml file
 
-You can restore using either a new VPC network or an existing one.
-You must set additional parameters to restore on an existing VPC network.
+You can only restore into a new VPC network.
 
 .For a new VPC
 
@@ -29,18 +28,3 @@ Provide values for the following parameters:
 This can be retrieved by checking the Deployments config in Deployment Manager.
 * `gcp_compute_zone` is the zone where the backup was taken.
 This can be retrieved by checking the Deployments config in Deployment Manager.
-
-.For an existing VPC
-
-If you want to restore using an existing VPC, you must set the parameters shown above.
-
-You must also set the following additional parameters:
-
-* `gcp_existing_vpc` is set to `true`.
-* `gcp_filestore_ip_range` must be set to a free ip/29 range of your VPC.
-For example: 192.168.245.0/29.
-You must not use 192.168.243.0/29 as this the default used when deploying {AAPonGCP}.
-* `gcp_cloud_sql_peering_network` must be set to a free `/24` subnet.
-You must not use 192.168.241.0/24 as this is used during the original deployment.
-* `gcp_controller_internal_ip_address` must be set to a free IP in your VPC network.
-* `gcp_hub_internal_ip_address` must set to a free IP in your VPC network.


### PR DESCRIPTION
Contains all backup and restore update suggestions for GCP.
Clarifies some topics, and updates expected outputs.
Removes existing VPC documentation and details it is unsupported.

Noting that the following links 404 as of now. Would be nice if we can redirect these broken links to their expected locations.

Bad Link: https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-aap-gcp-backup-and-recovery
Updated Value: https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-gcp-backup-and-restore