### PR TITLE
2.2.1 Add Direct docs feedback module

### DIFF
--- a/aap-common/providing-direct-documentation-feedback.adoc
+++ b/aap-common/providing-direct-documentation-feedback.adoc
@@ -1,0 +1,24 @@
+[preface]
+:_module-type: CONCEPT
+[id="providing-direct-documentation-feedback"]
+= Providing feedback on Red Hat documentation
+
+[role="_abstract"]
+We appreciate your feedback on our technical content and encourage you to tell us what you think.
+If you'd like to add comments, provide insights, correct a typo, or even ask a question, you can do so directly in the documentation.
+
+[NOTE]
+====
+You must have a Red Hat account and be logged in to the customer portal.
+====
+
+To submit documentation feedback from the customer portal, do the following:
+
+. Select the *Multi-page HTML* format.
+. Click the *Feedback* button at the top-right of the document.
+. Highlight the section of text where you want to provide feedback.
+. Click the *Add Feedback* dialog next to your highlighted text.
+. Enter your feedback in the text box on the right of the page and then click *Submit*.
+
+We automatically create a tracking issue each time you submit feedback.
+Open the link that is displayed after you click *Submit* and start watching the issue or add more comments.

--- a/titles/aap-on-aws/stories.adoc
+++ b/titles/aap-on-aws/stories.adoc
@@ -1,5 +1,6 @@
 // AAP common content
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
 include::aap-common/external-site-disclaimer.adoc[leveloffset=+1]
 // AAP on AWS user stories
 include::stories/assembly-aap-aws-intro.adoc[leveloffset=+1]

--- a/titles/aap-on-gcp/stories.adoc
+++ b/titles/aap-on-gcp/stories.adoc
@@ -1,5 +1,6 @@
 // AAP common content
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
 include::aap-common/external-site-disclaimer.adoc[leveloffset=+1]
 // AAP on GCP user stories
 include::stories/assembly-aap-gcp-intro.adoc[leveloffset=+1]


### PR DESCRIPTION
Add direct docs feedback module in AoC 2.2.1 docs (AWS and GCP)
