### PR TITLE
change asciidoc tag so that $ is not included when copy/paste used

### DIFF
--- a/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
+++ b/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
@@ -11,7 +11,7 @@ The `ansible-on-clouds-ops` container image tag must match the version that you 
 For example, if your foundation deployment version is 2.2.20230215-00, pull the `ansible-on-clouds-ops` image with tag 2.3.20230221 to upgrade to version 2.3.20230221.
 =====
 +
-[source,bash]
+[source,console]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.3.20230221
 $ docker pull $IMAGE
@@ -19,7 +19,7 @@ $ docker pull $IMAGE
 
 For EMEA regions (Europe, Middle East, Africa) run the following command instead:
 
-[source, bash]
+[source,console]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.3.20230221
 $ docker pull $IMAGE


### PR DESCRIPTION
This is a test of the proper [source tag to use to get the copy/paste to work the way we want.   I can't truly test this unless I get an official generated draft image.

If this works, we will have a bunch of places we need to change (and some we need to keep as is)