### PR TITLE
Remove source,bash line preceding codeblocks

### DIFF
--- a/aap-common/proc-aap-generate-command-data-file.adoc
+++ b/aap-common/proc-aap-generate-command-data-file.adoc
@@ -5,7 +5,7 @@
 .Procedure
 . Run the command generator.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run -rm -v <local_directory_data_file>:/data $IMAGE command_generator_vars <playbook_name> -output-data-file /data/<data-file>.yml
 ----
@@ -18,7 +18,7 @@ ifdef::product_GCP[]
 +
 The following example uses the `gcp_backup_deployment` playbook.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v <local_data_file_directory>:/data $IMAGE command_generator_vars gcp_backup_deployment \
 --output-data-file /data/backup.yml
@@ -26,7 +26,7 @@ $ docker run --rm -v <local_data_file_directory>:/data $IMAGE command_generator_
 +
 . Producing the following output.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 ===============================================
 Playbook: gcp_backup_deployment
@@ -57,7 +57,7 @@ ifdef::product_AWS[]
 +
 The following example uses the `aws_backup_stack` playbook.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v <local_data_file_directory>:/data $IMAGE command_generator_vars aws_backup_stack \
 --output-data-file /data/backup.yml
@@ -65,7 +65,7 @@ $ docker run --rm -v <local_data_file_directory>:/data $IMAGE command_generator_
 +
 . Producing the following output.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 ===============================================
 Playbook: aws_backup_stack

--- a/aap-common/proc-aap-list-available-playbooks.adoc
+++ b/aap-common/proc-aap-list-available-playbooks.adoc
@@ -5,7 +5,7 @@
 .Procedure
 . For the list of available playbooks without details, use the following command.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run —–-rm $IMAGE command_generator_vars | grep Playbook
 
@@ -31,7 +31,7 @@ Playbook: gcp_upgrade
 ----
 . To provide a list of all available playbooks, and to use the command generator, use the following command.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run —–-rm $IMAGE command_generator_vars
 ----
@@ -40,7 +40,7 @@ This provides a list of playbooks and a command similar to the following:
 
 ifdef::product_AWS[]
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 ===============================================
 Playbook: aws_add_extension_nodes
@@ -61,7 +61,7 @@ docker run --rm $IMAGE command_generator aws_add_extension_nodes [--ansible-conf
 endif::product_AWS[]
 ifdef::product_GCP[]
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 ===============================================
 Playbook: gcp_upgrade

--- a/aap-common/proc-aap-populate-command-data-file.adoc
+++ b/aap-common/proc-aap-populate-command-data-file.adoc
@@ -12,7 +12,7 @@ ifdef::product_GCP[]
 +
 For example, in the case of the `gcp_backup_deployment` playbook, the file becomes:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 gcp_backup_deployment
   cloud_credentials_path: /path/to/credentials
@@ -27,7 +27,7 @@ ifdef::product_AWS[]
 +
 For example, in the case of the `aws_backup_stack` playbook, the file becomes:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 aws_backup_stack:
   cloud_credentials_path: ~/.aws/credentials

--- a/aap-common/proc-aap-pull-command-container-image.adoc
+++ b/aap-common/proc-aap-pull-command-container-image.adoc
@@ -8,7 +8,7 @@ For example, if your foundation deployment version is 2.2.20230215, you must pul
 
 Use the following commands:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=<image-path>
 $ docker pull $IMAGE

--- a/aap-common/proc-aap-run-generated-command.adoc
+++ b/aap-common/proc-aap-run-generated-command.adoc
@@ -8,13 +8,13 @@
 ifdef::product_GCP[]
 For the `gcp_backup_deployment` playbook example, this is:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v /tmp:/data $IMAGE command_generator gcp_backup_deployment --data-file /data/backup.yml
 ----
 Which generates the following output:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 Command to run playbook:
 
@@ -29,13 +29,13 @@ ifdef::product_AWS[]
 +
 For the `aws_backup_stack` playbook example, this is:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v /tmp:/data $IMAGE command_generator aws_backup_stack --data-file /data/backup.yml
 ----
 Which generates the following output:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 Command to run playbook:
 

--- a/stories/topics/con-aws-pull-container-image.adoc
+++ b/stories/topics/con-aws-pull-container-image.adoc
@@ -8,7 +8,7 @@ For example, if your foundation deployment version is 2.3.20230221-00, you must 
 
 Use the following commands:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.3.20230221
 $ docker pull $IMAGE

--- a/stories/topics/con-aws-pull-deploy-container-image.adoc
+++ b/stories/topics/con-aws-pull-deploy-container-image.adoc
@@ -8,7 +8,7 @@ For example, if your foundation deployment version is 2.3.20230221-00, you must 
 
 Use the following commands:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.3.20230221
 $ docker pull $IMAGE

--- a/stories/topics/con-aws-update-backup-data-file.adoc
+++ b/stories/topics/con-aws-update-backup-data-file.adoc
@@ -31,7 +31,7 @@ For guidance on bucket naming, see link:https://www.google.com/url?q=https://doc
 When you have populated the data file, it should resemble the following. 
 The values in this file are provided as examples:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 aws_backup_stack:
   cloud_credentials_path: ~/.aws/credentials

--- a/stories/topics/con-aws-update-restore-data-file.adoc
+++ b/stories/topics/con-aws-update-restore-data-file.adoc
@@ -49,7 +49,7 @@ This must be the same bucket used for backup.
 When you have populated the data file, it should resemble the following. 
 The values in this file are provided as examples. 
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 aws_restore_stack:
   cloud_credentials_path: ~/.aws/credentials

--- a/stories/topics/con-gcp-use-container-image.adoc
+++ b/stories/topics/con-gcp-use-container-image.adoc
@@ -4,7 +4,7 @@
 
 Use the following commands:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.com/<image-path>
 ----

--- a/stories/topics/proc-aws-backup-platform-stack.adoc
+++ b/stories/topics/proc-aws-backup-platform-stack.adoc
@@ -11,7 +11,7 @@ The `ansible-on-clouds-ops` image tag must match the version of the foundation d
 For example, if your foundation deployment version is 2.2.20230215-00, pull the `ansible-on-clouds-ops` image with tag 2.2.20230215
 =====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.2.20230215
 $ docker pull $IMAGE

--- a/stories/topics/proc-aws-deploying-extension-nodes.adoc
+++ b/stories/topics/proc-aws-deploying-extension-nodes.adoc
@@ -5,14 +5,14 @@
 .Procedure
 . To deploy the extension nodes, run the command generator to generate the CLI command.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ---- 
 $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE command_generator --data-file /data/extra_vars.yml
 ----
 +
 Provides the following command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 -----------------------------------------------
 docker run --rm --env PLATFORM=AWS -v ~/.aws/credentials:/home/runner/.aws/credentials \
@@ -25,7 +25,7 @@ aws_asg_min_size=2 aws_asg_desired_capacity=2 aws_offer_type=100'
 
 . Run the supplied command to add the extension nodes.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm --env PLATFORM=AWS -v ~/.aws/credentials:/home/runner/.aws/credentials \
 --env ANSIBLE_CONFIG=../aws-ansible.cfg  $IMAGE redhat.ansible_on_clouds.aws_add_extension_nodes \

--- a/stories/topics/proc-aws-from-stack-prepare-environment.adoc
+++ b/stories/topics/proc-aws-from-stack-prepare-environment.adoc
@@ -5,7 +5,7 @@
 .Procedure
 . Ensure the `AWS_CREDS_ABS_PATH` environment variable is defined pointing to your AWS Credentials file.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 export AWS_CREDS_ABS_PATH=/Users/<USER>/.aws/credentials
 ----

--- a/stories/topics/proc-aws-from-stack-pull-container-image.adoc
+++ b/stories/topics/proc-aws-from-stack-pull-container-image.adoc
@@ -5,7 +5,7 @@
 .Procedure
 . Pull the `ansible-on-clouds-ops` 2.2 container image with the same tag as the foundation deployment.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.2.20230215
 $ docker pull $IMAGE

--- a/stories/topics/proc-aws-from-stack-run-to-upgrade.adoc
+++ b/stories/topics/proc-aws-from-stack-run-to-upgrade.adoc
@@ -4,7 +4,7 @@
 
 To restore the stack after your environment has been prepared, trigger the restore by running the following command:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ---- 
 $ docker run --rm --env PLATFORM=AWS \
 -v $(pwd)/extra_vars:/extra_vars:ro \

--- a/stories/topics/proc-aws-generate-add-data-files.adoc
+++ b/stories/topics/proc-aws-generate-add-data-files.adoc
@@ -8,13 +8,13 @@ These commands create a directory, and  an empty data template that, when popula
 .Procedure
 . Create a folder to hold the configuration files.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ mkdir command_generator_data
 ----
 . Populate the `command_generator_data` folder with the configuration file template.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE \
 command_generator_vars aws_add_extension_nodes \
@@ -24,7 +24,7 @@ command_generator_vars aws_add_extension_nodes \
 . When you have run these commands, a `command_generator_data/extra_vars.yml` template file is created. 
 This template file resembles the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Create 
 aws_add_extension_nodes:

--- a/stories/topics/proc-aws-generate-backup-data-file.adoc
+++ b/stories/topics/proc-aws-generate-backup-data-file.adoc
@@ -7,14 +7,14 @@ The following commands create a directory, and populate it with an empty data te
 .Procedure
 . Create a folder to hold the configuration 
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ mkdir command_generator_data
 ----
 . Populate the `command_generator_data` folder with the configuration file template.
 This creates the `extra-vars.yaml` file within the `command-generator_data` directory with `root:root_user` and `group` permissions.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE \
   command_generator_vars aws_backup_stack \
@@ -24,7 +24,7 @@ $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE \
 . After running these commands, a `command_generator_data/extra_vars.yaml` template file is created. 
 This template file resembles the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ---- 
 aws_backup_stack:
   cloud_credentials_path:

--- a/stories/topics/proc-aws-generate-restore-data-file.adoc
+++ b/stories/topics/proc-aws-generate-restore-data-file.adoc
@@ -7,13 +7,13 @@ The following commands create a directory, and populate it with an empty data te
 .Procedure
 . Create a folder to hold the configuration 
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ mkdir command_generator_data
 ----
 . Populate the `command_generator_data` folder with the configuration file template.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE \
   command_generator_vars aws_restore_stack \
@@ -23,7 +23,7 @@ $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE \
 . After running these commands, a `command_generator_data/extra_vars.yml` template file is created. 
 This template file resembles the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ---- 
 aws_restore_stack:
   cloud_credentials_path:

--- a/stories/topics/proc-aws-generate-upgrade-data-file.adoc
+++ b/stories/topics/proc-aws-generate-upgrade-data-file.adoc
@@ -9,13 +9,13 @@ Run the following commands to generate the required data file.
 .Procedure
 . Create a folder to hold the configuration files.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ mkdir command_generator_data
 ----
 . Populate the `command_generator_data` folder with the configuration file template.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE \
 command_generator_vars aws_upgrade \
@@ -24,7 +24,7 @@ command_generator_vars aws_upgrade \
 . After running these commands, a `command_generator_data/extra_vars.yml` template file is created. 
 This template file resembles the following: 
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 aws_upgrade:
   ansible_config_path:

--- a/stories/topics/proc-aws-prepare-backup-environment.adoc
+++ b/stories/topics/proc-aws-prepare-backup-environment.adoc
@@ -4,13 +4,13 @@
 
 . Ensure that the `AWS_CREDS_ABS_PATH` environment variable is defined pointing to your AWS Credentials file.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 export AWS_CREDS_ABS_PATH=/Users/<USER>/.aws/credentials
 ----
 . Create an `extra_vars/vars.yml file`, adding the following values and ensuring that they are customized to match your environment.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 aws_foundation_stack_name: "AnsibleAutomationPlatformmy-foundation-stack"
 aws_region: us-east-1

--- a/stories/topics/proc-aws-removing-extension-nodes.adoc
+++ b/stories/topics/proc-aws-removing-extension-nodes.adoc
@@ -5,14 +5,14 @@
 .Procedure
 . To remove a set of extension nodes, run the command generator to generate the CLI command.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE command_generator --data-file /data/extra_vars.yml
 ----
 +
 The command generator output provides the following command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 docker run --rm --env PLATFORM=AWS -v ~/.aws/credentials:/home/runner/.aws/credentials:ro\
  --env ANSIBLE_CONFIG=../aws-ansible.cfg  $IMAGE redhat.ansible_on_clouds.aws_remove_extension_nodes -e\ 'aws_foundation_stack_name=AnsibleAutomationPlatform aws_region=us-east-1 \
@@ -20,7 +20,7 @@ docker run --rm --env PLATFORM=AWS -v ~/.aws/credentials:/home/runner/.aws/crede
 ----
 . Run the supplied upgrade command to remove a set of extension nodes.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm --env PLATFORM=AWS -v ~/.aws/credentials:/home/runner/.aws/credentials:ro\
  --env ANSIBLE_CONFIG=../aws-ansible.cfg  $IMAGE redhat.ansible_on_clouds.aws_remove_extension_nodes -e\ 'aws_foundation_stack_name=AnsibleAutomationPlatform aws_region=us-east-1 <

--- a/stories/topics/proc-aws-running-upgrade.adoc
+++ b/stories/topics/proc-aws-running-upgrade.adoc
@@ -4,14 +4,14 @@
 
 . To run the upgrade, run the command generator to generate the upgrade CLI command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ---- 
 $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE command_generator --data-file /data/extra_vars.yml
 ----
 +
 This generates the following upgrade command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 -----------------------------------------------
 docker run --rm --env PLATFORM=AWS -v ~/.aws/credentials:/home/runner/.aws/credentials:ro --env ANSIBLE_CONFIG=../aws-ansible.cfg --env DEPLOYMENT_NAME=AnsibleAutomationPlatform --env GENERATE_INVENTORY=true  $IMAGE redhat.ansible_on_clouds.aws_upgrade -e 'aws_foundation_stack_name=AnsibleAutomationPlatform aws_region=us-east-1 aws_ssm_bucket_name=AnsibleAutomationPlatform-bucket'
@@ -19,7 +19,7 @@ docker run --rm --env PLATFORM=AWS -v ~/.aws/credentials:/home/runner/.aws/crede
 ----
 . Run the given upgrade command to trigger the upgrade.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm --env PLATFORM=AWS -v ~/.aws/credentials:/home/runner/.aws/credentials:ro \
 --env ANSIBLE_CONFIG=../aws-ansible.cfg --env DEPLOYMENT_NAME=AnsibleAutomationPlatform \
@@ -30,7 +30,7 @@ aws_ssm_bucket_name=AnsibleAutomationPlatform-bucket'
 . The upgrade can take some time to complete, but can take longer depending on the number of extension nodes on the system. 
 A successful upgrade is marked by the log below.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 TASK [redhat.ansible_on_clouds.standalone_aws_upgrade : [upgrade] [LOG] upgrade version] ***
 ok: [localhost] => {

--- a/stories/topics/proc-aws-secure-controller-load-balancer.adoc
+++ b/stories/topics/proc-aws-secure-controller-load-balancer.adoc
@@ -10,7 +10,7 @@ The following procedure describes how to secure the {ControllerName} load balanc
 .Procedure
 . Generate the {ControllerName} certificate with the following command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ openssl req -x509 -nodes -newkey rsa:4096 -keyout controller_key.pem -out controller_cert.pem -sha256 -days 365 -addext "subjectAltName = DNS:<CONTROLLER_DNS_NAME>"
 ----
@@ -60,21 +60,21 @@ Ensure you are in the correct region.
 . Select the {ControllerName} instance(s)
 . Paste the {ControllerName} key in the following location:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo vi /efs/certificates/controller_key.pem # Paste key. This step only needs to be done on the first controller node.
 ----
 +
 . Paste the controller certificate in the following location -
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo vi /efs/certificates/controller_cert.pem # Paste cert. This step only needs to be done on the first controller node.
 ----
 +
 . Copy the certificte and keys to the ca-trust directory. Then update the ca-trust directory using the following commands:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo cp /efs/certificates/controller_key.pem /etc/pki/ca-trust/source/anchors/controller-key.pem # Copy key
 $ sudo cp /efs/certificates/controller_cert.pem /etc/pki/ca-trust/source/anchors/controller-cert.pem # Copy cert

--- a/stories/topics/proc-aws-secure-hub-controller-connection.adoc
+++ b/stories/topics/proc-aws-secure-hub-controller-connection.adoc
@@ -10,7 +10,7 @@ The following procedure describes how to secure the {HubName} load balancer
 .Procedure
 . Generate the {HubName} certificate with the following command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ openssl req -x509 -nodes -newkey rsa:4096 -keyout hub_key.pem -out hub_cert.pem -sha256 -days 365 -addext "subjectAltName = DNS:<HUB_DNS_NAME>"
 ----
@@ -61,14 +61,14 @@ Ensure you are in the correct region.
 . Select the {HubName} instance(s)
 . Paste the {HubName} key in the following location:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo vi /efs/certificates/hub_key.pem # Paste key
 ----
 +
 . Paste the {HubName} certificate in the following location: 
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo vi /efs/certificates/hub_cert.pem # Paste cert
 ----
@@ -76,7 +76,7 @@ $ sudo vi /efs/certificates/hub_cert.pem # Paste cert
 . Copy the certificate and keys to the ca-trust directory. 
 Then update the ca-trust using the following commands:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo cp /efs/certificates/hub_key.pem /etc/pki/ca-trust/source/anchors/hub-key.pem # Copy key
 $ sudo cp /efs/certificates/hub_cert.pem /etc/pki/ca-trust/source/anchors/hub-cert.pem # Copy cert

--- a/stories/topics/proc-aws-set-container-image.adoc
+++ b/stories/topics/proc-aws-set-container-image.adoc
@@ -8,7 +8,7 @@ For example, if your foundation deployment version is 2.3.20230221-00, pull the 
 .Procedure
 . Pull the `ansible-on-clouds-ops` container image with the same tag version as the foundation deployment.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.3.20230221
 $ docker pull $IMAGE

--- a/stories/topics/proc-aws-update-add-data-files.adoc
+++ b/stories/topics/proc-aws-update-add-data-files.adoc
@@ -20,7 +20,7 @@ After populating the data file, it resembles the following:
 
 The values are provided as examples.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 aws_add_extension_nodes:
   cloud_credentials_path: ~/.aws/credentials

--- a/stories/topics/proc-aws-update-remove-data-file.adoc
+++ b/stories/topics/proc-aws-update-remove-data-file.adoc
@@ -17,7 +17,7 @@ After populating the data file, it should resemble the following:
 
 The values below are provided as examples.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 aws_remove_extension_nodes:
   cloud_credentials_path: ~/.aws/credentials

--- a/stories/topics/proc-aws-upgrade-pull-container-image.adoc
+++ b/stories/topics/proc-aws-upgrade-pull-container-image.adoc
@@ -10,7 +10,7 @@
 The Ansible on Clouds operational image tag must match the version that you want to upgrade to. For example, if your foundation deployment version is 2.2.20230215, pull the operational image with tag 2.3.20230221 to upgrade to version 2.3.20230221.
 ====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.3.20230221
 $ docker pull $IMAGE

--- a/stories/topics/proc-gcp-backup-container-image.adoc
+++ b/stories/topics/proc-gcp-backup-container-image.adoc
@@ -5,7 +5,7 @@
 .Procedure
 * Pull the docker image for the `ansible-on-clouds-ops` 2.3 container with the same tag as the foundation deployment.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.3.20230221
 $ docker pull $IMAGE

--- a/stories/topics/proc-gcp-backup-platform-stack.adoc
+++ b/stories/topics/proc-gcp-backup-platform-stack.adoc
@@ -37,7 +37,7 @@ For example, the filestore instance location might be `us-east1-d`
 For example, if your `gcp_compute_zone` location is `us-east1-d`, your region is `us-east1`.
 =====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 gcp_service_account_credentials_json_path: "/secrets/<service-account-creds-json-filename>"
 gcp_deployment_name: "" 
@@ -47,7 +47,7 @@ gcp_compute_zone: ""
 +
 . The final result should look similar to the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ tree
 tree

--- a/stories/topics/proc-gcp-create-data-file.adoc
+++ b/stories/topics/proc-gcp-create-data-file.adoc
@@ -10,14 +10,14 @@
 As `/tmp` is used, the `<local_data_file_directory>` must be set to `/tmp` unless you chose a different location for `backup.yml`.
 ====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 docker run -v /tmp:/data --rm $IMAGE command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 ----
 +
 Produces the following output:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 docker run --rm -v <local_data_file_directory>:/data $IMAGE \
 command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
@@ -33,7 +33,7 @@ For more information regarding backup and restore, visit our official documentat
 ----
 . Run the supplied command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v /tmp:/data $IMAGE \
 command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
@@ -41,7 +41,7 @@ command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 . After running the command, a `/tmp/backup.yml` template file is created. 
 This template file resembles the following: 
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 gcp_backup_deployment:
   cloud_credentials_path:

--- a/stories/topics/proc-gcp-from-stack-pull-container-image.adoc
+++ b/stories/topics/proc-gcp-from-stack-pull-container-image.adoc
@@ -5,7 +5,7 @@
 .Procedure
 * Pull the `ansible-on-clouds-ops 2.2` container image with the same tag version as the foundation deployment.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.2.20230215
 $ docker pull $IMAGE

--- a/stories/topics/proc-gcp-generate-playbook.adoc
+++ b/stories/topics/proc-gcp-generate-playbook.adoc
@@ -4,7 +4,7 @@
 
 To generate the playbook, run the command generator to generate the CLI command.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 docker run --rm -v /tmp:/data $IMAGE command_generator gcp_setup_logging_monitoring \
 --data-file /data/logging-monitoring.yaml
@@ -12,7 +12,7 @@ docker run --rm -v /tmp:/data $IMAGE command_generator gcp_setup_logging_monitor
 
 Provides the following command:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 docker run --rm --env PLATFORM=GCP -v /path/to/credentials:/home/runner/.gcp/credentials:ro \
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg --env DEPLOYMENT_NAME=mu-deployment \
@@ -24,7 +24,7 @@ monitoring_enabled=True logging_enabled=True default_collector_interval=60s'
 
 Run the supplied command to run the playbook.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm --env PLATFORM=GCP -v /path/to/credentials:/home/runner/.gcp/credentials:ro \
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg --env DEPLOYMENT_NAME=mu-deployment \
@@ -36,7 +36,7 @@ monitoring_enabled=True logging_enabled=True default_collector_interval=60s'
 
 The process may take some time, and provides output similar to the following:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 TASK [redhat.ansible_on_clouds.setup_logging_monitoring : Update runtime variable logging_enabled] ***
 changed: [<user_name> -> localhost]

--- a/stories/topics/proc-gcp-generate-restore-yml-file.adoc
+++ b/stories/topics/proc-gcp-generate-restore-yml-file.adoc
@@ -5,14 +5,14 @@
 .Procedure
 . Run the command generator `command_generator_vars`` to generate `restore.yml`.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 docker run --rm -v /tmp:/data $IMAGE command_generator_vars gcp_restore_deployment --output-data-file /data/restore.yml
 ----
 +
 Providing the following output:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 ===============================================
 Playbook: gcp_restore_deployment
@@ -29,7 +29,7 @@ docker run --rm -v /tmp:/data $IMAGE command_generator gcp_restore_deployment --
 +
 The template resembles the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 gcp_restore_deployment:
   cloud_credentials_path:

--- a/stories/topics/proc-gcp-generate-upgrade-data-file.adoc
+++ b/stories/topics/proc-gcp-generate-upgrade-data-file.adoc
@@ -7,7 +7,7 @@
 . Run the following commands  to generate the required data file. 
 These commands create a directory, and populate it with an empty data template that, when populated, is used during the upgrade. 
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Create a folder to hold the configuration files
 $ mkdir command_generator_data
@@ -19,7 +19,7 @@ command_generator_vars gcp_upgrade \
 . After running the previous commands, a `command_generator_data/extra_vars.yml` template is created. 
 This template file should resemble:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
   gcp_upgrade:
   ansible_config_path:

--- a/stories/topics/proc-gcp-generate-variables.adoc
+++ b/stories/topics/proc-gcp-generate-variables.adoc
@@ -23,7 +23,7 @@ command_generator_vars gcp_setup_logging_monitoring \
 +
 Creates the following command file:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 ===============================================
 Playbook: gcp_setup_logging_monitoring
@@ -46,7 +46,7 @@ In the following example file, `ansible_config_path` is optional.
 +
 This template file resembles the following:- 
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 gcp_setup_logging_monitoring:
   ansible_config_path:

--- a/stories/topics/proc-gcp-prepare-backup-environment.adoc
+++ b/stories/topics/proc-gcp-prepare-backup-environment.adoc
@@ -6,7 +6,7 @@
 
 * Create the directories used to configure the upgrade process using the following commands:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Secrets directory. Store the GCP credentials file.
 $ mkdir secrets

--- a/stories/topics/proc-gcp-pull-backup-container-image.adoc
+++ b/stories/topics/proc-gcp-pull-backup-container-image.adoc
@@ -5,7 +5,7 @@
 .Procedure
 * Pull the `ansible-on-clouds-ops 2.2` container image with the same tag version as the foundation deployment.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.2.20230215
 $ docker pull $IMAGE

--- a/stories/topics/proc-gcp-run-backup-playbook-as-container.adoc
+++ b/stories/topics/proc-gcp-run-backup-playbook-as-container.adoc
@@ -7,7 +7,7 @@
 +
 . Use the following command to run the playbook:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm \
 -v <absolute path to google application credentials dir>:/secrets:ro \

--- a/stories/topics/proc-gcp-run-backup-playbook.adoc
+++ b/stories/topics/proc-gcp-run-backup-playbook.adoc
@@ -5,14 +5,14 @@
 .Procedure
 . To run the backup, run the command generator to generate the backup command.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 docker run --rm -v /tmp:/data $IMAGE command_generator gcp_backup_deployment --data-file /data/backup.yml
 ----
 +
 Resulting in the following ouput:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 -----------------------------------------------
 Command to run playbook: 
@@ -25,7 +25,7 @@ gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket>’
 ----
 . Run the supplied backup command to trigger the backup.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm --env PLATFORM=GCP -v <local_credential_file>:/home/runner/.gcp/credentials:ro \
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg  $IMAGE redhat.ansible_on_clouds.gcp_backup_deployment \
@@ -35,7 +35,7 @@ gcp_compute_zone=<zone> gcp_bucket_backup_name=<bucket>’
 ----
 . When the playbook has finished running, the output resembles the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 TASK [redhat.ansible_on_clouds.standalone_gcp_backup : [backup_deployment] Print vars required for restore process] ***
 ok: [localhost] => 

--- a/stories/topics/proc-gcp-run-restore-command.adoc
+++ b/stories/topics/proc-gcp-run-restore-command.adoc
@@ -12,7 +12,7 @@ When `restore.yml` is populated, you can use the command generator to create the
 As `/tmp` is used, the `<local_data_file_directory>` must be set to `/tmp` unless you chose a different location for `restore.yml`.
 ====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm -v /tmp:/data $IMAGE command_generator gcp_restore_deployment --data-file /data/restore.yml
 ----
@@ -21,7 +21,7 @@ This generates a new command containing all needed volumes, environment variable
 +
 The generated command resembles the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 docker run --rm --env PLATFORM=GCP -v <local_credential_file>:/home/runner/.gcp/credentials:ro \
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg  $IMAGE redhat.ansible_on_clouds.gcp_restore_deployment \
@@ -31,7 +31,7 @@ gcp_compute_region=<region> gcp_compute_zone=<zone> gcp_bucket_backup_name=<buck
 ----
 . Run the generated command.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm --env PLATFORM=GCP -v <local_credential_file>:/home/runner/.gcp/credentials:ro \
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg  $IMAGE redhat.ansible_on_clouds.gcp_restore_deployment \
@@ -41,7 +41,7 @@ gcp_compute_region=<region> gcp_compute_zone=<zone> gcp_bucket_backup_name=<buck
 ----
 . When the playbook has completed, the output resembles the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 TASK [redhat.ansible_on_clouds.standalone_gcp_restore : Display internal IP addresses] ***
 ok: [localhost] =>

--- a/stories/topics/proc-gcp-run-restore-playbook-as-container.adoc
+++ b/stories/topics/proc-gcp-run-restore-playbook-as-container.adoc
@@ -8,7 +8,7 @@
 +
 . Use the following command to run the playbook.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm \
 -v <absolute path to Google application credentials dir>:/secrets:ro \

--- a/stories/topics/proc-gcp-running-upgrade.adoc
+++ b/stories/topics/proc-gcp-running-upgrade.adoc
@@ -4,14 +4,14 @@
 
 . To run the upgrade, run the command generator to generate the upgrade CLI command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ---- 
 $ docker run --rm -v $(pwd)/command_generator_data:/data $IMAGE command_generator --data-file /data/extra_vars.yml
 ----
 +
 This generates the following command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 -----------------------------------------------
 docker run --rm --env PLATFORM=GCP -v ~/secrets/GCP-secrets.json:/home/runner/.gcp/credentials:ro 
@@ -25,7 +25,7 @@ gcp_compute_region=us-east1 gcp_compute_zone=us-east1-b gcp_backup_taken=True'
 ----
 . Run the given upgrade command to trigger the upgrade.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm --env PLATFORM=GCP -v ~/secrets/GCP-secrets.json:/home/runner/.gcp/credentials:ro \
 --env ANSIBLE_CONFIG=../gcp-ansible.cfg \
@@ -38,7 +38,7 @@ gcp_compute_region=us-east1 gcp_compute_zone=us-east1-b gcp_backup_taken=True'
 . The upgrade can take some time to complete, but can take longer depending on the number of extension nodes on the system. 
 A successful upgrade is marked by the log below.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 TASK [redhat.ansible_on_clouds.standalone_gcp_upgrade : [upgrade] Show GCP current version] ***
 ok: [localhost] => {

--- a/stories/topics/proc-gcp-setup-environment.adoc
+++ b/stories/topics/proc-gcp-setup-environment.adoc
@@ -5,7 +5,7 @@
 .Procedure
 * Create a folder to hold the configuration files.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ mkdir command_generator_data
 ----

--- a/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
+++ b/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
@@ -11,7 +11,7 @@ The `ansible-on-clouds-ops` container image tag must match the version that you 
 For example, if your foundation deployment version is 2.2.20230215-00, pull the `ansible-on-clouds-ops` image with tag 2.3.20230221 to upgrade to version 2.3.20230221.
 =====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.3.20230221
 $ docker pull $IMAGE

--- a/stories/topics/ref-aws-from-stack-minimum-permissions.adoc
+++ b/stories/topics/ref-aws-from-stack-minimum-permissions.adoc
@@ -4,7 +4,7 @@
 
 You must have the following ASW IAM permissions to restore the stack:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 required-roles:
  autoscaling:

--- a/stories/topics/ref-aws-iam-minimum-permissions.adoc
+++ b/stories/topics/ref-aws-iam-minimum-permissions.adoc
@@ -4,7 +4,7 @@
 
 You must have the following ASW IAM permissions to backup the stack:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 required-roles:
  actions:

--- a/stories/topics/ref-aws-iam-upgrade-minimum-permissions.adoc
+++ b/stories/topics/ref-aws-iam-upgrade-minimum-permissions.adoc
@@ -4,7 +4,7 @@
 
 You must have the following ASW IAM permissions to upgrade the stack:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 required-roles:
   ec2:

--- a/stories/topics/ref-aws-permissions-to-manage-nodes.adoc
+++ b/stories/topics/ref-aws-permissions-to-manage-nodes.adoc
@@ -4,7 +4,7 @@
 
 You must have the following policies to manage both adding and removing the extension nodes.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 required-roles:
   ec2:

--- a/stories/topics/ref-aws-update-upgrade-data-file.adoc
+++ b/stories/topics/ref-aws-update-upgrade-data-file.adoc
@@ -16,7 +16,7 @@ The bucket name must not contain uppper case letters.
 After populating the data file, it should resemble the following. 
 
 The following values are provided as examples:
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ---- 
 aws_upgrade:
   ansible_config_path:

--- a/stories/topics/ref-gcp-update-upgrade-data-file.adoc
+++ b/stories/topics/ref-gcp-update-upgrade-data-file.adoc
@@ -20,7 +20,7 @@ After populating the data file, it should resemble the following.
 
 The following values are provided as examples:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ---- 
 gcp_upgrade:
   ansible_config_path:


### PR DESCRIPTION
Remove `[source,bash]` line preceding codeblocks

Removing the [source,bash] asciidoc tag so that the `$` prompt is not included when the copy/paste icon is used in the published docs in the customer portal