### PR TITLE
2.2.1 Remove source,bash line preceding codeblocks

### DIFF
--- a/stories/topics/proc-aap-aws-application-upgrade.adoc
+++ b/stories/topics/proc-aap-aws-application-upgrade.adoc
@@ -26,7 +26,7 @@ The upgrade process requires a few volumes to be mounted. Prepare a directory yo
 
 Create the directories used to configure the upgrade process.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Secrets directory. Store the AWS credentials and config files.
 $ mkdir secrets
@@ -89,7 +89,7 @@ aws_backup_iam_role_arn: arn:aws:iam::<YOUR_ACCOUNT_NUMBER>:role/service-role/AW
 
 The final result should look like this:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ tree
 .
@@ -113,7 +113,7 @@ The following instructions describe how to run the upgrade playbook.
 The Ansible on Clouds operational image tag must match with the version which you want to upgrade to. For example, if your foundation deployment version is 2.2.0, pull operational image with tag 2.2.20230215 to upgrade to version 2.2.20230215.
 =====
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=<image-path>
 $ docker pull $IMAGE
@@ -125,7 +125,7 @@ $ docker pull $IMAGE
 
 . Replace `<deployment-name>` with your foundation deployment name. Use the following command to run the playbook.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Export the volume paths
 $ export VOLUME_AWS_CREDENTIALS_DIR=<absolute path to workdir>/secrets
@@ -144,7 +144,7 @@ $ docker run --rm \
 
 . After successfully running the playbook, the playbook will return something like this
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 TASK [redhat.ansible_on_clouds.standalone_aws_upgrade : [upgrade] [LOG] upgrade version] ***
 ok: [localhost] => {

--- a/stories/topics/proc-aap-aws-backup-and-recovery.adoc
+++ b/stories/topics/proc-aap-aws-backup-and-recovery.adoc
@@ -29,7 +29,7 @@ Can use the AWS Backup Default Service Role for this which has the format `arn:a
 
 . Pull the `ansible-on-clouds-ops` container image having the tag with the same version as the foundation deployment
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=quay.io/ansible-on-clouds/ansible-on-clouds-ops:2.2.20230215-00
 $ docker pull $IMAGE
@@ -51,7 +51,7 @@ The `ansible-on-clouds-ops` image tag should match the version of your foundatio
 
 .. Use the following command to run the playbook.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm --env PLATFORM=AWS \
 -v <absolute path of extra vars dir>:/extra_vars:ro \
@@ -149,7 +149,7 @@ The keypair used must exist in the aws region you are restoring to.
 
 . Pull the `ansible-on-clouds-ops` container image having the tag with the same version as the foundation deployment
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=quay.io/ansible-on-clouds/ansible-on-clouds-ops:2.2.20230215-00
 $ docker pull $IMAGE
@@ -170,7 +170,7 @@ The `ansible-on-clouds-ops` image tag should match the version of your foundatio
 
 .. Use the following command to run the playbook.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm --env PLATFORM=AWS \
 -v <absolute path of extra vars dir>:/extra_vars:ro \

--- a/stories/topics/proc-aap-aws-create-extension-nodes.adoc
+++ b/stories/topics/proc-aap-aws-create-extension-nodes.adoc
@@ -13,7 +13,7 @@ The following procedure describes how to run the playbook to create the extensio
 * The `ansible-on-clouds-ops` container image tag must match the currently installed version of {AAPonAWS}
 ====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=<image-path>
 $ docker pull $IMAGE
@@ -21,7 +21,7 @@ $ docker pull $IMAGE
 
 . Run the `aws_add_extension_nodes` playbook as a container. Replace `<deployment-name>` with your foundation deployment name. Use the following command to run the playbook.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Export the volume paths
 $ export VOLUME_AWS_CREDENTIALS_DIR=<absolute path to workdir>/secrets

--- a/stories/topics/proc-aap-aws-prepare-environment.adoc
+++ b/stories/topics/proc-aap-aws-prepare-environment.adoc
@@ -7,7 +7,7 @@ The extension nodes deployment process requires a few volumes to be mounted, so 
 .Procedure
 . Create new directories for the extension nodes deployment process.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Secrets directory. Store the AWS credentials and config files.
 $ mkdir secrets
@@ -63,7 +63,7 @@ where:
 
 The final result resembles the following:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ tree
 .

--- a/stories/topics/proc-aap-aws-removing-extension-nodes.adoc
+++ b/stories/topics/proc-aap-aws-removing-extension-nodes.adoc
@@ -28,7 +28,7 @@ The extension nodes removal process requires a few volumes to be mounted, so *pr
 
 First, you need to create some directories where the configuration files will be placed:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Secrets directory. Store the AWS credentials and config files.
 $ mkdir secrets
@@ -95,7 +95,7 @@ Variables description:
 
 The final result should look like this:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ tree
 .
@@ -119,7 +119,7 @@ Pull the Docker image for `ansible-on-clouds-ops` container image having tag wit
 The `ansible-on-clouds-ops` container image tag must match the current installed version of {AAPonAWS}
 =====
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=<image-path>
 $ docker pull $IMAGE
@@ -127,7 +127,7 @@ $ docker pull $IMAGE
 
 Running the upgrade playbook as a container. Replace `<removal-name>` with your foundation deployment name. Use the following command to run the playbook.
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Export the volume paths
 $ export VOLUME_AWS_CREDENTIALS_DIR=<absolute path to workdir>/secrets

--- a/stories/topics/proc-aap-aws-secure-hub-controller-connection.adoc
+++ b/stories/topics/proc-aap-aws-secure-hub-controller-connection.adoc
@@ -10,7 +10,7 @@ The following procedure describes how to secure the {HubName} load balancer
 .Procedure
 . Generate the {HubName} certificate with the following command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ openssl req -x509 -nodes -newkey rsa:4096 -keyout hub_key.pem -out hub_cert.pem -sha256 -days 365 -addext "subjectAltName = DNS:<HUB_DNS_NAME>"
 ----
@@ -61,14 +61,14 @@ Ensure you are in the correct region.
 . Select the {HubName} instance(s)
 . Paste the {HubName} key in the following location:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo vi /efs/certificates/hub_key.pem # Paste key
 ----
 +
 . Paste the {HubName} certificate in the following location: 
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo vi /efs/certificates/hub_cert.pem # Paste cert
 ----
@@ -76,7 +76,7 @@ $ sudo vi /efs/certificates/hub_cert.pem # Paste cert
 . Copy the certificate and keys to the ca-trust directory. 
 Then update the ca-trust using the following commands:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo cp /efs/certificates/hub_key.pem /etc/pki/ca-trust/source/anchors/hub-key.pem # Copy key
 $ sudo cp /efs/certificates/hub_cert.pem /etc/pki/ca-trust/source/anchors/hub-cert.pem # Copy cert

--- a/stories/topics/proc-aap-gcp-application-upgrade.adoc
+++ b/stories/topics/proc-aap-gcp-application-upgrade.adoc
@@ -28,7 +28,7 @@ Prepare a fresh directory to be used for this process.
 .Procedure
 . Create the directories used to configure the upgrade process using the following commands:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 # Secrets directory. Store the GCP credentials file.
 $ mkdir secrets
@@ -68,7 +68,7 @@ For example, the filestore instance location might be `us-east1-d`
 For example, if your `gcp_compute_zone` location is `us-east1-d`, your region is `us-east1`.
 =====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 gcp_service_account_credentials_json_path: "/secrets/<service-account-creds-json-filename>"
 gcp_deployment_name: "" 
@@ -78,7 +78,7 @@ gcp_compute_zone: ""
 +
 . The final result should look similar to the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ tree
 tree
@@ -103,7 +103,7 @@ The `ansible-on-clouds-ops` container image tag must match the version of your f
 For example, if your foundation deployment version is 2.2.1, pull the `ansible-on-clouds-ops` image with tag 2.2.1.
 =====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=quay.io/ansible-on-clouds/ansible-on-clouds-ops:2.2.1
 $ docker pull $IMAGE
@@ -115,7 +115,7 @@ $ docker pull $IMAGE
 .Procedure
 . Set the `GOOGLE_APPLICATION_CREDENTIALS` variable to the Google cloud credential JSON file path.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export GOOGLE_APPLICATION_CREDENTIALS=<path to the Google credential JSON file>
 ----
@@ -126,7 +126,7 @@ $ export GOOGLE_APPLICATION_CREDENTIALS=<path to the Google credential JSON file
 . Replace `<deployment-name>` with your foundation deployment name.
 . Use the following command to run the playbook.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm \
   --env PLATFORM=GCP \
@@ -143,7 +143,7 @@ $ docker run --rm \
 +
 . After successfully running the playbook, the playbook returns something similar to the following:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 TASK [redhat.ansible_on_clouds.standalone_gcp_upgrade : [upgrade] Show GCP current version] ***
 ok: [localhost] => {

--- a/stories/topics/proc-aap-gcp-backup-process.adoc
+++ b/stories/topics/proc-aap-gcp-backup-process.adoc
@@ -48,7 +48,7 @@ For example, the filestore instance location might be `us-east1-d`
 For example, if your `gcp_compute_zone` location is `us-east1-d`, your region is `us-east1`.
 =====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 gcp_service_account_credentials_json_path: "/secrets/<service-account-creds-json-filename>"
 gcp_deployment_name: "" 
@@ -64,7 +64,7 @@ The `ansible-on-clouds-ops` container image tag must match the version of your f
 For example, if your foundation deployment version is 2.2.1, pull the `ansible-on-clouds-ops` image with tag 2.2.1.
 =====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=quay.io/ansible-on-clouds/ansible-on-clouds-ops:2.2.1
 $ docker pull $IMAGE
@@ -79,7 +79,7 @@ $ docker pull $IMAGE
 +
 . Use the following command to run the playbook:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm \
 -v <absolute path to google application credentials dir>:/secrets:ro \

--- a/stories/topics/proc-aap-gcp-restore-process.adoc
+++ b/stories/topics/proc-aap-gcp-restore-process.adoc
@@ -53,7 +53,7 @@ You receive this after executing the backup playbook.
 * *gcp_sql_backup_db_name*: GCP foundation SQL database name. 
 You receive this after executing backup the playbook.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 gcp_service_account_credentials_json_path: "/secrets/<service-account-creds-json-filename>"
 gcp_deployment_name: ""
@@ -73,7 +73,7 @@ The `ansible-on-clouds-ops` container image tag must match the version of your f
 For example, if your foundation deployment version is 2.2.1, pull the `ansible-on-clouds-ops` image with tag 2.2.1.
 =====
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ export IMAGE=quay.io/ansible-on-clouds/ansible-on-clouds-ops:2.2.1
 $ docker pull $IMAGE
@@ -88,7 +88,7 @@ $ docker pull $IMAGE
 +
 . Use the following command to run the playbook.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker run --rm \
 -v <absolute path to Google application credentials dir>:/secrets:ro \

--- a/stories/topics/proc-azure-podidentity.adoc
+++ b/stories/topics/proc-azure-podidentity.adoc
@@ -5,7 +5,7 @@
 {AAPonAzureNameShort} uses Azure features that require enablement.
 Run the following command from the Azure CLI or Cloud Console to enable those features:
 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 az feature register --name EnablePodIdentityPreview --namespace Microsoft.ContainerService
 ----

--- a/stories/topics/proc-secure-controller-load-balancer.adoc
+++ b/stories/topics/proc-secure-controller-load-balancer.adoc
@@ -10,7 +10,7 @@ The following procedure describes how to secure the {ControllerName} load balanc
 .Procedure
 . Generate the {ControllerName} certificate with the following command:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ openssl req -x509 -nodes -newkey rsa:4096 -keyout controller_key.pem -out controller_cert.pem -sha256 -days 365 -addext "subjectAltName = DNS:<CONTROLLER_DNS_NAME>"
 ----
@@ -60,21 +60,21 @@ Ensure you are in the correct region.
 . Select the {ControllerName} instance(s)
 . Paste the {ControllerName} key in the following location:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo vi /efs/certificates/controller_key.pem # Paste key. This step only needs to be done on the first controller node.
 ----
 +
 . Paste the controller certificate in the following location -
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo vi /efs/certificates/controller_cert.pem # Paste cert. This step only needs to be done on the first controller node.
 ----
 +
 . Copy the certificte and keys to the ca-trust directory. Then update the ca-trust directory using the following commands:
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ sudo cp /efs/certificates/controller_key.pem /etc/pki/ca-trust/source/anchors/controller-key.pem # Copy key
 $ sudo cp /efs/certificates/controller_cert.pem /etc/pki/ca-trust/source/anchors/controller-cert.pem # Copy cert


### PR DESCRIPTION
Remove `[source,bash]` line preceding codeblocks

Removing the [source,bash] asciidoc tag so that the `$` prompt is not included when the copy/paste icon is used in the published docs in the customer portal

Backports #131 to aap-clouds-2.2.1