### PR TITLE
AWS Fix assembly ID

### DIFF
--- a/stories/assembly-aws-networking-access.adoc
+++ b/stories/assembly-aws-networking-access.adoc
@@ -1,6 +1,6 @@
 ifdef::context[:parent-context: {context}]
 
-[id="assembly-aws-networking-access"]
+[id="assembly-aap-aws-networking-access"]
 = Networking and application access
 
 :context: aws-networking


### PR DESCRIPTION
Fix the `id` for `stories/assembly-aws-networking-access.adoc` so that current external links referencing this chapter do not break.
No internal `xref` instances reference this assembly.
The path to the affected assembly is updated in a local build.