### PR TITLE
GCP Fix ID for backup and restore assembly

### DIFF
--- a/stories/assembly-gcp-backup-and-restore.adoc
+++ b/stories/assembly-gcp-backup-and-restore.adoc
@@ -1,6 +1,6 @@
 ifdef::context[:parent-context: {context}]
 
-[id="assembly-aap-gcp-backup-and-recovery]
+[id="assembly-aap-gcp-backup-and-recovery"]
 = Backup and Restore for {AAPonGCP}
 
 :context: gcp-backup-restore

--- a/stories/assembly-gcp-backup-and-restore.adoc
+++ b/stories/assembly-gcp-backup-and-restore.adoc
@@ -1,6 +1,6 @@
 ifdef::context[:parent-context: {context}]
 
-[id="assembly-gcp-backup-and-restore"]
+[id="assembly-aap-gcp-backup-and-recovery]
 = Backup and Restore for {AAPonGCP}
 
 :context: gcp-backup-restore


### PR DESCRIPTION
Fix the `id` for `stories/assembly-gcp-backup-and-restore.adoc` so that current external links referencing this chapter do not break.
No internal `xref` instances reference this assembly.
The path to the affected assembly is updated in a local build of this PR.

Broken link: https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-aap-gcp-backup-and-recovery