### PR TITLE
AWS Fix ID for deploy extension nodes assembly

### DIFF
--- a/aap-common/proc-aap-list-available-playbooks.adoc
+++ b/aap-common/proc-aap-list-available-playbooks.adoc
@@ -48,7 +48,7 @@ Description: Add extension nodes to an existing Ansible Automation Platform from
 -----------------------------------------------
 This playbook is used to deploy extension nodes to an existing Ansible Automation Platform from AWS Marketplace environment.
 For more information regarding extension nodes, visit our official documentation -
-https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_aws_marketplace_guide/assembly-aap-aws-deploy-extension
+https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_aws_marketplace_guide/assembly-aap-aws-extension
 
 -----------------------------------------------
 Command generator template:

--- a/stories/assembly-aws-deploying-extension-nodes.adoc
+++ b/stories/assembly-aws-deploying-extension-nodes.adoc
@@ -1,6 +1,6 @@
 ifdef::context[:parent-context: {context}]
 
-[id="assembly-aws-deploy-extension"]
+[id="assembly-aap-aws-extension"]
 = Deploying extension nodes to {AAPonAWS}
 
 :context: aws-extension-nodes


### PR DESCRIPTION
Fix the `id` for `assembly-aws-deploying-extension-nodes.adoc` so that current external links referencing this chapter do not break.
No internal `xref` instances reference this assembly.
The path to the affected assembly is updated in a local build of this PR.

NOTE: This assembly originally contained procedures for both deploying and removing extension nodes. Check that the  link should point to the deployment of extension nodes.

Broken link: https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_from_aws_marketplace_guide/assembly-aap-aws-extension