### PR TITLE
Delete source,bash from line preceding codeblocks

### DIFF
--- a/aap-common/proc-aap-pull-command-container-image.adoc
+++ b/aap-common/proc-aap-pull-command-container-image.adoc
@@ -7,7 +7,7 @@ Pull the Docker image for the Ansible on Clouds operational container with the s
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com.
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/assembly-gcp-backup-and-restore.adoc
+++ b/stories/assembly-gcp-backup-and-restore.adoc
@@ -34,3 +34,4 @@ The restore process deploys a new {PlatformNameShort} with the filestore and SQL
 include::topics/con-gcp-backup-process.adoc[leveloffset=+1]
 :context: restore
 include::topics/con-gcp-restore-process.adoc[leveloffset=+1]
+

--- a/stories/topics/con-aws-pull-container-image.adoc
+++ b/stories/topics/con-aws-pull-container-image.adoc
@@ -7,7 +7,7 @@ Pull the Docker image for the Ansible on Clouds operational container which alig
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com.
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/con-aws-pull-deploy-container-image.adoc
+++ b/stories/topics/con-aws-pull-deploy-container-image.adoc
@@ -7,7 +7,7 @@ Pull the Docker image for the Ansible on Clouds operational container with the s
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com.
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/proc-aws-backup-platform-stack.adoc
+++ b/stories/topics/proc-aws-backup-platform-stack.adoc
@@ -8,7 +8,7 @@
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com. 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/proc-aws-from-stack-pull-container-image.adoc
+++ b/stories/topics/proc-aws-from-stack-pull-container-image.adoc
@@ -8,7 +8,7 @@
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com.
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/proc-aws-set-container-image.adoc
+++ b/stories/topics/proc-aws-set-container-image.adoc
@@ -11,7 +11,7 @@ For example, if your foundation deployment version is 2.3.20230221-00, pull the 
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com. 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/proc-aws-upgrade-pull-container-image.adoc
+++ b/stories/topics/proc-aws-upgrade-pull-container-image.adoc
@@ -8,7 +8,7 @@
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com. 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/proc-gcp-backup-container-image.adoc
+++ b/stories/topics/proc-gcp-backup-container-image.adoc
@@ -8,7 +8,7 @@
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com. 
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/proc-gcp-backup-container-image.adoc
+++ b/stories/topics/proc-gcp-backup-container-image.adoc
@@ -28,3 +28,4 @@ For EMEA regions (Europe, Middle East, Africa) run the following command instead
 $ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.3.20230221
 $ docker pull $IMAGE --platform=linux/amd64
 ----
+

--- a/stories/topics/proc-gcp-create-data-file.adoc
+++ b/stories/topics/proc-gcp-create-data-file.adoc
@@ -5,7 +5,7 @@
 .Procedure
 . Populate the `command_generator_data` directory with the configuration file template.
 +
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 docker run --rm -v $(pwd)/command_generator_data/:/data $IMAGE command_generator_vars gcp_backup_deployment --output-data-file /data/backup.yml
 ----

--- a/stories/topics/proc-gcp-from-stack-pull-container-image.adoc
+++ b/stories/topics/proc-gcp-from-stack-pull-container-image.adoc
@@ -9,7 +9,7 @@
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com.
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/proc-gcp-pull-backup-container-image.adoc
+++ b/stories/topics/proc-gcp-pull-backup-container-image.adoc
@@ -9,7 +9,7 @@
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com.
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/proc-gcp-setup-environment.adoc
+++ b/stories/topics/proc-gcp-setup-environment.adoc
@@ -1,4 +1,4 @@
-[id="proc-gcp-setup-environment"]
+[id="proc-gcp-setup-environment_{context}"]
 
 = Setting up the environment
 

--- a/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
+++ b/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
@@ -8,7 +8,7 @@
 [NOTE]
 ====
 Before Pulling the docker image, make sure you are logged in to registry.redhat.com using docker. Use the following command to login to registry.redhat.com.
-[source,bash]
+[literal, options="nowrap" subs="+quotes,attributes"]
 ----
 $ docker login registry.redhat.io
 ----

--- a/stories/topics/ref-aws-permissions-to-manage-nodes.adoc
+++ b/stories/topics/ref-aws-permissions-to-manage-nodes.adoc
@@ -4,7 +4,7 @@
 
 You must have the following policies to manage both adding and removing the extension nodes.
 
-[literal, options="nowrap" subs="+quotes,attributes"]
+[literal, options="nowrap" subs="+attributes"]
 ----
 required-roles:
   ec2:


### PR DESCRIPTION
Remove `[source,bash]` line preceding codeblocks

Removing the [source,bash] asciidoc tag so that the `$` prompt is not included when the copy/paste icon is used in the published docs in the customer portal