### PR TITLE
Fix AoC 2.4 build issues

### DIFF
--- a/stories/topics/ref-gcp-populate-restore-file.adoc
+++ b/stories/topics/ref-gcp-populate-restore-file.adoc
@@ -1,4 +1,4 @@
-[id=“ref-gcp-populate-restore-file”]
+[id="ref-gcp-populate-restore-file"]
 
 = Parameters of the restore.yml file
 


### PR DESCRIPTION
Fix a syntax error in a module ID: it was causing build issues.
