### PR TITLE
Add Direct Doc Feedback text to all Ansible on Clouds guides

### DIFF
--- a/aap-common/providing-direct-documentation-feedback.adoc
+++ b/aap-common/providing-direct-documentation-feedback.adoc
@@ -1,0 +1,25 @@
+[preface]
+:_module-type: CONCEPT
+[id="providing-direct-documentation-feedback"]
+= Providing feedback on Red Hat documentation
+
+[role="_abstract"]
+We appreciate your feedback on our technical content and encourage you to tell us what you think.
+If you'd like to add comments, provide insights, correct a typo, or even ask a question, you can do so directly in the documentation.
+
+[NOTE]
+====
+You must have a Red Hat account and be logged in to the customer portal.
+====
+
+To submit documentation feedback from the customer portal, do the following:
+
+. Select the *Multi-page HTML* format.
+. Click the *Feedback* button at the top-right of the document.
+. Highlight the section of text where you want to provide feedback.
+. Click the *Add Feedback* dialog next to your highlighted text.
+. Enter your feedback in the text box on the right of the page and then click *Submit*.
+
+We automatically create a tracking issue each time you submit feedback.
+Open the link that is displayed after you click *Submit* and start watching the issue or add more comments.
+

--- a/titles/aap-on-aws/stories.adoc
+++ b/titles/aap-on-aws/stories.adoc
@@ -2,6 +2,7 @@
 
 // AAP common content
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
 include::aap-common/external-site-disclaimer.adoc[leveloffset=+1]
 // AAP on AWS user stories
 include::stories/assembly-aws-intro.adoc[leveloffset=+1]

--- a/titles/aap-on-azure/stories.adoc
+++ b/titles/aap-on-azure/stories.adoc
@@ -1,5 +1,7 @@
 // AAP common content
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
+include::aap-common/external-site-disclaimer.adoc[leveloffset=+1]
 // AAP on Azure user stories
 include::stories/assembly-azure-intro.adoc[leveloffset=+1]
 include::stories/assembly-azure-install.adoc[leveloffset=+1]

--- a/titles/aap-on-gcp/stories.adoc
+++ b/titles/aap-on-gcp/stories.adoc
@@ -2,6 +2,7 @@
 
 // AAP common content
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
 include::aap-common/external-site-disclaimer.adoc[leveloffset=+1]
 // AAP on GCP user stories
 include::stories/assembly-gcp-intro.adoc[leveloffset=+1]


### PR DESCRIPTION
Add direct documentation feedback module to the aap-common folder.
Include the direct documentation module in all titles
Backport to 2.4
