### PR TITLE
Remove note about GCP automatic replication policy since release 2.4 …

### DIFF
--- a/stories/topics/con-gcp-service-account.adoc
+++ b/stories/topics/con-gcp-service-account.adoc
@@ -18,8 +18,3 @@ See link:https://cloud.google.com/iam/docs/granting-changing-revoking-access#sin
 
 The Compute Network Administrator role is only required at the time of deployment to configure the application properly. 
 When installation and configuration are complete, this role can be removed from the service account, which remains configured on the {PlatformNameShort} Virtual Machines. 
-
-[NOTE]
-====
-The secrets created during the deployment must be able to use the automatic replication policy.  The user specified replication policy is not supported and must be disabled during deployment, backup or upgrade.
-====


### PR DESCRIPTION
…now allows the use of user specified replication policy

For a task in spreadsheet of issue https://issues.redhat.com/browse/AAP-12921