### PR TITLE
Fix xrefs to technical note

### DIFF
--- a/stories/topics/proc-gcp-create-data-file.adoc
+++ b/stories/topics/proc-gcp-create-data-file.adoc
@@ -7,7 +7,7 @@
 +
 [NOTE]
 ====
-On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:con-tech-note-linux-files-owned-by-root[technical notes].
+On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:tech-note-linux-files-owned-by-root[technical notes].
 ====
 +
 [literal, options="nowrap" subs="+attributes"]

--- a/stories/topics/proc-gcp-deleting-backups-playbook.adoc
+++ b/stories/topics/proc-gcp-deleting-backups-playbook.adoc
@@ -16,7 +16,7 @@ The use of `gcp_backups_delete` is described in this section.
 +
 [NOTE]
 ====
-On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:con-tech-note-linux-files-owned-by-root[technical notes].
+On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:tech-note-linux-files-owned-by-root[technical notes].
 ====
 +
 [literal, options="nowrap" subs="+attributes"]

--- a/stories/topics/proc-gcp-generate-restore-yml-file.adoc
+++ b/stories/topics/proc-gcp-generate-restore-yml-file.adoc
@@ -7,7 +7,7 @@
 +
 [NOTE]
 ====
-On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:con-tech-note-linux-files-owned-by-root[technical notes].
+On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:tech-note-linux-files-owned-by-root[technical notes].
 ====
 +
 [literal, options="nowrap" subs="+attributes"]

--- a/stories/topics/proc-gcp-generate-upgrade-data-file.adoc
+++ b/stories/topics/proc-gcp-generate-upgrade-data-file.adoc
@@ -17,7 +17,7 @@ $ mkdir command_generator_data
 +
 [NOTE]
 ====
-On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:con-tech-note-linux-files-owned-by-root[technical notes].
+On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:tech-note-linux-files-owned-by-root[technical notes].
 ====
 +
 [literal, options="nowrap" subs="+attributes"]

--- a/stories/topics/proc-gcp-generate-variables.adoc
+++ b/stories/topics/proc-gcp-generate-variables.adoc
@@ -16,7 +16,7 @@ $ mkdir command_generator_data
 +
 [NOTE]
 ====
-On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:con-tech-note-linux-files-owned-by-root[technical notes].
+On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:tech-note-linux-files-owned-by-root[technical notes].
 ====
 +
 [options="nowrap" subs="+attributes"]

--- a/stories/topics/proc-gcp-listing-backups-playbook.adoc
+++ b/stories/topics/proc-gcp-listing-backups-playbook.adoc
@@ -8,7 +8,7 @@ This playbook enables you to list the existing backups in a specific bucket.
 +
 [NOTE]
 ====
-On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:con-tech-note-linux-files-owned-by-root[technical notes].
+On Linux, any file or directory created by the command generator is owned by `root:root` by default. To change the ownership of the files and directories, you can run the `sudo chmod` command after the files are created. For more information, read xref:tech-note-linux-files-owned-by-root[technical notes].
 ====
 +
 [literal, options="nowrap" subs="+attributes"]


### PR DESCRIPTION
Cross references to the technical note module were failing because they used the module title instead of the module ID.
Affects `/titles/aap-on-gcp`.