### PR TITLE
2.4 Restore proc-gcp-extension-nodes.adoc to archive

### DIFF
--- a/archive/archived-topics/proc-gcp-extension-nodes.adoc
+++ b/archive/archived-topics/proc-gcp-extension-nodes.adoc
@@ -1,0 +1,21 @@
+[id="proc-gcp-extension-nodes"]
+
+= Purchasing an extension node
+
+The extension node offering enables you to add additional Ansible managed node licenses and additional compute VMs into your {AAPonGCP} deployment. 
+
+Extension nodes for Red Hat {AAPonGCP} can be obtained directly from the Google Marketplace. 
+Follow these steps to purchase and deploy the public offer.
+
+.Procedure
+. In the Google Cloud Console, navigate to the link:https://console.cloud.google.com/marketplace[Marketplace].
+. In the *Search Marketplace* text box, search for *{PlatformNameShort}*.
+. Click one of the listings for *Extension Node - {PlatformNameShort}*.
+Depending on your needs, select 100, 200 or 400 Managed Nodes.
+. Ensure that you have selected the offer where Red Hat is the publisher.
+. Review the details, and click btn:[LAUNCH].
+
+[NOTE]
+====
+You can purchase private offers for extension nodes through your Red Hat account executive.
+==== 


### PR DESCRIPTION
`topics/proc-gcp-extension-nodes.adoc` was deleted in PR #224 
Restore it to the archive.
