### PR TITLE
Update RHEL suffix to rhel9 from rhel8

### DIFF
--- a/aap-common/proc-aap-pull-command-container-image.adoc
+++ b/aap-common/proc-aap-pull-command-container-image.adoc
@@ -20,14 +20,6 @@ Use the following commands:
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
-$ docker pull $IMAGE --platform=linux/amd64
-----
-
-For EMEA regions (Europe, Middle East, Africa) run the following command instead:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----

--- a/stories/topics/con-aws-pull-container-image.adoc
+++ b/stories/topics/con-aws-pull-container-image.adoc
@@ -20,14 +20,6 @@ Use the following commands:
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
-$ docker pull $IMAGE --platform=linux/amd64
-----
-
-For EMEA regions (Europe, Middle East, Africa) run the following command instead:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----

--- a/stories/topics/con-aws-pull-deploy-container-image.adoc
+++ b/stories/topics/con-aws-pull-deploy-container-image.adoc
@@ -20,14 +20,6 @@ Use the following commands:
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
-$ docker pull $IMAGE --platform=linux/amd64
-----
-
-For EMEA regions (Europe, Middle East, Africa) run the following command instead:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----

--- a/stories/topics/con-gcp-pull-deploy-container-image.adoc
+++ b/stories/topics/con-gcp-pull-deploy-container-image.adoc
@@ -23,14 +23,6 @@ Use the following commands:
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
-$ docker pull $IMAGE --platform=linux/amd64
-----
-
-For EMEA regions (Europe, Middle East, Africa) run the following command instead:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----

--- a/stories/topics/con-gcp-pull-remove-container-image.adoc
+++ b/stories/topics/con-gcp-pull-remove-container-image.adoc
@@ -21,14 +21,6 @@ Use the following commands:
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
-$ docker pull $IMAGE --platform=linux/amd64
-----
-
-For EMEA regions (Europe, Middle East, Africa) run the following command instead:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----

--- a/stories/topics/con-gcp-use-container-image.adoc
+++ b/stories/topics/con-gcp-use-container-image.adoc
@@ -20,14 +20,6 @@ Use the following commands:
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
-$ docker pull $IMAGE --platform=linux/amd64
-----
-
-For EMEA regions (Europe, Middle East, Africa) run the following command instead:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----

--- a/stories/topics/proc-aws-set-container-image.adoc
+++ b/stories/topics/proc-aws-set-container-image.adoc
@@ -20,14 +20,6 @@ For more information about registry login, see link:https://access.redhat.com/Re
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
-$ docker pull $IMAGE --platform=linux/amd64
-----
-
-For EMEA regions (Europe, Middle East, Africa) run the following command instead:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----

--- a/stories/topics/proc-aws-upgrade-pull-container-image.adoc
+++ b/stories/topics/proc-aws-upgrade-pull-container-image.adoc
@@ -22,6 +22,6 @@ The Ansible on Clouds operational image tag must match the version that you want
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----

--- a/stories/topics/proc-gcp-backup-container-image.adoc
+++ b/stories/topics/proc-gcp-backup-container-image.adoc
@@ -17,15 +17,6 @@ For more information about registry login, see link:https://access.redhat.com/Re
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----
-
-For EMEA regions (Europe, Middle East, Africa) run the following command instead:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.4.20230630
-$ docker pull $IMAGE --platform=linux/amd64
-----
-

--- a/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
+++ b/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
@@ -22,6 +22,6 @@ The Ansible on Clouds operational image tag must match the version that you want
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.4.20230630
+$ export IMAGE=registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
 $ docker pull $IMAGE --platform=linux/amd64
 ----


### PR DESCRIPTION
Also removes emea ops image, as this is no longer necessary and it is not being published.
https://issues.redhat.com/browse/AAP-14163

This issue updates our image reference in our documentation to be our expected image reference once published