### PR TITLE
Doc formatting fixes

### DIFF
--- a/aap-common/assembly-appendix-release-notes.adoc
+++ b/aap-common/assembly-appendix-release-notes.adoc
@@ -20,10 +20,10 @@ Automation Mesh and Event Driven Automation are not yet supported by the self-ma
 == Enhancements
 
 ifdef::product_AWS[]
-The release version2.4.20230630 of {AAPonAWS} includes the following enhancements:
+The release version 2.4.20230630 of {AAPonAWS} includes the following enhancements:
 endif::product_AWS[]
 ifdef::product_GCP[]
-The release version2.4.20230630 of {AAPonGCP} includes the following enhancements:
+The release version 2.4.20230630 of {AAPonGCP} includes the following enhancements:
 endif::product_GCP[]
 
 * Support for {PlatformNameShort} 2.4 has been added.

--- a/stories/assembly-aws-intro.adoc
+++ b/stories/assembly-aws-intro.adoc
@@ -22,4 +22,4 @@ The following {PlatformName} components are available on {AAPonAWS}:
 {AutomationMeshStart} is not available on {AAPonAWS} at this time.
 =====
 
-include::topics/con-aws-application-architecture.adoc[leveloffset+=1]
+include::topics/con-aws-application-architecture.adoc[leveloffset]

--- a/stories/assembly-aws-intro.adoc
+++ b/stories/assembly-aws-intro.adoc
@@ -22,4 +22,4 @@ The following {PlatformName} components are available on {AAPonAWS}:
 {AutomationMeshStart} is not available on {AAPonAWS} at this time.
 =====
 
-include::topics/con-aws-application-architecture.adoc[leveloffset]
+include::topics/con-aws-application-architecture.adoc[leveloffset=+1]

--- a/stories/assembly-gcp-intro.adoc
+++ b/stories/assembly-gcp-intro.adoc
@@ -22,4 +22,4 @@ The following {PlatformName} components are available on {AAPonGCP}:
 {AutomationMeshStart} is not available on {AAPonGCP} at this time.
 =====
 
-include::topics/con-gcp-application-architecture.adoc[leveloffset]
+include::topics/con-gcp-application-architecture.adoc[leveloffset=+1]

--- a/stories/assembly-gcp-intro.adoc
+++ b/stories/assembly-gcp-intro.adoc
@@ -22,4 +22,4 @@ The following {PlatformName} components are available on {AAPonGCP}:
 {AutomationMeshStart} is not available on {AAPonGCP} at this time.
 =====
 
-include::topics/con-gcp-application-architecture.adoc[leveloffset=+1]
+include::topics/con-gcp-application-architecture.adoc[leveloffset]

--- a/stories/assembly-gcp-upgrade.adoc
+++ b/stories/assembly-gcp-upgrade.adoc
@@ -44,6 +44,8 @@ The following procedures form the upgrade process:
 * Follow the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.3/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-aap-gcp-backup-and-recovery#con-gcp-restore-process[Ansible on Clouds 2.3 restore instructions].
 
 //context labels are here in case modules need to be reused within these container files.
+:context: backup
+include::topics/con-gcp-upgrade-backup-process.adoc[leveloffset=+1]
 :context: upgrade
 include::topics/con-gcp-upgrade-upgrading.adoc[leveloffset=+1]
 :context: restore

--- a/stories/topics/con-aws-application-architecture.adoc
+++ b/stories/topics/con-aws-application-architecture.adoc
@@ -1,6 +1,6 @@
 [id="con-aws-application-architecture"]
 
-== Application architecture
+= Application architecture
 
 {AAPonAWS} is installed into infrastructure resources running within your AWS account.
 
@@ -48,7 +48,7 @@ This is done automatically for you through the use of the included upgrade autom
 
 Customers can take advantage of these operational automations to simplify the operational readiness of {PlatformNameShort} within their own corporate standards freeing themselves up to focus on developing Ansible Automation to manage their own infrastructure and applications rather than spending time developing automations to manage {PlatformNameShort}.
 
-== Service descriptions
+= Service descriptions
 
 [cols="30%,30%",options="header"]
 |====

--- a/stories/topics/con-aws-application-architecture.adoc
+++ b/stories/topics/con-aws-application-architecture.adoc
@@ -22,7 +22,7 @@ The {PlatformNameShort} software runs as containers on the deployed VM instances
 _Autoscaling Groups_ (ASG) manage VM instances and monitor the health of each service running on the VM instances. ASGs will automatically cycle the VM instances down and replace them with new VM instances if the health check fails to respond ensuring that the {PlatformNameShort} services stay up and available to process requests.
 
 The VM instances run a customized _RedHat Enterprise Linux_ (RHEL) _Amazon Machine Image_ (AMI) as their base image. 
-This AMI is preloaded with all the required container images and packages to run the {PlatformNameShort} ({HubName}, {ControllerName}, and Execution Node components.
+This AMI is preloaded with all the required container images and packages to run the {PlatformNameShort} ({HubName}, {ControllerName}, and Execution Node components).
 
 A shared EFS (Elastic File Store) volume is mounted into each VM instance provisioned by the product and is used for shared access to common files and resources.  
 

--- a/stories/topics/con-aws-upgrade-backup-process.adoc
+++ b/stories/topics/con-aws-upgrade-backup-process.adoc
@@ -2,6 +2,9 @@
 
 = Backup before upgrade
 
+[IMPORTANT]
+====
 Before beginning the upgrade of your {PlatformNameShort} environment, it is first required to take a backup of your environment at its current version.
 
 To backup your {PlatformNameShort} environment at the earlier version, follow the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.3/html/red_hat_ansible_automation_platform_from_aws_marketplace_guide/assembly-aws-backup-and-restore#con-aws-backup-process[Ansible on Clouds 2.3 backup instructions].
+====

--- a/stories/topics/con-gcp-application-architecture.adoc
+++ b/stories/topics/con-gcp-application-architecture.adoc
@@ -1,6 +1,6 @@
 [id="con-gcp-application-architecture"]
 
-= Application architecture
+== Application architecture
 
 {PlatformName} from {GCPMarket} is installed into infrastructure resources running within your GCP account.
 

--- a/stories/topics/con-gcp-application-architecture.adoc
+++ b/stories/topics/con-gcp-application-architecture.adoc
@@ -1,6 +1,6 @@
 [id="con-gcp-application-architecture"]
 
-== Application architecture
+= Application architecture
 
 {PlatformName} from {GCPMarket} is installed into infrastructure resources running within your GCP account.
 
@@ -48,7 +48,7 @@ This is done automatically for you through the use of the included upgrade autom
 
 Customers can take advantage of these operational automations to simplify the operational readiness of {PlatformNameShort} within their own corporate standards freeing themselves up to focus on developing Ansible Automation to manage their own infrastructure and applications rather than spending time developing automations to manage {PlatformNameShort}.
 
-== Service descriptions
+= Service descriptions
 
 [cols="30%,30%",options="header"]
 |====

--- a/stories/topics/con-gcp-upgrade-backup-process.adoc
+++ b/stories/topics/con-gcp-upgrade-backup-process.adoc
@@ -1,8 +1,10 @@
 [id="con-gcp-upgrade-backup-process"]
 
+= Backup before upgrade
+
 [IMPORTANT]
 ====
-Before starting the upgrade of your {PlatformNameShort} environment, you must firts take a backup of your environment at its current version.
+Before starting the upgrade of your {PlatformNameShort} environment, you must first take a backup of your environment at its current version.
 
 To backup your {PlatformNameShort} environment at the earlier version, follow the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.3/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-aap-gcp-backup-and-recovery#con-gcp-backup-process[Ansible on Clouds 2.3 backup instructions].
 ====

--- a/stories/topics/con-gcp-upgrade-upgrading.adoc
+++ b/stories/topics/con-gcp-upgrade-upgrading.adoc
@@ -3,7 +3,6 @@
 = Upgrade {PlatformNameShort}
 
 :context: backup
-include::con-gcp-upgrade-backup-process.adoc[leveloffset=+1]
 include::proc-gcp-upgrade-pull-container-image.adoc[leveloffset=+1]
 include::ref-gcp-iam-upgrade-minimum-permissions.adoc[leveloffset=+1]
 include::proc-gcp-generate-upgrade-data-file.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-14166

Fixes Intro formatting to ensure at same level for both AWS/GCP - 
![image](https://github.com/ansible/aap-docs/assets/52431213/e3f8ff45-fe8c-41f7-a7f3-dd9f417dd2f8)

Also fixes AWS/GCP upgrade navigation bar steps, to ensure they are formatted correctly - 
![image](https://github.com/ansible/aap-docs/assets/52431213/0551e7d9-37f3-4e60-a904-d2687215cc6b)
