### PR TITLE
Update doc to add note for handling networking ui error

### DIFF
--- a/stories/topics/proc-gcp-deploying-extension-nodes.adoc
+++ b/stories/topics/proc-gcp-deploying-extension-nodes.adoc
@@ -26,6 +26,11 @@ This field is only used to filter the Network list.
 Do not select the subnet ending with `-aap-proxy-subnet`.
 ====
 +
+[NOTE]
+====
+In case of a error stating `Make sure all fields are correct to continue` and `You must select a Network`, please reselect values from dropdown as mentioned above and click done.
+====
++
 . Ensure *Extend {PlatformNameShort} deployment in selected VPC* is checked.
 . Click btn:[DEPLOY]. 
 . The Deployment Manager displays the running deployment.

--- a/stories/topics/proc-gcp-deploying-extension-nodes.adoc
+++ b/stories/topics/proc-gcp-deploying-extension-nodes.adoc
@@ -28,7 +28,7 @@ Do not select the subnet ending with `-aap-proxy-subnet`.
 +
 [NOTE]
 ====
-In case of a error stating `Make sure all fields are correct to continue` and `You must select a Network`, please reselect values from dropdown as mentioned above and click done.
+In case of a error stating `Make sure all fields are correct to continue` and `You must select a Network`. Reselect the values from the menu and click btn:[Done].
 ====
 +
 . Ensure *Extend {PlatformNameShort} deployment in selected VPC* is checked.

--- a/stories/topics/proc-gcp-deploying-extension-nodes.adoc
+++ b/stories/topics/proc-gcp-deploying-extension-nodes.adoc
@@ -28,7 +28,7 @@ Do not select the subnet ending with `-aap-proxy-subnet`.
 +
 [NOTE]
 ====
-In case of a error stating `Make sure all fields are correct to continue` and `You must select a Network`. Reselect the values from the menu and click btn:[Done].
+In case of an error stating `Make sure all fields are correct to continue` and `You must select a Network`. Reselect the values from the menu and click btn:[Done].
 ====
 +
 . Ensure *Extend {PlatformNameShort} deployment in selected VPC* is checked.


### PR DESCRIPTION
This PR adds a note to documentation - [section 2.6 of Red Hat Ansible Automation Platform from GCP Marketplace Guide ](https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/ansible_on_clouds/2.4/html-single/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/index?lb_target=preview&check_logged_in=1#proc-gcp-deploying-extension-nodes)about handling UI error when selecting network options.

JIRA: https://issues.redhat.com/browse/AAP-14124