### PR TITLE
Configuring automation controller on OCP

### DIFF
--- a/downstream/assemblies/platform/assembly-configure-controller-OCP.adoc
+++ b/downstream/assemblies/platform/assembly-configure-controller-OCP.adoc
@@ -1,6 +1,8 @@
 [id="assembly-configure-controller-OCP"]
 
-= Configuring Ansible {ControllerName} on {OCPShort} to minimize downtime during {OCPShort} upgrade
+= Configuring Ansible {ControllerName} on {OCPShort}
+
+During a Kubernetes upgrade, {ControllerName} must be running.
 
 include::platform/proc-configure-controller-OCP.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-configure-controller-OCP.adoc
+++ b/downstream/assemblies/platform/assembly-configure-controller-OCP.adoc
@@ -1,0 +1,6 @@
+[id="assembly-configure-controller-OCP"]
+
+= Configuring Ansible {ControllerName} on {OCPShort} to minimize downtime during {OCPShort} upgrade
+
+include::platform/proc-configure-controller-OCP.adoc[leveloffset=+1]
+

--- a/downstream/modules/platform/proc-configure-controller-OCP.adoc
+++ b/downstream/modules/platform/proc-configure-controller-OCP.adoc
@@ -17,7 +17,7 @@ Make the following configuration changes in {ControllerName} to minimize downtim
 
 .Procedure
 
-. Enable `RECEPTOR_KUBE_SUPPORT_RECONNECT` in AutomationController spec:
+. Enable `RECEPTOR_KUBE_SUPPORT_RECONNECT` in AutomationController specification:
 +
 -----
 apiVersion: automationcontroller.ansible.com/v1beta1
@@ -32,13 +32,13 @@ spec:
     ```
 -----
 +
-. Enable the graceful termination feature in AutomationController spec:
+. Enable the graceful termination feature in AutomationController specification:
 +
 -----
 termination_grace_period_seconds: <time to wait for job to finish>
 -----
 +
-. Configure `podAntiAffinity` for web and task pod to spread out the deployment in AutomationController spec:
+. Configure `podAntiAffinity` for web and task pod to spread out the deployment in AutomationController specification:
 +
 -----
 task_affinity:

--- a/downstream/modules/platform/proc-configure-controller-OCP.adoc
+++ b/downstream/modules/platform/proc-configure-controller-OCP.adoc
@@ -1,0 +1,106 @@
+[id="configure-controller-OCP"]
+
+During a Kubernetes upgrade, {ControllerName} has to be running. The following procedure outlines the configuration changes you need to make in automation controller to minimize downtime during the upgrade.
+
+.Prerequisites
+
+* {PlatformNameShort} 2.4
+* Ansible {ControllerName} 4.4
+* {OCPShort}
+** 4.10.42
+** 4.11.16
+** 4.12.0
+* High availability (HA) deployment of Postgres
+* Multiple worker node that {ControllerName} pods can be scheduled on
+
+.Procedure
+
+. Enable `RECEPTOR_KUBE_SUPPORT_RECONNECT` in {ControllerName} spec.
++
+-----
+ee_extra_env: |
+    - name: RECEPTOR_KUBE_SUPPORT_RECONNECT
+      value: enabled
+-----
++
+. Enable the graceful termination feature in {ControllerName} spec.
++
+-----
+termination_grace_period_seconds: <time to wait for job to finish>
+-----
++
+. Configure `podAntiAffinity` for web and task pod to spread out the deployment in {ControllerName} spec.
++
+-----
+task_affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - awx-task
+          topologyKey: topology.kubernetes.io/zone
+        weight: 100
+  web_affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - awx-web
+          topologyKey: topology.kubernetes.io/zone
+        weight: 100
+
+-----
++
+. Configure `PodDisruptionBudget` in {OCPShort}.
++
+-----
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: automationcontroller-job-pods
+spec:
+  maxUnavailable: 0
+  selector:
+    matchExpressions:
+      - key: ansible-awx-job-id
+        operator: Exists
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: automationcontroller-web-pods
+spec:
+  minAvailable: 1
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - <automationcontroller_instance_name>-web
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: automationcontroller-task-pods
+spec:
+  minAvailable: 1
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - <automationcontroller_instance_name>-task
+
+
+-----
+

--- a/downstream/modules/platform/proc-configure-controller-OCP.adoc
+++ b/downstream/modules/platform/proc-configure-controller-OCP.adoc
@@ -1,35 +1,44 @@
 [id="configure-controller-OCP"]
 
-During a Kubernetes upgrade, {ControllerName} has to be running. The following procedure outlines the configuration changes you need to make in automation controller to minimize downtime during the upgrade.
+= Minimizing downtime during {OCPShort} upgrade
+
+Make the following configuration changes in {ControllerName} to minimize downtime during the upgrade.
 
 .Prerequisites
 
 * {PlatformNameShort} 2.4
 * Ansible {ControllerName} 4.4
 * {OCPShort}
-** 4.10.42
-** 4.11.16
-** 4.12.0
+** > 4.10.42
+** > 4.11.16
+** > 4.12.0
 * High availability (HA) deployment of Postgres
 * Multiple worker node that {ControllerName} pods can be scheduled on
 
 .Procedure
 
-. Enable `RECEPTOR_KUBE_SUPPORT_RECONNECT` in {ControllerName} spec.
+. Enable `RECEPTOR_KUBE_SUPPORT_RECONNECT` in AutomationController spec:
 +
 -----
-ee_extra_env: |
+apiVersion: automationcontroller.ansible.com/v1beta1
+kind: AutomationController
+metadata:
+  ...
+spec:
+  ...
+  ee_extra_env: |
     - name: RECEPTOR_KUBE_SUPPORT_RECONNECT
       value: enabled
+    ```
 -----
 +
-. Enable the graceful termination feature in {ControllerName} spec.
+. Enable the graceful termination feature in AutomationController spec:
 +
 -----
 termination_grace_period_seconds: <time to wait for job to finish>
 -----
 +
-. Configure `podAntiAffinity` for web and task pod to spread out the deployment in {ControllerName} spec.
+. Configure `podAntiAffinity` for web and task pod to spread out the deployment in AutomationController spec:
 +
 -----
 task_affinity:
@@ -59,7 +68,7 @@ task_affinity:
 
 -----
 +
-. Configure `PodDisruptionBudget` in {OCPShort}.
+. Configure `PodDisruptionBudget` in {OCPShort}:
 +
 -----
 

--- a/downstream/titles/ocp_performance_guide/master.adoc
+++ b/downstream/titles/ocp_performance_guide/master.adoc
@@ -25,4 +25,5 @@ include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
 include::platform/assembly-pod-spec-modifications.adoc[leveloffset=+1]
 include::platform/assembly-control-plane-adjustments.adoc[leveloffset=+1]
 include::platform/assembly-specify-dedicated-nodes.adoc[leveloffset=+1]
+include::platform/assembly-configure-controller-OCP.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Adding chapter for configuring controller on OCP to minimize outage during upgrade

Document best practices and configuration requirement for tolerating k8s upgrade

https://issues.redhat.com/browse/AAP-12903

Affects `titles/ocp_performance-guide`