### PR TITLE
AAP-15176 Fix broken links in Upgrade and Migration Guide

### DIFF
--- a/downstream/modules/platform/con-aap-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-prereq.adoc
@@ -57,7 +57,7 @@ server <ntp-server-address> iburst
 ----
 # subscription-manager list --consumed
 ----
-If there is no Red Hat subscription attached to the node, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_planning_guide/index[Attaching your {PlatformNameShort} subscription] for more information.
+If there is no Red Hat subscription attached to the node, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/proc-attaching-subscriptions_planning[Attaching your {PlatformNameShort} subscription] for more information.
 
 .Creating non-root user with sudo privileges
 Before you upgrade {PlatformNameShort}, it is recommended to create a non-root user with sudo privileges for the deployment process. This user is used for:

--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -67,5 +67,5 @@ generate_automationhub_token=True
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario[Installing {PlatformName}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} Installation Guide]
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/assembly-deprovisioning-mesh[Deprovisioning individual nodes or instance groups]


### PR DESCRIPTION
This PR fixes broken links in the Upgrade and Migration Guide. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more info. 