### PR TITLE
Backport to 2.4: AAP-15176 fix broken links in Upgrade and Migration Guide

### DIFF
--- a/downstream/modules/platform/con-aap-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-prereq.adoc
@@ -57,7 +57,7 @@ server <ntp-server-address> iburst
 ----
 # subscription-manager list --consumed
 ----
-If there is no Red Hat subscription attached to the node, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_planning_guide/index[Attaching your {PlatformNameShort} subscription] for more information.
+If there is no Red Hat subscription attached to the node, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/proc-attaching-subscriptions_planning[Attaching your {PlatformNameShort} subscription] for more information.
 
 .Creating non-root user with sudo privileges
 Before you upgrade {PlatformNameShort}, it is recommended to create a non-root user with sudo privileges for the deployment process. This user is used for:

--- a/downstream/modules/platform/con-persisting-data-from-auto-runs.adoc
+++ b/downstream/modules/platform/con-persisting-data-from-auto-runs.adoc
@@ -31,7 +31,7 @@ The caveats need to be carefully observed. It is highly recommended to read up o
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://github.com/redhat-documentation/https://opensource.com/article/19/2/how-does-rootless-podman-work[Understanding rootless Podman].
+* link:https://opensource.com/article/19/2/how-does-rootless-podman-work[Understanding rootless Podman].
 * link:https://docs.podman.io/en/latest/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options[Podman volume mount runtime options].
 
 

--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -67,5 +67,5 @@ generate_automationhub_token=True
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario[Installing {PlatformName}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} Installation Guide]
 * link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/assembly-deprovisioning-mesh[Deprovisioning individual nodes or instance groups]


### PR DESCRIPTION
This PR backports changes in [PR 279](https://github.com/ansible/aap-docs/pull/279) to the 2.4 branch. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more info. 