### PR TITLE
Fix formatting issue in Upgrade guide

### DIFF
--- a/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
@@ -30,7 +30,7 @@ The below workflow describes how to migrate from legacy venvs to {ExecEnvName} u
 
 include::dev-guide/assembly-virt-env-to-ee.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
+// [role="_additional-resources"]
 // Remove comments once 2.2 version of the docs are published.
 //== Additional resources
 


### PR DESCRIPTION
Chapter 4 in the upgrade guide is enclosed in a box on the customer portal:
![image](https://github.com/ansible/aap-docs/assets/44700011/ca264ff3-0bf0-4a45-8058-584508336e5f)

This is due to an empty `Additional Resources` section at the end of chapter 3.