### PR TITLE
Updating route for webhook rulebooks (#295)

### DIFF
--- a/downstream/modules/eda/proc-eda-activate-webhook.adoc
+++ b/downstream/modules/eda/proc-eda-activate-webhook.adoc
@@ -34,7 +34,7 @@ The following is an example of rulebook with a given webhook:
 
 .Procedure
 
-. Create a Route (on OpenShift Container Platform) to expose the service. 
+. Create a Route (on {OCPShort}) to expose the service. 
 The following is an example Route for an ansible-rulebook source that expects POST's on port 5000 on the decision environment pod:
 +
 -----
@@ -45,16 +45,19 @@ metadata:
   namespace: dynatrace
   labels:
     app: eda
-    job-name: activation-job-1
+    job-name: activation-job-1-5000
 spec:
   host: test-sync-bug-dynatrace.apps.aap-dt.ocp4.testing.ansible.com
   to:
     kind: Service
-    name: activation-job-1
+    name: activation-job-1-5000
     weight: 100
   port:
     targetPort: 5000
-  wildcardPolicy: None
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None 
 -----
 +
 . When you create the Route, test it with a *Post to the Route URL*:


### PR DESCRIPTION
Updating route to be HTTPS and job name to append the port

Route needs updating to properly work for EDA

https://issues.redhat.com/browse/AAP-15433

Affects `titles/eda-user-guide`