### PR TITLE
Update GCP doc to add deprecation note for logging and monitoring

### DIFF
--- a/aap-common/assembly-appendix-release-notes.adoc
+++ b/aap-common/assembly-appendix-release-notes.adoc
@@ -54,6 +54,7 @@ The following is a list of major functionality deprecated and removed within {Pl
 
 * On-premise component Automation Services Catalog is now removed from {PlatformNameShort} 2.4 onwards.
 * With the {PlatformNameShort} 2.4 release, the Execution Environment container image for Ansible 2.9 (ee-29-rhel-8) is no longer loaded into the Automation Controller configuration by default.
+* The Cloud Monitoring and Cloud Logging integration for Ansible Automation Platform from GCP Marketplace will be removed in a future release.
 
 [discrete]
 == Additional Release Notes related to Ansible Automation Platform

--- a/stories/assembly-gcp-monitoring-logging.adoc
+++ b/stories/assembly-gcp-monitoring-logging.adoc
@@ -5,6 +5,11 @@ ifdef::context[:parent-context: {context}]
 
 :context: gcp-monitor-log
 
+[NOTE]
+====
+This feature will be removed in a future release.
+====
+
 You can send metrics to the {GCP} monitoring system to be visualized in the {GCP} UI.
 {AAPonGCP} metrics and logging are disabled by default as there is a cost to send these metrics to GCP.
 Refer to link:https://cloud.google.com/stackdriver/pricing#monitoring-costs[Cloud Monitoring] and link:https://cloud.google.com/stackdriver/pricing[Cloud Logging] respectively for more information.


### PR DESCRIPTION
This PR adds a note to documentation - [Chapter 9: Logging and Monitoring ](https://dxp-docp-prod.apps.ext-waf.spoke.prod.us-west-2.aws.paas.redhat.com/documentation/en-us/ansible_on_clouds/2.4/html-single/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/index?lb_target=preview&check_logged_in=1#assembly-gcp-monitoring-logging) regarding logging and monitoring deprecation in future release. 

Jira: https://issues.redhat.com/browse/AAP-15317