### PR TITLE
Add context to xref in aap-hardening module

### DIFF
--- a/downstream/modules/aap-hardening/con-credential-management-planning.adoc
+++ b/downstream/modules/aap-hardening/con-credential-management-planning.adoc
@@ -9,7 +9,7 @@
 
 Credentials are used for authentication when launching jobs against machines, synchronizing with inventory sources, and importing project content from a version control system. {ControllerNameStart} manages three sets of secrets:
 
-* User passwords for *local automation controller users*. See the xref:con-user-authentication-planning[User Authentication Planning] section of this guide for additional details.
+* User passwords for *local automation controller users*. See the xref:con-user-authentication-planning_hardening-aap[User Authentication Planning] section of this guide for additional details.
 * Secrets for automation controller *operational use* (database password, message bus password, and so on).
 * Secrets for *automation use* (SSH keys, cloud credentials, external password vault credentials, and so on).
 


### PR DESCRIPTION
Fix an xref in an aap-hardening module: In the xref, include the context from the assembly that contains the module that's referenced.