### PR TITLE
AAP-14809-2.1-a updated sections 2.1.3-2.1.5 (#324)

### DIFF
--- a/downstream/modules/aap-hardening/con-automation-credentials.adoc
+++ b/downstream/modules/aap-hardening/con-automation-credentials.adoc
@@ -3,11 +3,11 @@
 
 [id="con-automation-credentials_{context}"]
 
-= Automation credentials 
+= Automation use secrets
 
 [role="_abstract"]
 
-{ControllerNameStart} stores a variety of secrets in the database that are either used for automation or are a result of automation. These secrets include:
+{ControllerNameStart} stores a variety of secrets in the database that are either used for automation or are a result of automation. Automation use secrets include:
 
 * All secret fields of all credential types (passwords, secret keys, authentication tokens, secret cloud credentials).
 * Secret tokens and passwords for external services defined in {ControllerName} settings.

--- a/downstream/modules/aap-hardening/con-credential-management-planning.adoc
+++ b/downstream/modules/aap-hardening/con-credential-management-planning.adoc
@@ -7,7 +7,7 @@
 
 //[role="_abstract"]
 
-Credentials are used for authentication when launching jobs against machines, synchronizing with inventory sources, and importing project content from a version control system. {ControllerNameStart} manages three sets of secrets:
+{ControllerNameStart} uses credentials to authenticate requests to jobs against machines, synchronize with inventory sources, and import project content from a version control system. {ControllerNameStart} manages three sets of secrets:
 
 * User passwords for *local automation controller users*. See the xref:con-user-authentication-planning[User Authentication Planning] section of this guide for additional details.
 * Secrets for automation controller *operational use* (database password, message bus password, and so on).

--- a/downstream/modules/aap-hardening/ref-automation-controller-authentication.adoc
+++ b/downstream/modules/aap-hardening/ref-automation-controller-authentication.adoc
@@ -7,7 +7,7 @@
 
 [role="_abstract"]
 
-The {ControllerName} currently supports the following external authentication mechanisms:
+{ControllerNameStart} currently supports the following external authentication mechanisms:
 
 * Azure Activity Directory
 * GitHub single sign-on

--- a/downstream/modules/aap-hardening/ref-dns-load-balancing.adoc
+++ b/downstream/modules/aap-hardening/ref-dns-load-balancing.adoc
@@ -23,4 +23,4 @@ hub2.example.com
 
 Then the load balancer can use the FQDNs `controller.example.com` and `hub.example.com` for the user-facing name of these {PlatformNameShort} services.
 
-When a load balancer is used in front of the private automation hub, the installer will need to be aware of the load balancer FQDN. Before installing {PlatformNameShort}, in the installation inventory file set the `automationhub_main_url` variable to the FQDN of the load balancer. For example, to match the example above, you would set the variable to `automationhub_main_url = hub.example.com`.
+When a load balancer is used in front of the private automation hub, the installer must be aware of the load balancer FQDN. Before installing {PlatformNameShort}, in the installation inventory file set the `automationhub_main_url` variable to the FQDN of the load balancer. For example, to match the previous example, you would set the variable to `automationhub_main_url = hub.example.com`.

--- a/downstream/modules/aap-hardening/ref-private-automation-hub-authentication.adoc
+++ b/downstream/modules/aap-hardening/ref-private-automation-hub-authentication.adoc
@@ -1,4 +1,4 @@
-// Module included in teh following assemblies: 
+// Module included in teh following assemblies:
 // downstream/assemblies/assembly-hardening-aap.adoc
 
 [id="ref-private-automation-hub-authentication_{context}"]
@@ -14,7 +14,12 @@
 
 For production use, LDAP is the preferred external authentication mechanism for {PrivateHubName}. {PlatformNameShort} central authentication is an option that can be deployed with the {PlatformNameShort} installer, but it only deploys one central authentication server instance, making it a potential single point of failure. Standalone mode for {PlatformNameShort} central authentication is not recommended in a production environment. However, if you already have the separate {RHSSO} (RHSSO) product deployed in your production environment, it can be used as an external authentication source for {PrivateHubName}.
 
-LDAP authentication for {PrivateHubName} is configured at installation time with the {PlatformNameShort} installer. See, link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-ldap-config-on-pah_platform-install-scenario[LDAP configuration on a {PrivateHubName}] for details. The following installer inventory file variables will need to be filled out prior to installation:
+
+The {PlatformNameShort} Installer configures LDAP authentication for {PrivateHubName} during installation. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-ldap-config-on-pah_platform-install-scenario[LDAP configuration on a {PrivateHubName}].
+
+
+The following installer inventory file variables must be filled out prior to installation:
+
 
 .Inventory variable for automation hub LDAP settings
 |===
@@ -22,7 +27,7 @@ LDAP authentication for {PrivateHubName} is configured at installation time with
 
 | `automationhub_authentication_backend` | Set to "ldap" in order to use LDAP authentication.
 
-| `automationhub_ldap_server_uri` | The LDAP server URI, for example "ldap://ldap-server.example.com" or "ldaps://ldap-server.example.com:636". 
+| `automationhub_ldap_server_uri` | The LDAP server URI, for example "ldap://ldap-server.example.com" or "ldaps://ldap-server.example.com:636".
 
 | `automationhub_ldap_bind_dn` | The account used to connect to the LDAP server. This account should be one with sufficient privileges to query the LDAP server for users and groups, but it should not be an administrator account or one with the ability to modify LDAP records.
 


### PR DESCRIPTION
2.4 Backport for [PR324](https://github.com/ansible/aap-docs/pull/324)

Re [AAP-14809](https://issues.redhat.com/browse/AAP-14809), revisions for the following files:

con-automation-credentials.adoc
con-credential-management-planning.adoc
ref-automation-controller-authentication.adoc
ref-dns-load-balancing.adoc
ref-private-automation-hub-authentication.adoc
Comments and suggested changes resolved in[ Google doc](https://docs.google.com/document/d/1A6VLRNEzvKw4GWhcQpIMpSN9ylFpMGsGLeIUU-7p19I/edit)