### PR TITLE
Backport to 2.3: AAP-15176: fixes broken link in the Installation Guide

### DIFF
--- a/downstream/modules/platform/proc-approving-the-imported-collection.adoc
+++ b/downstream/modules/platform/proc-approving-the-imported-collection.adoc
@@ -19,10 +19,7 @@ NOTE: The collection is added to the "Published" repository regardless of its so
 
 . Import any dependency for the collection using these same steps.
 
-Recommended collections depend on your use case. Ansible and Red Hat provide the following collections:
-
-* https://console.redhat.com/ansible/automation-hub/repo/published/ansible
-* https://console.redhat.com/ansible/automation-hub/repo/published/redhat
+Recommended collections depend on your use case. Ansible and Red Hat provide link:https://console.redhat.com/ansible/automation-hub[these collections.]
 
 == Custom Execution Environments
 


### PR DESCRIPTION
This PR backports the changes from [PR 326](https://github.com/ansible/aap-docs/pull/326) to the 2.3 branch. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more infoo.