### PR TITLE
AAP-15176: fixes broken link in automation mesh guide v2.3

### DIFF
--- a/downstream/assemblies/platform/assembly-setting-up-automation-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-setting-up-automation-mesh.adoc
@@ -19,7 +19,7 @@ include::platform/proc-import-mesh-ca.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/planning-installation#red_hat_ansible_automation_platform_system_requirements[{PlatformName} System Requirements]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/platform-system-requirements[{PlatformName} System Requirements]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
This PR fixes a broken link in the 2.3 version of the automation mesh guide. See [AAP 15176](https://issues.redhat.com/browse/AAP-15176) for more info. 