### PR TITLE
AAP-15176: fixes broken link in operations guide v2.3

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-manifest-files.adoc
+++ b/downstream/assemblies/platform/assembly-aap-manifest-files.adoc
@@ -12,7 +12,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 You can obtain a subscription manifest in the link:https://access.redhat.com/management/subscription_allocations/[Subscription Allocations] section of Red Hat Subscription Management. After you obtain a subscription allocation, you can download its manifest file and upload it to activate {PlatformNameShort}.
 
-To begin, login to the link:https//www.access.redhat.com[Red Hat Customer Portal] using your administrator user account and follow the procedures in this section.
+To begin, login to the link:https://access.redhat.com[Red Hat Customer Portal] using your administrator user account and follow the procedures in this section.
 
 include::platform/proc-aap-create-subscription-allocation.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR fixes a broken link in the 2.3 version of the Operations Guide. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more info.