### PR TITLE
Link fix and formatting fix in Installation Guide v2.2

### DIFF
--- a/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
@@ -5,9 +5,9 @@ The following tables contain information about the pre-defined variables used in
 
 Not all of these variables are required.
 
-include::platform/ref-general-inventory-variables.adoc[leveloffset=+2]
-include::platform/ref-hub-variables.adoc[leveloffset=+2]
-include::platform/ref-sso-variables.adoc[leveloffset=+2]
-include::platform/ref-catalog-variables.adoc[leveloffset=+2]
-include::platform/ref-controller-variables.adoc[leveloffset=+2]
-include::platform/ref-ansible-inventory-variables.adoc[leveloffset=+2]
+include::platform/ref-general-inventory-variables.adoc[leveloffset=+1]
+include::platform/ref-hub-variables.adoc[leveloffset=+1]
+include::platform/ref-sso-variables.adoc[leveloffset=+1]
+include::platform/ref-catalog-variables.adoc[leveloffset=+1]
+include::platform/ref-controller-variables.adoc[leveloffset=+1]
+include::platform/ref-ansible-inventory-variables.adoc[leveloffset=+1]

--- a/downstream/modules/platform/ref-hub-configs.adoc
+++ b/downstream/modules/platform/ref-hub-configs.adoc
@@ -8,7 +8,7 @@ See the following resources to explore additional {HubName} configurations.
 [options="header"]
 |====
 |Link|Description
-|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in private {HubName}]|Configure user access for {HubName}
+|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_containers_in_private_automation_hub/configuring-user-access-containers#doc-wrapper[Managing user access in private {HubName}]|Configure user access for {HubName}
 |https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansible Galaxy collections in {HubName}]|Add content to your {HubName}
 |https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/publishing_proprietary_content_collections_in_automation_hub/index[Publishing proprietary content collections in {HubName}]|Publish internally developed collections on your {HubName}
 |====


### PR DESCRIPTION
Fixes a link in v2.2 of Installation Guide table 2.4 and a formatting issue in the appendix. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for further detail.