### PR TITLE
Fix formatting and title in containerized install doc (#377)

### DIFF
--- a/downstream/modules/platform/proc-installing-ansible-core.adoc
+++ b/downstream/modules/platform/proc-installing-ansible-core.adoc
@@ -15,9 +15,8 @@
 ----
 sudo dnf install -y ansible-core wget git
 ----
-+
 . Set a fully qualified hostname:
-
++
 ----
 sudo hostnamectl set-hostname your-FQDN-hostname
 ----

--- a/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
@@ -2,7 +2,7 @@
 
 [id="preparing-the-rhel-host-for-containerized-installation_{context}"]
 
-= Preparing-the-rhel-host-for-containerized-installation
+= Preparing the RHEL host for containerized installation
 
 [role="_abstract"]
 


### PR DESCRIPTION
Backports #377 to 2.4

Fixes a title and codeblock indentation.
Affects `titles/aap-containerized-install`