### PR TITLE
AAP15779 - adding missing assembly

### DIFF
--- a/downstream/assemblies/hub/assembly-user-access.adoc
+++ b/downstream/assemblies/hub/assembly-user-access.adoc
@@ -5,18 +5,20 @@ include::hub/con-user-access.adoc[leveloffset=+1]
 
 The following sections describe the workflows associated with organizing your users who will access Automation Hub and providing them with required permissions to reach their goals. See the permissions reference table for a full list and description of all permissions available.
 
-include::hub/proc-create-groups.adoc[leveloffset=+1]
+include::hub/proc-create-groups.adoc[leveloffset=+2]
 
-include::hub/proc-assigning-permissions.adoc[leveloffset=+1]
+include::hub/proc-assigning-permissions.adoc[leveloffset=+2]
 
-include::hub/proc-create-users.adoc[leveloffset=+1]
+include::hub/proc-create-users.adoc[leveloffset=+2]
 
-include::hub/proc-create-super-users.adoc[leveloffset=+1]
+include::hub/proc-create-super-users.adoc[leveloffset=+2]
 
-include::hub/proc-add-user-to-group.adoc[leveloffset=+1]
+include::hub/proc-add-user-to-group.adoc[leveloffset=+2]
 
-include::hub/proc-create-content-developers.adoc[leveloffset=+1]
+include::hub/proc-create-content-developers.adoc[leveloffset=+2]
 
-include::hub/ref-permissions.adoc[leveloffset=+1]
+include::hub/ref-permissions.adoc[leveloffset=+2]
 
-include::hub/proc-delete-user.adoc[leveloffset=+1]
+include::hub/proc-delete-user.adoc[leveloffset=+2]
+
+include::assembly-view-only-access.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR includes an assembly that was missed in the Getting started guide and updates some leveloffsets to correct topic nesting.