### PR TITLE
AAP-16032: Restructures disconnected installation chapter

### DIFF
--- a/downstream/assemblies/platform/assembly-disconnected-installation.adoc
+++ b/downstream/assemblies/platform/assembly-disconnected-installation.adoc
@@ -6,29 +6,7 @@ ifdef::context[:parent-context: {context}]
 [id="disconnected-installation"]
 = Disconnected installation
 
-include::platform/con-aap-installation-on-disconnected-rhel.adoc[leveloffset=+1]
-
-include::platform/proc-synchronizing-rpm-repositories-by-using-reposync.adoc[leveloffset=+1]
-
-include::platform/proc-creating-a-new-web-server-to-host-repositories.adoc[leveloffset=+1]
-
-include::platform/proc-accessing-rpm-repositories-for-locally-mounted-dvd.adoc[leveloffset=+1]
-
-include::platform/proc-adding-a-subscription-manifest-to-aap-without-an-internet-connection.adoc[leveloffset=+1]
-
 include::platform/proc-installing-the-aap-setup-bundle.adoc[leveloffset=+1]
-
-include::platform/proc-completing-post-installation-tasks.adoc[leveloffset=+1]
-
-include::platform/proc-importing-collections-into-private-automation-hub.adoc[leveloffset=+1]
-
-include::platform/proc-creating-collection-namespace.adoc[leveloffset=+1]
-
-include::platform/proc-approving-the-imported-collection.adoc[leveloffset=+1]
-
-include::platform/con-building-an-execution-environment-in-a-disconnected-environment.adoc[leveloffset=+1]
-
-include::platform/proc-installing-the-ansible-builder-rpm.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-planning-disconnected-installation.adoc
+++ b/downstream/assemblies/platform/assembly-planning-disconnected-installation.adoc
@@ -1,0 +1,40 @@
+
+ifdef::context[:parent-context: {context}]
+
+[id="assembly-planning-disconnected-installation_{context}"]
+= Planning a disconnected installation
+
+:context: planning-disconnected-installation
+
+[role="_abstract"]
+{PlatformName} can be installed without an active internet connection.
+
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+* X is installed. For information about installing X, see <link>.
+* You can log in to X with administrator privileges.
+
+// Include modules here.
+
+include::platform/con-aap-installation-on-disconnected-rhel.adoc[leveloffset=+1]
+
+include::platform/proc-synchronizing-rpm-repositories-by-using-reposync.adoc[leveloffset=+1]
+
+include::platform/proc-creating-a-new-web-server-to-host-repositories.adoc[leveloffset=+1]
+
+include::platform/proc-accessing-rpm-repositories-for-locally-mounted-dvd.adoc[leveloffset=+1]
+
+include::platform/proc-adding-a-subscription-manifest-to-aap-without-an-internet-connection.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources (or Next steps)
+// * A bulleted list of links to other closely-related material. These links can include `link:` and `xref:` macros.
+* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+// 
+ifdef::parent-context-of-assembly-planning-disconnected-installation[:context: {parent-context-of-assembly-planning-disconnected-installation}]
+ifndef::parent-context-of-assembly-planning-disconnected-installation[:!context:]
+

--- a/downstream/assemblies/platform/assembly-post-installation-tasks.adoc
+++ b/downstream/assemblies/platform/assembly-post-installation-tasks.adoc
@@ -1,0 +1,41 @@
+
+[id="post-installation-tasks_{context}"]
+
+= Post-installation tasks
+
+:context: post-installation-tasks
+
+[role="_abstract"]
+After you have completed the installation, review the post-installation tasks in this section to ensure that {HubName} and {ControllerName} deploy properly.
+
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+* X is installed. For information about installing X, see <link>.
+* You can log in to X with administrator privileges.
+
+// Include modules here.
+
+include::platform/proc-completing-post-installation-tasks.adoc[leveloffset=+1]
+
+include::platform/proc-importing-collections-into-private-automation-hub.adoc[leveloffset=+1]
+
+include::platform/proc-creating-collection-namespace.adoc[leveloffset=+1]
+
+include::platform/proc-approving-the-imported-collection.adoc[leveloffset=+1]
+
+include::platform/con-building-an-execution-environment-in-a-disconnected-environment.adoc[leveloffset=+1]
+
+include::platform/proc-installing-the-ansible-builder-rpm.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources (or Next steps)
+* A bulleted list of links to other closely-related material. These links can include `link:` and `xref:` macros.
+* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+
+ifdef::parent-context-of-post-installation-tasks[:context: {parent-context-of-post-installation-tasks}]
+ifndef::parent-context-of-post-installation-tasks[:!context:]
+

--- a/downstream/assemblies/platform/assembly-post-installation-tasks.adoc
+++ b/downstream/assemblies/platform/assembly-post-installation-tasks.adoc
@@ -1,3 +1,4 @@
+ifdef::context[:parent-context: {context}]
 
 [id="post-installation-tasks_{context}"]
 


### PR DESCRIPTION
This PR creates two new assemblies and reorganizes the modules within the (now three) assemblies. See[ AAP-16032 ](https://issues.redhat.com/browse/AAP-16032)for more info. 