### PR TITLE
Adding Credentials chapter to EDA user guide (#409)

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-credentials.adoc
+++ b/downstream/assemblies/eda/assembly-eda-credentials.adoc
@@ -1,0 +1,10 @@
+[id="eda-credentials"]
+
+= Setting up credentials for {EDAcontroller}
+
+Credentials are used by {EDAName} for authentication when launching rulebooks.
+
+include::eda/proc-eda-set-up-credential.adoc[leveloffset=+1]
+include::eda/con-credentials-list-view.adoc[leveloffset=+1]
+include::eda/proc-eda-edit-credential.adoc[leveloffset=+1]
+include::eda/proc-eda-delete-credential.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -6,6 +6,7 @@
 
 The following procedures form the user configuration:
 
+* xref:eda-set-up-credential[Setting up credentials]
 * xref:eda-set-up-new-project[Setting up a new project]
 * xref:eda-set-up-new-decision-environment[Setting up a new decision environment]
 * xref:eda-set-up-token[Setting up a token to authenticate to {PlatformNameShort} Controller]

--- a/downstream/modules/eda/con-credentials-list-view.adoc
+++ b/downstream/modules/eda/con-credentials-list-view.adoc
@@ -1,0 +1,12 @@
+[id="eda-credentials-list-view"]
+
+= Credentials list view
+
+On the *Credentials* page, you can view the list of created credentials that you have created along with the *Type* of credential.
+
+From the menu bar, you can search for credentials in the *Name* field. 
+
+You also have the following options in the menu bar:
+
+* Choose which columns are shown in the list view by clicking btn:[Manage columns].
+* Choose between a btn:[List view] or a btn:[Card view], by clicking the icons.

--- a/downstream/modules/eda/proc-eda-delete-credential.adoc
+++ b/downstream/modules/eda/proc-eda-delete-credential.adoc
@@ -1,0 +1,13 @@
+[id="eda-delete-credential"]
+
+= Deleting a credential
+
+.Procedure
+
+. Delete the credential by using one of these methods:
+* From the *Credentials* list view, click the btn:[More Actions] icon *{MoreActionsIcon}* next to the desired credential and click btn:[Delete credential].
+* From the *Credentials* list view, select the name of the credential, click the btn:[More Actions] icon *{MoreActionsIcon}* next to btn:[Edit credential], and click btn:[Delete credential].
+. In the pop-up window, select *Yes, I confirm that I want to delete this credential*.
+. Click btn:[Delete credential].
+
+You can delete multiple credentials at a time by selecting the checkbox next to each credential and clicking the btn:[More Actions] icon *{MoreActionsIcon}* in the menu bar and then clicking btn:[Delete selected credentials].

--- a/downstream/modules/eda/proc-eda-edit-credential.adoc
+++ b/downstream/modules/eda/proc-eda-edit-credential.adoc
@@ -1,0 +1,10 @@
+[id="eda-edit-credential"]
+
+= Editing a credential
+
+.Procedure
+
+. Edit the credential by using one of these methods:
+* From the *Credentials* list view, click the btn:[Edit credential] icon next to the desired credential.
+* From the *Credentials* list view, select the name of the credential, click btn:[Edit credential].
+. Edit the appropriate details and click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-set-up-credential.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-credential.adoc
@@ -1,0 +1,36 @@
+[id="eda-set-up-credential"]
+
+= Setting up credentials
+
+Create a credential to use with a private repository (GitHub or GitLab) or a private container registry.
+
+[IMPORTANT]
+====
+If you are using a GitHub or GitLab repository, use the `basic auth` method. 
+Both SCM servers are officially supported. 
+You can use any SCM provider that supports `basic auth`.
+====
+
+.Procedure
+
+. Log in to the {EDAcontroller} Dashboard.
+. From the navigation panel, select menu:Resources[Credentials].
+. Click btn:[Create credential].
+. Insert the following:
++
+Name:: Insert the name.
+Description:: This field is optional.
+Credential type:: The options available are a GitHub personal access token, a GitLab personal access token, or a container registry.
+Username:: Insert the username.
+Token:: Insert a token that allows you to authenticate to your destination.
++
+[NOTE]
+====
+If you are using a container registry, the token field can be a token or a password, depending on the registry provider.
+If you are using the {PlatformNameShort} hub registry, insert the password for that in the token field. 
+====
++
+. Click btn:[Create credential].
+
+After saving the credential, the credentials details page is displayed. 
+From there or the *Credentials* list view, you can edit or delete it.

--- a/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
@@ -8,8 +8,7 @@ The following steps describe how to import a decision environment into your {EDA
 
 * You are logged in to the {EDAcontroller} Dashboard as a Content Consumer.
 * You have set up a credential, if necessary. 
-For more information, refer to the link:https://docs.ansible.com/automation-controller/latest/html/userguide/credentials.html[Credentials] section
-of the {ControllerNameStart} documentation.
+For more information, see the xref:eda-set-up-credential[Setting up credentials] section.
 * You have pushed a decision environment image to an image repository or you chose to use the image `de-supported` provided at link:http://registry.redhat.io/[registry.redhat.io].
 
 .Procedure

--- a/downstream/modules/eda/proc-eda-set-up-new-project.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-new-project.adoc
@@ -6,8 +6,7 @@
 
 * You are logged in to the {EDAcontroller} Dashboard as a Content Consumer.
 * You have set up a credential, if necessary. 
-For more information, refer to the link:https://docs.ansible.com/automation-controller/latest/html/userguide/credentials.html[Credentials]
-section of the {ControllerName} documentation.
+For more information, see the xref:eda-set-up-credential[Setting up credentials] section.
 * You have an existing repository containing rulebooks that are integrated with playbooks contained in a repository to be used by {ControllerName}.
 
 .Procedure

--- a/downstream/titles/eda/eda-user-guide/docinfo.xml
+++ b/downstream/titles/eda/eda-user-guide/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>2.4</productnumber>
 <subtitle>Learn to configure and use {EDAcontroller} to enhance and expand automation</subtitle>
 <abstract>
-    <para> This guide helps you configure your {EDAcontroller} to set up new projects, decision environments, tokens to authenticate to Ansible Automation Platform Controller, and rulebook activation.</para>
+    <para> Learn how to configure your {EDAcontroller} to set up credentials, new projects, decision environments, tokens to authenticate to Ansible Automation Platform Controller, and rulebook activation.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/eda/eda-user-guide/master.adoc
+++ b/downstream/titles/eda/eda-user-guide/master.adoc
@@ -14,6 +14,7 @@ Developed by Red Hat, this feature is designed for simplicity and flexibility.
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
 include::eda/assembly-eda-user-guide-overview.adoc[leveloffset=+1]
+include::eda/assembly-eda-credentials.adoc[leveloffset=+1]
 include::eda/assembly-eda-projects.adoc[leveloffset=+1]
 include::eda/assembly-eda-decision-environments.adoc[leveloffset=+1]
 include::eda/assembly-eda-set-up-token.adoc[leveloffset=+1]


### PR DESCRIPTION
* Adding Credentials chapter to EDA user guide

Adding Chapter 2. Setting up credentials for Event-Driven Ansible controller

[DOCS][EDA] missing section and a wrong link for EDA credentials

https://issues.redhat.com/browse/AAP-16054

Affects `titles/eda-user-guide`

* Edits as per peer review