### PR TITLE
readthedocs preview site

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# RTD API version
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: >-
+      3.11
+    nodejs: >-
+      20
+
+  # Build preview site with asciidoctor
+  commands:
+    - npm i -g asciidoctor
+    - sh generate-preview.sh
+    - asciidoctor index.asciidoc
+    - mkdir -pv _readthedocs/html && mv index.html _readthedocs/html

--- a/generate-preview.sh
+++ b/generate-preview.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+######
+# This script creates an index.asciidoc file to generate preview builds.
+######
+
+assemblies=$(find downstream/assemblies/** -name '*.adoc')
+
+for f in $assemblies
+do
+  echo "include::$f"
+done > index.asciidoc
+
+sed -i -e 's|.adoc|.adoc\[leveloffset=+1\]|g' index.asciidoc
+
+sed -i '1iinclude::downstream/attributes/attributes.adoc\[\]' index.asciidoc
+sed -i '2i\\' index.asciidoc
+sed -i '3i= Content preview' index.asciidoc
+sed -i '4iIMPORTANT: This is a preview site of content that is in development and not supported. Visit link:https://www.redhat.com/en/technologies/management/ansible\[Red Hat Ansible Automation Platform\] for more information.' index.asciidoc
+sed -i '5i\\' index.asciidoc


### PR DESCRIPTION
Fixes issue #442 

Here is an example of the preview site. It is a single HTML page with default styling: https://oranod-platform.readthedocs.io/en/latest/