### PR TITLE
Backport-2.4-398 AAP-13785 New minimum requirement for EDA controller section

### DIFF
--- a/downstream/assemblies/platform/assembly-system-requirements.adoc
+++ b/downstream/assemblies/platform/assembly-system-requirements.adoc
@@ -16,6 +16,7 @@ Use this information when planning your {PlatformName} installations and designi
 include::platform/ref-system-requirements.adoc[leveloffset=+1]
 include::platform/ref-controller-system-requirements.adoc[leveloffset=+1]
 include::platform/ref-automation-hub-requirements.adoc[leveloffset=+1]
+include::platform/ref-eda-system-requirements.adoc[leveloffset=+1]
 include::platform/ref-postgresql-requirements.adoc[leveloffset=+1]
 include::platform/proc-enable-hstore-extension.adoc[leveloffset=+2]
 include::platform/proc-benchmark-postgresql.adoc[leveloffset=+2]

--- a/downstream/modules/platform/ref-eda-system-requirements.adoc
+++ b/downstream/modules/platform/ref-eda-system-requirements.adoc
@@ -1,0 +1,14 @@
+[id="event-driven-ansible-system-requirements"]
+
+= {EDAcontroller} system requirements
+
+The {EDAcontroller} is a single-node system capable of handling a variable number of long-running processes (such as, Rulebook activations) on-demand, depending on the number of CPU cores. Use the following minimum requirements to execute a maximum of 9 simultaneous activations:
+
+[cols="a,a",options="header"]
+|===
+h| Requirement | Required
+| *RAM* | 16 GB
+| *CPUs* | 4
+| *Local disk* | 40 GB minimum
+|===
+


### PR DESCRIPTION
- Added a new module "Event-Driven Ansible controller system requirements" to both the Installation and Planning guides.

- This was added to the assembly for the overall system requirements chapter (Chapter 4 in the Planning Guide and Chapter 2 in the Installation Guide)