### PR TITLE
AAP-15176: fixes link formatting in 2.2 version of install guide

### DIFF
--- a/downstream/modules/platform/con-why-migrate-ansible-core-212.adoc
+++ b/downstream/modules/platform/con-why-migrate-ansible-core-212.adoc
@@ -2,4 +2,4 @@
 
 = Migrating to Ansible Core 2.12
 
-When upgrading to Ansible Core 2.12, you will need to update your playbooks, plugins, or other parts of your Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content to be Ansible Core 2.12 compatible, see the https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.12.html[Ansible-core 2.12 Porting Guide].
+When upgrading to Ansible Core 2.12, you will need to update your playbooks, plugins, or other parts of your Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content to be Ansible Core 2.12 compatible, see the link:https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.12.html[Ansible-core 2.12 Porting Guide].

--- a/downstream/modules/platform/con-why-migrate-ansible-core-213.adoc
+++ b/downstream/modules/platform/con-why-migrate-ansible-core-213.adoc
@@ -2,4 +2,4 @@
 
 = Migrating to Ansible Core 2.13
 
-When upgrading to Ansible Core 2.13, you need to update your playbooks, plugins, or other parts of your Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content for Ansible Core 2.13 compatibility, see the https://https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.13.html[Ansible-core 2.13 Porting Guide].
+When upgrading to Ansible Core 2.13, you need to update your playbooks, plugins, or other parts of your Ansible infrastructure in order to be supported by the latest version of Ansible Core. For instructions on updating your Ansible content for Ansible Core 2.13 compatibility, see the link:https://docs.ansible.com/ansible-core/devel/porting_guides/porting_guide_core_2.13.html[Ansible-core 2.13 Porting Guide].


### PR DESCRIPTION
This PR fixes some broken link formatting in the Installation Guide v2.2. See [AAP 15176](https://issues.redhat.com/browse/AAP-15176) for context.