### PR TITLE
Correct variable typo for automationhub_pg_password (#481)

### DIFF
--- a/downstream/modules/central-auth/proc-aap-configure-centralauth.adoc
+++ b/downstream/modules/central-auth/proc-aap-configure-centralauth.adoc
@@ -23,7 +23,7 @@ $ cd ansible-automation-platform-setup-bundle-<latest-version>
 . Open the *inventory* file using a text editor.
 . Edit the inventory file parameters under `[automationhub]` to specify an installation of {HubName} host:
 .. Add group host information under `[automationhub]` using an IP address or FQDN for the {HubName} location.
-.. Enter passwords for `automationhub_admin_password`, `automation_pg_password`, and any additional parameters based on your installation specifications.
+.. Enter passwords for `automationhub_admin_password`, `automationhub_pg_password`, and any additional parameters based on your installation specifications.
 . Enter a password in the `sso_keystore_password` field.
 . Edit the inventory file parameters under `[SSO]` to specify a host on which to install {centralauth}:
 .. Enter a password in the `sso_console_admin_password` field, and any additional parameters based on your installation specifications.

--- a/downstream/titles/hub/install/master.adoc
+++ b/downstream/titles/hub/install/master.adoc
@@ -112,7 +112,7 @@ $ cd ansible-automation-platform-setup-<latest-version>
 Provide a reachable IP address for the `[automationhub]` host to ensure users can sync content from {PrivateHubName} from a different node.
 ====
 +
-.. Update the values for `automationhub_admin_password` and `automation_pg_password` and any additional parameters based on your installation specifications:
+.. Update the values for `automationhub_admin_password` and `automationhub_pg_password` and any additional parameters based on your installation specifications:
 +
 .Example
 -----


### PR DESCRIPTION
Correct typo with variable from automation_pg_password to automationhub_pg_password

[DDF] I'm not sure this is the correct parameter to use? Should it not be automationHUB_pg_password?

https://issues.redhat.com/browse/AAP-16095