### PR TITLE
Correct typo of FQDN abbreviation (#496)

### DIFF
--- a/downstream/modules/platform/con-install-scenario-examples.adoc
+++ b/downstream/modules/platform/con-install-scenario-examples.adoc
@@ -4,16 +4,16 @@
 
 
 [role="_abstract"]
-Red Hat supports a number of installation scenarios for {PlatformNameShort}. Review the following examples and choose those suitable for your preferred installation scenario.
+Red Hat supports several installation scenarios for {PlatformNameShort}. Review the following examples and select those suitable for your preferred installation scenario.
 
 [IMPORTANT]
 ====
-* For {PlatformName} or {HubName}: Add an {HubName} host in the [automationhub] group.
-* For internal databases: [database] cannot be used to point to another host in the {PlatformNameShort} cluster. 
-The database host set to be installed by the installer needs to be a unique host.
+* For {PlatformName} or {HubName}: Add an {HubName} host in the `[automationhub]` group.
+* For internal databases: `[database]` cannot be used to point to another host in the {PlatformNameShort} cluster. 
+The database host set to be installed needs to be a unique host.
 * Do not install {ControllerName} and {HubName} on the same node for versions of {PlatformNameShort} in a production or customer environment.
 This can cause contention issues and heavy resource use.
-* Provide a reachable IP address or fully qualified domain name (FDQN) for the [automationhub] and [automationcontroller] hosts to ensure users can sync and install content from automation hub from a different node. 
+* Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure users can sync and install content from {HubName} from a different node. 
 Do not use 'localhost'.
 * Do not use special characters for `pg_password`. It can cause the setup to fail.
 * Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.

--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -29,9 +29,9 @@ You can use the same `inventory` file from an existing {PlatformNameShort} 2.1 i
 +
 [NOTE]
 ====
-Provide a reachable IP address or fully qualified domain name (FDQN) for the [automationhub] and [automationcontroller] hosts to ensure that users can synchronize and install content from Ansible automation hub from a different node. 
+Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure that users can synchronize and install content from {HubNameMain} from a different node. 
 Do not use `localhost`.
-If `localhost is used`, the upgrade will be stopped as part of preflight checks.
+If `localhost` is used, the upgrade will be stopped as part of preflight checks.
 ====
 
 .Provisioning new nodes in a cluster
@@ -49,7 +49,7 @@ include::ini/clustered-nodes.ini[]
 
 .Importing and generating API tokens
 
-When upgrading from {PlatformName} 2.0 or earlier to {PlatformName} 2.1 or later, you can use your existing automation hub API token or generate a new token. In the inventory file, edit one of the following fields before running the {PlatformName} installer setup script `setup.sh`:
+When upgrading from {PlatformName} 2.0 or earlier to {PlatformName} 2.1 or later, you can use your existing {HubName} API token or generate a new token. In the inventory file, edit one of the following fields before running the {PlatformName} installer setup script `setup.sh`:
 
 * Import an existing API token with the `automationhub_api_token` flag as follows:
 +

--- a/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
+++ b/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
@@ -9,21 +9,21 @@
 
 .{HubNameStart}
 * If there is an `[automationhub]` group, you must include the variables `automationhub_pg_host` and `automationhub_pg_port`.
-* Add {HubNameMain} information in the `[automationhub]` group
-* Do not install {HubNamemain} and {ControllerName} on the same node.
-* Provide a reachable IP address or fully qualified domain name (FDQN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure that users can synchronize and install content from {HubNameMain} and {ControllerName} from a different node. 
+* Add {HubNameMain} information in the `[automationhub]` group.
+* Do not install {HubNameMain} and {ControllerName} on the same node.
+* Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure that users can synchronize and install content from {HubNameMain} and {ControllerName} from a different node. 
 Do not use `localhost`.
 
 .{PrivateHubNameStart}
 * Do not install {PrivateHubName} and {ControllerName} on the same node.
-* You can use the same Postgresql (database) instance, but they must use a different (database) name.
+* You can use the same PostgreSQL (database) instance, but they must use a different (database) name.
 * If you install {PrivateHubName} from an internal address, and have a certificate which only encompasses the external address, it can result in an installation you cannot use as a container registry without certificate issues.
 
 [IMPORTANT]
 ====
-You must separate the installation of {Controllername} and {HubNameMain} because the `[database]` group does not distinguish between the two if both are installed at the same time. 
+You must separate the installation of {ControllerName} and {HubNameMain} because the `[database]` group does not distinguish between the two if both are installed at the same time. 
 
-If you use one value in `[database]` and both {Controllername} and {HubNameMain} define it, they would use the same database.
+If you use one value in `[database]` and both {ControllerName} and {HubNameMain} define it, they would use the same database.
 ====
 
 .{ControllerNameStart}
@@ -35,11 +35,11 @@ If you use one value in `[database]` and both {Controllername} and {HubNameMain}
 * When upgrading an existing cluster, you can also reconfigure your cluster to omit existing instances or instance groups. 
 Omitting the instance or the instance group from the inventory file is not enough to remove them from the cluster. 
 In addition to omitting instances or instance groups from the inventory file, you must also deprovision instances or instance groups before starting the upgrade. See xref:ref-deprovisioning[Deprovisioning nodes or groups]. 
-Otherwise, omitted instances or instance groups continue to communicate with the cluster, which can cause issues with {Controllername} services during the upgrade.
+Otherwise, omitted instances or instance groups continue to communicate with the cluster, which can cause issues with {ControllerName} services during the upgrade.
 * If you are creating a clustered installation setup, you must replace `[localhost]` with the hostname or IP address of all instances. 
 Installers for {ControllerName}, {HubName}, and {CatalogName} do not accept `[localhost]`
-All nodes and instances must be able to reach any others using this hostname or address. 
-In other words, you cannot use the localhost `ansible_connection=local` on one of the nodes. 
+All nodes and instances must be able to reach any others by using this hostname or address. 
+You cannot use the localhost `ansible_connection=local` on one of the nodes. 
 Use the same format for the host names of all the nodes.
 +
 Therefore, this does not work:


### PR DESCRIPTION
* Correct typo of FQDN abbreviation

Replace typos FDQN with correct abbreviation FQDN

[DDF] Inventory requires FQDN ?

https://issues.redhat.com/browse/AAP-15819

* Implement feedback based on peer-review