### PR TITLE
Correct broken link typo in Containerized AAP Installation Guide (#509)

### DIFF
--- a/downstream/modules/platform/ref-aap-containerized-dns-config.adoc
+++ b/downstream/modules/platform/ref-aap-containerized-dns-config.adoc
@@ -8,13 +8,13 @@
 
 .Using unbound DNS
 
-To configure unbound DNS refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/ssembly_setting-up-an-unbound-dns-server_networking-infrastructure-services#proc_configuring-unbound-as-a-caching-dns-server_assembly_setting-up-an-unbound-dns-server[Chapter 2. Setting up an unbound DNS server Red Hat Enterprise Linux 9].
+To configure unbound DNS, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/assembly_setting-up-an-unbound-dns-server_networking-infrastructure-services[Chapter 2. Setting up an unbound DNS server - Red Hat Enterprise Linux 9].
 
 .Using BIND DNS
 
-To configure DNS using BIND refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/assembly_setting-up-and-configuring-a-bind-dns-server_networking-infrastructure-services[Chapter 1. Setting up and configuring a BIND DNS server Red Hat Enterprise Linux 9].
+To configure DNS using BIND, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/assembly_setting-up-and-configuring-a-bind-dns-server_networking-infrastructure-services[Chapter 1. Setting up and configuring a BIND DNS server - Red Hat Enterprise Linux 9].
 
-Optional: To have the installer automatically pick up and apply your AAP subscription manifest license, then follow this guide up to and including step 11, Tp generate a manifest file which can be downloaded for the installer refer to link:https://docs.ansible.com/ansible-tower/latest/html/userguide/import_license.html#obtain-sub-manifest[4. Import a Subscription — Ansible Tower User Guide v3.8.6].
+Optional: To ensure the installation program automatically picks up and applies your {PlatformNameShort} subscription manifest license, generate a manifest file. You can then download this manifest file for the installation program to refer to. To generate the manifest file, see link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html#obtaining-a-subscriptions-manifest[4.3. Obtaining a subscriptions manifest - Automation Controller User Guide].
 
 
 


### PR DESCRIPTION
* Correct broken link typo in Containerized AAP Installation Guide

Correct broken link to "Setting up an unbound DNS server - Red Hat Enterprise Linux 9"

[DDF] Link is broken

https://issues.redhat.com/browse/AAP-16502

* Update link to Controller instead of Tower user guide based on feedback