### PR TITLE
AAP-12198 Added important note to rulebook activation chapter

### DIFF
--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -38,6 +38,15 @@ The content would be equivalent to the file passed through the `--vars` flag of 
 
 . Click btn:[Create rulebook activation].
 
+[IMPORTANT]
+====
+To avoid potential saturation on {ControllerName}, note that each activation rulebook might potentially send numerous requests to the {ControllerName} and trigger multiple jobs, depending on how rules in your rulebook are defined and the volume of incoming events. Each rulebook activation (ansible-rulebook process) has a default throttling mechanism set at 30 connections when connecting to the {ControllerName}. 
+
+You can adjust this value using the environment variable `EDA_CONTROLLER_CONNECTION_LIMIT`. If you anticipate that your rulebook might trigger more jobs on the {ControllerName} than it can process, consider reducing this value. 
+
+Also note that, currently, {EDAcontroller} does not yet support the customization of environment variables per activation. As a workaround, you can define `EDA_CONTROLLER_CONNECTION_LIMIT` during the image build step.
+====
+
 Your rulebook activation is now created and can be managed in the *Rulebook Activations* screen.
 
 After saving the new rulebook activation, the rulebook activation's details page is displayed. 

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -40,11 +40,9 @@ The content would be equivalent to the file passed through the `--vars` flag of 
 
 [IMPORTANT]
 ====
-To avoid potential saturation on {ControllerName}, note that each activation rulebook might potentially send numerous requests to the {ControllerName} and trigger multiple jobs, depending on how rules in your rulebook are defined and the volume of incoming events. Each rulebook activation (ansible-rulebook process) has a default throttling mechanism set at 30 connections when connecting to the {ControllerName}. 
-
-You can adjust this value using the environment variable `EDA_CONTROLLER_CONNECTION_LIMIT`. If you anticipate that your rulebook might trigger more jobs on the {ControllerName} than it can process, consider reducing this value. 
-
-Also note that, currently, {EDAcontroller} does not yet support the customization of environment variables per activation. As a workaround, you can define `EDA_CONTROLLER_CONNECTION_LIMIT` during the image build step.
+ Each rulebook activation might potentially send numerous requests to the {ControllerName} and trigger multiple jobs, depending on how rules in your rulebook are defined and the volume of incoming events. To avoid potential saturation on {ControllerName}, each rulebook activation (ansible-rulebook process) has a default throttling mechanism set at 30 connections when connecting to the {ControllerName}. 
+ 
+ You can adjust this value in the inventory file using the environment variable `EDA_CONTROLLER_CONNECTION_LIMIT` if you anticipate that your rulebook might trigger more jobs on the {ControllerName} than it can process. However, please note that currently, {EDAcontroller} does not yet support the customization of environment variables per activation. As a workaround, you can define `EDA_CONTROLLER_CONNECTION_LIMIT` during the image build step. 
 ====
 
 Your rulebook activation is now created and can be managed in the *Rulebook Activations* screen.


### PR DESCRIPTION
Added an [IMPORTANT] admonition to the chapter, Setting up a rulebook activation" in the EDA controller user guide. 

(Note: Not settled on this yet; still working on updates based on feedback from Alejandro Izquierdo.) 