### PR TITLE
AAP-13758 EDA Installation information for hosts and groups

### DIFF
--- a/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
+++ b/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
@@ -30,6 +30,8 @@ If you use one value in `[database]` and both {ControllerName} and {HubNameMain}
 * {ControllerNameStart} does not configure replication or failover for the database that it uses.
 * {ControllerName} works with any replication that you have.
 
+.{EDAName}
+* {EDAName} must be installed on their own servers and cannot be installed on the same host as {HubName} and {ControllerName}.
 
 .Clustered installations
 * When upgrading an existing cluster, you can also reconfigure your cluster to omit existing instances or instance groups. 

--- a/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
+++ b/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
@@ -31,7 +31,7 @@ If you use one value in `[database]` and both {ControllerName} and {HubNameMain}
 * {ControllerName} works with any replication that you have.
 
 .{EDAName}
-* {EDAName} must be installed on their own servers and cannot be installed on the same host as {HubName} and {ControllerName}.
+* {EDAName} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
 
 .Clustered installations
 * When upgrading an existing cluster, you can also reconfigure your cluster to omit existing instances or instance groups. 

--- a/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
+++ b/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
@@ -30,8 +30,8 @@ If you use one value in `[database]` and both {ControllerName} and {HubNameMain}
 * {ControllerNameStart} does not configure replication or failover for the database that it uses.
 * {ControllerName} works with any replication that you have.
 
-.{EDAName}
-* {EDAName} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
+.{EDAcontroller}
+* {EDAcontroller} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
 
 .Clustered installations
 * When upgrading an existing cluster, you can also reconfigure your cluster to omit existing instances or instance groups. 

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -10,6 +10,10 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 {ControllerNameStart} must be installed before you populate the inventory file with the following {EDAName} variables.
 ====
 
+[IMPORTANT]
+====
+{EDAcontroller} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
+====
 -----
 # Automation EDA Controller Configuration
 #


### PR DESCRIPTION
Created a new section, Event-Driven Ansible controller, under heading [8.1. Guidelines for hosts and groups](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/about_the_installer_inventory_file#ref-guidelines-hosts-groups). 