### PR TITLE
Lightspeed: Add placeholders for assemblies in main doc

### DIFF
--- a/lightspeed/titles/lightspeed-user-guide/master.adoc
+++ b/lightspeed/titles/lightspeed-user-guide/master.adoc
@@ -12,3 +12,6 @@ include::attributes/attributes.adoc[]
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::assemblies/assembly-lightspeed-intro.adoc[leveloffset=+1]
+// include::assemblies/assembly-chapter-1.adoc[leveloffset=+1]
+// include::assemblies/assembly-chapter-2.adoc[leveloffset=+1]
+// include::assemblies/assembly-chapter-3.adoc[leveloffset=+1]


### PR DESCRIPTION
Add placeholders for assemblies in main doc.
The idea is that you un-comment one line, fix the assembly name, and create a PR to merge that new assembly.
This is to facilitate the process whereby you use one PR per assembly.