### PR TITLE
AAP 15795: Editorial changes to Managing Content  (#559)

### DIFF
--- a/downstream/assemblies/hub/assembly-collection-import-export.adoc
+++ b/downstream/assemblies/hub/assembly-collection-import-export.adoc
@@ -6,9 +6,9 @@ ifdef::context[:parent-context: {context}]
 :context: export-import
 
 [role="_abstract"]
-Ansible {HubName} stores automation content collections within repositories. These collections are versioned by the automation content creator; therefore, many versions of the same collection can exist in the same or different repositories at the same time.
+{HubNameMain} stores automation content collections within repositories. These collections are versioned by the automation content creator. Many versions of the same collection can exist in the same or different repositories at the same time.
 
-Collections are stored as tar files that can be imported and exported. This ensures the collection you are importing to a new repository is the same one that was originally created and exported.
+Collections are stored as .tar files that can be imported and exported. This storage format ensures that the collection you are importing to a new repository is the same one that was originally created and exported.
 
 include::hub/proc-export-collection.adoc[leveloffset=+1]
 include::hub/proc-import-collection.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-remote-management.adoc
+++ b/downstream/assemblies/hub/assembly-remote-management.adoc
@@ -1,7 +1,7 @@
 ifdef::context[:parent-context: {context}]
 
 [id="remote-management"]
-= Remote management in {HubName}
+= Managing remote configurations in {HubName}
 
 :context: remote-management
 

--- a/downstream/assemblies/hub/assembly-repo-management.adoc
+++ b/downstream/assemblies/hub/assembly-repo-management.adoc
@@ -8,13 +8,15 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 As an {HubName} administrator, you can create, edit, delete, and move automation content collections between repositories.
 
+== Types of repositories in automation hub
+
 In {HubName} you can publish collections to two types of repositories, depending on whether you want your collection to be verified:
 
-Staging repositories:: Any user with permission to upload to a namespace can publish collections into these repositories. Collections in these repositories are not available in the search page, but rather, are displayed on the approval dashboard for an administrator to verify.
+Staging repositories:: Any user with permission to upload to a namespace can publish collections into these repositories. Collections in these repositories are not available in the search page. Instead, they are displayed on the approval dashboard for an administrator to verify. Staging repositories are marked with the `pipeline=staging` label.
 
-Custom repositories:: Any user with write permissions on the repository can publish collections to these repositories. Custom repositories can be private repositories where only users with view permissions can see them, or public where all users can see them. These repositories are not displayed on the approval dashboard. If the repository owner enables search, the collection can appear in search results.
+Custom repositories:: Any user with write permissions on the repository can publish collections to these repositories. Custom repositories can be public where all users can see them, or private  where only users with view permissions can see them. These repositories are not displayed on the approval dashboard. If the repository owner enables search, the collection can appear in search results.
 
-Staging repositories are marked with the `pipeline=staging` label. By default, {HubName} ships with one staging repository that is automatically used when a repository is not specified for uploading collections. However, users can create new staging repositories during xref:proc-create-repository[repository creation].
+By default, {HubName} ships with one staging repository that is automatically used when a repository is not specified for uploading collections. Users can create new staging repositories during xref:proc-create-repository[repository creation].
 
 include::hub/con-approval-pipeline.adoc[leveloffset=+1]
 include::hub/con-repo-rbac.adoc[leveloffset=+1]

--- a/downstream/modules/hub/con-approval-pipeline.adoc
+++ b/downstream/modules/hub/con-approval-pipeline.adoc
@@ -6,15 +6,15 @@
 
 = Approval pipeline for custom repositories in {HubName}
 
-In {HubName} you can approve collections into any repository that is marked with the `pipeline=approved` label. By default, {HubName} ships with one repository for approved content, but you have the option to add more from the repository creation screen. Note that you cannot directly publish into a repository marked with this label. A collection must first go through a staging repository for approval before being published into a 'pipleline=approved' repository. 
+In {HubName} you can approve collections into any repository marked with the `pipeline=approved` label. By default, {HubName} ships with one repository for approved content, but you have the option to add more from the repository creation screen. You cannot directly publish into a repository marked with the `pipeline=approved` label. A collection must first go through a staging repository and be approved before being published into a 'pipleline=approved' repository. 
 
 Auto approval::
 When auto approve is enabled, any collection you upload to a staging repository is automatically promoted to all of the repositories marked as `pipeline=approved`.
 
 Approval required::
-From the approval dashboard, the administrator can see collections that have been uploaded into any of the staging repositories. Clicking btn:[Approve] displays a list of approved repositories. From this list, the administrator can select one or more repositories to which the content should be promoted.
+When auto approve is disabled, the administrator can view the approval dashboard and see collections that have been uploaded into any of the staging repositories. Clicking btn:[Approve] displays a list of approved repositories. From this list, the administrator can select one or more repositories to which the content should be promoted.
 +
 If only one approved repository exists, the collection is automatically promoted into it and the administrator is not prompted to select a repository.
 
 Rejection::
-Rejected collections are automatically placed into the pre-installed rejected repository.
+Rejected collections are automatically placed into the rejected repository, which is pre-installed.

--- a/downstream/modules/hub/con-repo-rbac.adoc
+++ b/downstream/modules/hub/con-repo-rbac.adoc
@@ -4,6 +4,6 @@
 
 [id="con-repo-rbac"]
 
-= Role Based Access Control
+= Role based access control to restrict access to custom repositories
 
 Use Role Based Access Control (RBAC) to restrict user access to custom repositories by defining access permissions based on user roles. By default, users can view all public repositories in their {HubName}, but they cannot modify a repository unless their role allows them access to do so. The same logic applies to other operations on the repository. For example, you can remove a user's ability to download content from a custom repository by changing their role permissions. See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Configuring user access for your {PrivateHubName}] for information about managing user access in {HubName}.

--- a/downstream/modules/hub/proc-adding-collections-repository.adoc
+++ b/downstream/modules/hub/proc-adding-collections-repository.adoc
@@ -12,5 +12,5 @@ After you create your repository, you can begin adding automation content collec
 . From the navigation panel, select menu:Collections[Repositories].
 . Locate your repository in the list and click the btn:[More Actions] icon *{MoreActionsIcon}*, then select *Edit*.
 . Select the *Collections version* tab.
-. Click btn:[Add Collection] and select the collections you want added to your repository.
+. Click btn:[Add Collection] and select the collections that you want to add to your repository.
 . Click btn:[Select].

--- a/downstream/modules/hub/proc-basic-repo-sync.adoc
+++ b/downstream/modules/hub/proc-basic-repo-sync.adoc
@@ -13,7 +13,7 @@ All collections in the configured remote are downloaded to your custom repositor
 +
 [NOTE]
 ====
-To limit repository synchronization to specific collections within a remote, you can identify specific collections to be pulled using a requirements.yml file. See xref:proc-create-remote_remote-management[Create a remote] for more information.
+To limit repository synchronization to specific collections within a remote, you can identify specific collections to be pulled by using a requirements.yml file. See xref:proc-create-remote_remote-management[Create a remote] for more information.
 ====
 
 [role="_additional-resources"]

--- a/downstream/modules/hub/proc-create-remote.adoc
+++ b/downstream/modules/hub/proc-create-remote.adoc
@@ -1,11 +1,11 @@
 // Module included in the following assemblies:
-// assembly-basic-remote-management.adoc
+// assembly-remote-management.adoc
 
 [id="proc-create-remote_{context}"]
 
 = Creating a remote configuration in {HubName}
 
-You can use {PlatformName} to create a remote configuration to an external collection source and sync the content from those collections to your custom repositories.
+You can use {PlatformName} to create a remote configuration to an external collection source. Then, you can sync the content from those collections to your custom repositories.
 
 .Procedure
 . Log in to {PlatformName}.
@@ -16,18 +16,18 @@ You can use {PlatformName} to create a remote configuration to an external colle
 +
 [NOTE]
 ====
-You can find the remote server URL and repository path by navigating to menu:Automation Hub[Repositories], selecting your repository, and clicking btn:[Copy CLI configuration].
+To find the remote server URL and repository path, navigate to menu:Automation Hub[Repositories], select your repository, and click btn:[Copy CLI configuration].
 ====
 +
 . Configure the credentials to the remote server by entering a *Token* or *Username* and *Password* required to access the external collection.
 +
 [NOTE]
 ====
-Generate a token from the navigation panel, by selecting menu:Collections[API token], clicking btn:[Load token] and copying the token that is loaded.
+To generate a token from the navigation panel, select menu:Collections[API token], click btn:[Load token] and copy the token that is loaded.
 ====
 +
 . To access collections from {Console}, enter the *SSO URL* to sign in to the identity provider (IdP).
-. Select or create a *YAML requirements* file to identify the collections and version ranges to synchronize with your custom repository. For example, to only download the kubernetes and AWS collection versions 5.0.0 or later the requirements file would look like this:
+. Select or create a *YAML requirements* file to identify the collections and version ranges to synchronize with your custom repository. For example, to download only the kubernetes and AWS collection versions 5.0.0 or later the requirements file would look like this:
 +
 -----
 Collections:
@@ -51,5 +51,5 @@ All collection dependencies are downloaded during the Sync process.
 +
 [NOTE]
 ====
-Some servers can have a specific rate limit set and if exceeded, synchronization will fail.
+Some servers can have a specific rate limit set, and if exceeded, synchronization fails.
 ====

--- a/downstream/modules/hub/proc-create-repository.adoc
+++ b/downstream/modules/hub/proc-create-repository.adoc
@@ -5,14 +5,14 @@
 
 = Creating a custom repository in {HubName}
 
-You can use {PlatformName} to create a repository and configure it to make it private or hide it from search results.
+When you use {PlatformName} to create a repository, you can configure the repository to be private or hide it from search results.
 
 .Procedure
 . Log in to {PlatformName}.
 . From the navigation panel, select menu:Collections[Repositories].
 . Click btn:[Add repository].
 . Enter a *Repository name*.
-. Enter a *Description* that indicates the purpose of the repository.
+. In the *Description* field, describe the purpose of the repository.
 . To retain previous versions of your repository each time you make a change, select *Retained number of versions*. The number of retained versions can range anywhere between 0 and unlimited. To save all versions, leave this set to null.
 +
 [NOTE]
@@ -20,15 +20,15 @@ You can use {PlatformName} to create a repository and configure it to make it pr
 If you have a problem with a change to your custom repository, you can xref:proc-revert-repository-version[revert to a different repository version] that you have retained.
 ====
 +
-. Select the *Pipeline* for the repository. This option defines who can publish a collection into the repository.
+. In the *Pipeline* field, select a pipeline for the repository. This option defines who can publish a collection into the repository.
 +
 Staging:: Anyone is allowed to publish automation content into the repository.
 Approved:: Collections added to this repository are required to go through the approval process by way of the staging repository. When auto approve is enabled, any collection uploaded to a staging repository is automatically promoted to all of the approved repositories.
-None:: Any user with permissions on the repository can publish to the repository directly and it is not part of the approval pipeline.
+None:: Any user with permissions on the repository can publish to the repository directly, and the repository is not part of the approval pipeline.
 +
-. Optional: To hide the repository from search results, select *Hide from search*. This is selected by default.
+. Optional: To hide the repository from search results, select *Hide from search*. This option is selected by default.
 . Optional: To make the repository private, select *Make private*. This hides the repository from anyone who does not have permissions to view the repository.
-. To sync the content from a remote into this repository, select *Remote* and select the remote that contains the collections you want included in your custom repository. For more information, see xref:proc-basic-repo-sync[Repository sync].
+. To sync the content from a remote repository into this repository, select *Remote* and select the remote that contains the collections you want included in your custom repository. For more information, see xref:proc-basic-repo-sync[Repository sync].
 . Click btn:[Save].
 
 [role="_additional-resources"]

--- a/downstream/modules/hub/proc-export-collection.adoc
+++ b/downstream/modules/hub/proc-export-collection.adoc
@@ -9,6 +9,6 @@ After collections are finalized, you can import them to a location where they ca
 
 .Procedure
 . Log in to {PlatformName}.
-. From the navigation panel, select menu:Collections[Collections]. The Collections page displays all of the collections across all of the repositories and allows you to search for a specific collection.
-. Select the collection you want to export. The collection details page is displayed.
-. From the *Installation* tab, select *Download tarball*. The tar file is downloaded to your default browser downloads folder and available to be imported to the location of your choosing.
+. From the navigation panel, select menu:Collections[Collections]. The *Collections* page displays all collections across all repositories. You can search for a specific collection.
+. Select the collection that you want to export. The collection details page opens.
+. From the *Install* tab, select *Download tarball*. The .tar file is downloaded to your default browser downloads folder. You can now import it to the location of your choosing.

--- a/downstream/modules/hub/proc-import-collection.adoc
+++ b/downstream/modules/hub/proc-import-collection.adoc
@@ -5,17 +5,17 @@
 
 = Importing an automation content collection in {HubName}
 
-As an automation content creator, you can import a collection for use in a custom repository. To use a collection in your custom repository, you must first import the collection into your namespace so the {HubName} adminstrator can approve it. 
+As an automation content creator, you can import a collection to use in a custom repository. To use a collection in your custom repository, you must first import the collection into your namespace so the {HubName} administrator can approve it. 
 
 .Procedure
 . Log in to {PlatformName}.
-. From the navigation panel, select menu:Collections[Namespaces]. The *Namepaces* page displays all of the namespaces available.
+. From the navigation panel, select menu:Collections[Namespaces]. The *Namespaces* page displays all of the namespaces available.
 . Click btn:[View Collections].
 . Click btn:[Upload Collection].
 . Navigate to the collection tarball file, select the file and click btn:[Open].
 . Click btn:[Upload].
 +
-The *My Imports* screen provides a summary of tests and notifies you whether the collection uploaded successfully or failed.
+The *My Imports* screen displays a summary of tests and notifies you if the collection upload is successful or has failed.
 +
 [NOTE]
 ====

--- a/downstream/modules/hub/proc-provide-remote-access.adoc
+++ b/downstream/modules/hub/proc-provide-remote-access.adoc
@@ -1,16 +1,16 @@
 // Module included in the following assemblies:
-// assembly-basic-remote-management.adoc
+// assembly-remote-management.adoc
 
 [id="proc-provide-remote-access_{context}"]
 
 = Providing access to a remote configuration
 
-After a remote configuration is created, you can provide access to it by doing the following.
+After you create a remote configuration, you must provide access to it before anyone can use it.
 
 .Procedure
 . Log in to {PlatformName}.
 . From the navigation panel, select menu:Collections[Remotes].
-. Locate your repository in the list and click the btn:[More Actions] icon *{MoreActionsIcon}*, then select *Edit*.
+. Locate your repository in the list, click the btn:[More Actions] icon *{MoreActionsIcon}*, and select *Edit*.
 . Select the *Access* tab.
 . Select a group for *Repository owners*. See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Configuring user access for your {PrivateHubName}] for information about implementing user access.
 . Select the appropriate roles for the selected group.

--- a/downstream/modules/hub/proc-revert-repository-version.adoc
+++ b/downstream/modules/hub/proc-revert-repository-version.adoc
@@ -5,11 +5,11 @@
 
 = Revert to a different {HubName} repository version
 
-When automation content collections are added or removed from a repository, a new version is created. If there are issues with a change to your repository, you can revert to a previous version. Reverting is a safe operation and does not delete collections from the system, but rather, changes the content associated with the repository. The number of versions saved is defined in the *Retained number of versions* setting when a xref:proc-create-repository[repository is created].
+When automation content collections are added or removed from a repository, a new version is created. If a change to your repository causes a problem, you can revert to a previous version. Reverting is a safe operation and does not delete collections from the system, but rather, changes the content associated with the repository. The number of versions saved is defined in the *Retained number of versions* setting when a xref:proc-create-repository[repository is created].
 
 .Procedure
 . Log in to {PlatformName}.
 . From the navigation panel, select menu:Collections[Repositories].
 . Locate your repository in the list and click the btn:[More Actions] icon *{MoreActionsIcon}*, then select *Edit*.
-. Locate the version you want to revert to and click the btn:[More Actions] icon *{MoreActionsIcon}*, then select *Revert to this version*.
+. Locate the version you want to revert to and click the btn:[More Actions] icon *{MoreActionsIcon}*, and select *Revert to this version*.
 . Click btn:[Revert].


### PR DESCRIPTION
This PR backports the changes from [PR 559](https://github.com/ansible/aap-docs/pull/559) to the 2.4 release. 