### PR TITLE
Assembly: Setting up the Ansible VSCode extension

### DIFF
--- a/lightspeed/assemblies/assembly_setting-up-ansible-vscode-extension.adoc
+++ b/lightspeed/assemblies/assembly_setting-up-ansible-vscode-extension.adoc
@@ -1,0 +1,35 @@
+ifdef::context[:parent-context-of-setting-up-ansible-vscode-extension: {context}]
+
+:_content-type: ASSEMBLY
+
+ifndef::context[]
+[id="setting-up-ansible-vscode-extension"]
+endif::[]
+ifdef::context[]
+[id="setting-up-ansible-vscode-extension_{context}"]
+endif::[]
+= setting-up-ansible-vscode-extension
+
+:context: setting-up-ansible-vscode-extension
+
+This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on.
+
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+* X is installed. For information about installing X, see <link>.
+* You can log in to X with administrator privileges.
+
+Include modules here.
+
+[role="_additional-resources"]
+== Additional resources (or Next steps)
+* A bulleted list of links to other closely-related material. These links can include `link:` and `xref:` macros.
+* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+
+ifdef::parent-context-of-setting-up-ansible-vscode-extension[:context: {parent-context-of-setting-up-ansible-vscode-extension}]
+ifndef::parent-context-of-setting-up-ansible-vscode-extension[:!context:]
+


### PR DESCRIPTION
This PR creates the fifth assembly titled "Setting up the Ansible VScode Extension." Filename is assembly_setting-up-ansible-vscode-extension.adoc.