### PR TITLE
Link duplicate topics in hub documentation

### DIFF
--- a/downstream/modules/hub/proc-add-user-to-group.adoc
+++ b/downstream/modules/hub/proc-add-user-to-group.adoc
@@ -6,16 +6,4 @@
 
 You can add users to groups when you create a group. But, you can also manually add users to existing groups.
 
-.Prerequisites
-
-* You have *groups* permissions and can create and manage group configuration and access in {PrivateHubName}.
-
-.Procedure
-
-. Log in to your {PrivateHubName}.
-. From the navigation panel, select menu:User Access[Groups].
-. Click on a *Group* name.
-. Navigate to the *Users* tab and click btn:[Add].
-. Select users to add from the list and click btn:[Add].
-
-You have added selected users to the group. These users now have the permissions for {PrivateHubName} that are assigned to the group.
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_automation_hub/index#proc-add-users-to-group[Adding users to existing groups] in the Getting started with automation hub guide.

--- a/downstream/modules/hub/proc-assigning-permissions.adoc
+++ b/downstream/modules/hub/proc-assigning-permissions.adoc
@@ -9,24 +9,4 @@ You can assign permissions to groups in {PrivateHubName} that enable users to ac
 
 You can add permissions when first creating a group or edit an existing group to add or remove permissions
 
-.Prerequisites
-
-* You have *Change group* permissions and can edit group permissions in {PrivateHubName}.
-
-.Procedure
-. Log in to your {PrivateHubName}.
-. From the navigation panel, select menu:User Access[Roles].
-. Click btn:[Add roles].
-. In the name field, enter the role name.
-. In the description field, enter a description.
-. Complete the *Permissions* section. For each permission type, select permissions from the list.
-. Click btn:[Save].
-. From the navigation panel, select menu:User Access[Groups].
-. Click a group name.
-. Click the *Access* tab.
-. Click btn:[Add roles].
-. Select the role saved in step 7.
-. To confirm the selected role, click btn:[Next].
-. Click btn:[Add].
-
-The group can now access features in {PrivateHubName} associated with their assigned permissions.
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_automation_hub/index#proc-assigning-permissions[Assigning permissions to groups] in the Getting started with automation hub guide.

--- a/downstream/modules/hub/proc-create-groups.adoc
+++ b/downstream/modules/hub/proc-create-groups.adoc
@@ -7,14 +7,4 @@
 You can create and assign permissions to a group in {PrivateHubName} that enables users to access specified features in the system.
 By default, the *Admin* group in the {HubName} has all permissions assigned and is available on initial login. Use the credentials created when installing {PrivateHubName}.
 
-.Prerequisites
-
-* You have *Groups* permissions and can create and manage group configuration and access in {PrivateHubName}.
-
-.Procedure
-. Log in to your {PrivateHubName} by using credentials for the *admin* user configured during installation.
-. From the navigation panel, select menu:User Access[Groups].
-. Click btn:[Create].
-. Provide a *Name* and click btn:[Create].
-
-You can now assign permissions and add users on the *Group edit* page.
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_automation_hub/index#proc-create-group[Creating a new group in private automation hub] in the Getting started with automation hub guide.


### PR DESCRIPTION
Adding links from the Managing content guide to the Getting started guide, to avoid duplication of content

[HubDocathon] Link duplicate topics from Managing content guide to the Getting started guide

https://issues.redhat.com/browse/AAP-16028

Affects `titles/hub/managing-content`