### PR TITLE
Update GalaxyNG S3 URL

### DIFF
--- a/downstream/archive/archived-modules/platform/ref-network-ports-protocols.adoc
+++ b/downstream/archive/archived-modules/platform/ref-network-ports-protocols.adoc
@@ -5,12 +5,12 @@
 
 [role="_abstract"]
 
-{PlatformName} (AAP) uses several ports to communicate with its services. These ports must be open and available for incoming connection to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
+{PlatformName} (AAP) uses several ports to communicate with its services. These ports must be open and available for incoming connections to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
 
 The following tables show the default {PlatformName} destination ports required for each application.
 
 [NOTE]
-The default destination ports and installer inventory listed below are configurable. If you choose to configure them to suit your environment, you might experience a change in behavior.
+The following default destination ports and installer inventory listed are configurable. If you choose to configure them to suit your environment, you might experience a change in behavior.
 
 
 

--- a/downstream/archive/archived-modules/platform/ref-network-ports-protocols.adoc
+++ b/downstream/archive/archived-modules/platform/ref-network-ports-protocols.adoc
@@ -5,12 +5,12 @@
 
 [role="_abstract"]
 
-{PlatformName} (AAP) uses a number of ports to communicate with its services. These ports must be open and available for incoming connection to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
+{PlatformName} (AAP) uses several ports to communicate with its services. These ports must be open and available for incoming connection to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
 
-The following tables provide the default {PlatformName} destination ports required for each application.
+The following tables show the default {PlatformName} destination ports required for each application.
 
 [NOTE]
-The default destination ports and installer inventory listed below are configurable. If you choose to configure them to suit your environment, you may experience a change in behavior.
+The default destination ports and installer inventory listed below are configurable. If you choose to configure them to suit your environment, you might experience a change in behavior.
 
 
 
@@ -73,7 +73,7 @@ Hybrid mode in a cluster
 |Receptor
 |Inbound and Outbound
 |`receptor_listener_port`
-|ALLOW receptor listener port across all controllers for mandatory & automatic control plane clustering
+|ALLOW receptor listener port across all controllers for mandatory and automatic control plane clustering
 |===
 
 .Hop Nodes
@@ -136,7 +136,7 @@ ALLOW connections from hop node(s) to Receptor port (if relayed through hop node
 |Receptor
 |Inbound and Outbound
 |`receptor_listener_port`
-a|Mesh - Nodes directly peered to controllers. Direct nodes involved. 27199 is bi-diretional for execution nodes
+a|Mesh - Nodes directly peered to controllers. Direct nodes involved. 27199 is bi-directional for execution nodes
 
 ENABLE connections from controller(s) to Receptor port for non-hop connected nodes
 
@@ -252,7 +252,7 @@ a|Open *only* if the internal database is used. Otherwise, this port should not 
 |link:https://sso.redhat.com:443[https://sso.redhat.com:443] |TCP
 |link:https://automation-hub-prd.s3.amazonaws.com[https://automation-hub-prd.s3.amazonaws.com] |
 |link:https://galaxy.ansible.com[https://galaxy.ansible.com] |Ansible Community curated Ansible content
-|link:https://ansible-galaxy.s3.amazonaws.com[https://ansible-galaxy.s3.amazonaws.com] |
+|link:https://ansible-galaxy-ng.s3.dualstack.us-east-1.amazonaws.com[https://ansible-galaxy-ng.s3.dualstack.us-east-1.amazonaws.com] |
 |link:https://registry.redhat.io:44[https://registry.redhat.io:443] |Access to container images provided by Red Hat and partners
 |link:https://cert.cloud.redhat.com:443[https://cert.cloud.redhat.com:443] |Red Hat and partner curated Ansible Collections
 |===

--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -5,17 +5,17 @@
 
 [role="_abstract"]
 
-{PlatformName} (AAP) uses a number of ports to communicate with its services. These ports must be open and available for incoming connection to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
+{PlatformName} (AAP) uses several ports to communicate with its services. These ports must be open and available for incoming connection to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
 
 The following architectural diagram is an example of a fully deployed {PlatformNameShort} with all possible components.
 
 .{PlatformNameShort} Network ports and protocols 
 image::aap-network-ports-protocols-314.png[Interaction of Ansible Automation Platform components on the network with information about the ports and protocols that are used.]
 
-The following tables provide the default {PlatformName} destination ports required for each application.
+The following tables show the default {PlatformName} destination ports required for each application.
 
 [NOTE]
-The default destination ports and installer inventory listed below are configurable. If you choose to configure them to suit your environment, you may experience a change in behavior.
+The default destination ports and installer inventory listed below are configurable. If you choose to configure them to suit your environment, you might experience a change in behavior.
 
 
 
@@ -78,7 +78,7 @@ Hybrid mode in a cluster
 |Receptor
 |Inbound and Outbound
 |`receptor_listener_port`
-|ALLOW receptor listener port across all controllers for mandatory & automatic control plane clustering
+|ALLOW receptor listener port across all controllers for mandatory and automatic control plane clustering
 |===
 
 .Hop Nodes
@@ -234,7 +234,7 @@ a|Open *only* if the internal database is used along with another component. Oth
 |link:https://sso.redhat.com:443[https://sso.redhat.com:443] |TCP
 |link:https://automation-hub-prd.s3.amazonaws.com[https://automation-hub-prd.s3.amazonaws.com] link:https://automation-hub-prd.s3.us-east-2.amazonaws.com/[https://automation-hub-prd.s3.us-east-2.amazonaws.com/]| Firewall access
 |link:https://galaxy.ansible.com[https://galaxy.ansible.com] |Ansible Community curated Ansible content
-|link:https://ansible-galaxy.s3.amazonaws.com[https://ansible-galaxy.s3.amazonaws.com] |
+|link:https://ansible-galaxy-ng.s3.dualstack.us-east-1.amazonaws.com[https://ansible-galaxy-ng.s3.dualstack.us-east-1.amazonaws.com] |
 |link:https://registry.redhat.io:44[https://registry.redhat.io:443] |Access to container images provided by Red Hat and partners
 |link:https://cert.console.redhat.com:443[https://cert.console.redhat.com:443] |Red Hat and partner curated Ansible Collections
 |===

--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 
-{PlatformName} (AAP) uses several ports to communicate with its services. These ports must be open and available for incoming connection to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
+{PlatformName} (AAP) uses several ports to communicate with its services. These ports must be open and available for incoming connections to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
 
 The following architectural diagram is an example of a fully deployed {PlatformNameShort} with all possible components.
 
@@ -15,7 +15,7 @@ image::aap-network-ports-protocols-314.png[Interaction of Ansible Automation Pla
 The following tables show the default {PlatformName} destination ports required for each application.
 
 [NOTE]
-The default destination ports and installer inventory listed below are configurable. If you choose to configure them to suit your environment, you might experience a change in behavior.
+The following default destination ports and installer inventory listed are configurable. If you choose to configure them to suit your environment, you might experience a change in behavior.
 
 
 


### PR DESCRIPTION
Update GalaxyNG S3 URL to reflect the new URL

[DDF] With the recent release of GalaxyNG, the new S3 URL is: https://ansible-galaxy-ng.s3.dualstack.us-east-1.amazonaws.com

https://issues.redhat.com/browse/AAP-16874