### PR TITLE
Assembly: Configuring RH Ansible Lightspeed to connect with IBM watsonx Code Assistant

### DIFF
--- a/lightspeed/assemblies/assembly_configure-code-assistant.adoc
+++ b/lightspeed/assemblies/assembly_configure-code-assistant.adoc
@@ -1,0 +1,20 @@
+ifdef::context[:parent-context: {context}]
+
+:_content-type: ASSEMBLY
+
+
+[id="configure-code-assistant_{context}"]
+
+= Configuring [lightspeedshortname] to connect with [ibmwatsonxcodeassistant]
+
+:context: configure-code-assistant
+
+[role="_abstract"]
+As an organization administrator, you must configure [lightspeedshortname] to connect with your [ibmwatsonxcodeassistant] instance. This configuration enables your [lightspeedshortname] instance to communicate with your [ibmwatsonxcodeassistant] instance and associated foundation models. 
+
+Include:: modules/con_wca-key-model-id.adoc[leveloffset=+1]
+Include:: modules/proc_obtain-config-wca-and-model-id.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]
+

--- a/lightspeed/modules/con_wca-key-model-id.adoc
+++ b/lightspeed/modules/con_wca-key-model-id.adoc
@@ -1,0 +1,21 @@
+:_content-type: CONCEPT
+
+[id="wca-key-model-id_{context}"]
+= About the Watsonx Code Assistant key and model ID
+
+You must have the following API keys to configure [lightspeedshortname] with [ibmwatsonxcodeassistant]:
+
+* Watsonx Code Assistant (WCA) key
++
+A WCA key is an IBM Cloud key that authenticates all requests made from [lightspeedshortname] to [ibmwatsonxcodeassistant]. Each Red Hat organization with an Ansible Lightspeed subscription must have an associated, configured WCA key. When an authenticated [RHSSOshort] user creates a request in [lightspeedshortname], the WCA key associated with the user’s Red Hat organization is used to authenticate the request to [ibmwatsonxcodeassistant]. 
+
+* Model ID
++
+A model ID enables you to leverage a foundational machine learning model from [ibmwatsonxcodeassistant] and make it available for your organization. [ibmwatsonxcodeassistant] provides multiple models that you can access based on your [lightspeedshortname] subscription, and the model that you use depends on the model ID that you configure in Ansible Lightspeed for your organization.  
++
+After a user request is authenticated using a WCA key, the request is routed to the model that is assigned for the user’s organization. Ansible Lightspeed uses this model to understand the nuances of your organization’s automation syntax and structure, and make code recommendations whenever best practices or quality improvement recommendations are available. 
+ 
+You must configure both the WCA key and the model ID when you are initially configuring Red Hat Ansible Lightspeed. If you decide to eventually connect to a custom model instead of IBM watsonx Code Assistant's default foundation model, you must configure the model ID again.
+
+
+

--- a/lightspeed/modules/proc_obtain-config-wca-and-model-id.adoc
+++ b/lightspeed/modules/proc_obtain-config-wca-and-model-id.adoc
@@ -1,0 +1,31 @@
+:_content-type: PROCEDURE
+
+[id="obtain-config-wca-and-model-id_{context}"]
+= Obtain and configure the WCA key and model ID from [ibmwatsonxcodeassistant]
+
+== Obtain the WCA key and model ID
+Obtain the WCA key and model ID of your model from [ibmwatsonxcodeassistant]t, which you can use later to authenticate and connect your instance of [ibmwatsonxcodeassistant] with [lightspeedshortname]. 
+
+For information on how to obtain a WCA key and model ID in IBM watsonx Code Assistant, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[IBM watsonx Code Assistant documentation]. 
+
+== Configure the WCA key and model ID in the Ansible Lightspeed administrator portal
+Use the WCA key and model ID that you obtained from [ibmwatsonxcodeassistant], and add these in Ansible Lightspeed administrator portal. [lightspeedshortname] uses the WCA key to authenticate your user requests to [ibmwatsonxcodeassistant], and routes the user requests to the foundation model associated with the user’s organization.
+
+.Procedure
+
+. Log in to the Ansible Lightspeed administrator portal as the organization administrator.
+. Specify the WCA key of your [ibmwatsonxcodeassistant] instance:
+.. Under *IBM Cloud API Key*, click *Add API key*. A screen to enter the API Key is displayed. 
+.. Enter the API Key for WCA that you obtained in the previous procedure.
+.. Click *Save*.
+.. Optional: Click *Test* to validate the WCA key.
+. Specify the model ID of the model that you want to use:
+.. Click *Model Settings*. 
+.. Under *Model ID*, click *Add Model ID*. A screen to enter the *Model Id* is displayed.
+.. Enter the *Model ID* that you obtained in the previous procedure as the default model for your organization.
+.. Click *Save*. 
+.. Optional: Click *Test model ID* to validate the model ID. 
++
+When the WCA key and model ID is successfully validated, [lightspeedshortname] is connected with your [ibmwatsonxcodeassistant] instance.  
+
+


### PR DESCRIPTION
Creates the assembly titled Configuring RH Ansible Lightspeed to connect with IBM watsonx Code Assistant. Filename is assembly_configure-code-assistant.adoc.

Also creates a concept module to go in this assembly called About the Watsonx Code Assistant key and model ID. Filename is con_wca-key-model-id.adoc. 

Also creates a procedure module to go in this assembly called Obtain and Configure the WCA key and model ID from IBM watsonx code assistant. Filename is proc_obtain-config-wca-and-model-id.adoc.