### PR TITLE
Break out code blocks for easier copying of config details

### DIFF
--- a/downstream/modules/platform/proc-using-postinstall.adoc
+++ b/downstream/modules/platform/proc-using-postinstall.adoc
@@ -16,30 +16,33 @@ controller_postinstall=true
 ----
 +
 
-. The default is false, so this must be enabled to activate the postinstaller. An {PlatformNameShort} license is required for this feature and must reside on the local filesystem so it can be automatically loaded:
+. The default is false, so you need to enable this to activate the postinstaller. You need a {PlatformNameShort} license for this feature that must reside on the local filesystem so it can be automatically loaded:
 +
 ----
 controller_license_file=/full_path_to/manifest_file.zip
 ----
 +
 
-. You can pull your configuration-as-code from a Git based repo. To do this, set the following variables to dictate where you pull the content from and where it will be stored for upload to the {PlatformNameShort} controller:
+. You can pull your configuration-as-code from a Git based repository. To do this, set the following variables to dictate where you pull the content from and where to store it for upload to the {PlatformNameShort} controller:
 +
 ----
 controller_postinstall_repo_url=https://your_cac_scm_repo
 controller_postinstall_dir=/full_path_to_where_you_want_the pulled_content_to_reside
 ----
 
-Definition files use the link:https://console.redhat.com/ansible/automation-hub/namespaces/infra/[infra certified collections]. The link:https://console.redhat.com/ansible/automation-hub/repo/validated/infra/controller_configuration/[controller_configuration] collection is preloaded as part of the installation and use the installation controller credentials you supply in the inventory file for access into the {PlatformNameShort} controller, so you simply need to provide the YAML configuration files. You can setup {PlatformNameShort} configuration attributes such as credentials, LDAP settings, users/teams, organizations, projects, inventory/hosts, job and workflow templates.
+Definition files use the link:https://console.redhat.com/ansible/automation-hub/namespaces/infra/[infra certified collections]. The link:https://console.redhat.com/ansible/automation-hub/repo/validated/infra/controller_configuration/[controller_configuration] collection is preinstalled as part of the installation and uses the installation controller credentials you supply in the inventory file for access into the {PlatformNameShort} controller. You simply need to give the YAML configuration files. 
 
-The following example shows a sample *your-config.yml* file defining and loading controller job templates. The example demonstrates a simple change to the preloaded demo example provided with an AAP installation.
+You can setup {PlatformNameShort} configuration attributes such as credentials, LDAP settings, users and teams, organizations, projects, inventories and hosts, job and workflow templates.
+
+The following example shows a sample *your-config.yml* file defining and loading controller job templates. The example demonstrates a simple change to the preloaded demo example provided with an {PlatformNameShort} installation.
 
 ----
 /full_path_to_your_configuration_as_code/
 ├── controller
     	└── job_templates.yml
+----
 
----
+----
 controller_templates:
  - name: Demo Job Template
    execution_environment: Default execution environment


### PR DESCRIPTION
Separate one code block into two to make it easier to copy relevant information

[DDF] This should be a separate code block so you can actually copy paste it in your terminal.

https://issues.redhat.com/browse/AAP-16743