### PR TITLE
Updates master.adocs so they will build

### DIFF
--- a/lightspeed/titles/lightspeed-release-notes/master.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/master.adoc
@@ -6,8 +6,6 @@
 
 include::attributes/attributes.adoc[]
 
+= {LightspeedFullName} Release Notes
 
-// Book Title
-= Red Hat Ansible Lightspeed with IBM watsonx Code Assistant Release Notes
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::platform/assembly-lightspeed-intro.adoc[leveloffset=+1]

--- a/lightspeed/titles/lightspeed-user-guide/master.adoc
+++ b/lightspeed/titles/lightspeed-user-guide/master.adoc
@@ -17,5 +17,4 @@ include::assemblies/assembly_configure-code-assistant.adoc[leveloffset=+1]
 include::assemblies/assembly_assigning-seat-licenses.adoc[leveloffset=+1]
 include::assemblies/assembly_logging-in-out-portal.adoc[leveloffset=+1]
 include::assemblies/assembly_configuring-vscode-extension.adoc[leveloffset=+1]
-include::assemblies/assembly_using-code-bot-for-suggestions.adoc[leveloffset=+1]
-include::assemblies/assembly_requesting-task-recommendations.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Removes intro assembly from release notes master.adoc
Removes empty assemblies from user guide master.adoc

We will add back the assemblies when they are ready. 