### PR TITLE
Add bundle errata releases to 2.4 release notes (#578)

### DIFF
--- a/downstream/titles/release-notes/attributes
+++ b/downstream/titles/release-notes/attributes
@@ -1,0 +1,1 @@
+../../attributes

--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -1,16 +1,18 @@
 // Templates for release notes are contained in the ..downstream/snippets folder.
 // For each release, make a copy of assembly-rn-template.adoc, rename and save as instructed in the template and add an include statement to this file.
+include::attributes/attributes.adoc[]
 
-= Red Hat Ansible Automation Platform Release Notes
+= {PlatformName} Release Notes
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+
 include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
 
 include::topics/platform-intro.adoc[leveloffset=+1]
 
 [[anchor-aap_2.4-release]]
-== Red Hat Ansible Automation Platform 2.4
-This release includes a number of enhancements, additions, and fixes that have been implemented in the Red Hat Ansible Automation Platform.
+== {PlatformName} 2.4
+This release includes several enhancements, additions, and fixes that have been implemented in the {PlatformName}.
 
 include::topics/aap-24.adoc[leveloffset=+2]
 
@@ -23,3 +25,13 @@ include::topics/eda-24.adoc[leveloffset=+2]
 include::topics/operator-240.adoc[leveloffset=+2]
 
 include::topics/docs-24.adoc[leveloffset=+2]
+
+include::topics/errata-24-sep-24.adoc[leveloffset=+2]
+
+include::topics/errata-24-sep-12.adoc[leveloffset=+2]
+
+include::topics/errata-24-aug-28.adoc[leveloffset=+2]
+
+include::topics/errata-24-aug-10.adoc[leveloffset=+2]
+
+include::topics/errata-24-jul-26.adoc[leveloffset=+2]

--- a/downstream/titles/release-notes/topics/aap-24.adoc
+++ b/downstream/titles/release-notes/topics/aap-24.adoc
@@ -3,24 +3,24 @@
 //Only include release note types that have updates for a given release. For example, if there are no Technology previews for the release, remove that section from this file.
 
 
-= Ansible Automation Platform 2.4
+= {PlatformNameShort} 2.4
 
-Red Hat Ansible Automation Platform simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across multiple IT domains including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, Red Hat Ansible Automation Platform provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
+{PlatformName} simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. It works across many IT domains including operations, networking, security, development, and across diverse hybrid environments. Simple to adopt, use, and understand, {PlatformName} provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
 
 == New features and enhancements
 
-This release of Ansible Automation Platform features the following enhancements:
+This release of {PlatformNameShort} features the following enhancements:
 
-* Previously, the Execution Environment container images were based on RHEL 8 only. With Ansible Automation Platform 2.4 onwards, the Execution Environment container images are now also available on RHEL 9. 
-The Execution Environment includes the following container images:
+* Before this update, the {ExecEnvShort} container images were based on RHEL 8 only. With {PlatformNameShort} 2.4 onwards, the {ExecEnvShort} container images are now also available on RHEL 9. 
+The {ExecEnvShort} includes the following container images:
 ** ansible-python-base
 ** ansible-python-toolkit
 ** ansible-builder
 ** ee-minimal
 ** ee-supported
 
-* The ansible-builder project recently released Ansible Builder version 3, a much-improved and simplified approach to creating execution environments. 
-You can use the following configuration YAML keys with Ansible Builder version 3:
+* The ansible-builder project recently released {Builder} version 3, a much-improved and simplified approach to creating execution environments. 
+You can use the following configuration YAML keys with {Builder} version 3:
 ** additional_build_files
 ** additional_build_steps
 ** build_arg_defaults
@@ -29,45 +29,44 @@ You can use the following configuration YAML keys with Ansible Builder version 3
 ** options
 ** version
 
-For more information about using Ansible Builder version 3, see 
+For more information about using {Builder} version 3, see 
 link:https://ansible.readthedocs.io/projects/builder/en/stable/[Ansible Builder Documentation] and link:https://docs.ansible.com/automation-controller/latest/html/userguide/ee_reference.html[Execution Environment Setup Reference].
 
-* Ansible Automation Platform 2.4 and later versions can now be run on ARM platforms, including both the control plane and the execution environments.
+* {PlatformNameShort} 2.4 and later versions can now be run on ARM platforms, including both the control plane and the execution environments.
 
-* Added an option to configure SSO logout URL for automation hub.
+* Added an option to configure the SSO logout URL for {HubName} if you need to change it from the default value.
 
 * Updated the ansible-lint RPM package to version 6.14.3.
 
-* Updated django for potential denial-of-service vulnerability in file uploads (CVE-2023-24580).
+* Updated Django for potential denial-of-service vulnerability in file uploads (CVE-2023-24580).
 
 * Updated sqlparse for ReDOS vulnerability (CVE-2023-30608).
 
-* Updated django for potential denial-of-service in Accept-Language headers (CVE-2023-23969).
-
+* Updated Django for potential denial-of-service in Accept-Language headers (CVE-2023-23969).
 
 == Deprecated and removed features
 
-Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in Ansible Automation Platform and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. 
+Some features available in earlier releases have been deprecated or removed. Deprecated functionality is still included in {PlatformNameShort} and continues to be supported. However, it will be removed in a future release of this product and is not recommended for new deployments. 
 
-The following is a list of major functionality deprecated and removed within Ansible Automation Platform 2.4:
+The following is a list of major functionality deprecated and removed within {PlatformNameShort} 2.4:
 
-* On-premise component Automation Services Catalog is now removed from Ansible Automation Platform 2.4 onwards.
+* On-premise component {CatalogName} is now removed from {PlatformNameShort} 2.4 onwards.
 
-* With the Ansible Automation Platform 2.4 release, the Execution Environment container image for Ansible 2.9 (*ee-29-rhel-8*) is no longer loaded into the Automation Controller configuration by default.
+* With the {PlatformNameShort} 2.4 release, the {ExecEnvShort} container image for Ansible 2.9 (*ee-29-rhel-8*) is no longer loaded into the Automation Controller configuration by default.
 
-* Although you can still synchronize content, the use of synclists is deprecated and will be removed in a later release. Instead, private automation hub administrators can upload manually-created requirements files from the `rh-certified` remote.
+* Although you can still synchronize content, the use of synclists is deprecated and will be removed in a later release. Instead, {PrivateHubName} administrators can upload manually-created requirements files from the `rh-certified` remote.
 
-* You can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter.  This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
+* You can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter. This change is compatible with earlier versions, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
 
 * Smart inventories have been deprecated in favor of constructed inventories and will be removed in a future release.
 
 == Bug fixes
 
-The following bugs were fixed in this release of Ansible Automation Platform:
+The following bugs were fixed in this release of {PlatformNameShort}:
 
-* Installer now ensures that collection auto signing cannot be enabled without enabling the collection signing service.
+* The installer now ensures that collection auto signing cannot be enabled without enabling the collection signing service.
 
-* Fixed an issue with restoring backups when the installed automation controller version is different from the backup version.
+* Fixed an issue with restoring backups when the installed {ControllerName} version is different from the backup version.
 
 * Fixed an issue with not adding user defined galaxy-importer settings to `galaxy-importer.cfg` file.
 
@@ -77,31 +76,31 @@ The following bugs were fixed in this release of Ansible Automation Platform:
 
 * Updated the `outdated base_packages.txt` file that is included in the bundle installer.
 
-* Fixed an issue where upgrading the Ansible Automation Platform did not update the nginx package by default.
+* Fixed an issue where upgrading the {PlatformNameShort} did not update the nginx package by default.
 
 * Fixed an issue where an *awx* user was created without creating an *awx* group on execution nodes.
 
 * Fixed the assignment of package version variable to work with flat file inventories. 
 
-* Added a FQDN check for the automation hub hostname required to run the Skopeo commands.
+* Added a FQDN check for the {HubName} hostname required to run the Skopeo commands.
 
 * Fixed an issue such that the front end URL for Red Hat Single Sign On (SSO) is now properly configured after you specify the `sso_redirect_host` variable.
 
 * Fixed the variable precedence for all component `nginx_tls_files_remote` variables.
 
-* Fixed the *setup.sh* script to escalate privileges if necessary for installing Ansible Automation Platform. 
+* Fixed the *setup.sh* script to escalate privileges if necessary for installing {PlatformNameShort}. 
 
-* Fixed an issue when restoring a backup to an automation hub with a different hostname.
+* Fixed an issue when restoring a backup to an {HubName} with a different hostname.
 
 == Technology Preview
 
-Some features in this release are currently classified as Technology Preview. Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. Please note that Red Hat does not recommend using technology preview features for production, and Red Hat SLAs do not support technology preview functions.
+Some features in this release are currently classified as Technology Preview. Technology Preview features offer early access to upcoming product features, enabling customers to test functionality and give feedback during the development process. Note that Red Hat does not recommend using Technology Preview features for production, and Red Hat SLAs do not support Technology Preview functions.
 
-Following are the technology preview features: 
+The following are Technology Preview features: 
 
-* Ansible Automation Platform 2.4 adds the ability to install the automation controller for IBM Power (ppc64le), IBM Z (s390x), and IBM(R) LinuxONE (s390x) architectures.
+* {PlatformNameShort} 2.4 adds the ability to install the {ControllerName} for IBM Power (ppc64le), IBM Z (s390x), and IBM(R) LinuxONE (s390x) architectures.
 
-* Starting with Ansible Automation Platform 2.4, the Platform Resource Operator can be used to create the following resources in automation controller by applying YAML to your OpenShift cluster:
+* Starting with {PlatformNameShort} 2.4, the Platform Resource Operator can be used to create the following resources in {ControllerName} by applying YAML to your OpenShift cluster:
 ** Inventories
 ** Projects
 ** Instance Groups
@@ -110,14 +109,14 @@ Following are the technology preview features:
 ** Workflow Job Templates
 ** Launch Workflows
 
-One notable change is that you can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter. This change is backwards compatible, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
+One notable change is that you can now configure the Controller Access Token for each resource with the `connection_secret` parameter, rather than the old `tower_auth_secret` parameter. This change is compatible with earlier versions, but the `tower_auth_secret` parameter is now deprecated and will be removed in a future release.
 
 [role="_additional-resources"]
 .Additional resources
 
-* For the most recent list of technology preview features, see link:https://access.redhat.com/articles/ansible-automation-platform-preview-features[Ansible Automation Platform - Preview Features].
+* For the most recent list of Technology Preview features, see link:https://access.redhat.com/articles/ansible-automation-platform-preview-features[Ansible Automation Platform - Preview Features].
 
-* For more information about support for technology preview features, see link:https://access.redhat.com/support/offerings/techpreview[Red Hat Technology Preview Features Support Scope].
+* For more information about support for Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[Red Hat Technology Preview Features Support Scope].
 
 * For information regarding execution node enhancements on OpenShift deployments, see link:https://docs.ansible.com/automation-controller/latest/html/administration/instances.html[Managing Capacity With Instances].
 

--- a/downstream/titles/release-notes/topics/controller-440.adoc
+++ b/downstream/titles/release-notes/topics/controller-440.adoc
@@ -1,12 +1,8 @@
 // This is the release notes for Automation Controller 4.4, the version number is removed from the topic title as part of the release notes restructuring efforts.
 
 [[controller-440-intro]]
-= Automation Controller
+= {ControllerNameStart}
 
-Automation controller replaces Ansible Tower.
-Automation controller introduces a distributed, modular architecture with a decoupled control and execution plane.
-The name change reflects these enhancements and the overall position within the Ansible Automation Platform suite.
-
-Automation controller provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
+{ControllerNameStart} provides a standardized way to define, operate and delegate automation across the enterprise. It also introduces new, exciting technologies and an enhanced architecture that enables automation teams to scale and deliver automation rapidly to meet ever-growing business demand.
 
 See link:https://docs.ansible.com/automation-controller/latest/html/release-notes/relnotes.html#release-notes-for-4-x[Automation Controller Release Notes for 4.x] for a full list of new features and enhancements.

--- a/downstream/titles/release-notes/topics/docs-24.adoc
+++ b/downstream/titles/release-notes/topics/docs-24.adoc
@@ -1,33 +1,33 @@
 // This is the release notes for AAP 2.4 documentation, the version number is removed from the topic title as part of the release notes restructuring efforts.
 
 [[docs-2.4-intro]]
-= Ansible Automation Platform Documentation
+= {PlatformNameShort} Documentation
 
-The documentation set for Red Hat Ansible Automation Platform 2.4 has had significant updates to improve the experience for our customers and the Ansible community.
+The documentation set for {PlatformName} 2.4 has had significant updates to improve the experience for our customers and the Ansible community.
 
-.Enhancements
+.New features and enhancements
 
-* With the removal of the on-premise component Automation Services Catalog from Ansible Automation Platform 2.4 onwards, all Automation Services Catalog documentation is removed from the Ansible Automation Platform 2.4 documentation.
+* With the removal of the on-premise component {CatalogName} from {PlatformNameShort} 2.4 onwards, all {CatalogName} documentation is removed from the {PlatformNameShort} 2.4 documentation.
 
-* The following documents are created to help you install and use Event-Driven Ansible, the newest capability of Ansible Automation Platform:
+* The following documents are created to help you install and use {EDAName}, the newest capability of {PlatformNameShort}:
 
 ** link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/getting_started_with_event-driven_ansible_guide/index[Getting Started with Event-Driven Ansible]
 
 ** link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/event-driven_ansible_controller_user_guide/index[Event Driven Ansible User Guide]
 
 In addition, sections of the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/index[Ansible Automation Platform Planning Guide]
-and the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide] are updated to include instructions for planning and installing Event-Driven Ansible.
+and the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide] are updated to include instructions for planning and installing {EDAName}.
 
-* The automation hub documentation has had significant reorganization to combine the content spread across 9 separate documents into the following documents:
+* The {HubName} documentation has had significant reorganization to combine the content spread across 9 separate documents into the following documents:
 
 _Getting started with automation hub_::
-Use this guide to perform the initial steps required to use Red Hat automation hub as the default source for Ansible collections content.
+Use this guide to perform the initial steps required to use Red Hat {HubName} as the default source for Ansible collections content.
 
 _Managing content with automation hub_::
-Use this guide to understand how to create and manage collections, content and repositories in automation hub.
+Use this guide to understand how to create and manage collections, content and repositories in {HubName}.
 
 _Red Hat Ansible Automation Platform Installation Guide_::
-Use this guide to learn how to install Ansible Automation Platform based on supported installation scenarios.
+Use this guide to learn how to install {PlatformNameShort} based on supported installation scenarios.
 
 * The name of the _Managing Red Hat Certified and Ansible Galaxy collections in automation hub Guide_ has changed to include validated content and is now _Managing Red Hat Certified, validated, and Ansible Galaxy content in automation hub_.
 +
@@ -36,9 +36,9 @@ Use this guide to learn how to install Ansible Automation Platform based on supp
 This content has been moved to the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/managing_content_in_automation_hub/index#managing-cert-valid-content[Managing Red Hat Certified, validated, and Ansible Galaxy content in automation hub] topic in the _Managing content with automation hub_ guide.
 ====
 
-* The Ansible Automation Platform 2.4 Release Notes are restructured to improve the experience for our customers and the Ansible Community. Users can now view the latest updates based on the Ansible Automation Platform versions, instead of their release timeline.
+* The {PlatformNameShort} 2.4 Release Notes are restructured to improve the experience for our customers and the Ansible Community. Users can now view the latest updates based on the {PlatformNameShort} versions, instead of their release timeline.
 
-* The document link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/managing_repositories_in_automation_hub/index[Managing repositories in automation hub] is created to help you create and manage custom repositories in automation hub.
+* The document link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/managing_repositories_in_automation_hub/index[Managing repositories in automation hub] is created to help you create and manage custom repositories in {HubName}.
 +
 [NOTE]
 ====

--- a/downstream/titles/release-notes/topics/eda-24.adoc
+++ b/downstream/titles/release-notes/topics/eda-24.adoc
@@ -1,11 +1,11 @@
 // This is the release notes for Event-Driven Ansible 1.0 for AAP 2.4 release, the version number is removed from the topic title as part of the release notes restructuring efforts.
 
 [[eda-24-intro]]
-= Event-Driven Ansible
+= {EDAName}
 
-Event-Driven Ansible is the newest capability of Ansible Automation Platform that is designed to enable automated response with user-defined, rules-based workflows. Event-Driven Ansible works by receiving events from third party tools, deciding on the actions to take, and acting automatically.
+{EDAName} is the newest capability of {PlatformNameShort} that is designed to enable automated response with user-defined, rules-based workflows. {EDAName} works by receiving events from third party tools, deciding on the actions to take, and acting automatically.
 
-Event-Driven Ansible is included in Ansible Automation Platform, making the platform even more capable as a single enterprise automation solution. Using Event-Driven Ansible, domain experts can easily create end-to-end fully automated OpsAsCode scenarios for a broad array of use cases across the IT landscape. By eliminating high-volume routine tasks and automatically responding to changing conditions, teams are free to innovate more efficiently, and act consistently and accurately at scale.
+{EDAName} is included in {PlatformNameShort}, making the platform even more capable as a single enterprise automation solution. Using {EDAName}, domain experts can easily create end-to-end fully automated Ops As Code scenarios for a broad array of use cases across the IT landscape. By eliminating high-volume routine tasks and automatically responding to changing conditions, teams are free to innovate more efficiently, and act consistently and accurately at scale.
 
 .Known issues
 
@@ -17,11 +17,11 @@ Event-Driven Ansible is included in Ansible Automation Platform, making the plat
 
 * The onboarding wizard does not request a controller token creation.
 
-* Users cannot filter through a list of tokens under the Controller Token tab. 
+* Users cannot filter through a list of tokens under the *Controller Token* tab. 
 
 * Only the users with administrator rights can set or modify their passwords. 
 
-* In the event of a failure, an activation with restart policy set to `Always` is unable to restart the failed activation. 
+* If there is a failure, an activation with restart policy set to `Always` is unable to restart the failed activation. 
 
 * Disabling and enabling an activation causes the restart count to increase by one count. This behavior results in an incorrect `restart` count. 
 
@@ -29,7 +29,7 @@ Event-Driven Ansible is included in Ansible Automation Platform, making the plat
 
 * Podman pods must be executed with memory limits.
 
-* Long running activations with loads of events can cause out of disk space issue.
+* Long running activations with loads of events can cause an out of disk space issue.
 
 * Users can add multiple tokens even when only the first AWX token is used. 
 
@@ -45,15 +45,15 @@ Event-Driven Ansible is included in Ansible Automation Platform, making the plat
 
 * An incorrect status is reported for activations that are disabled or enabled. 
 
-* If the *run_job_template* action fails, the rule is not counted as executed. 
+* If the `run_job_template` action fails, the rule is not counted as executed. 
 
 * RHEL 9.2 activations cannot connect to the host.
 
 * When there are more activations than available workers, disabling the activations incorrectly shows them in running state. 
 
-* Event-Driven Ansible activation pods are running out of memory on RHEL 9.
+* {EDAName} activation pods are running out of memory on RHEL 9.
 
-* Restarting the Event-Driven Ansible server can cause activation states to become stale.
+* Restarting the {EDAName} server can cause activation states to become stale.
 
 * Bulk deletion of rulebook activation lists is not consistent, and the deletion can be either successful or unsuccessful.
 

--- a/downstream/titles/release-notes/topics/errata-24-aug-10.adoc
+++ b/downstream/titles/release-notes/topics/errata-24-aug-10.adoc
@@ -1,0 +1,101 @@
+// This is the release notes file for AAP 2.4 errata bundle dated August 10 2023.
+
+= {PlatformNameShort} 2.4 - August 10, 2023
+
+link:https://access.redhat.com/errata/RHBA-2023:4621[Red Hat Errata Release]
+
+== {ControllerNameStart}
+
+.New features and enhancements
+
+* automation-controller has been updated to 4.4.1.
+
+.Security fixes
+
+* automation controller: Html injection in custom login info (CVE-2023-3971)
+
+.Bug fixes
+
+* Organization admin users are no longer shown an error on the Instances list.
+
+* Fixed the workflow job within workflow approval to display the correct details.
+
+* Credential name search in the ad hoc commands prompt no longer requires case-sensitive input.
+
+* The *Back to list* button in the controller UI now maintains previous search filters.
+
+* *Topology view* and *Instances* are only available as sidebar menu options to System Administrators and System Auditors.
+
+* Fixed the frequency of the scheduler to run on the correct day of the week as specified by the user.
+
+* Fixed an issue with slow database UPDATE statements when using nested tasks (include_tasks) causing task manager timeout.
+
+* Added a setting to enable the queuing for Rsyslog to handle higher work volumes (`LOG_AGGREGATOR_ACTION_MAX_DISK_USAGE_GB`).
+
+* Added the ability to add execution and hop nodes to VM-based controller installations from the UI.
+
+* Added the `awx-manage` command for creating future events table partitions.
+
+* Re-enabled Pendo support by providing the correct Pendo API key.
+
+* Added the ability to filter teams by using partial names in the dialog for granting teams access to a resource.
+
+* Fixed a bug where a weekly rrule string without a BYDAY value would result in the UI throwing a TypeError.
+
+* Fixed a server error that happened when deleting workflow jobs ran before event partitioning migration.
+
+* Added API reference documentation for the new bulk API endpoint.
+
+* Fixed a bug where forms provided in the custom login information would render and run.
+
+* Fixed an issue where related items were not visible in some cases. For example, job template instance groups, organization galaxy credentials, and organization instance groups.
+
+== {EDAName}
+
+.New features and enhancements
+
+* ansible-rulebook has been updated to 1.0.1.
+
+.Bug fixes
+
+* Fixed an issue where the `rule_run_at` field was not sent to the websocket.
+
+* Do not try to connect with AWX when the no `run_job_template` action is used.
+
+* The number of simultaneously open connections to controller is now limited to 30.
+
+== {HubNameStart}
+
+.New features and enhancements
+
+* automation-hub has been updated to 4.7.1-2.
+
+.Bug fixes
+
+* Fixed issue with using gpg key with passphrase for signing services.
+
+== Automation Platform Operator
+
+.New features and enhancements
+
+* automation-controller 4.4.1 RPM updates.
+
+* Added support for scaling {ControllerName} down to replicas 0 for maintenance.
+
+* Added the ability to provision Mesh and Execution nodes in limited network connectivity environments.
+
+== Creator Tools
+
+.New features and enhancements
+
+* ansible-navigator has been updated to 3.4.1.
+
+.Bug fixes
+
+* Removed the `introspect` script from `image_manager` directory.
+
+* Fixed image introspect for long python metadata.
+
+* Fixed logging dependencies.
+
+* Fixed collections in `stdout` mode.

--- a/downstream/titles/release-notes/topics/errata-24-aug-28.adoc
+++ b/downstream/titles/release-notes/topics/errata-24-aug-28.adoc
@@ -1,0 +1,105 @@
+// This is the release notes file for AAP 2.4 errata bundle dated August 28 2023.
+
+= {PlatformNameShort} 2.4 - August 28, 2023
+
+link:https://access.redhat.com/errata/RHBA-2023:4782[Red Hat Errata Release]
+
+== {ControllerNameStart}
+
+.New features and enhancements
+
+* automation-controller has been updated to 4.4.2.
+
+.Security fixes
+
+* automation-controller: python-django: Potential regular expression denial of service vulnerability in EmailValidator/URLValidator (CVE-2023-36053)
+
+* automation-controller: python-django: Potential denial-of-service vulnerability in file uploads (CVE-2023-24580)
+
+.Bug fixes
+
+* Changing credential types by using the drop-down list in the *Launch prompt* window no longer causes the screen to disappear.
+
+* Upgraded python dependencies which include upgrades from Django 3.2 to 4.2.3, psycopg2 to psycopg3, and additional libraries as needed. Also added a new setting in the UI exposing the `CSRF_TRUSTED_ORIGIN` settings.
+
+* Fixed slow database UPDATE statements on the job events table which could cause a task manager timeout.
+
+* Fixed an issue where adding a new label to a job through the *Prompt On Launch* option would not add the label to the job details.
+
+* Added `noopener` and `noreferrer` attributes to controller UI links that were missing these attributes.
+
+* Fixed the broken *User Guide* link in the *Edit Subscription Details* page.
+
+* Turned off auto-complete on the remaining controller UI forms that were missing that attribute.
+
+* The *Add* button on the credentials page is now accessible for users with the correct permissions.
+
+* Fixed an unexpected error that occurred when adding a new host while using a manifest with size 10.
+
+* Fixed the Trial toggle when using a manifest file.
+
+* Applied environment variables from the `AWX_TASK_ENV` setting when running credential lookup plugins.
+
+* Interrupted jobs (such as canceled jobs) no longer clear facts from hosts if the job ran on an execution node.
+
+* Using a license that is missing a `usage` attribute no longer returns a 400 error.
+
+* Fixed sub-keys under `data` from HashiCorp Vault Secret Lookup responses to check for secrets, if found.
+
+* Fixed Ansible facts to retry saving to hosts if there is a database deadlock.
+
+== {EDAName}
+
+.New features and enhancements
+
+* automation-eda-controller has been updated to 1.0.1.
+
+.Security fixes
+
+* automation-eda-controller: token exposed at importing project (CVE-2023-4380)
+
+* python3-cryptography/python39-cryptography: memory corruption via immutable objects (CVE-2023-23931)
+
+* python3-django/python39-django: Potential regular expression denial of service vulnerability in EmailValidator/URLValidator (CVE-2023-36053)
+
+* python3-requests/python39-requests: Unintended leak of Proxy-Authorization header (CVE-2023-32681)
+
+.Bug fixes
+
+* Contributor and editor roles now have permissions to access users and set the AWX token.
+
+* The onboarding wizard now requests controller token creation.
+
+* Corrected the filtering capability of the *Rule Audit* screens so that a search yields results with the `starts with` function.
+
+* Enabling or disabling rulebook activation no longer increases the restarts counter by 1.
+
+* Filtering by a text string now displays all applicable items in the UI, including those that are not visible in the list at that time.
+
+* Audit records are no longer missing when running activations with multiple jobs.
+
+* The event payload is no longer missing key attributes when a job template fails.
+
+* Fixed the Git token leak that occurs when importing a project fails.
+
+* The restart policy in Kubernetes (k8s) now restarts a successful activation that is incorrectly marked as failed.
+
+* Activation statuses are now reported correctly, whether you are disabling or enabling them.
+
+* When the `run_job_template` action fails, ansible-rulebook prints an error log in the activation output and creates an entry in rule audit so the user is alerted that the rule has failed.
+
+* When a user tries to bulk delete rulebook activations from the list, the request now completes successfully and consistently.
+
+* The *Rulebook Activation* link now functions correctly in the *Rule Audit Detail* UI.
+
+* The ansible-rulebook now only connects to the controller if the rulebook being processed has a `run_job_template` action.
+
+* Fixed a bug where some audit rule records had the wrong rulebook link.
+
+* Fixed a bug where only the first 10 audit rules had the right link.
+
+* Before this update, project credentials could not be updated if there was a change to the credential used in the project. With this update credentials can be updated in a project with a new or different credential.
+
+* The *User Access* section of the navigation panel no longer disappears after creating a decision environment.
+
+* Fixed a bug where filtering for audit rules did not work properly on {OCPShort}.

--- a/downstream/titles/release-notes/topics/errata-24-jul-26.adoc
+++ b/downstream/titles/release-notes/topics/errata-24-jul-26.adoc
@@ -1,0 +1,35 @@
+// This is the release notes file for AAP 2.4 errata bundle dated July 26 2023.
+
+= {PlatformNameShort} 2.4 - July 26, 2023
+
+link:https://access.redhat.com/errata/RHBA-2023:4288[Red Hat Errata Release]
+
+== {PlatformNameShort}
+
+.New features and enhancements
+
+* Initial release of aap-metrics-utility.
+
+.Bug fixes
+
+* Fixed file permissions in setup bundle.
+
+== {HubNameStart}
+
+.New features and enhancements
+
+* automation-hub has been updated to 4.7.1-2.
+
+.Bug fixes
+
+* Fixed issue using gpg key with passphrase for signing services.
+
+== Automation Platform Operator
+
+.Bug fixes
+
+* Resolved an issue where the Hub Operator Ansible signing key was not mounted in the hub worker container.
+
+* Updated the `ansible.eda` collection to 1.4.2 in `de-supported` container image.
+
+* Updated `automation-hub` 4.7.1-2 to add the pinentry dependency for signing collections with a passphrase.

--- a/downstream/titles/release-notes/topics/errata-24-sep-12.adoc
+++ b/downstream/titles/release-notes/topics/errata-24-sep-12.adoc
@@ -1,0 +1,25 @@
+// This is the release notes file for AAP 2.4 errata bundle dated September 12 2023.
+
+= {PlatformNameShort} 2.4 - September 12, 2023
+
+link:https://access.redhat.com/errata/RHBA-2023:5140[Red Hat Errata Release]
+
+== {ControllerNameStart}
+
+.New features and enhancements
+
+* automation-controller has been updated to 4.4.3.
+
+.Security fixes
+
+* automation-controller: cryptography: memory corruption via immutable objects (CVE-2023-23931)
+
+* automation-controller: GitPython: Insecure non-multi options in clone and clone_from is not blocked (CVE-2023-40267)
+
+* python3-gitpython/python39-gitpython: Insecure non-multi options in clone and clone_from is not blocked (CVE-2023-40267)
+
+.Bug fixes
+
+* Fixed a bug that caused a deadlock on shutdown when Redis was unavailable.
+
+* The login form no longer supports autocomplete on the password field due to security concerns.

--- a/downstream/titles/release-notes/topics/errata-24-sep-24.adoc
+++ b/downstream/titles/release-notes/topics/errata-24-sep-24.adoc
@@ -1,0 +1,111 @@
+// This is the release notes file for AAP 2.4 errata bundle dated September 24 2023.
+
+= {PlatformNameShort} 2.4 - September 25, 2023
+
+link:https://access.redhat.com/errata/RHBA-2023:5347[Red Hat Errata Release]
+
+== {PlatformNameShort}
+
+.New features and enhancements
+
+* automation-controller has been updated to 4.4.2.
+
+.Bug fixes
+
+* Podman configurations are now correctly aligned to the {EDAName} home directory.
+
+* Fixed an issue where the restore process failed to stop `pulpcore-worker` services on RHEL 9.
+
+* Fixed an issue with the `awx-rsyslogd` process where it starts with the wrong user.
+
+* Updated the inventory file to include SSL key and cert parameters for provided SSL web certificates.
+
+* Fixed postgres sslmode for `verify-full` that affected external postgres and postgres signed for 127.0.0.1 for internally managed postgres.
+
+* Subject alt names for component hosts will now only be checked for signing certificates when https is enabled.
+
+* Fixed the values used for signing installer managed certificates for internal postgres installations.
+
+* Fixed the linger configuration for an {EDAName} user.
+
+* You can now mount the `/var/lib/awx` directory as a separate filesystem on execution nodes.
+
+* *awx* user configuration now supports rootless Podman.
+
+* You are now able to sync {ExecEnvShort} images in {HubName} to {ControllerName} on upgrade.
+
+* The installer now correctly enforces only 1 {EDAName} host per {PlatformNameShort} installation.
+
+* Added new variables for additional nginx configurations per component.
+
+* Added temporary file cleanup for Podman to prevent `cannot re-exec process` error during job execution.
+
+* The installer will now properly generate a new `SECRET_KEY` for controller when running `setup.sh` with the `-k` option.
+
+== {ControllerNameStart}
+
+.New features and enhancements
+
+* automation-controller has been updated to 4.4.4.
+
+.Security fixes
+
+* python3-django/python39-django: Potential denial of service vulnerability in django.utils.encoding.uri_to_iri() (CVE-2023-41164)
+
+.Bug fixes
+
+* Fixed job error handling so that error text from `ansible-runner` or Receptor is correctly reported in cases that were previously shown as `Job terminated due to error`. 
+
+* The constructed inventory edit form no longer hangs indefinitely in the loading state for users with edit permissions.
+
+* Added views for a monthly summary of host metrics.
+
+* Added host metrics to exported analytics data.
+
+* Introduced a periodic task and management command for cleaning up old host metrics.
+
+* Fixed a bug where rapidly clicking the *launch* button in the preview step would start many jobs.
+
+* Fixed incorrect capacity allocation for remote execution nodes when resource limits are set in OpenShift.
+
+== {HubNameStart}
+
+.New features and enhancements
+
+* automation-hub has been updated to 4.7.3.
+
+* python3-galaxy-ng/python39-galaxy-ng has been updated to 4.7.3.
+
+* python3-pulp-ansible/python39-pulp-ansible has been updated to 0.17.4.
+
+.Bug fixes
+
+* Fixed an issue where the default remote URL for the `rh-certified` repository would not work.
+
+* Added a legacy role download count to the UI.
+
+* Added a collection upload modal.
+
+* Added repository-related actions to the collection detail screen.
+
+* Added the ability to delete a collection and a collection version from the current repository only.
+
+* Enhanced the *Repository List* page with several UI updates:
+
+** Combined the *sync status* and *last sync* columns into a single column.
+
+** Added *Labels* and *Private* columns.
+
+** Added *Pipeline*, *Private*, and *Remote* filters.
+
+* Added *Mirror* and *Optimize* sync options when performing a repository sync.
+
+* Resolved an issue in community mode where the token page handled null expiration incorrectly.
+
+* Resolved an issue with the filter in the Repository list where it would partially reset when loading.
+
+* Resolved an issue on the approval dashboard where a `Repository name not found` error occurred when the origin repository was not listed in the first page of results.
+
+Resolved an issue on the *Collections* page where using the filter and resetting it would cause all collection versions to display instead of just the latest collection version.
+
+* Improved the logic to select the most suitable distribution to use when uploading a collection to staging.

--- a/downstream/titles/release-notes/topics/hub-464.adoc
+++ b/downstream/titles/release-notes/topics/hub-464.adoc
@@ -1,22 +1,22 @@
 // This is the release notes for Automation Hub 4.6.4, the version number is removed from the topic title as part of the release notes restructuring efforts.
 
 [[hub-464-intro]]
-= Automation Hub
+= {HubNameStart}
 
-Automation hub allows you to discover and utilize new certified automation content from Red Hat Ansible and Certified Partners. On Ansible automation hub, you can discover and manage Ansible Collections, which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
+{HubNameStart} allows you to discover and use new certified automation content from Red Hat Ansible and Certified Partners. On {HubNameMain}, you can discover and manage Ansible Collections, which is supported automation content developed by both partners and Red Hat for use cases such as cloud automation, network automation, security automation, and more.
 
-.Enhancement
+.New features and enhancements
 
-* This release of automation hub provides repository management functionality. With repository management, you can create, edit, delete, and move content between repositories.
+* This release of {HubName} provides repository management functionality. With repository management, you can create, edit, delete, and move content between repositories.
 
 .Bug fixes
 
 * Fixed an issue in the collection keyword search which was returning an incorrect number of results.
 
-* Added the ability to set *OPT_REFERRALS* option for LDAP, so that users can now successfully log in to the automation hub using their LDAP credentials.
+* Added the ability to set *OPT_REFERRALS* option for LDAP, so that users can now successfully log in to the {HubName} by using their LDAP credentials.
 
 * Fixed an error on the UI when *redhat.openshift* collection's core dependency was throwing a `404 Not Found` error.
 
-* Fixed an error such that the deprecated execution environments are now skipped while syncing with *registry.redhat.io*.
+* Fixed an error such that the deprecated execution environments are now skipped while syncing with `registry.redhat.io`.
 
 

--- a/downstream/titles/release-notes/topics/operator-240.adoc
+++ b/downstream/titles/release-notes/topics/operator-240.adoc
@@ -3,13 +3,13 @@
 [[operator-240-intro]]
 = Automation Platform Operator
 
-Ansible Automation Platform Operator provides cloud-native, push-button deployment of new Ansible Automation Platform instances in your OpenShift environment.
+{OperatorPlatform} provides cloud-native, push-button deployment of new {PlatformNameShort} instances in your OpenShift environment.
 
 .Bug fixes
 
-* Enabled configuration of resource requirements for automation controller `init` containers.
+* Enabled configuration of resource requirements for {ControllerName} `init` containers.
 
-* Added *securityContext* for EDA Operator deployments to be Pod Security Admission compliant.
+* Added *securityContext* for Event-Driven Ansible Operator deployments to be Pod Security Admission compliant.
 
 * Resolved error `Controller: Error 413 Entity too large` when doing bulk updates.
 

--- a/downstream/titles/release-notes/topics/platform-intro.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro.adoc
@@ -18,23 +18,23 @@ Red Hat Ansible Automation Platform simplifies the development and operation of 
 
 |===
 
-== Red Hat Ansible Automation Platform life cycle
+== {PlatformName} life cycle
 
-Red Hat publishes a product life cycle page that identifies the levels of maintenance for each Ansible Automation Platform release.
+Red Hat publishes a product life cycle page that identifies the levels of maintenance for each {PlatformNameShort} release.
 Refer to link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle].
 
-== Upgrading Ansible Automation platform
+== Upgrading {PlatformNameShort}
 
-Use installer to perform upgrades to maintenance versions of Ansible Automation Platform. The installer performs all necessary actions required to upgrade to the latest versions of Ansible Automation Platform, including Ansible Tower and Private Automation Hub.
+Use the installer to perform upgrades to maintenance versions of {PlatformNameShort}. The installer performs all necessary actions required to upgrade to the latest versions of {PlatformNameShort}, including {ControllerName} and {PrivateHubName}.
 
 [IMPORTANT]
 ====
-Do not use `yum update` to run upgrades. Use installer instead.
+Do not use `yum update` to run upgrades. Use the installer instead.
 ====
 
 .Additional resources
-* Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of Ansible Automation Platform.
+* Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of {PlatformNameShort}.
 
-* For more information on upgrading your Ansible Automation Platform, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade and Migration Guide].
+* For more information on upgrading your {PlatformNameShort}, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade and Migration Guide].
 
-* For procedures related to using the Ansible Automation Platform installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide].
+* For procedures related to using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide].

--- a/downstream/titles/release-notes/topics/upgrading.adoc
+++ b/downstream/titles/release-notes/topics/upgrading.adoc
@@ -1,7 +1,7 @@
 [[upgrading]]
-= Upgrading Ansible Automation platform
+= Upgrading {PlatformName}
 
-Perform upgrades to maintenance versions of Ansible Automation Platform using the installer. The installer performs all necessary actions required to upgrade to the latest versions of Ansible Automation Platform, including Ansible Tower and Private Automation Hub.
+Perform upgrades to maintenance versions of {PlatformNameShort} using the installer. The installer performs all necessary actions required to upgrade to the latest versions of {PlatformNameShort}, including {ControllerName} and {PrivateHubName}.
 
 
 [IMPORTANT]
@@ -9,8 +9,8 @@ Perform upgrades to maintenance versions of Ansible Automation Platform using th
 Do not use `yum update` to run upgrades.
 ====
 
-Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of Ansible Automation Platform.
+Refer to the table in xref:whats-included[What's included in Ansible Automation Platform] for information on maintenance releases of {PlatformNameShort}.
 
-See the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade Guide] for information on upgrading your Ansible Automation Platform.
+See the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index[Red Hat Ansible Automation Platform Upgrade Guide] for information on upgrading your {PlatformNameShort}.
 
-See the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide] for procedures on using the Ansible Automation Platform installer.
+See the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/red_hat_ansible_automation_platform_installation_guide/index[Ansible Automation Platform Installation Guide] for procedures on using the {PlatformNameShort} installer.


### PR DESCRIPTION
* Add bundle errata releases to 2.4 release notes

Add the Ansible bundle errata releases to the 2.4 Release Notes

https://issues.redhat.com/browse/AAP-16768

* Update release notes based on peer review feedback

Update release notes based on peer review feedback including: added attributes symlink, replaced relevant keywords with attributes, various spelling & grammar updates, & updates to improve clarity.

Add the Ansible bundle errata releases to the 2.4 Release Notes

https://issues.redhat.com/browse/AAP-16768