### PR TITLE
Lightspeed: Move inclusivity statement below title

### DIFF
--- a/lightspeed/titles/lightspeed-release-notes/master.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/master.adoc
@@ -5,10 +5,11 @@
 :experimental:
 
 include::attributes/attributes.adoc[]
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 :context: lightspeed-release-notes
 
 = {LightspeedFullName} Release Notes
  
+include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::modules/lightspeed-rn-25oct2023.adoc[leveloffset=+1]
+


### PR DESCRIPTION
To fix build problems for lightspeed release notes, move the inclusivity statement below the title in master.adoc