### PR TITLE
AAP-15899 Updated EDA controller scenario in installation guide

### DIFF
--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -16,7 +16,6 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 [automationedacontroller]
 automationedacontroller.example.com ansible_connection=local
 
-
 [all:vars]
 automationedacontroller_admin_password='<eda-password>'
 

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -7,17 +7,13 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 
 [IMPORTANT]
 ====
-{ControllerNameStart} must be installed before you populate the inventory file with the following {EDAName} variables.
-====
-
-[IMPORTANT]
-====
 {EDAcontroller} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
 ====
 -----
 # Automation EDA Controller Configuration
 #
 
+[all:vars]
 automationedacontroller_admin_password='<eda-password>'
 
 automationedacontroller_pg_host=''
@@ -27,17 +23,9 @@ automationedacontroller_pg_database='automationedacontroller'
 automationedacontroller_pg_username='automationedacontroller'
 automationedacontroller_pg_password='<password>'
 
-# The full routable URL used by EDA to connect to a controller host.
-# This URL is required if there is no Automation Controller configured
-# in inventory.
-#
 automation_controller_main_url = 'https://controller.example.com/'
  
-# Boolean flag used to verify Automation Controller's
-# web certificates when making calls from Automation EDA Controller.
-#
 automationedacontroller_controller_verify_ssl = true
-
 -----
 
 [role="_additional-resources"]

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -23,9 +23,17 @@ automationedacontroller_pg_database='automationedacontroller'
 automationedacontroller_pg_username='automationedacontroller'
 automationedacontroller_pg_password='<password>'
 
+# The full routable URL used by EDA to connect to a controller host.
+# This URL is required if there is no Automation Controller configured
+# in inventory.
+#
 automation_controller_main_url = 'https://controller.example.com/'
  
+# Boolean flag used to verify Automation Controller's
+# web certificates when making calls from Automation EDA Controller.
+#
 automationedacontroller_controller_verify_ssl = true
+
 -----
 
 [role="_additional-resources"]

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -13,6 +13,10 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 # Automation EDA Controller Configuration
 #
 
+[automationedacontroller]
+automationedacontroller.example.com ansible_connection=local
+
+
 [all:vars]
 automationedacontroller_admin_password='<eda-password>'
 

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -27,7 +27,6 @@ automationedacontroller_pg_password='<password>'
 # This URL is required if there is no Automation Controller configured
 # in inventory.
 #
-automation_controller_main_url = 'https://controller.example.com/'
  
 # Boolean flag used to verify Automation Controller's
 # web certificates when making calls from Automation EDA Controller.

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -31,6 +31,7 @@ automationedacontroller_pg_password='<password>'
 # This URL is required if there is no Automation Controller configured
 # in inventory.
 #
+automation_controller_main_url = 'https://controller.example.com/'
  
 # Boolean flag used to verify Automation Controller's
 # web certificates when making calls from Automation EDA Controller.


### PR DESCRIPTION
- Corrected the code sample, per advice from SMEs in jira comments.
- Also, removed the Important admonition stating, "Automation controller must be installed before you populate the inventory file with the following Event-Driven Ansible variables." Per SME, a partner, and a customer, this is not true. We were told to add this note months ago.