### PR TITLE
Backport 2.4 685 AAP-15899 Updated EDA controller scenario in installation guide

### DIFF
--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -7,17 +7,16 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 
 [IMPORTANT]
 ====
-{ControllerNameStart} must be installed before you populate the inventory file with the following {EDAName} variables.
-====
-
-[IMPORTANT]
-====
 {EDAcontroller} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
 ====
 -----
 # Automation EDA Controller Configuration
 #
 
+[automationedacontroller]
+automationedacontroller.example.com ansible_connection=local
+
+[all:vars]
 automationedacontroller_admin_password='<eda-password>'
 
 automationedacontroller_pg_host=''


### PR DESCRIPTION
- Corrected the code sample in the Installation Guide, section 3.1.1.6, per advice from SMEs in jira comments.

- Also, removed the Important admonition stating, "Automation controller must be installed before you populate the inventory file with the following Event-Driven Ansible variables." Per SME, a partner, and a customer, this is not true. We were told to add this note months ago.
