### PR TITLE
Add RHEL attribute to the docs (#711)

### DIFF
--- a/downstream/assemblies/platform/assembly-planning-installation.adoc
+++ b/downstream/assemblies/platform/assembly-planning-installation.adoc
@@ -8,9 +8,9 @@ ifdef::context[:parent-context: {context}]
 :context: planning
 
 [role="_abstract"]
-Red Hat Ansible Automation Platform is supported on both Red Hat Enterprise Linux and Red Hat Openshift. Use this guide to plan your Red Hat Ansible Automation Platform installation on Red Hat Enterprise Linux.
+{PlatformName} is supported on both {RHEL} and Red Hat OpenShift. Use this guide to plan your {PlatformName} installation on {RHEL}.
 
-To install {PlatformName} on your Red Hat OpenShift Container Platform environment, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform].
+To install {PlatformName} on your {OCP} environment, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform].
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -32,7 +32,6 @@
 :OperatorController: Ansible Automation Platform Controller Operator
 :OperatorResource: Ansible Automation Platform Resource Operator
 
-
 // Automation services catalog
 :CatalogName: automation services catalog
 :CatalogNameStart: Automation services catalog
@@ -93,7 +92,6 @@
 :Runner: Ansible Runner
 :Role: Role ARG Spec
 
-
 // Ansible developer tools
 :ToolsName: Ansible developer tools
 :Test: Ansible-test
@@ -131,3 +129,7 @@
 
 // Feedback module
 :DocumentationFeedback: aap-common/providing-direct-documentation-feedback.adoc
+
+// Linux platforms
+:RHEL: Red Hat Enterprise Linux
+


### PR DESCRIPTION
Add RHEL (Red Hat Enterprise Linux) attribute to the docs for quick reference

Add an attribute for RHEL to the aap-docs repo

https://issues.redhat.com/browse/AAP-17745