### PR TITLE
Backport-2.4-725 (for AAP-14288) Added an admonition about creating a different name for EDA controller

### DIFF
--- a/downstream/assemblies/platform/assembly-deploy-eda-controller-on-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-deploy-eda-controller-on-aap-operator.adoc
@@ -12,7 +12,6 @@ ifdef::context[:parent: {context}]
 
 Use the following instructions to install {EDAName} with your {OperatorPlatform} on {OCPShort}.
 
-
 include::platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-deploy-eda-controller-with-aap-operator-ocp[:context: {parent-context-of-deploy-eda-controller-with-aap-operator-ocp}]

--- a/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
+++ b/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
@@ -18,9 +18,16 @@
 +
 This takes you to the Form View to customize your installation.
 
+. In the *Name* field, enter the name you want for your new {EDAcontroller} deployment. 
++
+[IMPORTANT]
+====
+If you have other {PlatformNameShort} components installed in your current {OCPShort} namespace, ensure that you provide a unique name for your {EDAcontroller} when you create your {EDAName} custom resource. Otherwise, naming conflicts can occur and impact {EDAcontroller} deployment.
+====
++
 . Specify your controller URL. 
 +
-If you deployed {ControllerName} in Openshift as well, you can find the URL on the Routes page.
+If you deployed {ControllerName} in Openshift as well, you can find the URL in the navigation panel under menu:Networking[Routes].
 +
 [NOTE]
 ====


### PR DESCRIPTION
- Added "Important" admonition to the Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform, Chapter 6, informing customers that they should give their EDA controller a different name if they are deploying it in the same namespace as other AAP components.

- Also, per @rooftopcellist, added a new step to specify name for EDA controller that's distinct from OpenShift Container Platform namespace
