### PR TITLE
WIP: Propose changes for GCP ops container info in separate release notes doc

### DIFF
--- a/aap-common/proc-aap-pull-command-container-image.adoc
+++ b/aap-common/proc-aap-pull-command-container-image.adoc
@@ -15,12 +15,14 @@ $ docker login {Registry}
 For more information about registry login, see link:https://access.redhat.com/RegistryAuthentication[Registry Authentication]
 ====
 
-For example, if your foundation deployment version is {ImageRef}-00, you must pull the operational image with tag {ImageRef}.
+NOTE: Remove the section below and instead reference/link to the Release Notes for more info on the proper operation image to use.
 
-Use the following commands:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
-$ docker pull $IMAGE --platform=linux/amd64
-----
+// For example, if your foundation deployment version is {ImageRef}-00, you must pull the operational image with tag {ImageRef}.
+//
+//  Use the following commands:
+//
+// [literal, options="nowrap" subs="+attributes"]
+// ----
+// $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
+// $ docker pull $IMAGE --platform=linux/amd64
+// ----

--- a/stories/topics/con-gcp-pull-deploy-container-image.adoc
+++ b/stories/topics/con-gcp-pull-deploy-container-image.adoc
@@ -17,12 +17,14 @@ For more information about registry login, read link:https://access.redhat.com/R
 
 ====
 
-For example, if your foundation deployment version is {ImageRef}-00, you must pull the operational image with tag {ImageRef} to deploy extension nodes to the foundation deployment.
+NOTE: Remove the section below and instead reference/link to the Release Notes for more info on the proper operation image to use.
 
-Use the following commands:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
-$ docker pull $IMAGE --platform=linux/amd64
-----
+// For example, if your foundation deployment version is {ImageRef}-00, you must pull the operational image with tag {ImageRef} to deploy extension nodes to the foundation deployment.
+//
+// Use the following commands:
+//
+// [literal, options="nowrap" subs="+attributes"]
+// ----
+// $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
+// $ docker pull $IMAGE --platform=linux/amd64
+// ----

--- a/stories/topics/con-gcp-pull-remove-container-image.adoc
+++ b/stories/topics/con-gcp-pull-remove-container-image.adoc
@@ -15,12 +15,14 @@ $ docker login {Registry}
 For more information about registry login, read link:https://access.redhat.com/RegistryAuthentication[Registry Authentication]
 ====
 
-For example, if your foundation deployment version is {ImageRef}-00, you must pull the operational image with tag {ImageRef} to deploy extension nodes to the foundation deployment.
+NOTE: Remove the section below and instead reference/link to the Release Notes for more info on the proper operation image to use.
 
-Use the following commands:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
-$ docker pull $IMAGE --platform=linux/amd64
-----
+// For example, if your foundation deployment version is {ImageRef}-00, you must pull the operational image with tag {ImageRef} to deploy extension nodes to the foundation deployment.
+//
+// Use the following commands:
+//
+// [literal, options="nowrap" subs="+attributes"]
+// ----
+// $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
+// $ docker pull $IMAGE --platform=linux/amd64
+// ----

--- a/stories/topics/con-gcp-use-container-image.adoc
+++ b/stories/topics/con-gcp-use-container-image.adoc
@@ -6,7 +6,7 @@ Pull the Docker image for the Ansible on Clouds operational container which alig
 
 [NOTE]
 ====
-Before pulling the docker image, ensure you are logged in to {Registry} using docker. Use the following command to login to {Registry}. 
+Before pulling the docker image, ensure you are logged in to {Registry} using docker. Use the following command to login to {Registry}.
 
 [literal, options="nowrap" subs="+attributes"]
 ----
@@ -15,12 +15,14 @@ $ docker login {Registry}
 For more information about registry login, see link:https://access.redhat.com/RegistryAuthentication[Registry Authentication]
 ====
 
-For example, if your foundation deployment version is {ImageRef}-00, you must pull the operational image with tag {ImageRef}.
+NOTE: Remove the section below and instead reference/link to the Release Notes for more info on the proper operation image to use.
 
-Use the following commands:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
-$ docker pull $IMAGE --platform=linux/amd64
-----
+// For example, if your foundation deployment version is {ImageRef}-00, you must pull the operational image with tag {ImageRef}.
+//
+// Use the following commands:
+//
+// [literal, options="nowrap" subs="+attributes"]
+// ----
+// $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
+// $ docker pull $IMAGE --platform=linux/amd64
+// ----

--- a/stories/topics/proc-gcp-backup-container-image.adoc
+++ b/stories/topics/proc-gcp-backup-container-image.adoc
@@ -7,7 +7,7 @@
 +
 [NOTE]
 ====
-Before pulling the docker image, ensure you are logged in to {Registry} using docker. Use the following command to login to {Registry}. 
+Before pulling the docker image, ensure you are logged in to {Registry} using docker. Use the following command to login to {Registry}.
 
 [literal, options="nowrap" subs="+attributes"]
 ----
@@ -15,9 +15,11 @@ $ docker login {Registry}
 ----
 For more information about registry login, see link:https://access.redhat.com/RegistryAuthentication[Registry Authentication]
 ====
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
-$ docker pull $IMAGE --platform=linux/amd64
-----
+NOTE: Remove the section below and instead reference/link to the Release Notes for more info on the proper operation image to use.
+
+// +
+// [literal, options="nowrap" subs="+attributes"]
+// ----
+// $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
+// $ docker pull $IMAGE --platform=linux/amd64
+// ----

--- a/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
+++ b/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
@@ -16,13 +16,15 @@ $ docker login {Registry}
 For more information about registry login, see link:https://access.redhat.com/RegistryAuthentication[Registry Authentication]
 ====
 +
-[NOTE]
-=====
-The Ansible on Clouds operational image tag must match the version that you want to upgrade to. For example, if your foundation deployment version is 2.3.20230221, pull the operational image with tag {ImageRef} to upgrade to version {ImageRef}.
-=====
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-$ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
-$ docker pull $IMAGE --platform=linux/amd64
-----
+NOTE: Remove the section below and instead reference/link to the Release Notes for more info on the proper operation image to use.
+
+// [NOTE]
+// =====
+// The Ansible on Clouds operational image tag must match the version that you want to upgrade to. For example, if your foundation deployment version is 2.3.20230221, pull the operational image with tag {ImageRef} to upgrade to version {ImageRef}.
+// =====
+// +
+// [literal, options="nowrap" subs="+attributes"]
+// ----
+// $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
+// $ docker pull $IMAGE --platform=linux/amd64
+// ----


### PR DESCRIPTION
Trying to build a prototype of changes that can be made to the existing SMAC GCP docs so that we can keep the ops container version info in a separate Release Notes doc that we can update more frequently than the major.minor versions shown at https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x

Issue is https://issues.redhat.com/browse/AAP-17732

Release note sample doc is at https://docs.google.com/document/d/1cCenzZFH29JYpITRxBrOMJyQYcPkgFZ6ymdIARInkMY/edit?usp=sharing