### PR TITLE
Clouds: Add GCP release notes book to Clouds docs

### DIFF
--- a/bin/sync_cloud_docs.sh
+++ b/bin/sync_cloud_docs.sh
@@ -32,20 +32,29 @@ rm -rf $target/aap-on-gcp/images
 rm -rf $target/aap-on-gcp/stories
 rm -rf $target/aap-on-gcp/stories.adoc
 
+rm -rf $target/release-notes-gcp/aap-common
+rm -rf $target/release-notes-gcp/attributes
+rm -rf $target/release-notes-gcp/images
+rm -rf $target/release-notes-gcp/stories
+rm -rf $target/release-notes-gcp/stories.adoc
+
 # Copy aap-common to the target directories.
 cp -r $source/aap-common/ $target/aap-on-azure/
 cp -r $source/aap-common/ $target/aap-on-aws/
 cp -r $source/aap-common/ $target/aap-on-gcp/
+cp -r $source/aap-common/ $target/release-notes-gcp/
 
 # Copy attributes to the target directories.
 cp -r $source/attributes/ $target/aap-on-azure/
 cp -r $source/attributes/ $target/aap-on-aws/
 cp -r $source/attributes/ $target/aap-on-gcp/
+cp -r $source/attributes/ $target/release-notes-gcp/
 
 # Copy images to the target directories.
 cp -r $source/images/ $target/aap-on-azure/
 cp -r $source/images/ $target/aap-on-aws/
 cp -r $source/images/ $target/aap-on-gcp/
+cp -r $source/images/ $target/release-notes-gcp/
 
 # Copy user stories to the target directories.
 cp -r $source/stories/ $target/aap-on-azure/
@@ -54,3 +63,5 @@ cp -r $source/stories/ $target/aap-on-aws/
 cp -r $source/titles/aap-on-aws/stories.adoc $target/aap-on-aws/
 cp -r $source/stories/ $target/aap-on-gcp/
 cp -r $source/titles/aap-on-gcp/stories.adoc $target/aap-on-gcp/
+cp -r $source/stories/ $target/release-notes-gcp/
+cp -r $source/titles/release-notes-gcp/stories.adoc $target/release-notes-gcp/


### PR DESCRIPTION
Add a new book for GCP release notes.

- This PR does not modify the release notes content. It includes the release notes assembly from the current GCP guide as a temporary measure to test the docs build.
- It modifies the script that syncs to the Gitlab production repo.


Additional tasks: 
- Add master.adoc and docinfo.xml to the production repo - DONE (PR-28)
- Create a title in Pantheon - DONE