### PR TITLE
Add bundle installer release 2.4-2.4 updates to AAP release notes

### DIFF
--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -25,6 +25,8 @@ include::topics/operator-240.adoc[leveloffset=+2]
 
 include::topics/docs-24.adoc[leveloffset=+2]
 
+include::topics/bundle-installer-24-24.adoc[leveloffset=+2]
+
 include::topics/bundle-installer-24-23.adoc[leveloffset=+2]
 
 include::topics/bundle-installer-24-22.adoc[leveloffset=+2]

--- a/downstream/titles/release-notes/topics/bundle-installer-24-24.adoc
+++ b/downstream/titles/release-notes/topics/bundle-installer-24-24.adoc
@@ -1,0 +1,31 @@
+// This is the release notes file for AAP 2.4 bundle installer release 2.4-2.4 dated November 08, 2023
+
+= Bundle installer release 2.4-2.4 - November 08, 2023
+
+link:https://access.redhat.com/errata/RHBA-2023:6831[Red Hat Errata Advisory - Issued November 08, 2023]
+
+//Ansible Automation Platform
+== {PlatformNameShort}
+
+.New features and enhancements
+
+* python3-urllib3/python39-urllib3 has been updated to 1.26.18.
+
+.Security fixes
+
+* python3-urllib3/python39-urllib3: Cookie request header is not stripped during cross-origin redirects (CVE-2023-43804).
+
+//Automation controller
+== {ControllerNameStart}
+
+.New features and enhancements
+
+* automation-controller has been updated to 4.4.7.
+
+.Security fixes
+
+* automation-controller: Django: Denial-of-service possibility in django.utils.text.Truncator (CVE-2023-43665).
+
+.Bug fixes
+
+* Customers using the `infra.controller_configuration` collection (which uses `ansible.controller` collection) to update their {PlatformNameShort} environment no longer receive an HTTP 499 response.


### PR DESCRIPTION
Add bundle installer release 2.4-2.4 updates to AAP release notes

2.4 Release Notes - AAP 2.4-2.4 Bundle Installer Release

https://issues.redhat.com/browse/AAP-18030