### PR TITLE
Remove Operator related items from bundle installer release notes (#768)

### DIFF
--- a/downstream/titles/release-notes/topics/bundle-installer-24-11.adoc
+++ b/downstream/titles/release-notes/topics/bundle-installer-24-11.adoc
@@ -25,13 +25,3 @@ link:https://access.redhat.com/errata/RHBA-2023:4288[Red Hat Errata Advisory - I
 .Bug fixes
 
 * Fixed issue using gpg key with passphrase for signing services.
-
-== Automation Platform Operator
-
-.Bug fixes
-
-* Resolved an issue where the Hub Operator Ansible signing key was not mounted in the hub worker container.
-
-* Updated the `ansible.eda` collection to 1.4.2 in `de-supported` container image.
-
-* Updated `automation-hub` 4.7.1-2 to add the pinentry dependency for signing collections with a passphrase.

--- a/downstream/titles/release-notes/topics/bundle-installer-24-12.adoc
+++ b/downstream/titles/release-notes/topics/bundle-installer-24-12.adoc
@@ -51,16 +51,6 @@ link:https://access.redhat.com/errata/RHBA-2023:4621[Red Hat Errata Advisory - I
 
 * Fixed an issue where related items were not visible in some cases. For example, job template instance groups, organization galaxy credentials, and organization instance groups.
 
-== Automation Platform Operator
-
-.New features and enhancements
-
-* automation-controller 4.4.1 RPM updates.
-
-* Added support for scaling {ControllerName} down to replicas 0 for maintenance.
-
-* Added the ability to provision Mesh and Execution nodes in limited network connectivity environments.
-
 == Creator Tools
 
 .New features and enhancements


### PR DESCRIPTION
Remove Operator related release items from bundle installer release notes. These will be added at a later date in their own section. https://issues.redhat.com/browse/AAP-18174