### PR TITLE
Updated codebot version and limitations

### DIFF
--- a/lightspeed/assemblies/assembly_troubleshooting-lightspeed.adoc
+++ b/lightspeed/assemblies/assembly_troubleshooting-lightspeed.adoc
@@ -4,7 +4,7 @@ ifdef::context[:parent-context: {context}]
 
 [id="troubleshooting-lightspeed_{context}"]
 
-= Troubleshooting Lightspeed
+= Troubleshooting
 
 :context: troubleshooting-lightspeed
 

--- a/lightspeed/assemblies/assembly_using-code-bot-for-suggestions.adoc
+++ b/lightspeed/assemblies/assembly_using-code-bot-for-suggestions.adoc
@@ -10,11 +10,17 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-The {AnsibleCodeBot} scans existing content collections, roles, and playbooks hosted in Git repositories, and proactively creates pull requests whenever best practices or quality improvement recommendations are available. The bot automatically submits pull requests to the repository, which proactively alerts the repository owner to a recommended change to their content . You can configure {AnsibleCodeBot} to scan your existing Git repositories (both public and private). Your organization must have a valid {LightspeedFullName} subscription to use Ansible code bot. 
+The {AnsibleCodeBot} scans existing content collections, roles, and playbooks hosted in GitHub repositories, and proactively creates pull requests whenever best practices or quality improvement recommendations are available. The bot automatically submits pull requests to the repository, which proactively alerts the repository owner to a recommended change to their content . You can configure {AnsibleCodeBot} to scan your existing Git repositories (both public and private). Your organization must have a valid {LightspeedFullName} subscription to use Ansible code bot. 
 
 {AnsibleCodeBot} uses Ansible lint to recommend code quality improvements. {AnsibleCodeBot} is intended to promote proven practices, patterns, and behaviors while avoiding common errors that can easily lead to bugs or make code harder to maintain. {AnsibleCodeBot} scans your content based on the configured rules, to ensure that your content adheres to Ansible best practices.
 
-NOTE: {LightspeedShortName} provides Ansible code bot in Service Preview, that you can deploy to your GitHub account. 
+[NOTE]
+====
+* {LightspeedShortName} provides {AnsibleCodeBot} in Service Preview, that you can deploy to your GitHub account. 
+* {AnsibleCodeBot} is supported on the following GitHub versions:
+** Github.com
+** GitHub Enterprise Cloud
+====
 
 The following examples are code recommendations that the {AnsibleCodeBot} can suggest:
 

--- a/lightspeed/modules/proc_configure-repo-scan.adoc
+++ b/lightspeed/modules/proc_configure-repo-scan.adoc
@@ -16,7 +16,7 @@ For each interval cadence, {AnsibleCodeBot} starts scanning your Git repositorie
 
 .Procedure
 
-. In Github, navigate to the configuration file in the repository that you want to scan.
+. In GitHub, navigate to the configuration file in the repository that you want to scan.
 . Optional: If the `ansible-code-bot.yml` file was not created automatically, manually create a `.yml` configuration file named `ansible-code-bot.yml` in your repository `.github` folder. For example, `.github/ansible-code-bot.yml`.
 . In the configuration file, specify the `interval` parameter. You can specify the `interval` parameter as *daily*, *weekly*, or *monthly*. For example:
 +

--- a/lightspeed/modules/proc_install-code-bot.adoc
+++ b/lightspeed/modules/proc_install-code-bot.adoc
@@ -8,16 +8,13 @@ Install the {AnsibleCodeBot} to get code recommendations.
 
 .Procedure
 
-. Log in to Github by using the account associated with your organization.
-. Install the Github app for the organization that you are a member of. 
+. Log in to GitHub by using the account associated with your organization.
+. Install the GitHub app for the organization that you are a member of. 
 . Go to the link:https://github.com/apps/ansible-code-bot[Ansible code bot] GitHub app. 
 . Select the repositories that you want the app to access: 
 * *All repositories*: Provides access to read the metadata of all repositories.
 * *Only select repositories*: Provides access to read the metadata of only the repositories that you select. 
 . Optional: If you selected *Only select repositories* in the previous step, select the repositories that you want the {AnsibleCodeBot} to access from the *Select repositories* list. 
-+
-NOTE: You can select the repositories associated with your Red Hat organization only. 
-+
 . Click *Install & Authorize*. 
 A message is displayed that specifies the following permissions are granted automatically to the bot during installation: 
 * Read access to metadata

--- a/lightspeed/modules/proc_troubleshooting-vscode.adoc
+++ b/lightspeed/modules/proc_troubleshooting-vscode.adoc
@@ -15,17 +15,26 @@ To resolve this error, ensure that:
 ** You have a valid {LightspeedShortName} seat license. 
 * You have not configured the required Ansible VS code extension settings.
 ** To resolve this error, ensure that you have enabled the *Lightspeed:Enabled* and menu:Lightspeed[Suggestions:Enabled] settings. For more information, see xref:configure-vscode-extension_configuring-with-code-assistant[Configure the Ansible VS Code extension].
+
 * You receive a `Failure on completion requests` error when you make inference requests in VS Code.
 +
-If you have an assigned seat license for Ansible Lightspeed but your organization administrator has not configured an {ibmwatsonxcodeassistant} model for your organization, you will encounter a `Failure on completion requests` error when you make inference requests in VS Code. 
-* You entered a multitask prompt, but code recommendations were not generated.
-+
-To resolve this error, log out of VS Code and log in again using your Red Hat account. 
+If you have an assigned seat license for {LightspeedShortName} but your organization administrator has not configured an {ibmwatsonxcodeassistant} model for your organization, you will encounter a `Failure on completion requests` error when you make inference requests in VS Code. 
+
 * You are logged in using an account that does not have a valid {LightspeedShortName} seat license. 
 +
 If you logged in using an account that does not have an assigned seat license, you must log out and log in again. In VS Code, click the *Accounts* icon and sign in using your Red Hat account with an assigned seat license. 
+
 * Your VS Code Workspace settings override user settings.
 +
 If your Workspace settings are configured, they can override our user settings even if you have configured the Ansible VS Code extension correctly. The Workspace settings can disable your VS Code extension settings, and therefore you cannot access the Ansible Lightspeed service. 
 +
 To resolve this error, ensure that there are no Workspace settings configured in VS Code. For more information, see link:https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings[Workspace settings] in the VS Code documentation. 
+
+* You entered a multitask prompt, but code recommendations were not generated.
++
+To resolve this error, log out of VS Code and log in again using your Red Hat account. 
+
+* You clicked a different location or window; therefore, the populated code recommendations disappeared. 
++
+Ansible Lightspeed service takes around 5 seconds per task to populate the code recommendations. If you are using a multitask prompt, the Ansible Lightspeed service takes a bit longer (number of tasks times 5 seconds) to populate the results. Do not move your cursor or press any key while the code recommendation is being generated. If you change the cursor location or press any key, Ansible VS Code extension cancels the request and the Ansible Lightspeed service does not process your request. In such scenario, you must get the cursor back to it's original position and repopulate the results.  
+


### PR DESCRIPTION
This PR addresses the following change requests:

- JIRA [AAP-17720](https://issues.redhat.com/browse/AAP-17720)
- JIRA [AAP-17826](https://issues.redhat.com/browse/AAP-17826)
- Change request by Marty Turner (Lightspeed PM) to 'remove the note `You can select the repositories associated with your Red Hat organization only` in section 'Installing the Ansible code bot'. 