### PR TITLE
Update GCP documentation for gcp_manage_labels playbook

### DIFF
--- a/aap-common/proc-aap-list-available-playbooks.adoc
+++ b/aap-common/proc-aap-list-available-playbooks.adoc
@@ -25,7 +25,7 @@ Playbook: aws_restore_stack
 Playbook: aws_upgrade
 Playbook: gcp_aap_health_check
 Playbook: gcp_add_extension_nodes
-Playbook: gcp_add_labels
+Playbook: gcp_manage_labels
 Playbook: gcp_backup_delete
 Playbook: gcp_backup_deployment
 Playbook: gcp_backup_list
@@ -37,7 +37,6 @@ Playbook: gcp_health_check
 Playbook: gcp_list_deployments
 Playbook: gcp_nodes_health_check
 Playbook: gcp_remove_extension_nodes
-Playbook: gcp_remove_labels
 Playbook: gcp_restore_deployment
 Playbook: gcp_setup_logging_monitoring
 Playbook: gcp_upgrade

--- a/aap-common/proc-aap-playbooks.adoc
+++ b/aap-common/proc-aap-playbooks.adoc
@@ -14,7 +14,7 @@ Which generates the following output:
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
 Playbook: gcp_aap_health_check
-Playbook: gcp_add_labels
+Playbook: gcp_manage_labels
 Playbook: gcp_backup_delete
 Playbook: gcp_backup_deployment
 Playbook: gcp_backup_list
@@ -25,7 +25,6 @@ Playbook: gcp_get_aoc_version
 Playbook: gcp_health_check
 Playbook: gcp_list_deployments
 Playbook: gcp_nodes_health_check
-Playbook: gcp_remove_labels
 Playbook: gcp_restore_deployment
 Playbook: gcp_setup_logging_monitoring
 Playbook: gcp_upgrade

--- a/aap-common/ref-aap-using-playbooks.adoc
+++ b/aap-common/ref-aap-using-playbooks.adoc
@@ -46,13 +46,13 @@ localhost                  : ok=29   changed=1    unreachable=0    failed=0    s
 A _failed_ not equal zero indicates an issue with Ansible on Cloud deployment.
 
 [discrete]
-== gcp_add_labels
+== gcp_manage_labels
 
-This playbook adds labels to the deployment.
+This playbook adds/removes labels to the deployment.
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-$ docker run --rm $IMAGE command_generator_vars gcp_add_labels
+$ docker run --rm $IMAGE command_generator_vars gcp_manage_labels
 ----
 
 Which generates the following output:
@@ -60,19 +60,21 @@ Which generates the following output:
 [literal, options="nowrap" subs="+attributes"]
 ----
 ===============================================
-Playbook: gcp_add_labels
-Description: This playbook adds labels to the deployment.
+Playbook: gcp_manage_labels
+Description: This playbook adds/removes labels to the deployment.
 -----------------------------------------------
-Add labels to the Ansible Automation Platform from GCP Marketplace deployment.
+Add/Remove labels to the Ansible Automation Platform from GCP Marketplace deployment.
 
 -----------------------------------------------
 Command generator template:
 
-docker run --rm $IMAGE command_generator gcp_add_labels -d <deployment_name> -c <cloud_credentials_path> --extra-vars 'gcp_compute_region=<gcp_compute_region> gcp_compute_zone=<gcp_compute_zone> gcp_labels=<gcp_labels>'
+docker run --rm $IMAGE command_generator gcp_manage_labels -d <deployment_name> -c <cloud_credentials_path> --extra-vars 'gcp_compute_region=<gcp_compute_region> gcp_compute_zone=<gcp_compute_zone> gcp_labels=<gcp_labels>'
 ===============================================
 ----
 
-The parameter `gcp_labels` is a comma separated list of `key=value` pairs to add or update. For example: key1=value1,key2=value2
+To add or update labels, the parameter `gcp_labels` is a comma separated list of `key=value` pairs. For example: gcp_labels="key1=value1,key2=value2"
+
+To remove labels, the parameter `gcp_labels` is a list of comma separated `keys`. For example: gcp_labels="key1,key2"
 
 Launching this command by replacing the parameters generates a new command to launch and outputs:
 
@@ -82,46 +84,6 @@ Launching this command by replacing the parameters generates a new command to la
 PLAY RECAP *********************************************************************
 localhost                  : ok=22   changed=2    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
 ----
-
-
-[discrete]
-== gcp_remove_labels
-
-This playbook removes labels from the deployment.
-
-[literal, options="nowrap" subs="+attributes"]
-----
-$ docker run --rm $IMAGE command_generator_vars gcp_remove_labels
-----
-
-Which generates the following output:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-===============================================
-Playbook: gcp_remove_labels
-Description: This playbook removes labels from the deployment.
------------------------------------------------
-Remove labels from the {AAPonGCP} deployment.
-
------------------------------------------------
-Command generator template:
-
-docker run --rm $IMAGE command_generator gcp_remove_labels -d <deployment_name> -c <cloud_credentials_path> --extra-vars 'gcp_compute_region=<gcp_compute_region> gcp_compute_zone=<gcp_compute_zone> gcp_labels=<gcp_labels>'
-===============================================
-----
-
-The parameter `gcp_labels` is a comma separated list of keys to remove. For example: key1,key2
-
-Launching this command by replacing the parameters generates a new command to launch and outputs:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-...
-PLAY RECAP *********************************************************************
-localhost                  : ok=22   changed=2    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
-----
-
 
 [discrete]
 == gcp_check_aoc_version

--- a/aap-common/ref-aap-using-playbooks.adoc
+++ b/aap-common/ref-aap-using-playbooks.adoc
@@ -61,9 +61,9 @@ Which generates the following output:
 ----
 ===============================================
 Playbook: gcp_manage_labels
-Description: This playbook adds/removes labels to the deployment.
+Description: This playbook adds labels to, or removes labels from the deployment
 -----------------------------------------------
-Add/Remove labels to the Ansible Automation Platform from GCP Marketplace deployment.
+Add labels to or remove labels from the {AAPonGCP} deployment
 
 -----------------------------------------------
 Command generator template:


### PR DESCRIPTION
This PR updates GCP documentation to reflect replacement of `gcp_add_labels` and `gcp_remove_labels` playbooks with `gcp_manage_labels`  that handles both the functionalities in a unified playbook.

Jira for reference: https://issues.redhat.com/browse/AAP-18317