### PR TITLE
AAP-15692 Single EDA controller with internal database requires minimum automation controller 2.4

### DIFF
--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -7,8 +7,15 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 
 [IMPORTANT]
 ====
+{ControllerName} 2.4 or later must be installed to successfully deploy {EDAcontroller}.
+====
+
+[IMPORTANT]
+====
 {EDAcontroller} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
 ====
+
+
 -----
 # Automation EDA Controller Configuration
 #

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -7,7 +7,7 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 
 [IMPORTANT]
 ====
-{ControllerNameStart} 2.4 or later must be installed to successfully deploy {EDAcontroller}.
+This scenario requires a minimum of {ControllerName} 2.4 for successful deployment of {EDAcontroller}.
 ====
 
 [IMPORTANT]

--- a/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
+++ b/downstream/modules/platform/ref-single-eda-controller-with-internal-db.adoc
@@ -7,7 +7,7 @@ Use this example to populate the inventory file to install {EDAcontroller}. This
 
 [IMPORTANT]
 ====
-{ControllerName} 2.4 or later must be installed to successfully deploy {EDAcontroller}.
+{ControllerNameStart} 2.4 or later must be installed to successfully deploy {EDAcontroller}.
 ====
 
 [IMPORTANT]


### PR DESCRIPTION
Added an admonition to section "[3.1.1.7 Single Event-Driven Ansible controller node with internal database](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-single-eda-controller-with-internal-db_platform-install-scenario)" in the AAP Installation Guide.