### PR TITLE
Clouds-2.4: Add GCP release notes (#838)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,11 @@ $ firefox titles/aap-on-aws/aap-on-aws.html                         # Open in Fi
 $ asciidoctor titles/aap-on-gcp/aap-on-gcp.asciidoc
 $ open -a "Google Chrome" titles/aap-on-gcp/aap-on-gcp.html         # Open in Chrome
 $ firefox titles/aap-on-gcp/aap-on-gcp.html                         # Open in Firefox
+# GCP Release Notes
+$ asciidoctor titles/release-notes-gcp/release-notes-gcp.asciidoc
+$ open -a "Google Chrome" titles/release-notes-gcp/release-notes-gcp.html # Open in Chrome
+$ firefox titles/release-notes-gcp/release-notes-gcp.html                 # Open in Firefox
+
 ----
 
 [NOTE]

--- a/aap-common/proc-aap-list-available-playbooks.adoc
+++ b/aap-common/proc-aap-list-available-playbooks.adoc
@@ -11,18 +11,6 @@ $ docker run --rm $IMAGE command_generator_vars | grep Playbook
 
 The current version of the operational playbooks collection contains the following playbooks:
 
-Playbook: aws_add_extension_nodes
-Playbook: aws_add_labels
-Playbook: aws_backup_delete
-Playbook: aws_backup_stack
-Playbook: aws_backups_delete
-Playbook: aws_check_aoc_version
-Playbook: aws_deployment_inventory
-Playbook: aws_get_aoc_version
-Playbook: aws_remove_extension_nodes
-Playbook: aws_remove_labels
-Playbook: aws_restore_stack
-Playbook: aws_upgrade
 Playbook: gcp_aap_health_check
 Playbook: gcp_add_extension_nodes
 Playbook: gcp_add_labels

--- a/aap-common/proc-aap-pull-command-container-image.adoc
+++ b/aap-common/proc-aap-pull-command-container-image.adoc
@@ -2,7 +2,7 @@
 
 = Pulling the ansible-on-clouds-ops container image
 
-Pull the Docker image for the Ansible on Clouds operational container with the same tag version as your deployment.
+Pull the Docker image for the Ansible on Clouds operational container with the same tag version as your deployment. If you are unsure of the version you have deployed, see xref:ref-aap-using-playbooks[Command Generator] and playbook *gcp_get_aoc_version* for more information on finding the currention of Ansible on Clouds deployment.
 
 [NOTE]
 ====
@@ -24,3 +24,8 @@ Use the following commands:
 $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
 $ docker pull $IMAGE --platform=linux/amd64
 ----
+
+[NOTE]
+====
+If your foundation deployment version is not {ImageRef}-00, refer to the tables on the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/ansible-automation-platform-from-gcp-release-notes/assembly-gcp-release-notes-24[Released versions] page for a matching deployment version, in the column *Ansible on Clouds version*, and find the corresponding operational image to use, in the column *Ansible-on-clouds-ops container image*, for the IMAGE environment variable.
+====

--- a/attributes/attributes.adoc
+++ b/attributes/attributes.adoc
@@ -18,9 +18,10 @@
 :GCP: Google Cloud Platform
 :AAPonAWS: Ansible Automation Platform from AWS Marketplace
 :AAPonGCP: Ansible Automation Platform from GCP Marketplace
-:OpImageName: ansible-on-clouds-ops-rhel9:2.4.20230630
+:OpImageName: ansible-on-clouds-ops-rhel9:2.4.20231024
 :Registry: registry.redhat.io
-:ImageRef: 2.4.20230630
+:ImageRef: 2.4.20231024
+:PrevImageRef: 2.3.20230630
 
 // Automation Mesh
 :AutomationMesh: automation mesh

--- a/stories/assembly-gcp-release-notes-24.adoc
+++ b/stories/assembly-gcp-release-notes-24.adoc
@@ -1,0 +1,24 @@
+ifdef::context[:parent-context: {context}]
+
+[id="assembly-gcp-release-notes-24"]
+
+= Release notes for Ansible on Clouds 2.4
+
+:context: release-notes-24
+
+This release includes a number of enhancements, additions, and fixes that have been implemented for {AAPonGCP}.
+
+include::topics/ref-gcp-release-notes-2-4-20231024-00.adoc[leveloffset=+1]
+include::topics/ref-gcp-release-notes-2-4-20230630-00.adoc[leveloffset=+1]
+include::topics/ref-gcp-release-notes-2-3-20230221-00.adoc[leveloffset=+1]
+
+[NOTE]
+====
+Automation Mesh and Event Driven Automation are not yet supported by the self-managed Ansible on Cloud offerings at this time.
+====
+
+[discrete]
+== Additional Release Notes related to Ansible Automation Platform
+
+* Check out latest features in link:https://access.redhat.com/login?redirectTo=https%3A%2F%2Faccess.redhat.com%2Fdocumentation%2Fen-us%2Fred_hat_enterprise_linux%2F9[Red Hat Enterprise Linux 9]
+* Read more about latest link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_release_notes/index?extIdCarryOver=true&intcmp=7013a0000026H45AAE&sc_cid=7013a000003SeN0AAK[Ansible Automation Platform features]

--- a/stories/assembly-gcp-upgrade.adoc
+++ b/stories/assembly-gcp-upgrade.adoc
@@ -15,7 +15,7 @@ You are required to create a backup before running the upgrade.
 =====
 {AAPonGCP} supports sequential upgrades. 
 All upgrades should be no more than one major version behind the version you are currently upgrading to. 
-For example, to upgrade {PlatformNameShort} to {ImageRef}, you must be on version 2.3.20230221.
+For example, to upgrade {PlatformNameShort} to {ImageRef}, you must be on version {PrevImageRef}.
 
 Logging and monitoring must be disabled before running the upgrade. 
 Follow these link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.3/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-gcp-monitoring-logging#con-gcp-setup-after-deployment[instructions] to toggle off monitoring and logging for your current version before beginning the upgrade.
@@ -30,18 +30,18 @@ When the upgrade has completed, logging and monitoring can be reenabled by follo
 
 The following procedures form the upgrade process:
 
-. Backup your {PlatformNameShort} 2.3 stack.
-* Follow the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.3/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-aap-gcp-backup-and-recovery#con-gcp-backup-process[Ansible on Clouds 2.3 backup instructions].
+. Backup your {PlatformNameShort} stack.
+* Follow the xref:con-gcp-backup-process[Ansible on Clouds backup instructions].
 
 . Upgrade {PlatformNameShort}
-.. Pull the ansible-on-clouds-ops 2.4 container image
+.. Pull the next sequential ansible-on-clouds-ops version container image
 .. Ensure minimum required permissions are met
 .. Generate the data file
 .. Update the data file
 .. Begin upgrading {PlatformNameShort} by running the operational container
 
 . (Optional) Restore the stack from a backup. 
-* Follow the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.3/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-aap-gcp-backup-and-recovery#con-gcp-restore-process[Ansible on Clouds 2.3 restore instructions].
+* Follow the xref:#con-gcp-restore-process[Ansible on Clouds restore instructions].
 
 //context labels are here in case modules need to be reused within these container files.
 :context: backup

--- a/stories/topics/con-gcp-pull-deploy-container-image.adoc
+++ b/stories/topics/con-gcp-pull-deploy-container-image.adoc
@@ -3,6 +3,7 @@
 = Pulling the ansible-on-clouds-ops container image
 
 Pull the Docker image for the Ansible on Clouds operational container with the same tag as the version you are deploying to.
+If you are unsure of the version you have deployed, see xref:ref-aap-using-playbooks[Command Generator] and playbook *gcp_get_aoc_version* for more information on finding the current version of Ansible on Clouds deployment.
 
 [NOTE]
 ====
@@ -26,3 +27,8 @@ Use the following commands:
 $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
 $ docker pull $IMAGE --platform=linux/amd64
 ----
+
+[NOTE]
+====
+If your foundation deployment version is not {ImageRef}-00, refer to the tables on the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/ansible-automation-platform-from-gcp-release-notes/assembly-gcp-release-notes-24[Released versions] page for a matching deployment version, in the *Ansible on Clouds version* column. Find the corresponding operational image to use, in the *Ansible-on-clouds-ops container image* column, for the IMAGE environment variable.
+====

--- a/stories/topics/con-gcp-pull-remove-container-image.adoc
+++ b/stories/topics/con-gcp-pull-remove-container-image.adoc
@@ -3,6 +3,7 @@
 = Pulling the ansible-on-clouds-ops container image
 
 Pull the Docker image for the Ansible on Clouds operational container with the same tag as your foundation deployment.
+If you are unsure of the version you have deployed, see xref:ref-aap-using-playbooks[Command Generator] and playbook *gcp_get_aoc_version* for more information on finding the current version of Ansible on Clouds deployment.
 
 [NOTE]
 ====
@@ -24,3 +25,8 @@ Use the following commands:
 $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
 $ docker pull $IMAGE --platform=linux/amd64
 ----
+
+[NOTE]
+====
+If your foundation deployment version is not {ImageRef}-00, refer to the tables on the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/ansible-automation-platform-from-gcp-release-notes/assembly-gcp-release-notes-24[Released versions] page for a matching deployment version, in the *Ansible on Clouds version* column. Find the corresponding operational image to use, in the *Ansible-on-clouds-ops container image* column, for the IMAGE environment variable.
+====

--- a/stories/topics/con-gcp-restore-process.adoc
+++ b/stories/topics/con-gcp-restore-process.adoc
@@ -12,7 +12,7 @@ The restore process creates a new deployment, and restores the filestore and SQL
 The following procedures describe how to restore the {AAPonGCP} deployment.
 
 :context: restore
-include::proc-gcp-backup-container-image.adoc[leveloffset=+1]
+include::proc-gcp-restore-container-image.adoc[leveloffset=+1]
 include::proc-gcp-setup-environment.adoc[leveloffset=+1]
 include::ref-gcp-iam-restore-minimum-permissions.adoc[leveloffset=+1]
 include::proc-gcp-generate-restore-yml-file.adoc[leveloffset=+1]

--- a/stories/topics/con-gcp-upgrade-backup-process.adoc
+++ b/stories/topics/con-gcp-upgrade-backup-process.adoc
@@ -6,5 +6,5 @@
 ====
 Before starting the upgrade of your {PlatformNameShort} environment, you must first take a backup of your environment at its current version.
 
-To backup your {PlatformNameShort} environment at the earlier version, follow the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.3/html/red_hat_ansible_automation_platform_from_gcp_marketplace_guide/assembly-aap-gcp-backup-and-recovery#con-gcp-backup-process[Ansible on Clouds 2.3 backup instructions].
+To backup your {PlatformNameShort} environment at the earlier version, follow the xref:con-gcp-backup-process[Ansible on Clouds backup instructions].
 ====

--- a/stories/topics/con-gcp-use-container-image.adoc
+++ b/stories/topics/con-gcp-use-container-image.adoc
@@ -3,6 +3,7 @@
 = Pulling the ansible-on-clouds-ops container image
 
 Pull the Docker image for the Ansible on Clouds operational container which aligns with the version of your foundation deployment.
+If you are unsure of the version you have deployed, see xref:ref-aap-using-playbooks[Command Generator] and playbook *gcp_get_aoc_version* for more information on finding the current version of Ansible on Clouds deployment.
 
 [NOTE]
 ====
@@ -24,3 +25,8 @@ Use the following commands:
 $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
 $ docker pull $IMAGE --platform=linux/amd64
 ----
+
+[NOTE]
+====
+If your foundation deployment version is not {ImageRef}-00, refer to the tables on the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/ansible-automation-platform-from-gcp-release-notes/assembly-gcp-release-notes-24[Released versions] page for a matching deployment version, in the *Ansible on Clouds version* column. Find the corresponding operational image to use, in the *Ansible-on-clouds-ops container image* column, for the IMAGE environment variable.
+====

--- a/stories/topics/proc-gcp-backup-container-image.adoc
+++ b/stories/topics/proc-gcp-backup-container-image.adoc
@@ -4,6 +4,7 @@
 
 .Procedure
 * Pull the docker image for the `ansible-on-clouds-ops` container with the same tag as the foundation deployment.
+If you are unsure of the version you have deployed, see xref:ref-aap-using-playbooks[Command Generator] and playbook *gcp_get_aoc_version* for more information on finding the current version of Ansible on Clouds deployment.
 +
 [NOTE]
 ====
@@ -21,3 +22,8 @@ For more information about registry login, see link:https://access.redhat.com/Re
 $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
 $ docker pull $IMAGE --platform=linux/amd64
 ----
+
+[NOTE]
+====
+If your foundation deployment version is not {ImageRef}-00, refer to the tables on the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/ansible-automation-platform-from-gcp-release-notes/assembly-gcp-release-notes-24[Released versions] page for a matching deployment version, in the *Ansible on Clouds version* column. Find the corresponding operational image to use, in the *Ansible-on-clouds-ops container image* column, for the IMAGE environment variable.
+====

--- a/stories/topics/proc-gcp-pull-backup-container-image.adoc
+++ b/stories/topics/proc-gcp-pull-backup-container-image.adoc
@@ -30,3 +30,8 @@ For EMEA regions (Europe, Middle East, Africa) run the following command instead
 $ export IMAGE={Registry}/ansible-on-clouds/ansible-on-clouds-ops-emea-rhel8:2.2.20230215
 $ docker pull $IMAGE --platform=linux/amd64
 ----
+
+[NOTE]
+====
+If your foundation deployment version is not {ImageRef}-00, refer to the tables on the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/ansible-automation-platform-from-gcp-release-notes/assembly-gcp-release-notes-24[Released versions] page for a matching deployment version, in the column *Ansible on Clouds version*, and find the corresponding operational image to use, in the column *Ansible-on-clouds-ops container image*, for the IMAGE environment variable.
+====

--- a/stories/topics/proc-gcp-restore-container-image.adoc
+++ b/stories/topics/proc-gcp-restore-container-image.adoc
@@ -1,0 +1,28 @@
+[id="proc-gcp-restore-pull-container-image_{context}"]
+
+= Pulling the ansible-on-clouds-ops container image
+
+.Procedure
+* Pull the docker image for the `ansible-on-clouds-ops` container with the same tag as the backup was created with. If you are unsure of the version backed up, you can look in the backup json file for the key *restore_properties.aoc_version*.
++
+[NOTE]
+====
+Before pulling the docker image, ensure you are logged in to {Registry} using docker. Use the following command to login to {Registry}. 
+
+[literal, options="nowrap" subs="+attributes"]
+----
+$ docker login {Registry}
+----
+For more information about registry login, see link:https://access.redhat.com/RegistryAuthentication[Registry Authentication]
+====
++
+[literal, options="nowrap" subs="+attributes"]
+----
+$ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
+$ docker pull $IMAGE --platform=linux/amd64
+----
+
+[NOTE]
+====
+If your backup version is not {ImageRef}-00, refer to the tables on the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/ansible-automation-platform-from-gcp-release-notes/assembly-gcp-release-notes-24[Released versions] page to for a matching version, in the *Ansible on Clouds version* column. Find the corresponding operational image to use, in the *Ansible-on-clouds-ops container image* column, for the IMAGE environment variable.
+====

--- a/stories/topics/proc-gcp-running-upgrade.adoc
+++ b/stories/topics/proc-gcp-running-upgrade.adoc
@@ -47,7 +47,7 @@ A successful upgrade is marked by the log below.
 ----
 TASK [redhat.ansible_on_clouds.standalone_gcp_upgrade : [upgrade] Show GCP current version] ***
 ok: [localhost] => {
-    "msg": "gcp_current_version: 2.3.20230221-00"
+    "msg": "gcp_current_version: {PrevImageRef}-00"
 }
 ----
 . Your {AAPonGCP} deployment is now upgraded to a newer version and you can log in to Red Hat Ansible Automation Platform automation controller and automation hub using your deployment credentials.

--- a/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
+++ b/stories/topics/proc-gcp-upgrade-pull-container-image.adoc
@@ -3,7 +3,8 @@
 = Pulling the ansible-on-clouds-ops container image
 
 .Procedure
-* Pull the Docker image for Ansible on Clouds operational container with the same tag as the version you want to upgrade to.
+* Pull the Docker image for Ansible on Clouds operational container with the tag based on the version you want to upgrade to.
+If you are unsure of the version you have deployed and the one you need to upgrade to, see xref:ref-aap-using-playbooks[Command Generator] and playbook *gcp_get_aoc_version* for more information on finding the current version of Ansible on Clouds deployment and the version to upgrade to.
 +
 [NOTE]
 ====
@@ -18,7 +19,7 @@ For more information about registry login, see link:https://access.redhat.com/Re
 +
 [NOTE]
 =====
-The Ansible on Clouds operational image tag must match the version that you want to upgrade to. For example, if your foundation deployment version is 2.3.20230221, pull the operational image with tag {ImageRef} to upgrade to version {ImageRef}.
+The Ansible on Clouds operational image tag must match the version that you want to upgrade to. For example, if your foundation deployment version is {PrevImageRef}, pull the operational image with tag {ImageRef} to upgrade to version {ImageRef}.
 =====
 +
 [literal, options="nowrap" subs="+attributes"]
@@ -26,3 +27,8 @@ The Ansible on Clouds operational image tag must match the version that you want
 $ export IMAGE={Registry}/ansible-on-clouds/{OpImageName}
 $ docker pull $IMAGE --platform=linux/amd64
 ----
+
+[NOTE]
+====
+If your foundation deployment version is not {ImageRef}-00, refer to the tables on the link:https://access.redhat.com/documentation/en-us/ansible_on_clouds/2.x/html/ansible-automation-platform-from-gcp-release-notes/assembly-gcp-release-notes-24[Released versions] page for a matching deployment version, in the *Upgrade from version* column. Find the corresponding operational image to use, in the *Ansible-on-clouds-ops container image* column, for the IMAGE environment variable.
+====

--- a/stories/topics/ref-gcp-release-notes-2-2-20230215-00.adoc
+++ b/stories/topics/ref-gcp-release-notes-2-2-20230215-00.adoc
@@ -1,0 +1,17 @@
+[id="gcp-release-notes-2-2-20230215-00_{context}"]
+
+= Self-managed version 2.2.20230215-00 (March 14, 2023)
+
+[cols="15%,15%,15%,15%,15%,25%",options="header"]
+|====
+| Ansible on Clouds version | AAP version | Controller UI version | Hub UI version | Upgrade from version | Ansible-on-clouds-ops container image
+| 2.2.20230215-00 | 2.2 | 4.2.1 | 4.5.2 | NA | registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.2.20230215
+|====
+
+== New features and enhancements
+
+== Security fixes
+
+== Bug fixes
+
+== Deprecated and removed features

--- a/stories/topics/ref-gcp-release-notes-2-3-20230221-00.adoc
+++ b/stories/topics/ref-gcp-release-notes-2-3-20230221-00.adoc
@@ -1,0 +1,23 @@
+[id="gcp-release-notes-2-3-20230221-00_{context}"]
+
+= Self-managed version 2.3.20230221-00 (May 22, 2023)
+
+[cols="15%,15%,15%,15%,15%,25%",options="header"]
+|====
+| Ansible on Clouds version | AAP version | Controller UI version | Hub UI version | Upgrade from version | Ansible-on-clouds-ops container image
+| 2.3.20230221-00 | 2.3 | 4.3.5 | 4.6.3 | 2.2.20230215-00 | registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel8:2.3.20230221
+|====
+
+[discrete]
+== New features and enhancements
+
+* Support for {PlatformNameShort} 2.3 has been added.
+
+[discrete]
+== Security fixes
+
+[discrete]
+== Bug fixes
+
+[discrete]
+== Deprecated and removed features

--- a/stories/topics/ref-gcp-release-notes-2-4-20230630-00.adoc
+++ b/stories/topics/ref-gcp-release-notes-2-4-20230630-00.adoc
@@ -1,0 +1,42 @@
+[id="gcp-release-notes-2-4-20230630-00_{context}"]
+
+= Self-managed version 2.4.20230630-00 (Aug 3, 2023)
+
+[cols="15%,15%,15%,15%,15%,25%",options="header"]
+|====
+| Ansible on Clouds version | AAP version | Controller UI version | Hub UI version | Upgrade from version | Ansible-on-clouds-ops container image
+| 2.4.20230630-00 | 2.4 | 4.4.0 | 4.7.1 | 2.4.20230221-00-00 | registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20230630
+|====
+
+[discrete]
+== New features and enhancements
+
+* Support for {PlatformNameShort} 2.4 has been added.
+* Added internal encryption to the web servers.
+** Addition of custom certificates is now supported.
+* Support has been added for custom tagging and labelling.
+** Support has been added to GCP to add or remove tag support for resources owned by the deployment.
+* {AAPonGCP} now has operational playbooks to add and remove extension nodes.
+* There are improvements to backup and restore functionality.
+** Support has been added for taking multiple backups.
+** An operational playbook has been added to list available backups.
+** An operational playbook has been added to delete a selected backup.
+** The capability to restore an existing VPC has been added.
+* Operational functionality to check the current version has been added.
+** Operational playbooks now check to ensure that the {PlatformNameShort} environment they are operating upon is at the same version before beginning their operation.
+
+[discrete]
+== Security fixes
+
+[discrete]
+== Bug fixes
+
+[discrete]
+== Deprecated and removed features
+
+Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in {PlatformNameShort} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+The following is a list of major functionality deprecated and removed within {PlatformNameShort} 2.4:
+
+* On-premise component Automation Services Catalog is now removed from {PlatformNameShort} 2.4 onwards.
+* With the {PlatformNameShort} 2.4 release, the Execution Environment container image for Ansible 2.9 (ee-29-rhel-8) is no longer loaded into the {ControllerName} configuration by default.
+* The process of deploying the application using a new VPC has been deprecated, and the functionality will be removed from {AAPonGCP} in a future release.

--- a/stories/topics/ref-gcp-release-notes-2-4-20231024-00.adoc
+++ b/stories/topics/ref-gcp-release-notes-2-4-20231024-00.adoc
@@ -1,0 +1,24 @@
+[id="gcp-release-notes-2-4-20231024-00_{context}"]
+
+= Self-managed version 2.4.20231024-00 (Nov 2023)
+
+[cols="15%,15%,15%,15%,15%,25%",options="header"]
+|====
+| Ansible on Clouds version | AAP version | Controller UI version | Hub UI version | Upgrade from version | Ansible-on-clouds-ops container image
+| 2.4.20231024-00 | 2.4 | 4.4.6 | 4.7.3 | 2.4.20230630-00 | registry.redhat.io/ansible-on-clouds/ansible-on-clouds-ops-rhel9:2.4.20231024
+|====
+
+[discrete]
+== New features and enhancements
+
+[discrete]
+== Security fixes
+
+* Various CVE fixes
+
+[discrete]
+== Bug fixes
+
+
+[discrete]
+== Deprecated and removed features

--- a/titles/release-notes-gcp/stories.adoc
+++ b/titles/release-notes-gcp/stories.adoc
@@ -1,0 +1,8 @@
+:product_GCP:
+
+// AAP common content
+include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::aap-common/providing-direct-documentation-feedback.adoc[leveloffset=+1]
+include::aap-common/external-site-disclaimer.adoc[leveloffset=+1]
+// GCP Release notes user stories
+include::stories/assembly-gcp-release-notes-24.adoc[leveloffset=+1]


### PR DESCRIPTION
Backports #838 to aap-clouds-2.4 branch:

* Add content for 2.4.20231024-00 GCP release notes (#741)
* Update GCP SMAC version to ops image version mapping to allow multipl… (#748)
* Update GCP SMAC version to ops image version mapping to allow multiple micro versions in each major.minor version
* add more info on figuring out current SMAC version
* Point restore and backup to the newer info on figuring out the aoc version and ops image to use