### PR TITLE
AAP-18404: Added info. about removing licenses for deactivated users

### DIFF
--- a/lightspeed/assemblies/assembly_assigning-seat-licenses.adoc
+++ b/lightspeed/assemblies/assembly_assigning-seat-licenses.adoc
@@ -11,7 +11,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 After connecting {LightspeedShortName} to an {ibmwatsonxcodeassistant} instance, Red Hat Customer Portal organization administrators can assign seat licenses to users in their organization. The seat assignment feature enables select Ansible users in your organization to access and use {LightspeedShortName}. 
 
-Your {PlatformName} subscription includes a specific number of Ansible Lightspeed named seats depending on the number of {PlatformNameShort} subscriptions your organization has purchased. {LightspeedShortName} authenticates users by using Red Hat Single Sign On (SSO) and verifies that they have an assigned seat license.
+Your {PlatformName} subscription includes a specific number of Ansible Lightspeed named seats depending on the number of {PlatformNameShort} subscriptions your organization has purchased. {LightspeedShortName} authenticates users by using Red Hat Single Sign-On (RH-SSO) and verifies that they have an assigned seat license.
 
 include::modules/proc_assign-seat-licenses.adoc[leveloffset=+1]
 include::modules/proc_remove-seat-licenses.adoc[leveloffset=+1]

--- a/lightspeed/modules/proc_remove-seat-licenses.adoc
+++ b/lightspeed/modules/proc_remove-seat-licenses.adoc
@@ -5,10 +5,14 @@
 = Removing seat licenses
 
 [role="_abstract"]
-You can remove users who no longer need to access {LightspeedShortName}, which makes licenses available for others to use.
+You can remove users who no longer need to access {LightspeedShortName}, which makes licenses available for others to use. 
+
+You can also remove seat licenses of deactivated RH-SSO users, so that they can no longer access {LightspeedShortName}. When RH-SSO users are deactivated, their {LightspeedShortName} seat licenses are not removed automatically. These users can continue accessing {LightspeedShortName} until the next time they are forced to reauthenticate with RH-SSO. To prevent deactivated RH-SSO users from accessing {LightspeedShortName}, you must remove their {LightspeedShortName} seat licenses.
+
 [NOTE]
 ====
-This task removes the Ansible user's {LightspeedShortName} seat license only; it does not remove the user from your Red Hat Customer Portal organization.
+When you remove a user, the Ansible user's {LightspeedShortName} seat license only is removed; it does not remove the user from your Red Hat Customer Portal organization. 
+
 ====
 
 .Procedure

--- a/lightspeed/modules/proc_remove-seat-licenses.adoc
+++ b/lightspeed/modules/proc_remove-seat-licenses.adoc
@@ -9,7 +9,7 @@ Remove users who no longer need to access {LightspeedShortName}, which makes lic
 
 [IMPORTANT]
 ====
-To prevent deactivated RH-SSO users from accessing {LightspeedShortName}, you must remove their {LightspeedShortName} seat licenses. When RH-SSO users are deactivated, their {LightspeedShortName} seat licenses are not removed automatically. These users can continue accessing accessing {LightspeedShortName} until the next time they are forced to reauthenticate with RH-SSO.
+To prevent deactivated RH-SSO users from accessing {LightspeedShortName}, you must remove their {LightspeedShortName} seat licenses. When RH-SSO users are deactivated, their {LightspeedShortName} seat licenses are not removed automatically. These users can continue accessing {LightspeedShortName} until the next time they are forced to reauthenticate with RH-SSO. Removing the users' seat licenses revokes their access to {LightspeedShortName} immediately. 
 
 ====
 

--- a/lightspeed/modules/proc_remove-seat-licenses.adoc
+++ b/lightspeed/modules/proc_remove-seat-licenses.adoc
@@ -5,7 +5,7 @@
 = Removing seat licenses
 
 [role="_abstract"]
-Remove users who no longer need to access {LightspeedShortName}, which makes licenses available for others to use. When you remove a user, the Ansible user's {LightspeedShortName} seat license only is removed; it does not remove the user from your Red Hat Customer Portal organization. 
+You can remove users who no longer need to access {LightspeedShortName}, which makes licenses available for others to use. When you remove a user, the Ansible user's {LightspeedShortName} seat license only is removed; it does not remove the user from your Red Hat Customer Portal organization. 
 
 [IMPORTANT]
 ====

--- a/lightspeed/modules/proc_remove-seat-licenses.adoc
+++ b/lightspeed/modules/proc_remove-seat-licenses.adoc
@@ -5,13 +5,11 @@
 = Removing seat licenses
 
 [role="_abstract"]
-You can remove users who no longer need to access {LightspeedShortName}, which makes licenses available for others to use. 
+Remove users who no longer need to access {LightspeedShortName}, which makes licenses available for others to use. When you remove a user, the Ansible user's {LightspeedShortName} seat license only is removed; it does not remove the user from your Red Hat Customer Portal organization. 
 
-You can also remove seat licenses of deactivated RH-SSO users, so that they can no longer access {LightspeedShortName}. When RH-SSO users are deactivated, their {LightspeedShortName} seat licenses are not removed automatically. These users can continue accessing {LightspeedShortName} until the next time they are forced to reauthenticate with RH-SSO. To prevent deactivated RH-SSO users from accessing {LightspeedShortName}, you must remove their {LightspeedShortName} seat licenses.
-
-[NOTE]
+[IMPORTANT]
 ====
-When you remove a user, the Ansible user's {LightspeedShortName} seat license only is removed; it does not remove the user from your Red Hat Customer Portal organization. 
+To prevent deactivated RH-SSO users from accessing {LightspeedShortName}, you must remove their {LightspeedShortName} seat licenses. When RH-SSO users are deactivated, their {LightspeedShortName} seat licenses are not removed automatically. These users can continue accessing accessing {LightspeedShortName} until the next time they are forced to reauthenticate with RH-SSO.
 
 ====
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-18404.

Changes:

- Added info. about removing Lightspeed licenses for deactivated RH-SSO users. 