### PR TITLE
Corrected typo

### DIFF
--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -323,7 +323,7 @@ If your configuration makes any references to LDAP groups, this and `automationh
 Must be set when integrating {PrivateHubName} with LDAP, or the installation will fail.
 
 Default = `None`
-| *`automatiohub_ldap_group_search_filter`* | _Optional_
+| *`automationhub_ldap_group_search_filter`* | _Optional_
 
 Search filter for finding group membership.
 


### PR DESCRIPTION
Corrected automatiohub to automationhub

Typo in hub variables

https://issues.redhat.com/browse/AAP-18772