### PR TITLE
AAP install Guide editorial revamp and controller 4.5 variable (#488)(#801)(#867)

### DIFF
--- a/downstream/modules/platform/ref-ansible-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-ansible-inventory-variables.adoc
@@ -4,49 +4,51 @@
 
 The following variables control how {PlatformNameShort} interacts with remote hosts.
 
-Additional information on variables specific to certain plugins can be found in the documentation for link:https://docs.ansible.com/ansible-core/devel/collections/ansible/builtin/index.html[Ansible.Builtin].
+For more information about variables specific to certain plugins, see the documentation for link:https://docs.ansible.com/ansible-core/devel/collections/ansible/builtin/index.html[Ansible.Builtin].
 
-A list of global configuration options can be found in link:https://docs.ansible.com/ansible-core/devel/reference_appendices/config.html[Ansible Configuration Settings].
+For a list of global configuration options, see link:https://docs.ansible.com/ansible-core/devel/reference_appendices/config.html[Ansible Configuration Settings].
 
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description*
 | *`ansible_connection`* | The connection plugin used for the task on the target host.
 
-This can be the name of any of ansible connection plugin.
+This can be the name of any of Ansible connection plugin.
 SSH protocol types are `smart`, `ssh` or `paramiko`.
 
 Default = `smart`
 | *`ansible_host`* | The ip or name of the target host to use instead of *`inventory_hostname`*.
-| *`ansible_port`* | The connection port number, if not, the default (22 for ssh).
+| *`ansible_port`* | The connection port number.
+
+Default: 22 for ssh
 | *`ansible_user`* | The user name to use when connecting to the host.
-| *`ansible_password`* | The password to use to authenticate to the host.
+| *`ansible_password`* | The password to authenticate to the host.
 
 Never store this variable in plain text.
 
 Always use a vault.
-| *`ansible_ssh_private_key_file`* | Private key file used by ssh.
+| *`ansible_ssh_private_key_file`* | Private key file used by SSH.
 Useful if using multiple keys and you do not want to use an SSH agent.
 | *`ansible_ssh_common_args`* | This setting is always appended to the default command line for `sftp`, `scp`, and `ssh`.
-Useful to configure a ProxyCommand for a certain host (or group).
+Useful to configure a ProxyCommand for a certain host or group.
 | *`ansible_sftp_extra_args`* | This setting is always appended to the default `sftp` command line.
 | *`ansible_scp_extra_args`* | This setting is always appended to the default `scp` command line.
 | *`ansible_ssh_extra_args`* | This setting is always appended to the default `ssh` command line.
 | *`ansible_ssh_pipelining`* | Determines if SSH pipelining is used.
 This can override the pipelining setting in `ansible.cfg`.
-If using SSH key-based authentication, then the key must be managed by an SSH agent.
-| *`ansible_ssh_executable`* | (added in version 2.2)
+If using SSH key-based authentication, the key must be managed by an SSH agent.
+| *`ansible_ssh_executable`* | Added in version 2.2.
 
-This setting overrides the default behavior to use the system ssh.
+This setting overrides the default behavior to use the system SSH.
 This can override the ssh_executable setting in `ansible.cfg`.
 | *`ansible_shell_type`* | The shell type of the target system.
-You should not use this setting unless you have set the `ansible_shell_executable` to a non-Bourne (sh) compatible shell.
+Do not use this setting unless you have set the `ansible_shell_executable` to a non-Bourne (sh) compatible shell.
 By default commands are formatted using sh-style syntax.
 Setting this to `csh` or `fish` causes commands executed on target systems to follow the syntax of those shells instead.
-| *`ansible_shell_executable`* | This sets the shell that the ansible controller uses on the target machine, and overrides the executable in `ansible.cfg` which defaults to `/bin/sh`.
+| *`ansible_shell_executable`* | This sets the shell that the Ansible controller uses on the target machine, and overrides the executable in `ansible.cfg` which defaults to `/bin/sh`.
 
-You should only change if it is not possible to use `/bin/sh`, that is, if `/bin/sh` is not installed on the target machine or cannot be run from sudo.
-| *`inventory_hostname`* | This variable takes the hostname of the machine from the inventory script or the ansible configuration file.
+Do not change this variable unless `/bin/sh` is not installed on the target machine or cannot be run from sudo.
+| *`inventory_hostname`* | This variable takes the hostname of the machine from the inventory script or the Ansible configuration file.
 
 You cannot set the value of this variable.
 

--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -105,6 +105,7 @@ Default = `awx`.
 
 `/path/to/pgsql.key`
 | *`postgres_use_ssl`* | If postgres is to use SSL.
+| *`postgres_max_connections`* | Max database connections setting to apply, if using installer-managed postgres. See the administration guide for help selecting a value.
 | *`receptor_listener_port`* | Port to use for recptor connection.
 
 Default = 27199.

--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -5,7 +5,7 @@
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description*
-| *`admin_password`* | The password for an administration user to access the UI upon install completion.
+| *`admin_password`* | The password for an administration user to access the UI when the installation is complete.
 
 Passwords must be enclosed in quotes when they are provided in plain text in the inventory file.
 | *`automation_controller_main_url`* | For an alternative front end URL needed for SSO configuration, provide the URL.
@@ -20,7 +20,7 @@ Default = 80
 | *`nginx_https_port`* | The nginx HTTPS server listens for secure connections.
 
 Default = 443
-| *`nginx_hsts_max_age`* | This variable specifies how long, in seconds, the system should be considered as a _HTTP Strict Transport Security_ (HSTS) host. That is, how long HTTPS is used exclusively for communication.
+| *`nginx_hsts_max_age`* | This variable specifies how long, in seconds, the system must be considered as a _HTTP Strict Transport Security_ (HSTS) host. That is, how long HTTPS is used exclusively for communication.
 
 Default = 63072000 seconds, or two years.
 | *`nginx_tls_protocols`* | Defines support for `ssl_protocols` in Nginx.
@@ -34,22 +34,22 @@ Default = empty list
 | *`node_state`* | _Optional_
 
 The status of a node or group of nodes.
-Valid options are `active`, `deprovision` to remove a node from a cluster or `iso_migrate` to migrate a legacy isolated node to an execution node.
+Valid options are `active`, `deprovision` to remove a node from a cluster, or `iso_migrate` to migrate a legacy isolated node to an execution node.
 
 Default = `active`.
 | *`node_type`* | For `[automationcontroller]` group.
 
 Two valid `node_types` can be assigned for this group.
 
-A `node_type=control` implies that the node only runs project and inventory updates, but not regular jobs.
+A `node_type=control` means that the node only runs project and inventory updates, but not regular jobs.
 
-A `node_type=hybrid` has the ability to run everything.
+A `node_type=hybrid` can run everything.
 
-Default for this group = `hybrid`.
+Default for this group = `hybrid`
 
-For `[execution_nodes]` group
+For `[execution_nodes]` group:
 
-Two valid node_types can be assigned for this group.
+Two valid `node_types` can be assigned for this group.
 
 A `node_type=hop` implies that the node forwards jobs to an execution node.
 
@@ -58,15 +58,14 @@ A `node_type=execution` implies that the node can run jobs.
 Default for this group = `execution`.
 | *`peers`* | _Optional_
 
-The `peers` variable is used to indicate which nodes a specific host or group connects to. Wherever the peers variable is defined, an outbound connection will be established to the specific host or group.
+The `peers` variable is used to indicate which nodes a specific host or group connects to. Wherever  this variable is defined, an outbound connection to the specific host or group is established.
 
 This variable is used to add `tcp-peer` entries in the `receptor.conf` file used for establishing network connections with other nodes.
-See link:https://receptor.readthedocs.io/en/latest/connecting_nodes.html?highlight=tcp-peer[Peering]
 
-The peers variable can be a comma-separated list of hosts and/or groups from the inventory.
+The peers variable can be a comma-separated list of hosts and groups from the inventory.
 This is resolved into a set of hosts that is used to construct the `receptor.conf` file.
 
-| *`pg_database`* | The name of the postgres database.
+| *`pg_database`* | The name of the postgreSQL database.
 
 Default = `awx`.
 | *`pg_host`* | The postgreSQL host, which can be an externally managed database.
@@ -84,34 +83,36 @@ When you supply `pg_password` in the inventory file for the installer, PostgreSQ
 | *`pg_port`* | The postgreSQL port to use.
 
 Default = 5432
-| *`pg_ssl_mode`* | One of `prefer` or `verify-full`.
+| *`pg_ssl_mode`* | Choose one of the two available modes: `prefer` and `verify-full`.
 
 Set to `verify-full` for client-side enforced SSL.
 
 Default = `prefer`.
-| *`pg_username`* | Your postgres database username.
+| *`pg_username`* | Your postgreSQL database username.
 
 Default = `awx`.
-| *`postgres_ssl_cert`* | location of postgres ssl certificate.
+| *`postgres_ssl_cert`* | Location of the postgreSQL SSL certificate.
 
 `/path/to/pgsql_ssl.cert`
-| *`postgres_ssl_key`* | location of postgres ssl key.
+| *`postgres_ssl_key`* | Location of the postgreSQL SSL key.
 
 `/path/to/pgsql_ssl.key`
-| *`postgres_use_cert`* | Location of postgres user certificate.
+| *`postgres_use_cert`* | Location of the postgreSQL user certificate.
 
 `/path/to/pgsql.crt`
-| *`postgres_use_key`* | Location of postgres user key.
+| *`postgres_use_key`* | Location of the postgreSQL user key.
 
 `/path/to/pgsql.key`
-| *`postgres_use_ssl`* | If postgres is to use SSL.
-| *`postgres_max_connections`* | Max database connections setting to apply, if using installer-managed postgres. See the administration guide for help selecting a value.
+| *`postgres_use_ssl`* | Use this variable if postgreSQL uses SSL.
+| *`postgres_max_connections`* | Max database connections setting to apply if you are using installer-managed postgreSQL. See the administration guide for help selecting a value.
 | *`receptor_listener_port`* | Port to use for recptor connection.
 
-Default = 27199.
-| *`supervisor_start_retry_count`* | When specified (no default value exists), adds `startretries = <value specified>` to the supervisor config file (/etc/supervisord.d/tower.ini).
+Default = 27199
+| *`supervisor_start_retry_count`* | When specified, it adds `startretries = <value specified>` to the supervisor config file (/etc/supervisord.d/tower.ini).
 
-See link:http://supervisord.org/configuration.html#program-x-section-values[program:x Section Values] for further explanation about `startretries`.
+See link:http://supervisord.org/configuration.html#program-x-section-values[program:x Section Values] for more information about `startretries`.
+
+No default value exists.
 
 | *`web_server_ssl_cert`* | _Optional_
 

--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -104,7 +104,8 @@ Default = `awx`.
 
 `/path/to/pgsql.key`
 | *`postgres_use_ssl`* | Use this variable if postgreSQL uses SSL.
-| *`postgres_max_connections`* | Max database connections setting to apply if you are using installer-managed postgreSQL. See the administration guide for help selecting a value.
+// The postgres_max_connections variable is for Controller v4.5: Do not include it until v4.5 is released.
+// | *`postgres_max_connections`* | Max database connections setting to apply if you are using installer-managed postgreSQL. See the administration guide for help selecting a value.
 | *`receptor_listener_port`* | Port to use for recptor connection.
 
 Default = 27199

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -17,7 +17,7 @@ Default = `admin@example.com`
 | *`automationedacontroller_allowed_hostnames`* | List of additional addresses to enable for user access to {EDAcontroller}.
 
 Default = empty list
-| *`automationedacontroller_controller_verify_ssl`* | Boolean flag used to verify Automation Controller's web certificates when making calls from {EDAcontroller}. Verified is `true`; not verified is `false`.
+| *`automationedacontroller_controller_verify_ssl`* | Boolean flag used to verify automation controller's web certificates when making calls from {EDAcontroller}. Verified is `true`; not verified is `false`.
 
 Default = `false`
 | *`automationedacontroller_disable_https`* | Boolean flag to disable HTTPS {EDAcontroller}. 
@@ -40,22 +40,22 @@ Default = empty list
 | *`automationedacontroller_gunicorn_workers`* | Number of workers for the API served through gunicorn.
 
 Default = (# of cores or threads) * 2 + 1
-| *`automationedacontroller_pg_database`* | The postgres database used by {EDAController}.
+| *`automationedacontroller_pg_database`* | The Postgres database used by {EDAController}.
 
 Default = `automtionedacontroller`.
-| *`automationnedacontroller_pg_host`* | The hostname of the postgres database used by {EDAController}, which can be an externally managed database.
-| *`automationedacontroller_pg_password`* | The password for the postgres database used by {EDAController}.
+| *`automationnedacontroller_pg_host`* | The hostname of the Postgres database used by {EDAController}, which can be an externally managed database.
+| *`automationedacontroller_pg_password`* | The password for the Postgres database used by {EDAController}.
 
 Use of special characters for `automationedacontroller_pg_password` is limited.
 The `!`, `#`, `0` and `@` characters are supported.
 Use of other special characters can cause the setup to fail.
-| *`automationedacontroller_pg_port`* | The port number of the postgres database used by {EDAController}.
+| *`automationedacontroller_pg_port`* | The port number of the Postgres database used by {EDAController}.
 
 Default = `5432`.
-| *`automationedacontroller_pg_username`* | The username for your {EDAController} postgres database.
+| *`automationedacontroller_pg_username`* | The username for your {EDAController} Postgres database.
 
 Default = `automationedacontroller`.
-| *`automationedacontroller_rq_workers`* | Number of rq workers (Python processes that run in the background) used by {EDAcontroller}.
+| *`automationedacontroller_rq_workers`* | Number of Redis Queue (RQ) workers used by {EDAcontroller}. RQ workers are Python processes that run in the background.
 
 Default =  2 * (# of cores or threads) + 1
 |====

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -22,7 +22,7 @@ Used for both `[automationcontroller]` and `[automationhub]` groups.
 
 Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
 
-When `registry_url` is `registry.redhat.io`, username and password are required if not using bundle installer.
+When `registry_url` is `registry.redhat.io`, username and password are required if not using a bundle installer.
 | *`registry_url`* | Used for both `[automationcontroller]` and `[automationhub]` groups.
 
 Default = `registry.redhat.io`.
@@ -35,10 +35,10 @@ Used for both `[automationcontroller]` and `[automationhub]` groups, but only if
 Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
 | *`routable_hostname`* | `routable hostname` is used if the machine running the installer can only route to the target host through a specific URL, for example, if you use shortnames in your inventory, but the node running the installer can only resolve that host using FQDN.
 
-If `routable_hostname` is not set, it should default to `ansible_host`. Then if, and only if `ansible_host` is not set, `inventory_hostname` is used as a last resort.
+If `routable_hostname` is not set, it should default to `ansible_host`. If you do not set `ansible_host`, `inventory_hostname` is used as a last resort.
 
-Note that this variable is used as a host variable for particular hosts and not under the `[all:vars]` section. 
-For further information, see link:https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#assigning-a-variable-to-one-machine-host-variables[Assigning a variable to one machine:host variables]
+This variable is used as a host variable for particular hosts and not under the `[all:vars]` section. 
+For further information, see link:https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html#assigning-a-variable-to-one-machine-host-variables[Assigning a variable to one machine:host variables].
 |====
 
 

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -38,10 +38,15 @@ Default = `false`.
 {HubNameMain} provides artifacts in `/var/lib/pulp`.
 {ControllerNameStart} automatically backs up the artifacts by default.
 
-You can also set `automationhub_backup_collections = false` and the backup/restore process does not then backup or restore `/var/lib/pulp`.
+You can also set `automationhub_backup_collections` to false and the backup/restore process does not then backup or restore `/var/lib/pulp`.
 
-Default = `true`
-| *`automationhub_collection_seed_repository`* a| When the bundle installer is run, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository.
+Default = `true`.
+| *`automationhub_collection_download_count`* | _Optional_
+
+Determines whether download count is displayed on the UI.
+
+Default = `false`.
+| *`automationhub_collection_seed_repository`* a| When you run the bundle installer, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository.
 
 By default, both certified and validated content are uploaded.
 
@@ -56,47 +61,40 @@ If you only want one type of content, set `automationhub_seed_collections` to `t
 | *`automationhub_collection_signing_service_script`* | If a collection signing service is enabled, you must provide this variable to ensure that collections can be properly signed.
 
 `/absolute/path/to/script/that/signs`
-| *`automationhub_create_default_collection_signing_service`* | The default install does not create a collection signing service.
-If set to `true` a signing service is created.
+| *`automationhub_create_default_collection_signing_service`* | Set this variable to true to create a collection signing service.
 
-Default = `false`
+Default = `false`.
 | *`automationhub_container_signing_service_key`* | If a container signing service is enabled, you must provide this variable to ensure that containers can be properly signed.
 
 `/absolute/path/to/key/to/sign`
 | *`automationhub_container_signing_service_script`* | If a container signing service is enabled, you must provide this variable to ensure that containers can be properly signed.
 
 `/absolute/path/to/script/that/signs`
-| *`automationhub_create_default_container_signing_service`* | The default install does not create a container signing service.
-If set to `true` a signing service is created.
+| *`automationhub_create_default_container_signing_service`* | Set this variable to true to create a container signing service.
 
-Default = `false`
-| *`automationhub_disable_hsts`* | The default install deploys a TLS enabled {HubNameMain}.
-Use if {HubName} is deployed with _HTTP Strict Transport Security_ (HSTS) web-security policy enabled.
-Unless specified otherwise, the HSTS web-security policy mechanism is enabled.
-This setting allows you to disable it if required.
+Default = `false`.
+| *`automationhub_disable_hsts`* | The default installation deploys a TLS enabled {HubNameMain}.
+Use this variable if you deploy {HubName} with _HTTP Strict Transport Security_ (HSTS) web-security policy enabled.
+This variable disables, the HSTS web-security policy mechanism.
 
-Default = `false`
+Default = `false`.
 | *`automationhub_disable_https`* | _Optional_
 
 If {HubNameMain} is deployed with HTTPS enabled.
 
 Default = `false`.
-| *`automationhub_enable_api_access_log`* | When set to `true`, creates a log file at `/var/log/galaxy_api_access.log` that logs all user actions made to the platform, including their username and IP address.
+| *`automationhub_enable_api_access_log`* | When set to `true`, this variable creates a log file at `/var/log/galaxy_api_access.log` that logs all user actions made to the platform, including their username and IP address.
 
 Default = `false`.
 | *`automationhub_enable_analytics`* | A Boolean indicating whether to enable pulp analytics for the version of pulpcore used in {HubName} in {PlatformNameShort} {PlatformVers}.
 
-To enable pulp analytics, set `automationhub_enable_analytics = true`.
+To enable pulp analytics, set `automationhub_enable_analytics` to true.
 
 Default = `false`.
-| *`automationhub_enable_unauthenticated_collection_access`* | Enables unauthorized users to view collections.
-
-To enable unauthorized users to view collections, set `automationhub_enable_unauthenticated_collection_access = true`.
+| *`automationhub_enable_unauthenticated_collection_access`* | Set this variable to true to enable unauthorized users to view collections.
 
 Default = `false`.
-| *`automationhub_enable_unauthenticated_collection_download`* | Enables unauthorized users to download collections.
-
-To enable unauthorized users to download collections, set `automationhub_enable_unauthenticated_collection_download = true`.
+| *`automationhub_enable_unauthenticated_collection_download`* | Set this variable to true to enable unauthorized users to download collections.
 
 Default = `false`.
 | *`automationhub_importer_settings`* | _Optional_
@@ -114,45 +112,45 @@ This parameter enables you to drive this configuration.
 
 For example, \https://<load balancer host>.
 
-If not specified, the first node in the `[automationhub]` group is used.
-
 Use `automationhub_main_url` to specify the main {HubName} URL that clients connect to if you are implementing {RHSSO} on your {HubName} environment.
+
+If not specified, the first node in the `[automationhub]` group is used.
 | *`automationhub_pg_database`* | _Required_
 
 The database name.
 
-Default = `automationhub`
-| *`automationhub_pg_host`* | Required if not using internal database.
+Default = `automationhub`.
+| *`automationhub_pg_host`* | Required if not using an internal database.
 
-The hostname of the remote postgres database used by {HubName}
+The hostname of the remote PostgreSQL database used by {HubName}.
 
-Default = `127.0.0.1`
+Default = `127.0.0.1`.
 | *`automationhub_pg_password`* | The password for the {HubName} PostgreSQL database.
 
 Use of special characters for `automationhub_pg_password` is limited.
 The `!`, `#`, `0` and `@` characters are supported. 
 Use of other special characters can cause the setup to fail.
-| *`automationhub_pg_port`* | Required if not using internal database.
+| *`automationhub_pg_port`* | Required if not using an internal database.
 
-Default = 5432
+Default = 5432.
 | *`automationhub_pg_sslmode`* | Required.
 
-Default = `prefer`
+Default = `prefer`.
 | *`automationhub_pg_username`* | Required
 
-Default = `automationhub`
+Default = `automationhub`.
 | *`automationhub_require_content_approval`* | _Optional_
 
 Value is `true` if {HubName} enforces the approval mechanism before collections are made available.
 
-By default when you upload collections to {HubName} an administrator must approve it before it is made available to the users.
+By default when you upload collections to {HubName} an administrator must approve it before they are made available to the users.
 
 If you want to disable the content approval flow, set the variable to `false`.
 
-Default = `true`
-| *`automationhub_seed_collections`* | A boolean that defines whether or not preloading is enabled.
+Default = `true`.
+| *`automationhub_seed_collections`* | A Boolean that defines whether or not preloading is enabled.
 
-When the bundle installer is run, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository.
+When you run the bundle installer, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository.
 
 By default, both certified and validated content are uploaded.
 
@@ -164,15 +162,15 @@ Default = `true`.
 | *`automationhub_ssl_cert`* | _Optional_
 
 `/path/to/automationhub.cert`
-Same as `web_server_ssl_cert` but for {HubName} UI and API
+Same as `web_server_ssl_cert` but for {HubName} UI and API.
 | *`automationhub_ssl_key`* | _Optional_
 
-`/path/to/automationhub.key`
+`/path/to/automationhub.key`.
 
 Same as `web_server_ssl_key` but for {HubName} UI and API
 | *`automationhub_ssl_validate_certs`* | For {PlatformName} 2.2 and later, this value is no longer used.
 
-Value is `true` if {HubName} should validate certificate when requesting itself because by default, {PlatformNameShort} deploys with self-signed certificates.
+Set value to `true` if {HubName} must validate certificates when requesting itself because by default, {PlatformNameShort} deploys with self-signed certificates.
 
 Default = `false`.
 | *`automationhub_upgrade`* | *Deprecated*
@@ -187,14 +185,14 @@ Each element in the list is provided to the web server's nginx configuration as 
 Default = empty list
 | *`ee_from_hub_only`* | When deployed with {HubName} the installer pushes execution environment images to {HubName} and configures {ControllerName} to pull images from the {HubName} registry.
 
-To make {HubName} the only registry to pull execution environment images from, set 'ee_from_hub_only' to `true`.
+To make {HubName} the only registry to pull execution environment images from, set this variable to `true`.
 
 If set to `false`, execution environment images are also taken directly from Red Hat.
 
 Default = `true` when the bundle installer is used.
-| *`generate_automationhub_token`* a| If upgrading from {PlatformName} 2.0 or earlier, you must either:
+| *`generate_automationhub_token`* a| If upgrading from {PlatformName} 2.0 or earlier, choose one of the following options:
 
-* provide an existing {HubNameMain} token as `automationhub_api_token` or
+* provide an existing {HubNameMain} token as `automationhub_api_token`
 
 * set `generate_automationhub_token` to `true` to generate a new token.
 Generating a new token will invalidate the existing token.
@@ -204,9 +202,9 @@ Default = 63072000 seconds, or two years.
 | *`nginx_tls_protocols`* | Defines support for `ssl_protocols` in Nginx.
 
 Default = `TLSv1.2`.
-| *`pulp_db_fields_key`* | Relative or absolute path to the Fernet symmetric encryption key you want to import.
+| *`pulp_db_fields_key`* | Relative or absolute path to the Fernet symmetric encryption key that you want to import.
 The path is on the Ansible management node.
-It is used to encrypt certain fields in the database (such as credentials.)
+It is used to encrypt certain fields in the database, such as credentials.
 If not specified, a new key will be generated.
 | *`sso_automation_platform_login_theme`* | _Optional_
 
@@ -215,21 +213,21 @@ Used for {PlatformNameShort} managed and externally managed {RHSSO}.
 Path to the directory where theme files are located.
 If changing this variable, you must provide your own theme files.
 
-Default = `ansible-automation-platform`
+Default = `ansible-automation-platform`.
 | *`sso_automation_platform_realm`* | _Optional_
 
 Used for {PlatformNameShort} managed and externally managed {RHSSO}.
 
 The name of the realm in SSO.
 
-Default = `ansible-automation-platform`
+Default = `ansible-automation-platform`.
 | *`sso_automation_platform_realm_displayname`* | _Optional_
 
 Used for {PlatformNameShort} managed and externally managed {RHSSO}.
 
 Display name for the realm.
 
-Default = `Ansible Automation Platform`
+Default = `Ansible Automation Platform`.
 //| *`sso_http_port`* or *`sso_https_port`* | IP or routable hostname for SSO.
 //
 //Default = `8080` for http, `8443` for https
@@ -239,7 +237,7 @@ Used for {PlatformNameShort} managed and externally managed {RHSSO}.
 
 SSO administration username.
 
-Default = `admin`
+Default = `admin`.
 | *`sso_console_admin_password`* | _Required_
 
 Used for {PlatformNameShort} managed and externally managed {RHSSO}.
@@ -267,14 +265,14 @@ Used for {PlatformNameShort} managed {RHSSO} only.
 
 Set to `true` if the customer-provided keystore is on a remote node.
 
-Default = `false`
+Default = `false`.
 | *`sso_keystore_name`* | _Optional_
 
 Used for {PlatformNameShort} managed {RHSSO} only.
 
 Name of keystore for SSO.
 
-Default = `ansible-automation-platform`
+Default = `ansible-automation-platform`.
 | *`sso_keystore_password`* | Password for keystore for HTTPS enabled SSO.
 
 Required when using {PlatformNameShort} managed SSO and when HTTPS is enabled. The default install deploys SSO with `sso_use_https=true`.
@@ -289,21 +287,19 @@ This must be reachable from client machines.
 
 Used for {PlatformNameShort} managed and externally managed {RHSSO}.
 
-Set to `true` if the certificate is to be validated during connection.
+Set to `true` if the certificate must be validated during connection.
 
-Default = `true`
+Default = `true`.
 
 | *`sso_use_https`* | _Optional_
 
-Used for {PlatformNameShort} managed and externally managed {RHSSO}.
+Used for {PlatformNameShort} managed and externally managed {RHSSO} if Single Sign On uses HTTPS.
 
-If Single Sign On uses https.
-
-Default = `true`
+Default = `true`.
 |====
 
-For {HubNameMain} to connect to LDAP directly; the following variables must be configured.
-A list of other LDAP related variables (not covered by the `automationhub_ldap_xxx` variables below) that can be passed using the `ldap_extra_settings` variable can be found in the link:https://django-auth-ldap.readthedocs.io/en/latest/reference.html#settings[Django reference documentation].
+For {HubNameMain} to connect to LDAP directly, you must configure the following variables:
+A list of additional LDAP related variables that can be passed using the `ldap_extra_settings` variable, see the link:https://django-auth-ldap.readthedocs.io/en/latest/reference.html#settings[Django reference documentation].
 
 [cols="50%,50%",options="header"]
 |====
@@ -317,8 +313,9 @@ Must be set when integrating {PrivateHubName} with LDAP, or the installation wil
 The password to use with `automationhub_ldap_bind_dn`.
 
 Must be set when integrating {PrivateHubName}  LDAP, or the installation will fail.
-| *`automationhub_ldap_group_search_base_dn`* | An LDAPSearch object that finds all LDAP groups that users might belong to.
-If your configuration makes any references to LDAP groups, this and `automationhub_ldap_group_type` must be set.
+| *`automationhub_ldap_group_search_base_dn`* | An LDAP Search object that finds all LDAP groups that users might belong to.
+
+If your configuration makes any references to LDAP groups, you must set this variable and `automationhub_ldap_group_type`.
 
 Must be set when integrating {PrivateHubName} with LDAP, or the installation will fail.
 
@@ -358,11 +355,11 @@ Default =`django_auth_ldap.config:GroupOfNamesType`
 //Default = "name_attr": "cn"
 | *`automationhub_ldap_server_uri`* | The URI of the LDAP server.
 
-This can be any URI that is supported by your underlying LDAP libraries.
+Use any URI that is supported by your underlying LDAP libraries.
 
 Must be set when integrating {PrivateHubName}  LDAP, or the installation will fail.
-| *`automationhub_ldap_user_search_base_dn`* | An LDAPSearch object that locates a user in the directory.
-The filter parameter should contain the placeholder %(user)s for the username.
+| *`automationhub_ldap_user_search_base_dn`* | An LDAP Search object that locates a user in the directory.
+The filter parameter must contain the placeholder %(user)s for the username.
 It must return exactly one result for authentication to succeed.
 
 Must be set when integrating {PrivateHubName} with LDAP, or the installation will fail.
@@ -371,7 +368,7 @@ Must be set when integrating {PrivateHubName} with LDAP, or the installation wil
 Default = `'(uid=%(user)s)'`
 | *`automationhub_ldap_user-search_scope`* | _Optional_
 
-Scope to search for users in an LDAP tree using django framework for LDAP authentication.
+Scope to search for users in an LDAP tree by using the django framework for LDAP authentication.
 Used for installing {HubName} with LDAP.
 
 Default = `SUBTREE`


### PR DESCRIPTION
Backports the following commits to 2.4:
- #488 
- #801 
- #867 

Affects titles/aap-installation-guide

- Adds an inventory variable (`postgres_max_connections `) to controller, but this is only valid for controller v 4.5
- Implements editorial changes to installation guide
- Comments out `postgres_max_connections` - uncomment this when controller 4.5 is released. 