### PR TITLE
Azure Add RH account sign-in to deployment engine driver

### DIFF
--- a/stories/topics/proc-azure-monitor-deployment-engine.adoc
+++ b/stories/topics/proc-azure-monitor-deployment-engine.adoc
@@ -18,6 +18,13 @@ Approximately 10 minutes into the deployment process, the *Outputs* section of t
 . Login to the deployment using the following credentials:
   * *Username*: _admin_
   * *Password*: Use the _Administrator Password_ that you chose when configuring your deployment.
+. The deployment driver displays a message indicating that your deployment is underway.
+Click btn:[Log in with Red Hat account]. The **Red Hat login** page opens.
+. In the **Red Hat login** page, enter your credentials if you already have a Red Hat account.
++
+If you do not have a Red Hat account, click btn:[Register for a Red Hat account] to create one.
++
+After logging in with your Red Hat account, the {PlatformNameShort} Deployment Engine page opens.
 
 [discrete]
 == {PlatformNameShort} Deployment Engine interface


### PR DESCRIPTION
The Azure team are adding Single Sign On in the deployment driver; the login will require both the admin password and a new or existing RH account for the SSO portion.

Affects `/titles/aap-on-azure`

