### PR TITLE
AAP-18896 Remove instances of EDA acronym; replace with spelled out attributes

### DIFF
--- a/downstream/modules/eda/ref-eda-controller-tasks.adoc
+++ b/downstream/modules/eda/ref-eda-controller-tasks.adoc
@@ -1,6 +1,6 @@
 [id="eda-controller-tasks"]
 
-//= EDA controller tasks
+
 
 Depending on your role, you can use Event-Driven Ansible controller for any of the following tasks:
 

--- a/downstream/modules/eda/ref-eda-controller-tasks.adoc
+++ b/downstream/modules/eda/ref-eda-controller-tasks.adoc
@@ -1,8 +1,8 @@
 [id="eda-controller-tasks"]
 
+= {EDAcontroller} tasks
 
-
-Depending on your role, you can use Event-Driven Ansible controller for any of the following tasks:
+Depending on your role, you can use {EDAcontroller} for any of the following tasks:
 
 * Configuring a new project
 * Setting up a new decision environment

--- a/downstream/modules/platform/con-aap-example-architecture.adoc
+++ b/downstream/modules/platform/con-aap-example-architecture.adoc
@@ -8,15 +8,15 @@ The {PlatformName} {PlatformVers} reference architecture provides an example set
 {ControllerNameStart}:: Provides the control plane for automation through its UI, Restful API, RBAC workflows and CI/CD integrations.
 {AutomationMeshStart}:: Is an overlay network that provides the ability to ease the distribution of work across a large and dispersed collection of workers through nodes that establish peer-to-peer connections with each other using existing networks.
 {PrivateHubNameStart}:: Provides automation developers the ability to collaborate and publish their own automation content and streamline delivery of Ansible code within their organization.
-Event-Driven Ansible (EDA):: Provides the event-handling capability needed to automate time-consuming tasks and respond to changing conditions in any IT domain.
+{EDAName}:: Provides the event-handling capability needed to automate time-consuming tasks and respond to changing conditions in any IT domain.
 
 The architecture for this example consists of the following:
 
 * A two node {ControllerName} cluster
 * An optional hop node to connect {ControllerName} to execution nodes
 * A two node automation hub cluster
-* A single node EDA controller cluster
-* A single PostgreSQL database connected to the {ControllerName}, {HubName}, and EDA controller clusters
+* A single node {EDAcontroller} cluster
+* A single PostgreSQL database connected to the {ControllerName}, {HubName}, and {EDAcontroller} clusters
 * Two execution nodes per automation controller cluster
 
 .Example {PlatformNameShort} {PlatformVers} architecture

--- a/downstream/modules/platform/con-aap-example-architecture.adoc
+++ b/downstream/modules/platform/con-aap-example-architecture.adoc
@@ -14,10 +14,10 @@ The architecture for this example consists of the following:
 
 * A two node {ControllerName} cluster
 * An optional hop node to connect {ControllerName} to execution nodes
-* A two node automation hub cluster
+* A two node {HubName} cluster
 * A single node {EDAcontroller} cluster
 * A single PostgreSQL database connected to the {ControllerName}, {HubName}, and {EDAcontroller} clusters
-* Two execution nodes per automation controller cluster
+* Two execution nodes per  {ControllerName} cluster
 
 .Example {PlatformNameShort} {PlatformVers} architecture
 // dcd - Image in progress with graphics team and will be added once complete.

--- a/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
+++ b/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
@@ -32,7 +32,7 @@ The {ControllerName} UI is available by default at:
 https://<your_rhel_host>:443
 ----
 
-Login as the admin user with the password you created for *controller_admin_password*.
+Log in as the admin user with the password you created for *controller_admin_password*.
 
 If you supplied the license manifest as part of the installation, the {PlatformNameShort} dashboard is displayed. If you did not supply a license file, the *Subscription* screen is displayed where you must supply your license details. This is documented here: link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-activate[Chapter 1. Activating Red Hat Ansible Automation Platform]. 
 

--- a/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
+++ b/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
@@ -44,7 +44,7 @@ The {HubName} UI is available by default at:
 https://<hub node>:444
 ----
 
-Login as the admin user with the password you created for *hub_admin_password*.
+Log in as the admin user with the password you created for *hub_admin_password*.
 
 
 .Accessing {EDAName} UI
@@ -54,4 +54,4 @@ The {EDAName} UI is available by default at:
 https://<eda node>:445
 ----
 
-Login as the admin user with the password you created for *eda_admin_password*.
+Log in as the admin user with the password you created for *eda_admin_password*.

--- a/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
+++ b/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
@@ -2,28 +2,31 @@
 
 [id="accessing-control-auto-hub-eda-control_{context}"]
 
-= Accessing controller, automation hub, and {EDAName} controller
+= Accessing {ControllerName}, {HubName}, and {EDAcontroller}
 
 [role="_abstract"]
 
 
-Once the installation completes, these are the default protocol and ports used:
+After the installation completes, these are the default protocol and ports used:
 
 * https protocol
 
-* Port 443 for controller
+* Port 443 for {ControllerName}
 
-* Port 444 for automation hub
+* Port 444 for {HubName}
 
 * Port 445 for {EDAcontroller}
 
 These can be changed. Consult the *README.md* for further details. It is recommended that you leave the defaults unless you need to change them due to port conflicts or other factors.
 
-NOTE: Port 445 has been known to be blocked by some ISPs. If port 445 is blocked, please refer to the *README.md* file for more information on changing port values. 
+[NOTE]
+====
+ Port 445 has been known to be blocked by some ISPs. If port 445 is blocked, please refer to the *README.md* file for more information on changing port values. 
+====
 
-.Accessing Automation Controller UI
+.Accessing {ControllerName} UI
 
-The automation controller UI is available by default at:
+The {ControllerName} UI is available by default at:
 
 ----
 https://<your_rhel_host>:443
@@ -33,7 +36,7 @@ Login as the admin user with the password you created for *controller_admin_pass
 
 If you supplied the license manifest as part of the installation, the {PlatformNameShort} dashboard is displayed. If you did not supply a license file, the *Subscription* screen is displayed where you must supply your license details. This is documented here: link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-activate[Chapter 1. Activating Red Hat Ansible Automation Platform]. 
 
-.Accessing {HubNameStart} UI
+.Accessing {HubName} UI
 
 The {HubName} UI is available by default at:
 

--- a/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
+++ b/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
@@ -15,7 +15,7 @@ Once the installation completes, these are the default protocol and ports used:
 
 * Port 444 for automation hub
 
-* Port 445 for EDA controller
+* Port 445 for {EDAcontroller}
 
 These can be changed. Consult the *README.md* for further details. It is recommended that you leave the defaults unless you need to change them due to port conflicts or other factors.
 

--- a/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
+++ b/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
@@ -21,7 +21,7 @@ These can be changed. Consult the *README.md* for further details. It is recomme
 
 [NOTE]
 ====
- Port 445 has been known to be blocked by some ISPs. If port 445 is blocked, please refer to the *README.md* file for more information on changing port values. 
+Port 445 has been known to be blocked by some ISPs. If port 445 is blocked, refer to the *README.md* file for more information on changing port values.  
 ====
 
 .Accessing {ControllerName} UI


### PR DESCRIPTION
Completed the following:

- Replaced the EDA acronym with the attributes (spelled out) in the following 2 files that impact the **AAP Planning Guide** and **Getting started with Event-Driven Ansible**, respectively: 
    - `con-aap-example-architecture.adoc`, [2.1 Example AAP Architecture](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_planning_guide/index#aap_example_architecture_planning) 
    - `ref-eda-controller-tasks.adoc`, [Chapter 4, Using Event-Driven Ansible controller](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_event-driven_ansible_guide/index#using-event-driven-ansible-controller)

- Replaced the EDA acronym throughout `ref-accessing-control-auto-hub-eda-control.adoc`, [1.7 Accessing automation controller, automation hub, and Event-Driven Ansible controller](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/containerized_ansible_automation_platform_installation_guide/index#accessing-control-auto-hub-eda-control_aap-containerized-installation) in the **Containerized AAP Installation Guide** along with a couple other _minor_ updates: 
    -  Replaced hard-coded instances of automation controller and automation hub where necessary with the appropriate attributes.
    -  Reformatted the note after the intro to comply with [RH supplementary style guide's example asciidoctor format](https://redhat-documentation.github.io/supplementary-style-guide/#admonitions). 
    -  Updated "Login" (noun or adj) w/ "Log in" (verb) in a couple procedural steps (per IBM style guidelines, https://www.ibm.com/docs/en/ibm-style?topic=word-usage#l).