### PR TITLE
Added content to stop EDA activations before upgrade to AAP 2.4

### DIFF
--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -28,3 +28,9 @@ Before you begin the upgrade process, review the following considerations to pla
 [role="_additional-resources"]
 .Additional resources
 * <<editing-inventory-file-for-updates_{context}, Setting up the inventory file >>
+
+[discrete]
+== {EDAcontroller}
+//ATTENTION: Remove this section for EDA 1.0.4; customers will no longer need to perform deactivation because services will be automatically restored after upgrade and migration. 
+
+* If you are currently running {EDAcontroller} and plan to deploy it when you upgrade to {PlatformNameShort} {PlatformVers}, it is recommended that you disable all {EDAName} activations before upgrading to ensure that only new activations run after the upgrade process has completed. This prevents possibilities of orphaned containers running activations from the previous version.


### PR DESCRIPTION
Added a new discrete heading to [Chapter 2.1 in the RH AAP Upgrade and Migration Guide](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index#aap-upgrade-planning_aap-upgrading-platform) that informs the customer to stop all activations before beginning the upgrade process if they plan to deploy EDA, per proposal from SMEs.