### PR TITLE
Fixing broken link (#898)

### DIFF
--- a/downstream/modules/platform/proc-controller-create-job-template.adoc
+++ b/downstream/modules/platform/proc-controller-create-job-template.adoc
@@ -96,7 +96,7 @@ As with core Ansible:
 * a:b:&c means "in a or b but must be in c"
 * a:!b means "in a, and definitely not in b"
 
-For more information see, link:http://docs.ansible.com/intro_patterns.html[Patterns] in the Ansible documentation. | Yes
+For more information see, link:https://docs.ansible.com/ansible/latest/inventory_guide/intro_patterns.html[Patterns: targeting hosts and groups] in the Ansible documentation. | Yes
 | Verbosity | Control the level of output Ansible produces as the playbook executes.
 Choose the verbosity from Normal to various Verbose or Debug settings.
 This only appears in the *details* report view.


### PR DESCRIPTION
Fixing broken link in Job templates section

Documentation for "Job templates" refer to a wrong link for patterns in the limit section

https://issues.redhat.com/browse/AAP-18785

Affects `titles/controller-user-guide`