### PR TITLE
AAP-18896B Remove EDA or Event-Driven Ansible from 2.3 docs

### DIFF
--- a/downstream/modules/platform/con-aap-example-architecture.adoc
+++ b/downstream/modules/platform/con-aap-example-architecture.adoc
@@ -17,7 +17,7 @@ The architecture for this example consists of the following:
 * An optional hop node to connect {ControllerName} to execution nodes
 * A two node automation hub cluster
 //* A single node EDA controller cluster
-* A single PostgreSQL database connected to the {ControllerName}, {HubName}, and EDA controller clusters
+* A single PostgreSQL database connected to the {ControllerName} and {HubName}
 * Two execution nodes per automation controller cluster
 
 .Example {PlatformNameShort} {PlatformVers} architecture


### PR DESCRIPTION
Removed any instance of EDA from 2.3 docs: 

- 4th bullet, [section 2.1 of Chapter 2. Example AAP architecture](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_planning_guide/aap_architecture#aap_example_architecture_planning).