### PR TITLE
AAP-18088: adds info on download count configuration; fixes a namespace error

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -46,6 +46,7 @@ include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
 include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
 include::platform/proc-operator-external-db-hub.adoc[leveloffset=+1]
 include::platform/proc-find-delete-PVCs.adoc[leveloffset=+1]
+include::platform/ref-ocp-additional-configs.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/modules/platform/proc-installing-hub-using-operator.adoc
+++ b/downstream/modules/platform/proc-installing-hub-using-operator.adoc
@@ -18,7 +18,7 @@ apiVersion: automationhub.ansible.com/v1beta1
 kind: AutomationHub
 metadata:
   name: private-ah                              <1>
-  namespace: ansible-automation-platform
+  namespace: aap
 spec:
   sso_secret: automation-hub-sso                <2>
   pulp_settings:

--- a/downstream/modules/platform/ref-ocp-additional-configs.adoc
+++ b/downstream/modules/platform/ref-ocp-additional-configs.adoc
@@ -10,9 +10,7 @@ A collection download count can help you understand collection usage. To add a c
 -----
 spec:
   pulp_settings:
-    api_root: "/api/galaxy/pulp/"
     ansible_collect_download_count: true 
-
 -----
 
 When `ansible_collect_download_count` is enabled, {HubName} will display a download count by the collection.

--- a/downstream/modules/platform/ref-ocp-additional-configs.adoc
+++ b/downstream/modules/platform/ref-ocp-additional-configs.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ocp-additional-configs_{context}"]
+= Additional configurations
+
+[role="_abstract"]
+
+A collection download count can help you understand collection usage. To add a collection download count to {HubName}, set the following configuration:
+
+-----
+spec:
+  pulp_settings:
+    api_root: "/api/galaxy/pulp/"
+    ansible_collect_download_count: true 
+
+-----
+
+When `ansible_collect_download_count` is enabled, {HubName} will display a download count by the collection.


### PR DESCRIPTION
This PR adds info on setting a download count configuration for automation hub on OCP. The change will appear in the Deploying the RH AAP operator on OpenShift Container Platform guide. 

See[ AAP-18088](https://issues.redhat.com/browse/AAP-18088) for further context. 