### PR TITLE
AAP-19195: Removed single-tenant references

### DIFF
--- a/lightspeed/modules/con-lightspeed-about.adoc
+++ b/lightspeed/modules/con-lightspeed-about.adoc
@@ -10,7 +10,7 @@
 
 {LightspeedShortName} uses {ibmwatsonxcodeassistant} models trained on subject matter expertise across the Ansible ecosystem, which includes {Galaxy}, GitHub, and Ansible Certified and Validated content.
 
-{LightspeedShortName} is integrated with your existing Ansible developer workflows. You can use your existing Git repositories (both public and private) to train your single-tenant {ibmwatsonxcodeassistant} model. You can access {LightspeedShortName} content suggestions in Visual Studio Code (VS Code) by using the Ansible VS Code extension. 
+{LightspeedShortName} is integrated with your existing Ansible developer workflows. You can use your existing Git repositories (both public and private) to train your {ibmwatsonxcodeassistant} model. You can access {LightspeedShortName} content suggestions in Visual Studio Code (VS Code) by using the Ansible VS Code extension. 
 
 == Benefits of using {LightspeedShortName}
 {LightspeedFullName} offers the following benefits: 

--- a/lightspeed/modules/con_lightspeed-key-features.adoc
+++ b/lightspeed/modules/con_lightspeed-key-features.adoc
@@ -7,7 +7,7 @@
 
 * *Ansible-specific {ibmwatsonxcodeassistant} models*
 +
-{LightspeedFullName} uses Ansible-specific, single-tenant IBM watsonx Granite models unique to your organization, which are provided, managed, and maintained by IBM.
+{LightspeedFullName} uses Ansible-specific IBM watsonx Granite models unique to your organization, which are provided, managed, and maintained by IBM.
 
 * *Single tasks and multitask generation*
 +

--- a/lightspeed/modules/con_training-data.adoc
+++ b/lightspeed/modules/con_training-data.adoc
@@ -6,7 +6,7 @@
 
 == Models
 
-{LightspeedFullName} uses single-tenant Ansible-specific IBM watsonx Granite models unique to your organization. These models are provided, managed, and maintained by IBM. 
+{LightspeedFullName} uses Ansible-specific IBM watsonx Granite models unique to your organization. These models are provided, managed, and maintained by IBM. 
 
 You can use the Ansible-specific IBM watsonx Granite model as the default model for{LightspeedShortName}, so that all Ansible Lightspeed users in your organization can use the fine-tuned model. 
 

--- a/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-25oct2023.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-25oct2023.adoc
@@ -19,7 +19,7 @@ This release includes the following key features that were implemented in {Light
 
 * *Ansible-specific {ibmwatsonxcodeassistant} models*
 +
-{LightspeedFullName} uses Ansible-specific, single-tenant IBM watsonx Granite models unique to your organization, which are provided, managed, and maintained by IBM.
+{LightspeedFullName} uses Ansible-specific IBM watsonx Granite models unique to your organization, which are provided, managed, and maintained by IBM.
 
 * *Single tasks and multitask generation*
 +


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-19195. 

Changes made:
Removed 'single-tenant' references from the following files:

- titles/lightspeed-user-guide/modules/con-lightspeed-about.adoc
- titles/lightspeed-user-guide/modules/con_lightspeed-key-features.adoc
- titles/lightspeed-user-guide/modules/con_training-data.adoc
- titles/lightspeed-release-notes/modules/lightspeed-rn-25oct2023.adoc
