### PR TITLE
bp 2.4: AAP-15176 fix broken link in installation guide (#920)

### DIFF
--- a/downstream/modules/platform/ref-hub-configs.adoc
+++ b/downstream/modules/platform/ref-hub-configs.adoc
@@ -10,5 +10,5 @@ See the following resources to explore additional {HubName} configurations.
 |Resource link|Description
 |link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Managing user access in {PrivateHubName}]|Configure user access for {HubName}.
 |link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_content_in_automation_hub/managing-cert-valid-content[Managing Red Hat Certified, validated, and Ansible Galaxy content in {HubName}]|Add content to your {HubName}.
-|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_content_in_automation_hub/assembly-managing-private-collections[Publishing proprietary content collections in {HubName}]|Publish internally developed collections on your {HubName}.
+|link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_content_in_automation_hub/managing-collections-hub#assembly-managing-private-collections[Publishing proprietary content collections in {HubName}]|Publish internally developed collections on your {HubName}.
 |====


### PR DESCRIPTION
Backports update from [PR 920](https://github.com/hherbly/aap-docs/pull/new/bp-2.4-install-guide-broken-links) to the 2.4 release.

See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for further detail