### PR TITLE
AAP-16022 - updated the information to state admin is default userid

### DIFF
--- a/downstream/modules/platform/con-install-scenario-recommendations.adoc
+++ b/downstream/modules/platform/con-install-scenario-recommendations.adoc
@@ -3,15 +3,16 @@
 = Inventory file recommendations based on installation scenarios
 
 [role="_abstract"]
-Before selecting your installation method for {PlatformNameShort}, review the following recommendations. Familiarity with these recommendations will streamline the installation process.  
+Before selecting your installation method for {PlatformNameShort}, review the following recommendations. Familiarity with these recommendations will streamline the installation process.
 
 * For {PlatformName} or {HubName}: Add an {HubName} host in the `[automationhub]` group.
-* For internal databases: `[database]` cannot be used to point to another host in the {PlatformNameShort} cluster. 
+* For internal databases: `[database]` cannot be used to point to another host in the {PlatformNameShort} cluster.
 The database host set to be installed needs to be a unique host.
 * Do not install {ControllerName} and {HubName} on the same node for versions of {PlatformNameShort} in a production or customer environment.
 This can cause contention issues and heavy resource use.
-* Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure users can sync and install content from {HubName} from a different node. 
+* Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure users can sync and install content from {HubName} from a different node.
 Do not use 'localhost'.
+* `admin` is the default userid for the initial log in to Ansible Automation Platform and can not be changed in the inventory file.
 * Use of special characters for `pg_password` is limited. The `!`, `#`, `0` and `@` characters are supported. Use of other special characters can cause the setup to fail.
 * Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
 * The inventory file variables `registry_username` and `registry_password` are only required if a non-bundle installer is used.

--- a/downstream/modules/platform/con-install-scenario-recommendations.adoc
+++ b/downstream/modules/platform/con-install-scenario-recommendations.adoc
@@ -12,7 +12,7 @@ The database host set to be installed needs to be a unique host.
 This can cause contention issues and heavy resource use.
 * Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure users can sync and install content from {HubName} from a different node.
 Do not use 'localhost'.
-* `admin` is the default userid for the initial log in to Ansible Automation Platform and can not be changed in the inventory file.
+* `admin` is the default user ID for the initial log in to Ansible Automation Platform and cannot be changed in the inventory file.
 * Use of special characters for `pg_password` is limited. The `!`, `#`, `0` and `@` characters are supported. Use of other special characters can cause the setup to fail.
 * Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
 * The inventory file variables `registry_username` and `registry_password` are only required if a non-bundle installer is used.

--- a/downstream/modules/platform/proc-verify-controller-installation.adoc
+++ b/downstream/modules/platform/proc-verify-controller-installation.adoc
@@ -10,7 +10,7 @@ Verify that you installed automation controller successfully by logging in with 
 
 .Procedure
 . Navigate to the IP address specified for the {ControllerName} node in the `inventory` file.
-. Log in with the userid `admin` and the password credentials you set in the `inventory` file.
+. Log in with the user ID `admin` and the password credentials you set in the `inventory` file.
 
 [NOTE]
 ====

--- a/downstream/modules/platform/proc-verify-controller-installation.adoc
+++ b/downstream/modules/platform/proc-verify-controller-installation.adoc
@@ -10,7 +10,7 @@ Verify that you installed automation controller successfully by logging in with 
 
 .Procedure
 . Navigate to the IP address specified for the {ControllerName} node in the `inventory` file.
-. Log in with the admin credentials you set in the `inventory` file.
+. Log in with the userid `admin` and the password credentials you set in the `inventory` file.
 
 [NOTE]
 ====

--- a/downstream/modules/platform/proc-verify-eda-controller-installation.adoc
+++ b/downstream/modules/platform/proc-verify-eda-controller-installation.adoc
@@ -10,7 +10,7 @@ Verify that you installed {EDAcontroller} successfully by logging in with the ad
 
 . Navigate to the IP address specified for the {EDAcontroller} node in the `inventory` file.
 
-. Log in with the userid `admin` and the password credentials you set in the `inventory` file.
+. Log in with the user ID `admin` and the password credentials you set in the `inventory` file.
 
 [IMPORTANT]
 ====

--- a/downstream/modules/platform/proc-verify-eda-controller-installation.adoc
+++ b/downstream/modules/platform/proc-verify-eda-controller-installation.adoc
@@ -10,7 +10,7 @@ Verify that you installed {EDAcontroller} successfully by logging in with the ad
 
 . Navigate to the IP address specified for the {EDAcontroller} node in the `inventory` file.
 
-. Log in with the admin credentials you set in the `inventory` file.
+. Log in with the userid `admin` and the password credentials you set in the `inventory` file.
 
 [IMPORTANT]
 ====

--- a/downstream/modules/platform/proc-verify-hub-installation.adoc
+++ b/downstream/modules/platform/proc-verify-hub-installation.adoc
@@ -7,7 +7,7 @@ Verify that you installed your {HubName} successfully by logging in with the adm
 
 .Procedure
 . Navigate to the IP address specified for the {HubName} node in the `inventory` file.
-. Log in with the admin credentials you set in the `inventory` file.
+. Log in with the userid `admin` and the password credentials you set in the `inventory` file.
 
 
 [IMPORTANT]

--- a/downstream/modules/platform/proc-verify-hub-installation.adoc
+++ b/downstream/modules/platform/proc-verify-hub-installation.adoc
@@ -7,7 +7,7 @@ Verify that you installed your {HubName} successfully by logging in with the adm
 
 .Procedure
 . Navigate to the IP address specified for the {HubName} node in the `inventory` file.
-. Log in with the userid `admin` and the password credentials you set in the `inventory` file.
+. Log in with the user ID `admin` and the password credentials you set in the `inventory` file.
 
 
 [IMPORTANT]


### PR DESCRIPTION
This PR addresses the change requested in https://issues.redhat.com/browse/AAP-16022 to clarify that admin is the default initial log in userid and can not be changed in the inventory file.