### PR TITLE
Fix missing link in Red Hat AAP Installation Guide

### DIFF
--- a/downstream/modules/platform/con-aap-installation-on-disconnected-rhel.adoc
+++ b/downstream/modules/platform/con-aap-installation-on-disconnected-rhel.adoc
@@ -4,11 +4,11 @@
 = {PlatformNameShort} installation on disconnected RHEL
 
 [role="_abstract"]
-You can install {PlatformNameShort} {ControllerName} and a {PrivateHubName} without an internet connection by using the installer-managed database located on the {ControllerName}. The setup bundle is recommended for disconnected installation because it includes additional components that make installing {PlatformNameShort} easier in a disconnected environment. These include the {PlatformNameShort} Red Hat package managers (RPMs) and the default {ExecEnvShort} (EE) images.
+You can install {PlatformNameShort} {ControllerName} and {PrivateHubName} without an internet connection by using the installer-managed database located on the {ControllerName}. Use the setup bundle for a disconnected installation as it includes additional components that make installing {PlatformNameShort} easier in a disconnected environment. These include the {PlatformNameShort} Red Hat package managers (RPMs) and the default {ExecEnvShort} (EE) images.
 
 == System requirements for disconnected installation
 
-Ensure that your system has all the hardware requirements before performing a disconnected installation of Ansible Automation Platform. You can find these requirements in Chapter 2. System Requirements [link] in the {PlatformNameShort} Installation Guide.
+Ensure that your system has all the hardware requirements before performing a disconnected installation of {PlatformNameShort}. For more information about hardware requirements, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_installation_guide/index#platform-system-requirements[Chapter 2. System requirements].
 
 == RPM Source
 
@@ -20,8 +20,8 @@ RPM dependencies for {PlatformNameShort} that come from the BaseOS and AppStream
 [NOTE]
 
 ====
-The RHEL Binary DVD method requires the DVD for supported versions of RHEL, including version 8.6 or higher. See link:https://access.redhat.com/support/policy/updates/errata[Red Hat Enterprise Linux Life Cycle] for information on which versions of RHEL are currently supported.
+The RHEL Binary DVD method requires the DVD for supported versions of RHEL, including version 8.6 or higher. See link:https://access.redhat.com/support/policy/updates/errata[Red Hat Enterprise Linux Life Cycle] for information about which versions of RHEL are currently supported.
 ====
 
-.Additonal Resources
+.Additional Resources
 * link:https://access.redhat.com/documentation/en-us/red_hat_satellite/6.11/html/installing_satellite_server_in_a_disconnected_network_environment/index[Satellite]


### PR DESCRIPTION
Fix missing link in section “4.2.1 System requirements for disconnected installation” in the installation guide

Red Hat Ansible Automation Platform Installation Guide: Link broken

https://issues.redhat.com/browse/AAP-19268