### PR TITLE
AAP-19290: Fixed typo in Lightspeed docs

### DIFF
--- a/lightspeed/modules/con_overview-and-best-practices.adoc
+++ b/lightspeed/modules/con_overview-and-best-practices.adoc
@@ -14,7 +14,7 @@ Write a description of your task in the `- name:` key of a new task line in your
 +
 Place your cursor on a new line in your Ansible YAML file at the correct indentation, and start your prompt with a Pound key (#).
 +
-Write the descriptions of your tasks, separating each prompt by using Ampersand symbols (&). For example, to automate a multitask of installing PostgreSQL server and running the initial PostgreSQL setup command, you can enter the prompt `# Install postgresql-server & run postgresqul-setup command`.
+Write the descriptions of your tasks, separating each prompt by using Ampersand symbols (&). For example, to automate a multitask of installing PostgreSQL server and running the initial PostgreSQL setup command, you can enter the prompt `# Install postgresql-server & run postgresql-setup command`.
 
 The Ansible Lightspeed service reads the text, interacts with the {ibmwatsonxcodeassistant} model, and generates Ansible task recommendations based on your natural language prompt.
 


### PR DESCRIPTION
THIs PR addresses JIRA issue https://issues.redhat.com/browse/AAP-19290.

Changes:
- Fixed typo: postgresqul-setup > postgresql-setup in file con_overview-and-best-practices.adoc.

