### PR TITLE
Fixing incorrect UI in controller user guide

### DIFF
--- a/downstream/modules/platform/proc-controller-creating-a-user.adoc
+++ b/downstream/modules/platform/proc-controller-creating-a-user.adoc
@@ -40,7 +40,7 @@ image:users-edit-user-form.png[Edit User Form]
 . Click btn:[Delete] to delete the user, or you can delete users from a list of current users.
 For more information, see xref:proc-controller-deleting-a-user[Deleting a user].
 +
-The same window opens whether you click on the user's name, or the Edit image:leftpencil.png[Edit, 15,15] icon beside the user. You can use this window to review and modify the User's *Organizations*, *Teams*, *Roles*, and other user membership details.
+The same window opens whether you click the user's name, or the Edit image:leftpencil.png[Edit, 15,15] icon beside the user. You can use this window to review and modify the User's *Organizations*, *Teams*, *Roles*, and other user membership details.
 
 [NOTE]
 ====

--- a/downstream/modules/platform/ref-controller-user-roles.adoc
+++ b/downstream/modules/platform/ref-controller-user-roles.adoc
@@ -2,8 +2,8 @@
 
 = Users - Roles
 
-From the *Users > Details* page, select *Organizations* tab to display the set of roles assigned to this user. 
-These provide the ability to read, modify, and administer projects, inventories, job templates, and other elements.
+From the *Users > Details* page, select the *Roles* tab to display the set of roles assigned to this user. 
+These offer the ability to read, change, and administer projects, inventories, job templates, and other elements.
 
 You can sort or search the list by *Name*, *Type*, or *Role*.
 

--- a/downstream/modules/platform/ref-controller-user-teams.adoc
+++ b/downstream/modules/platform/ref-controller-user-teams.adoc
@@ -12,6 +12,6 @@ You cannot modify team membership from this display panel.
 For more information, see xref:assembly-controller-teams[Teams].
 ====
 
-Until you create a team and assign a user to that team, the assigned teams details for that user appears empty.
+Until you create a team and assign a user to that team, the assigned teams details for that user is displayed as empty.
 
 //image:users-teams-list-for-example-user.png[Users - teams list]

--- a/downstream/modules/platform/ref-controller-user-teams.adoc
+++ b/downstream/modules/platform/ref-controller-user-teams.adoc
@@ -2,16 +2,16 @@
 
 = Users - Teams
 
-From the *Users > Details* page, select *Organizations* tab to display the list of teams of which that user is a member. 
+From the *Users > Details* page, select the *Teams* tab to display the list of teams of which that user is a member. 
 
 You can search this list by *Team Name* or *Description*. 
 
 [NOTE]
 ====
-Team membership cannot be modified from this display panel. 
-For more information, see [Teams].
+You cannot modify team membership from this display panel. 
+For more information, see xref:assembly-controller-teams[Teams].
 ====
 
-Until a Team has been created and a user has been assigned to that team, the assigned Teams Details for that User appears empty.
+Until you create a team has and assign a user to that team, the assigned teams details for that user appears empty.
 
 //image:users-teams-list-for-example-user.png[Users - teams list]

--- a/downstream/modules/platform/ref-controller-user-teams.adoc
+++ b/downstream/modules/platform/ref-controller-user-teams.adoc
@@ -12,6 +12,6 @@ You cannot modify team membership from this display panel.
 For more information, see xref:assembly-controller-teams[Teams].
 ====
 
-Until you create a team has and assign a user to that team, the assigned teams details for that user appears empty.
+Until you create a team and assign a user to that team, the assigned teams details for that user appears empty.
 
 //image:users-teams-list-for-example-user.png[Users - teams list]


### PR DESCRIPTION
Reference to the UI in the Teams section is incorrect

Incorrect menu selection in Controller User's Guide

https://issues.redhat.com/browse/AAP-19671

Affects `titles/controller-user-guide`