### PR TITLE
Remove duplicate automation mesh attribute

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -25,6 +25,8 @@
 // Automation Mesh
 :AutomationMesh: automation mesh
 :AutomationMeshStart: Automation mesh
+:ReceptorRpm: receptor rpm/container
+:RunnerRpm: Ansible-runner rpm/container
 
 // Operators
 :OperatorPlatform: Ansible Automation Platform Operator
@@ -77,10 +79,7 @@
 :ControllerAG: Automation controller Administration Guide
 :Analytics: Automation Analytics
 
-// Automation Mesh
-:MeshName: automation mesh
-:ReceptorRpm: receptor rpm/container
-:RunnerRpm: Ansible-runner rpm/container
+
 
 // Execution environments
 :ExecEnvNameStart: Automation execution environments


### PR DESCRIPTION
Group together mesh related attributes and remove duplicate automation mesh attribute: MeshName

Remove duplicate attribute for automation mesh and add AutomationMeshStart attribute

https://issues.redhat.com/browse/AAP-19776