### PR TITLE
Backport to 2.4: Updates to Builder Documentation

### DIFF
--- a/downstream/assemblies/builder/assembly-definition-file-breakdown.adoc
+++ b/downstream/assemblies/builder/assembly-definition-file-breakdown.adoc
@@ -19,4 +19,4 @@ include::builder/con-additional-custom-build-steps.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For example definition files for common scenarios, see link:https://ansible.readthedocs.io/projects/builder/en/latest/scenario_guides/scenario_copy/[Common scenarios section] of the _Ansible Builder Documentation_
+* For example definition files for common scenarios, see the link:https://ansible.readthedocs.io/projects/builder/en/latest/scenario_guides/scenario_copy/[Common scenarios section] of the _Ansible Builder Documentation_

--- a/downstream/modules/builder/con-additional-build-files.adoc
+++ b/downstream/modules/builder/con-additional-build-files.adoc
@@ -2,16 +2,15 @@
 
 = Additional build files
 
-You can add any file to the build context directory by referring or copying them to the `additional_build_steps` section of the definition file. The format is a list of dictionary values, each with a `src` and `dest` key and value.
+You can add any external file to the build context directory by referring or copying them to the `additional_build_steps` section of the definition file. The format is a list of dictionary values, each with a `src` and `dest` key and value.
 
-Each list item must be a dictionary containing the following (non-optional) keys:
+Each list item must be a dictionary containing the following required keys:
 
-.`src`
-Specifies the source files to copy into the build context directory. This can be an absolute path (for example, `/home/user/.ansible.cfg`), or a path that is relative to the execution environment file. Relative paths can be glob expressions matching one or more files (for example,  `files/*.cfg`).
+`src`:: Specifies the source files to copy into the build context directory. This can be an absolute path (for example, `/home/user/.ansible.cfg`), or a path that is relative to the {ExecEnvShort} file. Relative paths can be glob expressions matching one or more files (for example, `files/*.cfg`).
+
 [NOTE]
 ====
 Absolute paths can not include a regular expression. If `src` is a directory, the entire contents of that directory are copied to `dest`.
 ====
 
-.`dest`
-Specifies a subdirectory path underneath the `_build` subdirectory of the build context directory that contains the source files (for example, `files/configs`). This can not be an absolute path or contain `..` within the path. This directory is created for you if it does not already exist.
+`dest`:: Specifies a subdirectory path underneath the `_build` subdirectory of the build context directory that contains the source files (for example, `files/configs`). This can not be an absolute path or contain `..` within the path. Builder creates this directory for you if it does not already exist.

--- a/downstream/modules/builder/con-additional-custom-build-steps.adoc
+++ b/downstream/modules/builder/con-additional-custom-build-steps.adoc
@@ -2,9 +2,9 @@
 
 = Additional custom build steps
 
-You can specify custom build commands for any build phase in the `additional_build_steps` section of the definition file.
+You can specify custom build commands for any build phase in the `additional_build_steps` section of the definition file. This allows fine-grained control over the build phases.
 
-Use `prepend_` and `append_` commands to add commands to the `Containerfile` which will run either before or after the main build steps are executed. The commands must conform to any rules required for the runtime system.
+Use the `prepend_` and `append_` commands to add directives to the `Containerfile` that run either before or after the main build steps are executed. The commands must conform to any rules required for the runtime system.
 
 See the following table for a list of values that can be used in `additional_build_steps`:
 
@@ -25,10 +25,10 @@ See the following table for a list of values that can be used in `additional_bui
 | Allows you to insert after building the galaxy image.
 
 | `prepend_builder`
-| Allows you to insert commands before building the builder image.
+| Allows you to insert commands before building the Python builder image.
 
 | `append_builder`
-| Allows you to insert commands after building the builder image.
+| Allows you to insert commands after building the Python builder image.
 
 | `prepend_final`
 | Allows you to insert before building the final image.
@@ -38,10 +38,8 @@ See the following table for a list of values that can be used in `additional_bui
 
 |===
 
-The syntax for `additional_build_steps` supports both of the following:
+The syntax for `additional_build_steps` supports both multi-line strings and lists. See the following examples:
 
-* a multi-line string
-+
 .A multi-line string entry
 [example]
 ====
@@ -52,8 +50,6 @@ prepend_final: |
 ----
 ====
 
-* a list
-+
 .A list entry
 [example]
 ====

--- a/downstream/modules/builder/con-building-definition-file.adoc
+++ b/downstream/modules/builder/con-building-definition-file.adoc
@@ -2,11 +2,9 @@
 
 = Building a definition file
 
-After you have {Builder} installed, you can create a definition file that {Builder} uses to create your {ExecEnvNameSing} image. The high level process to build an {ExecEnvNameSing} image is for {Builder} to read and validate your definition file, then create a `Containerfile`, and finally pass the `Containerfile` to Podman, which then packages and creates your {ExecEnvNameSing} image. The definition file created is in `yaml` format and contains different sections.
+After you install {Builder}, you can create a definition file that {Builder} uses to create your {ExecEnvNameSing} image. {Builder} makes an {ExecEnvNameSing} image by reading and validating your definition file, then creating a `Containerfile`, and finally passing the `Containerfile` to Podman, which then packages and creates your {ExecEnvNameSing} image. The definition file that you create must be in `yaml` format and contain different sections. The default definition filename, if not provided, is `execution-environment.yml`. For more information on the parts of a definition file, see xref:assembly-definition-file-breakdown[Breakdown of definition file content].
 
-The following is an example of a version 3 definition file. Each definition file should specify the major version number of the Ansible Builder feature set it uses. If not specified, the default version is 1, and most new features and definition keywords will be unavailable.
-
-// ddacosta - there is a Ansible Builder version 3 Porting Guide in progress that discusses the changes from v1/2 to v3. A link should be included to that document once its published.
+The following is an example of a version 3 definition file. Each definition file must specify the major version number of the {Builder} feature set it uses. If not specified, {Builder} defaults to version 1, making most new features and definition keywords unavailable.
 
 .Definition file example
 ====
@@ -17,10 +15,6 @@ build_arg_defaults: <1>
   ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: '--pre'
 
 dependencies: <2>
-  ansible_core:
-    package_pip: ansible-core==2.14.4
-  ansible_runner:
-    package_pip: ansible-runner
   galaxy: requirements.yml
   python:
     - six
@@ -30,29 +24,23 @@ dependencies: <2>
 images: <3>
   base_image:
     name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel9:latest
-    # Other available base images:
-    #   - docker.io/redhat/ubi9:latest
-    #   - quay.io/rockylinux/rockylinux:9
-    #   - quay.io/centos/centos:stream9
-    #   - registry.fedoraproject.org/fedora:38
-    #     (needs an account)
 
 # Custom package manager path for the RHEL based images
-# options: <4>
-#  package_manager_path: /usr/bin/microdnf
+ options: <4>
+ package_manager_path: /usr/bin/microdnf
 
-additional_build_files: <5>
-    - src: files/ansible.cfg
-      dest: configs
-
-additional_build_steps: <6>
+additional_build_steps: <5>
   prepend_base:
     - RUN echo This is a prepend base command!
-    # Enable Non-default stream before packages provided by it can be installed. (optional)
-    # - RUN $PKGMGR module enable postgresql:15 -y
-    # - RUN $PKGMGR install -y postgresql
+
   prepend_galaxy:
-    - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+      # Environment variables used for Galaxy client configurations
+    - ENV ANSIBLE_GALAXY_SERVER_LIST=automation_hub
+    - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_URL=https://console.redhat.com/api/automation-hub/content/xxxxxxx-synclist/
+    - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_AUTH_URL=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+    # define a custom build arg env passthru - we still also have to pass
+    # `--build-arg ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN` to get it to pick it up from the env
+    - ARG ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN
 
   prepend_final: |
     RUN whoami
@@ -67,9 +55,9 @@ additional_build_steps: <6>
 <2> Specifies the location of various requirements files.
 <3> Specifies the base image to be used. Red Hat support is only provided for the redhat.registry.io base image.
 <4> Specifies options that can affect builder runtime functionality.
-<5> Specifies files to be added to the build context directory.
-<6> Commands for additional custom build steps.
+<5> Commands for additional custom build steps.
 
 [role="_additional-resources"]
 .Additional resources
 * For more information about the definition file content, see xref:assembly-definition-file-breakdown[Breakdown of definition file content].
+* To read more about the differences between {Builder} versions 2 and 3, see the link:https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_3.html[Ansible 3 Porting Guide].

--- a/downstream/modules/builder/con-container_file.adoc
+++ b/downstream/modules/builder/con-container_file.adoc
@@ -2,13 +2,10 @@
 
 = Containerfile
 
-Once your definition file is created, Ansible Builder reads and validates it, then creates a `Containerfile`, and finally passes the `Containerfile` to Podman to package and create your automation execution environment image using the following instructions:
+After your definition file is created, {Builder} reads and validates it, creates a `Containerfile` and container build context, and optionally passes these to Podman to build your {ExecEnvNameSing} image. The container build occurs in several distinct stages: `base` , `galaxy`, `builder`, and `final`. The image build steps (along with any corresponding custom `prepend_` and `append_` steps defined in `additional_build_steps`) are:
 
-. Fetch base image.
-. In the ephemeral copy of base image, collections are downloaded and the list of declared Python and system dependencies, if any, are collected for later.
-. In the ephemeral builder image, Python wheels for all Python dependencies listed in the definition file are downloaded and built (as needed), including all Python dependencies declared by collections listed in the definition file.
-. Any `prepend_` commands defined for additional_build_steps from the definition file are run.
-. In the final {ExecEnvName} image, system dependencies listed in the definition file are installed, including all system dependencies declared by collections listed in the definition file.
-. In the final {ExecEnvName} image, the downloaded collections are copied and the previously fetched Python dependencies are installed.
-. Any `append_` commands defined for additional_build_steps from the definition file are run.
+. During the `base` build stage, the specified base image is (optionally) customized with components required by other build stages, including Python, `pip`, `ansible-core`, and `ansible-runner`. The resulting image is then validated to ensure that the required components are available (as they may have already been present in the base image). Ephemeral copies of the resulting customized `base` image are used as the base for all other build stages.
+. During the `galaxy` build stage, collections specified by the definition file are downloaded and stored for later installation during the `final` build stage. Python and system dependencies declared by the collections, if any, are also collected for later analysis.
+. During the `builder` build stage, Python dependencies declared by collections are merged with those listed in the definition file. This final set of Python dependencies is downloaded and built as Python wheels and stored for later installation during the `final` build stage.
+. During the `final` build stage, the previously-downloaded collections are installed, along with system packages and any previously-built Python packages that were declared as dependencies by the collections or listed in the definition file.
 //Note if a diagram with the Main step actions gets created, it should be included here. Check with @nitzmahone

--- a/downstream/modules/builder/con-definition-dependencies.adoc
+++ b/downstream/modules/builder/con-definition-dependencies.adoc
@@ -2,4 +2,4 @@
 
 You can include dependencies that must be installed into the final image in the dependencies section of your definition file.
 
-To avoid issues with your {ExecEnvNameSing} image, make sure that the entries for Galaxy, Python, and system point to a valid requirements file.
+To avoid issues with your {ExecEnvNameSing} image, make sure that the entries for Galaxy, Python, and system point to a valid requirements file, or are valid content for their respective file types.

--- a/downstream/modules/builder/con-galaxy-dependencies.adoc
+++ b/downstream/modules/builder/con-galaxy-dependencies.adoc
@@ -3,7 +3,7 @@
 = Galaxy
 The `galaxy` entry points to a valid requirements file or includes inline content for the `ansible-galaxy collection install -r ...` command.
 
-The entry `requirements.yml` can be a relative path from the directory of the {ExecEnvNameSing} definition’s folder, or an absolute path.
+The entry `requirements.yml` can be a relative path from the directory of the {ExecEnvNameSing} definition's folder, or an absolute path.
 
 The content might look like the following:
 

--- a/downstream/modules/builder/con-optional-build-command-arguments.adoc
+++ b/downstream/modules/builder/con-optional-build-command-arguments.adoc
@@ -12,10 +12,10 @@ $ ansible-builder build -t my_first_ee_image
 
 [NOTE]
 ====
-If you do not use `-t` with `build`, an image called `ansible-execution-env`` is created and loaded into the local container registry.
+If you do not use `-t` with `build`, an image called `ansible-execution-env` is created and loaded into the local container registry.
 ====
 
-If you have multiple definition files, you can specify which one to use by utilizing the `-f` flag:
+If you have multiple definition files, you can specify which one to use by including the `-f` flag:
 
 [[example1]]
 ====
@@ -24,6 +24,6 @@ $ ansible-builder build -f another-definition-file.yml -t another_ee_image
 ----
 ====
 
-In <<example1, the previous example,>> {Builder} will use the specifications provided in the file `another-definition-file.yml` instead of the default `execution-environment.yml` to build an {ExecEnvNameSing} image named `another_ee_image`.
+In <<example1, this example,>> {Builder} will use the specifications provided in the file named `another-definition-file.yml` instead of the default `execution-environment.yml` to build an {ExecEnvNameSing} image named `another_ee_image`.
 
-For other specifications and flags that are possible to use with the build command, enter `ansible-builder build --help` to see a list of additional options.
+For other specifications and flags that you can use with the `build` command, enter `ansible-builder build --help` to see a list of additional options.

--- a/downstream/modules/builder/con-python-dependencies.adoc
+++ b/downstream/modules/builder/con-python-dependencies.adoc
@@ -4,7 +4,7 @@
 
 The `python` entry in the definition file points to a valid requirements file or to an inline list of Python requirements in PEP508 format for the `pip install -r ...` command.
 
-The entry `requirements.txt` is a file that installs extra Python requirements on top of what the Collections already list as their Python dependencies. It may be listed as a relative path from the directory of the {ExecEnvNameSing} definition’s folder, or an absolute path. The contents of a `requirements.txt` file should be formatted like the following example, similar to the standard output from a `pip freeze` command:
+The entry `requirements.txt` is a file that installs extra Python requirements on top of what the Collections already list as their Python dependencies. It may be listed as a relative path from the directory of the {ExecEnvNameSing} definition's folder, or an absolute path. The contents of a `requirements.txt` file should be formatted like the following example, similar to the standard output from a `pip freeze` command:
 
 .Python entry
 [example]
@@ -19,9 +19,6 @@ packaging
 requests>=2.4.2
 xmltodict
 azure-cli-core==2.11.1
-python_version >= '2.7'
-collection community.vmware
-google-auth
 openshift>=0.6.2
 requests-oauthlib
 openstacksdk>=0.13

--- a/downstream/modules/builder/con-system-dependencies.adoc
+++ b/downstream/modules/builder/con-system-dependencies.adoc
@@ -2,7 +2,7 @@
 
 = System
 
-The `system` entry in the definition points to a https://docs.opendev.org/opendev/bindep/latest/readme.html[bindep] requirements file or to an inline list of bindep entries, which will install system-level dependencies that are outside of what the collections already include as their dependencies. It can be listed as a relative path from the directory of the {ExecEnvNameSing} definition’s folder, or an absolute path. A minimum expectation is that the collection(s) specify necessary requirements for `[platform:rpm]`.
+The `system` entry in the definition points to a link:https://docs.opendev.org/opendev/bindep/latest/readme.html[bindep] requirements file or to an inline list of bindep entries, which install system-level dependencies that are outside of what the collections already include as their dependencies. It can be listed as a relative path from the directory of the {ExecEnvNameSing} definition's folder, or as an absolute path. At a minimum, the the collection(s) must specify necessary requirements for `[platform:rpm]`.
 
 To demonstrate this, the following is an example `bindep.txt` file that adds the `libxml2` and `subversion` packages to a container:
 

--- a/downstream/modules/builder/con-why-builder.adoc
+++ b/downstream/modules/builder/con-why-builder.adoc
@@ -4,4 +4,4 @@
 
 Before {Builder} was developed, {PlatformName} users could run into dependency issues and errors when creating custom virtual environments or containers that included all of the required dependencies installed.
 
-Now, with {Builder}, you can easily create a customizable {ExecEnvName} definition file that specifies the content you want included in your {ExecEnvName} such as, collections, requirements, and system level packages. This allows you to fulfill all of the necessary requirements and dependencies to get jobs running.
+Now, with {Builder}, you can easily create a customizable {ExecEnvName} definition file that specifies the content you want included in your {ExecEnvName} such as Ansible Core, Python, Collections, third-party Python requirements, and system level packages. This allows you to fulfill all of the necessary requirements and dependencies to get jobs running.

--- a/downstream/modules/builder/proc-installing-builder.adoc
+++ b/downstream/modules/builder/proc-installing-builder.adoc
@@ -2,12 +2,9 @@
 
 = Installing {Builder}
 
-You can install {Builder} using Red Hat Subscription Management (RHSM) to attach your {PlatformName} subscription. https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_planning_guide/index#proc-attaching-subscriptions_planning[Attaching your {PlatformName} subscription] allows you to access subscription-only resources necessary to install `ansible-builder`. Once you attach your subscription, the necessary repository for `ansible-builder` is automatically enabled.
-
-[NOTE]
-====
-You must have valid subscriptions attached on the host before installing `ansible-builder`.
-====
+.Prerequisites
+* You have installed the Podman container runtime.
+* You have valid subscriptions attached on the host. Doing so allows you to access the subscription-only resources needed to install `ansible-builder`, and ensures that the necessary repository for `ansible-builder` is automatically enabled. See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_planning_guide/index#proc-attaching-subscriptions_planning[Attaching your Red Hat {PlatformNameShort} subscription] for more information. 
 
 .Procedure
 

--- a/downstream/modules/builder/ref-definition-file-images.adoc
+++ b/downstream/modules/builder/ref-definition-file-images.adoc
@@ -1,8 +1,8 @@
 [id="ref-definition-file-image"]
 
-= images
+= Images
 
-The `images` section of the definition file is a dictionary used to define the base image to be used. Verification of signed container images is supported with the `podman` container runtime.
+The `images` section of the definition file identifies the base image. Verification of signed container images is supported with the `podman` container runtime.
 
 See the following table for a list of values that can be used in `images`:
 
@@ -11,9 +11,9 @@ See the following table for a list of values that can be used in `images`:
 | Value | Description
 
 | `base_image`
-| Specifies the parent image for the automation execution environment, enabling a new image to be built that is based off of an already-existing image. This is typically a supported execution environment base image like ee-minimal or ee-supported, but it can also be an execution environment image that you've created previously and want to customize further.
+| Specifies the parent image for the {ExecEnvNameSing}, enabling a new image to be built that is based on an already-existing image. This is typically a supported execution environment base image like _ee-minimal_ or _ee-supported_, but it can also be an execution environment image that you've created previously and want to customize further.
 
-A `name` key is required for the container image to use. Specify the `signature _original_name` key if the image is mirrored within your repository, but signed with the image's original signature key. Image names must contain a tag, such as `:latest`.
+A `name` key is required for the container image to use. Specify the `signature _original_name` key if the image is mirrored within your repository, but is signed with the image's original signature key. Image names must contain a tag, such as `:latest`.
 
 The default image is `registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel8:latest`.
 


### PR DESCRIPTION
This PR ports the changes from [PR 957](https://github.com/ansible/aap-docs/pull/957) to the 2.4 release. See [AAP-17700](https://issues.redhat.com/browse/AAP-17700) for more info. 

* add prereqs to procedure for installing builder

* updates sample definition file example

* adds SME edits to definition file breakdown assembly

* formatting fix

* format fixes

* changes based on SME feedback

* fix attribute

* edits based on team member peer review