### PR TITLE
[Backport] AAP-14300 Add verification steps for controller backup and restore (#948)

### DIFF
--- a/downstream/modules/platform/proc-aap-controller-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-backup.adoc
@@ -18,7 +18,8 @@ Use this procedure to back up a deployment of the controller, including jobs, in
 . Select the *Automation Controller Backup* tab.
 . Click btn:[Create AutomationControllerBackup].
 . Enter a *Name* for the backup.
-. Enter the *Deployment name* for the deployment being backed up.
+. Enter the *Deployment name* of the deployed {PlatformNameShort} instance being backed up.
+For example, if your {ControllerName} must be backed up and the deployment name is `aap-controller`, enter 'aap-controller' in the *Deployment name* field.
 . If you want to use a custom, pre-created pvc:
 .. Optionally enter the name of the *Backup persistant volume claim*.
 .. Optionally enter the *Backup PVC storage requirements*, and *Backup PVC storage class*.
@@ -40,3 +41,16 @@ $ df -h | grep "/var/lib/pgsql/data"
 . Click btn:[Create].
 +
 A backup tarball of the specified deployment is created and available for data recovery or deployment rollback. Future backups are stored in separate tar files on the same pvc.
+
+.Verification
+. Log in to Red Hat *{OCP}*
+. Navigate to menu:Operators[Installed Operators].
+. Select the {OperatorPlatform} installed on your project namespace.
+. Select the *AutomationControllerBackup* tab.
+. Select the backup resource you want to verify.
+. Scroll to *Conditions* and check that the *Successful* status is `True`.
++
+[NOTE]
+====
+If *Successful* is `False`, the backup has failed. Check the {ControllerName} operator logs for the error to fix the issue.
+====

--- a/downstream/modules/platform/proc-aap-controller-restore.adoc
+++ b/downstream/modules/platform/proc-aap-controller-restore.adoc
@@ -35,3 +35,17 @@ This should be different from the original deployment name.
 . Click btn:[Create].
 +
 A new deployment is created and your backup is restored to it. This can take approximately 5 to 15 minutes depending on the size of your database.
+
+
+.Verification
+. Log in to Red Hat *{OCP}*
+. Navigate to menu:Operators[Installed Operators].
+. Select the {OperatorPlatform} installed on your project namespace.
+. Select the *AutomationControllerRestore* tab.
+. Select the restore resource you want to verify.
+. Scroll to *Conditions* and check that the *Successful* status is `True`.
++
+[NOTE]
+====
+If *Successful* is `False`, the recovery has failed. Check the {ControllerName} operator logs for the error to fix the issue.
+====

--- a/downstream/modules/platform/proc-aap-hub-backup.adoc
+++ b/downstream/modules/platform/proc-aap-hub-backup.adoc
@@ -18,7 +18,8 @@ Use this procedure to back up a deployment of the hub, including all hosted Ansi
 . Select the *Automation Hub Backup* tab.
 . Click btn:[Create AutomationHubBackup].
 . Enter a *Name* for the backup.
-. Enter the *Deployment name* for the deployment being backed up.
+. Enter the *Deployment name* of the deployed {PlatformNameShort} instance being backed up.
+For example, if your {HubName} must be backed up and the deployment name is `aap-hub`, enter 'aap-hub' in the *Deployment name* field.
 . If you want to use a custom, pre-created pvc:
 .. Optionally, enter the name of the *Backup persistent volume claim*, *Backup persistent volume claim namespace*, *Backup PVC storage requirements*, and *Backup PVC storage class*.
 . Click btn:[Create].


### PR DESCRIPTION
This PR backports the changes from #948 to the 2.3 branch and includes the following:

* AAP-14300 Add verification steps for controller backup and restore

* AAP-14300 corrected the working for the restore setction

* AAP-14300 - Changed from text to attribute for automation controller