### PR TITLE
AAP-10305 modified hub signing procedures (#973)

### DIFF
--- a/downstream/modules/automation-hub/proc-configuring-the-client-to-verify-signatures.adoc
+++ b/downstream/modules/automation-hub/proc-configuring-the-client-to-verify-signatures.adoc
@@ -3,56 +3,67 @@
 
 = Configuring the client to verify signatures
 
-.Prerequsites
+To ensure a container image pulled from the remote registry is properly signed, you must first configure the image with the proper public key in a policy file. 
+
+.Prerequisites
 * The client must have sudo privileges configured to verify signatures.
 
 .Procedure
 
-. In a terminal type:
-
-    > sudo <name of editor> __/etc/containers/policy.json__
-
-The file may look similar to this:
-
+. Open your terminal and use the following command: 
++
 ----
-    {
-        "default": [{"type": "reject"}],
-        "transports": {
-            "docker": {
-              "quay.io": [{"type": "insecureAcceptAnything}],
-              "docker.io": [{"type": "insecureAcceptAnything}],
-              "_<server-address>_": [
-                {
-                    "type": "signedBy",
-                    "keyType": "GPGKeys",
-                    "keyPath": "/tmp/containersig.txt"
-    }
+>  sudo <name of editor> /etc/containers/policy.json
 ----
-
-This shows there will be no verification from either `quay.io`, or `docker.io` since the type is `insecureAcceptAnything` which overrides the default type of `reject`. However, there will be verification from `_<server-address>_` as the parameter `type` has been set to `"signedBy"``.
-
-NOTE: The only `keyType` currently supported is GPG keys.
-
-. Under the `_<server-address>_` entry, modify the `keyPath` <1> to reflect the
++
+The file that is displayed is similar to this:
++
+----
+{
+  "default": [{"type": "reject"}],
+  "transports": {
+  	"docker": {
+    	"quay.io": [{"type": "insecureAcceptAnything"}],
+    	"docker.io": [{"type": "insecureAcceptAnything"}],
+    	"<server-address>": [
+      	{
+          	    "type": "signedBy",
+          	    "keyType": "GPGKeys",
+          	    "keyPath": "/tmp/containersig.txt"
+      	}]
+  	}
+  }
+}
+----
++
+This file shows that neither `quay.io`, or `docker.io` will perform the verification, because the type is `insecureAcceptAnything` which overrides the default type of `reject`. However, `_<server-address>_` will perform the verification, because the parameter `type` is set to `"signedBy"`.
++
+[NOTE]
+====
+The only `keyType` currently supported is GPG keys.
+====
++
+. Under the `_<server-address>_` entry, modify the `keyPath` <1> to include the
 name of your key file.
 +
 ----
-    {
-        "default": [{"type": "reject"}],
-        "transports": {
-            "docker": {
-              "quay.io": [{"type": "insecureAcceptAnything}],
-              "docker.io": [{"type": "insecureAcceptAnything}],
-              "_<server-address>_1": [
-                {
-                    "type": "signedBy",
-                    "keyType": "GPGKeys",
-                    "keyPath": "/tmp/<key file name", <1>
-                    "signedIdentity": {
-                      "type": "remapIdentity",
-                      "prefix": "_<server-address>_",
-                      "signedPrefix": "0.0.0.0:8002"
-    }
+{
+    	"default": [{"type": "reject"}],
+    	"transports": {
+        	"docker": {
+          	  "quay.io": [{"type": "insecureAcceptAnything"}],
+          	  "docker.io": [{"type": "insecureAcceptAnything"}],
+          	  "<server-address>": [{
+                	"type": "signedBy",
+                	"keyType": "GPGKeys",
+                	"keyPath": "/tmp/<key file name>",
+                	"signedIdentity": {
+                  	  "type": "matchExact"
+                    }
+            	  }]
+            }
+    	}
+}
 ----
 +
 . Save and close the file.
@@ -60,8 +71,10 @@ name of your key file.
 . Pull the file using podman, or your client of choice:
 
 ----
-> podman pull _<server-address>_/<container-name>:<tag name>
---tls-verify=false
+> podman pull <server-address>/<container-name>:<tag name> --tls-verify=false
 ----
 
-This verifies the signature with no errors.
+This response verifies the image has been signed with no errors. If the image is not signed, the command fails.
+
+.Additional resources
+* For more information about policy.json, see link:https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#signedby[documentation for containers-policy.json]. 

--- a/downstream/modules/automation-hub/proc-deploying-your-system-for-container-signing.adoc
+++ b/downstream/modules/automation-hub/proc-deploying-your-system-for-container-signing.adoc
@@ -3,28 +3,69 @@
 
 = Deploying your system for container signing
 
-Execution Environments are container images used by Ansible {ControllerName} to run jobs. This content can be downloaded to the private automation hub, and published within your organization.
+{HubNameStart} implements image signing to provide better security for the execution environment container images.
 
-{HubNameStart} is now implementing image signing so the user can rely on better security for the EE container images.
+To deploy your system so that it is ready for container signing, create a signing script.
 
-As an {PlatformNameShort} user, you can now confirm if an EE/Container is already signed, or how to use the proper tools to sign and verify the signature yourself. This section details how to deploy your system so it is ready for container signing.
-
+[NOTE]
+==== 
+Installer looks for the script and key on the same server where installer is located.
+====
 
 .Procedure
-. Deploy your system with support for container signing activated.
+. From a terminal, create create a signing script, and pass the script path as an installer parameter.
++
+*Example*:
++
+-----
+#!/usr/bin/env bash
 
-    _automation_hub:
-        automationhub_create_default_container_signing_service: true
-        automationhub_container_signing_service_key: _path/to/gpg.key_
-        automationhub_container_signing_service_script: _path/to/executable_
+# pulp_container SigningService will pass the next 4 variables to the script.
+MANIFEST_PATH=$1
+FINGERPRINT="$PULP_SIGNING_KEY_FINGERPRINT"
+IMAGE_REFERENCE="$REFERENCE"
+SIGNATURE_PATH="$SIG_PATH"
 
+# Create container signature using skopeo
+skopeo standalone-sign \
+  $MANIFEST_PATH \
+  $IMAGE_REFERENCE \
+  $FINGERPRINT \
+  --output $SIGNATURE_PATH
 
-. Navigate to automation hub.
+# Optionally pass the passphrase to the key if password protected.
+# --passphrase-file /path/to/key_password.txt
 
-. In the navigation pane, select menu:Signature Keys[].
+# Check the exit status
+STATUS=$?
+if [ $STATUS -eq 0 ]; then
+  echo {\"signature_path\": \"$SIGNATURE_PATH\"}
+else
+  exit $STATUS
+fi
+-----
++
+. Review the {PlatformNameShort} installer inventory file for options for container signing that begin with `automationhub_*`. 
++
+-----
+[all:vars]
+.
+.
+.
 
-. Ensure you have a key titled *container-default*, or *container*-_anyname_.
+automationhub_create_default_container_signing_service = True
+automationhub_container_signing_service_key = /absolute/path/to/key/to/sign
+automationhub_container_signing_service_script = /absolute/path/to/script/that/signs
+-----
++
+. Once installation is complete, navigate to your {HubName}.
 
-NOTE: The 'container-default' service is created by the {PlatformNameShort} installer.
+. From the navigation panel, select menu:Signature Keys[].
 
+. Ensure that you have a key titled *container-default*, or *container*-_anyname_.
+
+[NOTE]
+==== 
+The `container-default` service is created by the {PlatformNameShort} installer.
+====
 

--- a/downstream/modules/automation-hub/proc-pushing-container-images-from-your-local.adoc
+++ b/downstream/modules/automation-hub/proc-pushing-container-images-from-your-local.adoc
@@ -3,50 +3,46 @@
 
 = Pushing container images from your local
 
+Use the following procedure to sign images on a local system and push those signed images to the {HubName} registry. 
+
 .Procedure
 . From a terminal, log into podman, or any container client currently in use.
 +
 ----
-> podman pull <__container-name__>
+> podman pull <container-name>
 ----
 +
-. After the image is pulled, add tags:
+. After the image is pulled, add tags (for example: latest, rc, beta, or version numbers, such as 1.0; 2.3, and so on):
 +
 ----
-> podman tag <container-name> _<server-address>_/<container-name>:<tag name>
+> podman tag <container-name> <server-address>/<container-name>:<tag name>
 ----
 +
-. Sign the image after changes have been made, and push it back up:
+. Sign the image after changes have been made, and push it back up to the {HubName} registry:
 +
 ----
-> podman push _<server-address>_/<container-name>:<tag name>
---tls-verify=false --sign-by<reference to the gpg key on your local>
+> podman push <server-address>/<container-name>:<tag name> --tls-verify=false --sign-by <reference to the gpg key on your local>
 ----
 +
-If the image is not signed, it can only be pushed with any current signature
-embedded.
-
-. Push the image without signing it:
+If the image is not signed, it can only be pushed with any current signature embedded. Alternatively, you can use the following script to push the image without signing it:
 +
 ----
-> podman push _<server-address>_/<container-name>:<tag name>
---tls-verify=false
+> podman push <server-address>/<container-name>:<tag name> --tls-verify=false
 ----
 +
-. Navigate to the automation hub and click on *Execution Environments* if that
-window is not open.
+. Once the image has been pushed, navigate to your {HubName}.
 
 . Click the "Refresh" icon to refresh the page to show the new execution
 environment.
 
-. Click the name of the image.
+. Click the name of the image  to view your pushed image.
 
 In the details page, below the image name, will be displayed whether or not the
 image has been signed. In this case, it displays "Unsigned."
 
-To sign the image from automation hub:
+The details page in {HubName} indicates whether or not an image has been signed. If the details page indicates that an image is *Unsigned*, you can sign the image from {HubName}  using the following steps: 				
 
-. Click the image name to open the details page.
+. Click the image name to navigate to the details page.
 
 . Click the three dots in the upper right hand corner of the details page.
 Three options are available:


### PR DESCRIPTION
2.3 backport of [PR 973](https://github.com/ansible/aap-docs/pull/973)

Updated signing script and procedures in line with [AAP-10305](https://issues.redhat.com/browse/AAP-10305)

Updated content in [Google doc](https://docs.google.com/document/d/17S1ZrkTMpFZV4Cpc9x9QqamdIKt5_SJdIhmyTkj_d40/edit)

Files modified:

proc-configuring-the-client-to-verify-signatures.adoc
proc-deploying-your-system-for-container-signing.adoc
proc-pushing-container-images-from-your-local.adoc

Affects `titles/hub/manage-containers`