### PR TITLE
AAP-10305 modified hub signing procedures (#973)

### DIFF
--- a/downstream/modules/hub/proc-configuring-the-client-to-verify-signatures.adoc
+++ b/downstream/modules/hub/proc-configuring-the-client-to-verify-signatures.adoc
@@ -3,61 +3,67 @@
 
 = Configuring the client to verify signatures
 
+To ensure a container image pulled from the remote registry is properly signed, you must first configure the image with the proper public key in a policy file. 
+
 .Prerequisites
 * The client must have sudo privileges configured to verify signatures.
 
 .Procedure
 
-. In a terminal type:
+. Open your terminal and use the following command: 
 +
 ----
->  sudo <name of editor> __/etc/containers/policy.json
+>  sudo <name of editor> /etc/containers/policy.json
 ----
 +
 The file that is displayed is similar to this:
 +
 ----
-    {
-        "default": [{"type": "reject"}],
-        "transports": {
-            "docker": {
-              "quay.io": [{"type": "insecureAcceptAnything}],
-              "docker.io": [{"type": "insecureAcceptAnything}],
-              "_<server-address>_": [
-                {
-                    "type": "signedBy",
-                    "keyType": "GPGKeys",
-                    "keyPath": "/tmp/containersig.txt"
-    }
+{
+  "default": [{"type": "reject"}],
+  "transports": {
+  	"docker": {
+    	"quay.io": [{"type": "insecureAcceptAnything"}],
+    	"docker.io": [{"type": "insecureAcceptAnything"}],
+    	"<server-address>": [
+      	{
+          	    "type": "signedBy",
+          	    "keyType": "GPGKeys",
+          	    "keyPath": "/tmp/containersig.txt"
+      	}]
+  	}
+  }
+}
 ----
 +
 This file shows that neither `quay.io`, or `docker.io` will perform the verification, because the type is `insecureAcceptAnything` which overrides the default type of `reject`. However, `_<server-address>_` will perform the verification, because the parameter `type` is set to `"signedBy"`.
 +
 [NOTE]
 ====
-The only `keyType`` currently supported is GPG keys.
+The only `keyType` currently supported is GPG keys.
 ====
 +
 . Under the `_<server-address>_` entry, modify the `keyPath` <1> to include the
 name of your key file.
 +
 ----
-    {
-        "default": [{"type": "reject"}],
-        "transports": {
-            "docker": {
-              "quay.io": [{"type": "insecureAcceptAnything}],
-              "docker.io": [{"type": "insecureAcceptAnything}],
-              "_<server-address>_1": [
-                {
-                    "type": "signedBy",
-                    "keyType": "GPGKeys",
-                    "keyPath": "/tmp/<key file name", <1>
-                    "signedIdentity": {
-                      "type": "remapIdentity",
-                      "prefix": "_<server-address>_",
-                      "signedPrefix": "0.0.0.0:8002"
-    }
+{
+    	"default": [{"type": "reject"}],
+    	"transports": {
+        	"docker": {
+          	  "quay.io": [{"type": "insecureAcceptAnything"}],
+          	  "docker.io": [{"type": "insecureAcceptAnything"}],
+          	  "<server-address>": [{
+                	"type": "signedBy",
+                	"keyType": "GPGKeys",
+                	"keyPath": "/tmp/<key file name>",
+                	"signedIdentity": {
+                  	  "type": "matchExact"
+                    }
+            	  }]
+            }
+    	}
+}
 ----
 +
 . Save and close the file.
@@ -66,8 +72,10 @@ name of your key file.
 * Pull the file using Podman, or your client of choice:
 
 ----
-> podman pull _<server-address>_/<container-name>:<tag name>
---tls-verify=false
+> podman pull <server-address>/<container-name>:<tag name> --tls-verify=false
 ----
 
-This response verifies the signature with no errors.
+This response verifies the image has been signed with no errors. If the image is not signed, the command fails.
+
+.Additional resources
+* For more information about policy.json, see link:https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#signedby[documentation for containers-policy.json]. 

--- a/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
+++ b/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
@@ -3,20 +3,62 @@
 
 = Deploying your system for container signing
 
-{HubNameStart} implements image signing to provided better security for the {ExecEnvShort} container images.
+{HubNameStart} implements image signing to provide better security for the execution environment container images.
 
-To deploy your system so that it is ready for container signing, you must confirm if an {ExecEnvShort} or container is already signed or use the proper tools to sign and verify the signature yourself. 
+To deploy your system so that it is ready for container signing, create a signing script.
+
+[NOTE]
+==== 
+Installer looks for the script and key on the same server where installer is located.
+====
 
 .Procedure
-. Deploy your system with support for container signing activated.
+. From a terminal, create create a signing script, and pass the script path as an installer parameter.
++
+*Example*:
++
+-----
+#!/usr/bin/env bash
 
-    _automation_hub:
-        automationhub_create_default_container_signing_service: true
-        automationhub_container_signing_service_key: _path/to/gpg.key_
-        automationhub_container_signing_service_script: _path/to/executable_
+# pulp_container SigningService will pass the next 4 variables to the script.
+MANIFEST_PATH=$1
+FINGERPRINT="$PULP_SIGNING_KEY_FINGERPRINT"
+IMAGE_REFERENCE="$REFERENCE"
+SIGNATURE_PATH="$SIG_PATH"
 
+# Create container signature using skopeo
+skopeo standalone-sign \
+  $MANIFEST_PATH \
+  $IMAGE_REFERENCE \
+  $FINGERPRINT \
+  --output $SIGNATURE_PATH
 
-. Navigate to {HubName}.
+# Optionally pass the passphrase to the key if password protected.
+# --passphrase-file /path/to/key_password.txt
+
+# Check the exit status
+STATUS=$?
+if [ $STATUS -eq 0 ]; then
+  echo {\"signature_path\": \"$SIGNATURE_PATH\"}
+else
+  exit $STATUS
+fi
+-----
++
+. Review the {PlatformNameShort} installer inventory file for options for container signing that begin with `automationhub_*`. 
++
+-----
+[all:vars]
+.
+.
+.
+
+automationhub_create_default_container_signing_service = True
+automationhub_container_signing_service_key = /absolute/path/to/key/to/sign
+automationhub_container_signing_service_script = /absolute/path/to/script/that/signs
+-----
++
+. Once installation is complete, navigate to your {HubName}.
 
 . From the navigation panel, select menu:Signature Keys[].
 

--- a/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
+++ b/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
@@ -3,49 +3,46 @@
 
 = Pushing container images from your local environment
 
+Use the following procedure to sign images on a local system and push those signed images to the {HubName} registry. 
+
 .Procedure
 . From a terminal, log into podman, or any container client currently in use:
 +
 ----
-> podman pull <__container-name__>
+> podman pull <container-name>
 ----
 +
-. After the image is pulled, add tags:
+. After the image is pulled, add tags (for example: latest, rc, beta, or version numbers, such as 1.0; 2.3, and so on):
 +
 ----
-> podman tag <container-name> _<server-address>_/<container-name>:<tag name>
+> podman tag <container-name> <server-address>/<container-name>:<tag name>
 ----
 +
-. Sign the image after changes have been made, and push it back up:
+. Sign the image after changes have been made, and push it back up to the {HubName} registry:
 +
 ----
-> podman push _<server-address>_/<container-name>:<tag name>
---tls-verify=false --sign-by<reference to the gpg key on your local>
+> podman push <server-address>/<container-name>:<tag name> --tls-verify=false --sign-by <reference to the gpg key on your local>
 ----
 +
-If the image is not signed, it can only be pushed with any current signature embedded.
-
-. Push the image without signing it:
+If the image is not signed, it can only be pushed with any current signature embedded. Alternatively, you can use the following script to push the image without signing it:
 +
 ----
-> podman push _<server-address>_/<container-name>:<tag name>
---tls-verify=false
+> podman push <server-address>/<container-name>:<tag name> --tls-verify=false
 ----
 +
-. Navigate to {HubName}. 
+. Once the image has been pushed, navigate to your {HubName}.
 
 . From the navigation panel, select menu:Execution Environments[Execution Environments].
 
 . To display the new {ExecEnvShort}, click the *Refresh* icon.
 
-. Click the name of the image.
+. Click the name of the image  to view your pushed image.
 
 .Troubleshooting
 
-The details page displays whether or not the image has been signed. 
-If it displays *Unsigned* you can sign the image from {HubName} with the following steps:
+The details page in {HubName} indicates whether or not an image has been signed. If the details page indicates that an image is *Unsigned*, you can sign the image from {HubName}  using the following steps: 				
 
-. Click the image name to open the details page.
+. Click the image name to navigate to the details page.
 
 . Click the btn:[More Actions] icon *{MoreActionsIcon}*.
 Three options are available:


### PR DESCRIPTION
2.4 backport of https://github.com/ansible/aap-docs/pull/973

Updated signing script and procedures in line with [AAP-10305](https://issues.redhat.com/browse/AAP-10305)

Updated content in [Google doc](https://docs.google.com/document/d/17S1ZrkTMpFZV4Cpc9x9QqamdIKt5_SJdIhmyTkj_d40/edit)

Files modified:

proc-configuring-the-client-to-verify-signatures.adoc
proc-deploying-your-system-for-container-signing.adoc
proc-pushing-container-images-from-your-local.adoc