### PR TITLE
Backport to 2.3: AAP-10252 add note to remind user not to leave fields blank (#989)

### DIFF
--- a/downstream/modules/platform/proc-configure-ldap-hub-ocp.adoc
+++ b/downstream/modules/platform/proc-configure-ldap-hub-ocp.adoc
@@ -33,5 +33,11 @@ spec:
       auth_ldap_user_flags_by_group: '@json {"is_superuser": "cn=tower-admin,cn=groups,cn=accounts,dc=example,dc=com"}' 
 ----
 
+[NOTE]
 
+====
+
+Do not leave any fields empty. For fields with no variable, enter ```` to indicate a default value.
+
+====
 


### PR DESCRIPTION
This PR ports the changes from [PR 989](https://github.com/ansible/aap-docs/pull/989/files) to the 2.3 release. See [AAP-10252](https://issues.redhat.com/browse/AAP-10252) for more info.