### PR TITLE
Renaming mesh guide

### DIFF
--- a/downstream/assemblies/platform/assembly-planning-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-planning-mesh.adoc
@@ -5,13 +5,13 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="assembly-planning-mesh"]
-= Planning for automation mesh in your {PlatformName} environment
+= Planning for automation mesh in your VM-based {PlatformName} environment
 
 :context: planning-mesh
 
 
 [role="_abstract"]
-The following topics contain information to help plan an automation mesh deployment in your {PlatformNameShort} environment. The subsequent sections explain the concepts that comprise automation mesh in addition to providing examples on how you can design automation mesh topologies. Simple to complex topology examples are included to illustrate the various ways you can deploy automation mesh.
+The following topics contain information to help plan an automation mesh deployment in your VM-based {PlatformNameShort} environment. The subsequent sections explain the concepts that comprise automation mesh in addition to providing examples on how you can design automation mesh topologies. Simple to complex topology examples are included to illustrate the various ways you can deploy automation mesh.
 
 
 include::platform/con-about-automation-mesh.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-about-automation-mesh.adoc
+++ b/downstream/modules/platform/con-about-automation-mesh.adoc
@@ -8,9 +8,11 @@ Automation mesh is an overlay network intended to ease the distribution of work 
 
 {PlatformName} 2 replaces Ansible Tower and isolated nodes with {ControllerName} and {HubName}. {ControllerNameStart} provides the control plane for automation through its UI, Restful API, RBAC, workflows and CI/CD integration, while Automation Mesh can be used for setting up, discovering, changing or modifying the nodes that form the control and execution layers.
 
+Automation mesh uses TLS encryption for communication, so traffic that traverses external networks (the internet or other) is encrypted in transit.
+
 Automation Mesh introduces:
 
-* Dynamic cluster capacity that scales independently, allowing you to create, register, group, ungroup and deregister nodes with minimal downtime.
+* Dynamic cluster capacity that scales independently, enabling you to create, register, group, ungroup and deregister nodes with minimal downtime.
 * Control and execution plane separation that enables you to scale playbook execution capacity independently from control plane capacity.
-* Deployment choices that are resilient to latency, reconfigurable without outage, and that dynamically re-reroute to choose a different path when outages may exist. mesh routing changes.
-* Connectivity that includes bi-directional, multi-hopped mesh communication possibilities which are Federal Information Processing Standards (FIPS) compliant.
+* Deployment choices that are resilient to latency, reconfigurable without outage, and that dynamically re-reroute to choose a different path when outages occur.
+* Connectivity that includes bi-directional, multi-hopped mesh communication possibilities which are _Federal Information Processing Standards_ (FIPS) compliant.

--- a/downstream/modules/platform/con-automation-mesh-node-types.adoc
+++ b/downstream/modules/platform/con-automation-mesh-node-types.adoc
@@ -20,7 +20,7 @@ The *execution plane* consists of execution nodes that execute automation on beh
 
 * *Execution nodes* - Execution nodes run jobs under `ansible-runner` with `podman` isolation. This node type is similar to isolated nodes. This is the default node type for execution plane nodes.
 
-* *Hop nodes* - similar to a jump host, hop nodes will route traffic to other execution nodes. Hop nodes cannot execute automation.
+* *Hop nodes* - similar to a jump host, hop nodes route traffic to other execution nodes. Hop nodes cannot execute automation.
 
 == Peers
 

--- a/downstream/modules/platform/proc-defining-node-types.adoc
+++ b/downstream/modules/platform/proc-defining-node-types.adoc
@@ -10,8 +10,8 @@ The examples in this section demonstrate how to set the node type for the hosts 
 You can set the `node_type` for single nodes in the control plane or execution plane inventory groups.
 To define the node type for an entire group of nodes, set the `node_type` in the `vars` stanza for the group.
 
-* The allowed values for `node_type` in the control plane `[automationcontroller]` group are `hybrid` (default) and `control`.
-* The allowed values for `node_type` in the `[execution_nodes]` group are `execution` (default) and `hop`.
+* The permitted values for `node_type` in the control plane `[automationcontroller]` group are `hybrid` (default) and `control`.
+* The permitted values for `node_type` in the `[execution_nodes]` group are `execution` (default) and `hop`.
 
 .Hybrid node
 

--- a/downstream/titles/automation-mesh/docinfo.xml
+++ b/downstream/titles/automation-mesh/docinfo.xml
@@ -1,9 +1,9 @@
-<title>Red Hat Ansible Automation Platform Automation Mesh Guide</title>
+<title>Red Hat Ansible Automation Platform Automation Mesh Guide for VM-based installations</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.4</productnumber>
 <subtitle>Automate at scale in a cloud-native way</subtitle>
 <abstract>
-<para>This guide shows how to deploy automation mesh as part of your Ansible Automation Platform environment.</para>
+<para>This guide shows how to deploy automation mesh as part of your VM-based Ansible Automation Platform environment.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/automation-mesh/master.adoc
+++ b/downstream/titles/automation-mesh/master.adoc
@@ -9,7 +9,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} automation mesh guide for VM-based installations
+= Red Hat Ansible Automation Platform Automation Mesh Guide for VM-based installations
 
 Thank you for your interest in {PlatformName}. 
 {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.

--- a/downstream/titles/automation-mesh/master.adoc
+++ b/downstream/titles/automation-mesh/master.adoc
@@ -3,16 +3,19 @@
 :toclevels: 1
 
 :experimental:
+:mesh-VM:
 
 include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} automation mesh guide
+= {PlatformName} automation mesh guide for VM-based installations
 
-Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
+Thank you for your interest in {PlatformName}. 
+{PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
-This guide helps you to understand the installation requirements and processes behind installing {PlatformNameShort}. This document has been updated to include information for the latest release of {PlatformNameShort}.
+This guide helps you to understand the requirements and processes behind setting up an automation mesh on a VM-based installation of {PlatformName}. 
+This document has been updated to include information for the latest release of {PlatformNameShort}.
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::{DocumentationFeedback}[leveloffset=+1]


### PR DESCRIPTION
Renamed the guide in the master and docinfo files, and mae some of the note changes from AAP-19132

Rename existing automation mesh guide

https://issues.redhat.com/browse/AAP-20269