### PR TITLE
Backport to 2.4: AAP-17700 Further updates to Builder documentation (#980)

### DIFF
--- a/downstream/modules/builder/con-additional-build-files.adoc
+++ b/downstream/modules/builder/con-additional-build-files.adoc
@@ -13,4 +13,4 @@ Each list item must be a dictionary containing the following required keys:
 Absolute paths can not include a regular expression. If `src` is a directory, the entire contents of that directory are copied to `dest`.
 ====
 
-`dest`:: Specifies a subdirectory path underneath the `_build` subdirectory of the build context directory that contains the source files (for example, `files/configs`). This can not be an absolute path or contain `..` within the path. Builder creates this directory for you if it does not already exist.
+`dest`:: Specifies a subdirectory path underneath the `_build` subdirectory of the build context directory that contains the source files (for example, `files/configs`). This can not be an absolute path or contain `..` within the path. {Builder} creates this directory for you if it does not already exist.

--- a/downstream/modules/builder/con-building-definition-file.adoc
+++ b/downstream/modules/builder/con-building-definition-file.adoc
@@ -34,7 +34,7 @@ additional_build_steps: <5>
     - RUN echo This is a prepend base command!
 
   prepend_galaxy:
-      # Environment variables used for Galaxy client configurations
+    # Environment variables used for Galaxy client configurations
     - ENV ANSIBLE_GALAXY_SERVER_LIST=automation_hub
     - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_URL=https://console.redhat.com/api/automation-hub/content/xxxxxxx-synclist/
     - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_AUTH_URL=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token

--- a/downstream/modules/builder/ref-scenario-using-authentication-ee.adoc
+++ b/downstream/modules/builder/ref-scenario-using-authentication-ee.adoc
@@ -4,7 +4,7 @@
 
 
 [role="_abstract"]
-Use this example to customize the default definition file to pass {HubName} authentication details into the {ExecEnvNameSing} build without exposing them in the final {ExecEnvNameSing} image.
+Use the following example to customize the default definition file to pass {HubName} authentication details into the {ExecEnvNameSing} build without exposing them in the final {ExecEnvNameSing} image.
 
 .Prerequisites
 
@@ -15,22 +15,12 @@ export ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$(cat <token.txt>)
 ----
 
 -----
-additional_build_files:
-  # copy arbitrary files next to this EE def into the build context- we can refer to them later.
-  - src: files
-    dest: configs
-
 additional_build_steps:
   prepend_galaxy:
-    # Copy ansible.cfg from build directory to EE
-    - COPY _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-    # Environment variables used for Galaxy client configurations
-    - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_URL=https://console.redhat.com/api/automation-hub/content/xxxxxxx-synclist/
-    - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_AUTH_URL=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-    # define a custom build arg env passthru - we still also have to pass
-    # `--build-arg ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN` to get it to pick it up from the env
+    # define a custom build arg env passthru- we still also have to pass
+    # `--build-arg ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN` to get it to pick it up from the host env
     - ARG ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN
-
-options:
-  package_manager_path: /usr/bin/microdnf  # downstream images use non-standard package manager
+    - ENV ANSIBLE_GALAXY_SERVER_LIST=automation_hub
+    - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_URL=https://console.redhat.com/api/automation-hub/content/<yourhuburl>-synclist/
+    - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_AUTH_URL=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
 -----


### PR DESCRIPTION
This PR ports the changes from [PR 980](https://github.com/ansible/aap-docs/pull/980/files) to the 2.4 release. See [AAP-17700](https://issues.redhat.com/browse/AAP-17700) for more detail. 

* attribute fix

* update addit'l build file config in section 3.2

* removed one extra space from yaml file

* edits based on SME feedback--cleaned up sample yaml