### PR TITLE
AAP-18798 Added a note with link to article re: adding cgroup V2 enabled

### DIFF
--- a/downstream/assemblies/eda/assembly-installation-eda-controller.adoc
+++ b/downstream/assemblies/eda/assembly-installation-eda-controller.adoc
@@ -13,7 +13,7 @@ Similar to the {ControllerName} and {HubName} components, the setup for {EDAcont
 
 [NOTE]
 ====
-If you are running {RHEL} 8 and want to set your memory limits, you must have cgroup v2 enabled before you install {EDAName}. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for RHEL 8 requires cgroupv2].
+If you are running {RHEL} 8 and want to set your memory limits, you must have cgroup v2 enabled before you install {EDAName}. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for {RHEL} 8 requires cgroupv2].
 ====
 
 include::eda/ref-installing-eda-controller-on-aap.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-installation-eda-controller.adoc
+++ b/downstream/assemblies/eda/assembly-installation-eda-controller.adoc
@@ -11,6 +11,11 @@ Similar to the {ControllerName} and {HubName} components, the setup for {EDAcont
 {EDAcontroller} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
 ====
 
+[NOTE]
+====
+If you plan to run {EDAName} on {RHEL} 8, you must have cgroup v2 enabled on your system to set memory limits. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for RHEL 8 requires cgroupv2].
+====
+
 include::eda/ref-installing-eda-controller-on-aap.adoc[leveloffset=+1]
 include::eda/ref-deploy-eda-controller-with-aap-operator-on-ocp.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/eda/assembly-installation-eda-controller.adoc
+++ b/downstream/assemblies/eda/assembly-installation-eda-controller.adoc
@@ -13,7 +13,7 @@ Similar to the {ControllerName} and {HubName} components, the setup for {EDAcont
 
 [NOTE]
 ====
-If you plan to run {EDAName} on {RHEL} 8, you must have cgroup v2 enabled on your system to set memory limits. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for RHEL 8 requires cgroupv2].
+If you are running {RHEL} 8 and want to set your memory limits, you must have cgroup v2 enabled before you install {EDAName}. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for RHEL 8 requires cgroupv2].
 ====
 
 include::eda/ref-installing-eda-controller-on-aap.adoc[leveloffset=+1]

--- a/downstream/modules/platform/ref-eda-system-requirements.adoc
+++ b/downstream/modules/platform/ref-eda-system-requirements.adoc
@@ -6,7 +6,7 @@ The {EDAcontroller} is a single-node system capable of handling a variable numbe
 
 [NOTE]
 ====
-If you are running {RHEL} 8 and want to set your memory limits, you must have cgroup v2 enabled before you install {EDAName}. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for RHEL 8 requires cgroupv2].
+If you are running {RHEL} 8 and want to set your memory limits, you must have cgroup v2 enabled before you install {EDAName}. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for {RHEL} 8 requires cgroupv2].
 ====
 
 [cols="a,a",options="header"]

--- a/downstream/modules/platform/ref-eda-system-requirements.adoc
+++ b/downstream/modules/platform/ref-eda-system-requirements.adoc
@@ -6,7 +6,7 @@ The {EDAcontroller} is a single-node system capable of handling a variable numbe
 
 [NOTE]
 ====
-If you plan to run {EDAName} on {RHEL} 8, you must have cgroup v2 enabled on your system to set memory limits. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for RHEL 8 requires cgroupv2].
+If you are running {RHEL} 8 and want to set your memory limits, you must have cgroup v2 enabled before you install {EDAName}. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for RHEL 8 requires cgroupv2].
 ====
 
 [cols="a,a",options="header"]

--- a/downstream/modules/platform/ref-eda-system-requirements.adoc
+++ b/downstream/modules/platform/ref-eda-system-requirements.adoc
@@ -4,6 +4,11 @@
 
 The {EDAcontroller} is a single-node system capable of handling a variable number of long-running processes (such as, Rulebook activations) on-demand, depending on the number of CPU cores. Use the following minimum requirements to execute a maximum of 9 simultaneous activations:
 
+[NOTE]
+====
+If you plan to run {EDAName} on {RHEL} 8, you must have cgroup v2 enabled on your system to set memory limits. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for RHEL 8 requires cgroupv2].
+====
+
 [cols="a,a",options="header"]
 |===
 h| Requirement | Required


### PR DESCRIPTION
Added a note that contains a link to a KCS article that describes how to enable the cgroup v2 for RHEL 8 systems. Note included in the following docs: 

- AAP Planning Guide, [Chapter 4.4 EDA controller system requirements](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/platform-system-requirements#event-driven-ansible-system-requirements)
- AAP Installation Guide, [Chapter 2.4 EDA controller system requirements](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#event-driven-ansible-system-requirements)
- Getting Started with EDA, [Chapter 3.1 Installing Event-Driven Ansible controller on Red Hat Ansible Automation Platform](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_event-driven_ansible_guide/index#installing-eda-controller-on-red-hat-aap_eda-getting-started)