### PR TITLE
Update ref-system-requirements.adoc

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -16,7 +16,7 @@ h| Subscription | Valid {PlatformName} |
 
 h| OS | {RHEL} 8.6 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
-h| Ansible | version 2.14 (to install) | {PlatformNameShort} ships with execution environments that contain ansible-core {AnsibleCoreVers}.
+h| Ansible | version 2.9 | {PlatformNameShort} ships with execution environments that contain ansible-core {AnsibleCoreVers}.
 
 h| Python | 3.9 or later |
 
@@ -24,6 +24,11 @@ h| Browser | A currently supported version of Mozilla FireFox or Google Chrome |
 
 h| Database | PostgreSQL version 13 |
 |===
+
+[NOTE]
+====  
+The next major release of Ansible Tower will not support Red Hat Enterprise Linux 7 or CentOS (any version) as an installation platform.
+====
 
 The following are necessary for you to work with project updates and collections:
 
@@ -33,7 +38,7 @@ The following are necessary for you to work with project updates and collections
 [NOTE]
 ====
 The requirements for systems managed by {PlatformNameShort} are the same as for Ansible.
-See link:https://docs.ansible.com/ansible/latest/getting_started/index.html[Getting started with Ansible] in the Ansible _User Guide_.
+See link:https://docs.ansible.com/ansible-tower/3.8.3/html/installandreference/install_notes_reqs.html#ir-general-install-notes[Ansible Automation Hub General Installation Notes] in the Ansible documentation database.
 ====
 
 .Additional notes for {PlatformName} requirements

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -25,11 +25,6 @@ h| Browser | A currently supported version of Mozilla FireFox or Google Chrome |
 h| Database | PostgreSQL version 13 |
 |===
 
-[NOTE]
-====  
-The next major release of Ansible Tower will not support Red Hat Enterprise Linux 7 or CentOS (any version) as an installation platform.
-====
-
 The following are necessary for you to work with project updates and collections:
 
 * Ensure that the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/ref-network-ports-protocols_planning[network ports and protocols] listed in _Table 5.9. Automation Hub_ are available for successful connection and download of collections from {HubName} or {Galaxy} server.
@@ -38,7 +33,7 @@ The following are necessary for you to work with project updates and collections
 [NOTE]
 ====
 The requirements for systems managed by {PlatformNameShort} are the same as for Ansible.
-See link:https://docs.ansible.com/ansible-tower/3.8.3/html/installandreference/install_notes_reqs.html#ir-general-install-notes[Ansible Automation Hub General Installation Notes] in the Ansible documentation database.
+See link:https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#prerequisites[Installing Ansible] in the Ansible documentation database.
 ====
 
 .Additional notes for {PlatformName} requirements


### PR DESCRIPTION
User mentions that the resource we link does not give a page from the Ansible docs for AAP installation that matches the system requirements. I found those requirements mentioned here and aligned those requirements with our page. https://docs.ansible.com/ansible-tower/3.8.3/html/installandreference/install_notes_reqs.html#ir-general-install-notes

The doc in the Jira ticket notes that 2.1 is required to install AAP, but the doc also says "to install AND RUN", capslock mine. Since 2.9 is required to run, and https://docs.ansible.com/ansible-tower/3.8.3/html/installandreference/install_notes_reqs.html#ir-general-install-notes is the only real resource that we can share outside of Red Hat official docs, I propose that the requirements page for AAP in the Ansible docs (the original linked page) be updated to reflect this.

https://access.redhat.com/support/policy/updates/ansible-automation-platform#overview was used to verify the latest version of RHEL that comes with AAP 2.4:
 - RHEL 8.6+
 - RHEL 9.0+

This page also verified the latest version of PostgreSQL database that comes with AAP 2.4:
 - 13

These figures were used, as AAP 2.3 is in maintenance support, while 2.4 is the only version fully supported at this time.

However, the original link made a note of RHEL 7 or CentOS for installation, which seemed relevant to add.