### PR TITLE
Update proc-push-container.adoc

### DIFF
--- a/downstream/modules/hub/proc-push-container.adoc
+++ b/downstream/modules/hub/proc-push-container.adoc
@@ -23,6 +23,11 @@ You can push tagged container images to {PrivateHubName} to create new container
 $ podman login -u=__<username>__ -p=__<password>__ __<automation_hub_url>__
 -----
 +
+[WARNING]
+====
+Let Podman prompt you for your password when you log in. Entering your password at the same time as your username can expose your password to the shell history.
+====
++
 . Push your container image to your {HubName} container registry:
 +
 [subs="+quotes"]


### PR DESCRIPTION
The previous version of this doc has the user enter both their username and password into the CLI in step 1.

As per https://issues.redhat.com/browse/AAP-18025, this exposes the password to the shell history. It is more secure to allow Podman to prompt the user for the password.