### PR TITLE
 adding proc-enable-hstore-extension.adoc to assembly

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -46,6 +46,7 @@ include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
 include::platform/proc-configure-ldap-hub-ocp.adoc[leveloffset=+1]
 include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
 include::platform/proc-operator-external-db-hub.adoc[leveloffset=+1]
+include::platform/proc-enable-hstore-extension.adoc[leveloffset=+2]
 include::platform/proc-find-delete-PVCs.adoc[leveloffset=+1]
 include::platform/ref-ocp-additional-configs.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Just adding an already existing module into the Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform doc.

[AAP-20860](https://issues.redhat.com/browse/AAP-20860)

