### PR TITLE
Removed statement on database support

### DIFF
--- a/downstream/modules/platform/con-install-scenario-recommendations.adoc
+++ b/downstream/modules/platform/con-install-scenario-recommendations.adoc
@@ -6,7 +6,8 @@
 Before selecting your installation method for {PlatformNameShort}, review the following recommendations. Familiarity with these recommendations will streamline the installation process.
 
 * For {PlatformName} or {HubName}: Add an {HubName} host in the `[automationhub]` group.
-* Internal databases `[database]` are not supported. See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/containerized_ansible_automation_platform_installation_guide/index[Containerized {PlatformName} Installation Guide] for further information on using the containerized installer for environments requiring a monolithc deployment. 
+// Removed for AAP-20847 and until such time as a decision is made regarding database support.
+//* Internal databases `[database]` are not supported. See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/containerized_ansible_automation_platform_installation_guide/index[Containerized {PlatformName} Installation Guide] for further information on using the containerized installer for environments requiring a monolithc deployment. 
 * Do not install {ControllerName} and {HubName} on the same node for versions of {PlatformNameShort} in a production or customer environment.
 This can cause contention issues and heavy resource use.
 * Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure users can sync and install content from {HubName} from a different node.


### PR DESCRIPTION
Removed database support statement until a decision is made about the support.

Please correct the docs for AAP2.4 state : Internal databases [database] are not supported.

https://issues.redhat.com/browse/AAP-20847