### PR TITLE
Replace plain text with attribute for content in the builder module (…

### DIFF
--- a/downstream/modules/builder/con-about-ee.adoc
+++ b/downstream/modules/builder/con-about-ee.adoc
@@ -4,13 +4,13 @@
 
 [role="_abstract"]
 
-{ExecEnvNameStart} are container images on which all automation in {PlatformName} is run.
-{ExecEnvNameStart} create a common language for communicating automation dependencies, and provide a standard way to build and distribute the automation environment.
+All automation in {PlatformName} runs on container images called {ExecEnvName}.
+{ExecEnvNameStart} create a common language for communicating automation dependencies, and offer a standard way to build and distribute the automation environment.
 
-An {ExecEnvNameSing} is expected to contain the following:
+An {ExecEnvNameSing} should contain the following:
 
 * Ansible 2.9 or Ansible Core 2.11-2.15
 * Python 3.8-3.11
-* Ansible Runner
+* {Runner}
 * Ansible content collections and their dependencies
 * System dependencies

--- a/downstream/modules/builder/con-ee-precedence.adoc
+++ b/downstream/modules/builder/con-ee-precedence.adoc
@@ -10,9 +10,9 @@ Project updates will always use the control plane {ExecEnvName} by default, howe
 . The `default_environment` defined on the organization of the inventory the job uses.
 . The current `DEFAULT_EXECUTION_ENVIRONMENT` setting (configurable at `api/v2/settings/jobs/`)
 . Any image from the `GLOBAL_JOB_EXECUTION_ENVIRONMENTS` setting.
-. Any other global execution environment.
+. Any other global {ExecEnvShort}.
 
 [NOTE]
 ====
-If more than one execution environment fits a criteria (applies for 6 and 7), the most recently created one is used.
+If more than one {ExecEnvShort} fits a criteria (applies for 6 and 7), the most recently created one is used.
 ====

--- a/downstream/modules/builder/proc-customize-ee-image.adoc
+++ b/downstream/modules/builder/proc-customize-ee-image.adoc
@@ -2,10 +2,10 @@
 
 = Customizing an existing {ExecEnvName} image
 
-Ansible Controller ships with three default execution environments:
+Ansible Controller includes three default execution environments:
 
-* `Ansible 2.9` - no collections are installed other than Controller modules
-* `Minimal` - contains the latest Ansible 2.15 release along with Ansible Runner, but contains no collections or other additional content
+* `Ansible 2.9` - Includes Controller modules only
+* `Minimal` - Includes the latest Ansible 2.15 release along with {Runner}, but does not include collections or other content
 * `EE Supported` - Minimal, plus all Red Hat-supported collections and dependencies
 
 While these environments cover many automation use cases, you can add additional items to customize these containers for your specific needs. The following procedure adds the `kubernetes.core` collection to the `ee-minimal` default image:
@@ -16,13 +16,13 @@ While these environments cover many automation use cases, you can add additional
 ----
 $ podman login -u="[username]" -p="[token/hash]" registry.redhat.io
 ----
-. Ensure that you can pull the desired {ExecEnvNameSing} base image:
+. Ensure that you can pull the required {ExecEnvNameSing} base image:
 +
 -----
 podman pull registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel8:latest
 -----
 +
-. Configure your {Builder} files to specify the desired base image and any additional content to add to the new execution environment image.
+. Configure your {Builder} files to specify the required base image and any additional content to add to the new {ExecEnvShort} image.
 .. For example, to add the link:https://galaxy.ansible.com/kubernetes/core[Kubernetes Core Collection from Galaxy] to the image, use the Galaxy entry:
 +
 ====
@@ -31,7 +31,7 @@ collections:
   - kubernetes.core
 ----
 ====
-.. For more information on definition files and their content, refer to <<assembly-definition-file-breakdown,to definition file breakdown section>>.
+.. For more information about definition files and their content, see the <<assembly-definition-file-breakdown,definition file breakdown section>>.
 . In the {ExecEnvShort} definition file, specify the original `ee-minimal` container's URL and tag in the `EE_BASE_IMAGE` field. In doing so, your final `execution-environment.yml` file will look like the following:
 +
 .A customized `execution-environment.yml` file
@@ -54,7 +54,7 @@ dependencies:
 ====
 Since this example uses the community version of `kubernetes.core` and not a certified collection from {HubName}, we do not need to create an `ansible.cfg` file or reference that in our definition file.
 ====
-. Build the new {ExecEnvShort} image using the following command:
+. Build the new {ExecEnvShort} image by using the following command:
 +
 [subs=+quotes]
 ----
@@ -92,7 +92,7 @@ $ podman tag [username]/new-ee [automation-hub-IP-address]/[username]/new-ee
 +
 [NOTE]
 =====
-You must have `admin` or appropriate container repository permissions for {HubName} to push a container. See _Managing containers in private automation hub_ in the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform[Red Hat Ansible Automation Platform documentation] for more information.
+You must have `admin` or appropriate container repository permissions for {HubName} to push a container. For more information, see the _Manage containers in {PrivateHubName}_ section in link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html-single/managing_content_in_automation_hub/index#managing-containers-hub[Managing content in automation hub].
 =====
 +
 -----
@@ -106,7 +106,7 @@ $ podman push [automation-hub-IP-address]/[username]/new-ee
 ----
 +
 . Pull your new image into your {ControllerName} instance:
-.. Navigate to {ControllerName}.
+.. Go to {ControllerName}.
 .. From the navigation panel, click menu:Administration[Execution Environments].
 .. Click btn:[Add].
 .. Enter the appropriate information then click btn:[Save] to pull in the new image.

--- a/downstream/modules/builder/ref-definition-file-images.adoc
+++ b/downstream/modules/builder/ref-definition-file-images.adoc
@@ -4,14 +4,14 @@
 
 The `images` section of the definition file identifies the base image. Verification of signed container images is supported with the `podman` container runtime.
 
-See the following table for a list of values that can be used in `images`:
+See the following table for a list of values that you can use in `images`:
 
 [cols="a,a"]
 |===
 | Value | Description
 
 | `base_image`
-| Specifies the parent image for the {ExecEnvNameSing}, enabling a new image to be built that is based on an already-existing image. This is typically a supported execution environment base image like _ee-minimal_ or _ee-supported_, but it can also be an execution environment image that you've created previously and want to customize further.
+| Specifies the parent image for the {ExecEnvNameSing} which enables a new image to be built that is based on an existing image. This is typically a supported {ExecEnvShort} base image such as _ee-minimal_ or _ee-supported_, but it can also be an {ExecEnvShort} image that you have created and want to customize further.
 
 A `name` key is required for the container image to use. Specify the `signature _original_name` key if the image is mirrored within your repository, but is signed with the image's original signature key. Image names must contain a tag, such as `:latest`.
 


### PR DESCRIPTION
…#1036)

Replace plain text with attribute for content in the builder module. Affects `/titles/builder` and `/titles/builder/builder`.

Replace plain-text with attributes where appropriate

https://issues.redhat.com/browse/AAP-19894