### PR TITLE
remove-wca-prereq: Modified prereq for Ansible code bot

### DIFF
--- a/lightspeed/assemblies/assembly_using-code-bot-for-suggestions.adoc
+++ b/lightspeed/assemblies/assembly_using-code-bot-for-suggestions.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-The {AnsibleCodeBot} scans existing content collections, roles, and playbooks hosted in GitHub repositories, and proactively creates pull requests whenever best practices or quality improvement recommendations are available. The bot automatically submits pull requests to the repository, which proactively alerts the repository owner to a recommended change to their content . You can configure {AnsibleCodeBot} to scan your existing Git repositories (both public and private). Your organization must have a valid {LightspeedFullName} subscription to use {AnsibleCodeBot}. 
+The {AnsibleCodeBot} scans existing content collections, roles, and playbooks hosted in GitHub repositories, and proactively creates pull requests whenever best practices or quality improvement recommendations are available. The bot automatically submits pull requests to the repository, which proactively alerts the repository owner to a recommended change to their content . You can configure {AnsibleCodeBot} to scan your existing Git repositories (both public and private). Your organization must have an active subscription to {PlatformName} to use {AnsibleCodeBot}. 
 
 {AnsibleCodeBot} scans your code repositories to recommend code quality improvements. It promotes Ansible best practices while avoiding common errors that can lead to bugs or make code harder to maintain. 
 


### PR DESCRIPTION
This PR addresses PM feedback to update First paragraph of Chapter 7 of the Ansible Lightspeed User Guide: "Your organization must have a valid Red Hat Ansible Lightspeed with IBM watsonx Code Assistant subscription to use Ansible code bot." 

It should not reference WCA. Update should be: "Your organization must have an active subscription to Red Hat Ansible Automation Platform to use Ansible code bot."