### PR TITLE
Replace plain text with attributes for content in the core module

### DIFF
--- a/downstream/modules/core/con-ansible-roles.adoc
+++ b/downstream/modules/core/con-ansible-roles.adoc
@@ -5,9 +5,9 @@
 
 [role="_abstract"]
 
-A role is Ansible’s way of bundling automation content as well as loading related vars, files, tasks, handlers, and other artifacts automatically by utilizing a known file structure. Instead of creating huge playbooks with hundreds of tasks, you can use roles to break the tasks apart into smaller, more discrete and composable units of work.
+A role is Ansible's way of bundling automation content in addition to loading related vars, files, tasks, handlers, and other artifacts automatically by utilizing a known file structure. Instead of creating huge playbooks with hundreds of tasks, you can use roles to break the tasks apart into smaller, more discrete units of work.
 
-You can find roles for provisioning infrastructure, deploying applications, and all of the tasks you do every day on Ansible Galaxy. Filter your search by *Type* and select *Role*. Once you find a role that you're interested in, you can download it by using the `ansible-galaxy` command that comes bundled with Ansible:
+You can find roles for provisioning infrastructure, deploying applications, and all of the tasks you do every day on {Galaxy}. Filter your search by *Type* and select *Role*. Once you find a role that you are interested in, you can download it by using the `ansible-galaxy` command that comes bundled with Ansible:
 
 -----
 $ ansible-galaxy role install username.rolename

--- a/downstream/modules/core/con-content-collections.adoc
+++ b/downstream/modules/core/con-content-collections.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 
-An Ansible Content Collection is a ready-to-use toolkit for automation. It includes multiple types of content such as playbooks, roles, modules, and plugins all in one place. The diagram below shows the basic structure of a collection:
+An Ansible Content Collection is a ready-to-use toolkit for automation. It includes several types of content such as playbooks, roles, modules, and plugins all in one place. The following diagram shows the basic structure of a collection:
 
 ....
 collection/
@@ -39,4 +39,4 @@ collection/
     └── unit/
 ....
 
-In {PlatformName}, {HubName} serves as the source for Ansible Certified Content Collections.
+In {PlatformName}, {HubName} serves as the source for {CertifiedName}.

--- a/downstream/modules/core/con-execution-environments.adoc
+++ b/downstream/modules/core/con-execution-environments.adoc
@@ -5,7 +5,7 @@
 The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID so you can include it multiple times in the same guide.
 ////
 
-= About Execution Environments
+= About execution environments
 
 
 [role="_abstract"]
@@ -15,15 +15,15 @@ The `context` attribute enables module reuse. Every module ID includes {context}
 {ExecEnvNameStart} contain:
 
 * Ansible Core
-* Ansible Runner
+* {Runner}
 * Ansible Collections
 * Python libraries
 * System dependencies
 * Custom user needs
 
-You can define and create an automation execution environment using {Builder}.
+You can define and create an {ExecEnvNameSing} using {Builder}.
 
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].
+* For more information about {Builder}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments].


### PR DESCRIPTION
Replace plain text with attributes for content in the core module. Affects `/titles/dev-guide/core`

Replace plain-text with attributes where appropriate

https://issues.redhat.com/browse/AAP-19894