### PR TITLE
Replace plain text with attributes for content in the dev-guide module

### DIFF
--- a/downstream/modules/dev-guide/proc-create-collections.adoc
+++ b/downstream/modules/dev-guide/proc-create-collections.adoc
@@ -5,7 +5,7 @@
 = Creating collections
 
 [role="_abstract"]
-You can create your own Collections locally with the {Galaxy} CLI tool. All of the Collection-specific commands can be activated by using the `collection` subcommand.
+You can create your own Collections locally with the {Galaxy} CLI tool. You can use the `collection` subcommand to activate the Collection-specific commands.
 
 
 .Prerequisites
@@ -15,8 +15,8 @@ You can create your own Collections locally with the {Galaxy} CLI tool. All of t
 
 .Procedure
 
-. In your terminal, navigate to where you want your namespace root directory to be. For simplicity, this should be a path in link:https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths[COLLECTIONS_PATH] but that is not required.
-. Run the following command, replacing `my_namespace` and `my_collection_name` with the values you choose:
+. In your terminal, go to where you want your namespace root directory to be. For simplicity, this should be a path in link:https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths[COLLECTIONS_PATH] but that is not required.
+. Run the following command, replacing `my_namespace` and `my_collection_name` with your own values:
 +
 -----
 $ ansible-galaxy collection init <my_namespace>.<my_collection_name>
@@ -24,21 +24,21 @@ $ ansible-galaxy collection init <my_namespace>.<my_collection_name>
 +
 [NOTE]
 ====
-Make sure you have the proper permissions to upload to a namespace by checking under the "My Content" tab on galaxy.ansible.com or {Console}/ansible/automation-hub
+Make sure you have the proper permissions to upload to a namespace by checking under the *My Content* tab on galaxy.ansible.com or {Console}/ansible/automation-hub
 ====
 
-The above command will create a directory named from the namespace argument above (if one does not already exist) and then create a directory under that with the Collection name. Inside of that directory will be the default or "skeleton" Collection. This is where you can add your roles or plugins and start working on developing your own Collection.
+The earlier command will create a directory named from the namespace argument (if one does not already exist) and then create a directory under that with the Collection name. Inside of that directory will be the default or "skeleton" Collection. This is where you can add your roles or plugins and start working on developing your own Collection.
 
-In relation to execution environments, Collection developers can declare requirements for their content by providing the appropriate metadata via Ansible Builder.
+In relation to execution environments, Collection developers can declare requirements for their content by providing the appropriate metadata in {Builder}.
 
 Requirements from a Collection can be recognized in these ways:
 
-* A file `meta/execution-environment.yml` references the Python and/or `bindep` requirements files
-* A file named `requirements.txt`, which contains information on the Python dependencies and can sometimes be found at the root level of the Collection
-* A file named `bindep.txt`, which contains system-level dependencies and can be sometimes found in the root level of the Collection
-* If any of these files are in the `build_ignore` of the Collection, Ansible Builder will not pick up on these since this section is used to filter any files or directories that should not be included in the build artifact
+* A file `meta/execution-environment.yml`, which references the Python or `bindep` requirements files.
+* A file named `requirements.txt`, which includes information about the Python dependencies, and is sometimes found at the root level of the Collection.
+* A file named `bindep.txt`, which includes system-level dependencies, and is sometimes found at the root level of the Collection.
+* If any of these files are in the `build_ignore` of the Collection, {Builder} will not pick up on these. The `build_ignore` section filters any files or directories that should not be included in the build artifact.
 
-Collection maintainers can verify that ansible-builder recognizes the requirements they expect by using the introspect command:
+Collection maintainers can verify that ansible-builder recognizes the requirements they expect by using the `introspect` command:
 
 -----
 $ ansible-builder introspect --sanitize ~/.ansible/collections/
@@ -47,4 +47,4 @@ $ ansible-builder introspect --sanitize ~/.ansible/collections/
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on creating collections, see link:https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html#creating-collections[Creating collections] in the Ansible _Developer Guide_.
+* For more information about creating collections, see link:https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html#creating-collections[Creating collections] in the Ansible _Developer Guide_.

--- a/downstream/modules/dev-guide/proc-create-role.adoc
+++ b/downstream/modules/dev-guide/proc-create-role.adoc
@@ -5,24 +5,24 @@
 = Creating roles
 
 [role="_abstract"]
-You can create roles using the Ansible Galaxy CLI tool. Role-specific commands can be accessed from the `roles` subcommand.
+You can create roles by using the {Galaxy} CLI tool. You can access Role-specific commands from the `roles` subcommand.
 
 -----
 ansible-galaxy role init <role_name>
 -----
 
-Standalone roles outside of Collections are still supported, but new roles should be created inside of a Collection to take advantage of all the features {PlatformNameShort} has to offer.
+Standalone roles outside of Collections are still supported, but create new roles inside of a Collection to take advantage of all the features {PlatformNameShort} has to offer.
 
 .Procedure
 
-. In your terminal, navigate to the `roles` directory inside a collection.
-. Create a role called `role_name` inside the collection created previously:
+. In your terminal, go to the `roles` directory inside a collection.
+. Create a role called `role_name` inside the collection:
 +
 -----
 $ ansible-galaxy role init my_role
 -----
 +
-The collection now contains a role named `my_role` inside the `roles` directory:
+The collection now includes a role named `my_role` inside the `roles` directory:
 +
 -----
     ~/.ansible/collections/ansible_collections/<my_namespace>/<my_collection_name>
@@ -48,7 +48,7 @@ The collection now contains a role named `my_role` inside the `roles` directory:
                 └── main.yml
 -----
 +
-. A custom role skeleton directory can be supplied using the `--role-skeleton` argument. This allows organizations to create standardized templates for new roles to suit their needs.
+. A custom role skeleton directory can be supplied by using the `--role-skeleton` argument. This allows organizations to create standardized templates for new roles to suit their needs.
 
     ansible-galaxy role init my_role --role-skeleton ~/role_skeleton
 
@@ -58,4 +58,4 @@ This will create a role named `my_role` by copying the contents of `~/role_skele
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on creating roles, see link:https://galaxy.ansible.com/docs/contributing/creating_role.html[Creating roles] in the Ansible Galaxy documentation.
+* For more information about creating roles, see link:https://galaxy.ansible.com/docs/contributing/creating_role.html[Creating roles] in the {Galaxy} documentation.


### PR DESCRIPTION
Replace plain text with attributes for content in the dev-guide module.

Replace plain-text with attributes where appropriate

Affects the following titles:

- ./aap-operations-guide/platform/dev-guide
- ./upgrade/platform/dev-guide
- ./aap-operator-installation/platform/dev-guide
- ./aap-installation-guide/platform/dev-guide
- ./aap-planning-guide/platform/dev-guide
- ./automation-mesh/platform/dev-guide
- ./ocp_performance_guide/platform/dev-guide
- ./controller/controller-user-guide/platform/dev-guide
- ./controller/controller-admin-guide/platform/dev-guide
- ./controller/controller-getting-started/platform/dev-guide
- ./aap-operator-backup/platform/dev-guide
- ./aap-containerized-install/platform/dev-guide
- ./dev-guide/dev-guide


https://issues.redhat.com/browse/AAP-19894