### PR TITLE
Add openssl commands to validate SSL certs

### DIFF
--- a/downstream/modules/platform/proc-renew-ssl-cert.adoc
+++ b/downstream/modules/platform/proc-renew-ssl-cert.adoc
@@ -14,3 +14,16 @@ aap_service_regen_cert=true
 ----
 . Run the installer.
 
+.Verification
+
+* Validate the CA file and server.crt file on {ControllerName}:
+----
+openssl verify -CAfile ansible-automation-platform-managed-ca-cert.crt /etc/tower/tower.cert
+openssl s_client -connect <AUTOMATION_HUB_URL>:443
+----
+
+* Validate the CA file and server.crt file on {HubName}:
+----
+openssl verify -CAfile ansible-automation-platform-managed-ca-cert.crt /etc/pulp/certs/pulp_webserver.crt
+openssl s_client -connect <AUTOMATION_CONTROLLER_URL>:443
+----


### PR DESCRIPTION
Add openssl commands to validate SSL certs

Need to include openssl commands to validate the custom SSL certificates for AAP/PAH

https://issues.redhat.com/browse/AAP-20776