### PR TITLE
Bp to 2.4: AAP 19025 create procedure for updating proxy remote settings and updated link title

### DIFF
--- a/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
+++ b/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
@@ -48,3 +48,5 @@ include::hub/proc-obtaining-org-collection-url.adoc[leveloffset=+1]
 include::hub/proc-set-rhcertified-remote.adoc[leveloffset=+1]
 
 include::hub/proc-set-community-remote.adoc[leveloffset=+1]
+
+include::hub/proc-configure-proxy-remote.adoc[leveloffset=+1]

--- a/downstream/modules/hub/proc-configure-proxy-remote.adoc
+++ b/downstream/modules/hub/proc-configure-proxy-remote.adoc
@@ -1,0 +1,23 @@
+:_newdoc-version: 2.16.0
+:_template-generated: 2024-02-16
+:_mod-docs-content-type: PROCEDURE
+
+[id="configure-proxy-remote_{context}"]
+= Configuring proxy settings
+
+[role="_abstract"]
+If your {PrivateHubName} is behind a network proxy, you can configure proxy settings on the remote to sync content located outside of your local network. 
+
+.Prerequisites
+
+* You have valid *Modify Ansible repo content* permissions.
+For more information on permissions, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Configuring user access for your {PrivateHubName}].
+* You have a proxy URL and credentials from your local network administrator. 
+
+.Procedure
+. Log in to {PlatformNameShort}.
+. From the navigation panel, select menu:Collections[Remotes].
+. In either the *rh-certified* or *Community* remote, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Edit*.
+. Expand the *Show advanced options* drop-down menu.
+. Enter your proxy URL, proxy username, and proxy password in the appropriate fields. 
+. Click btn:[Save].

--- a/downstream/modules/hub/proc-set-community-remote.adoc
+++ b/downstream/modules/hub/proc-set-community-remote.adoc
@@ -10,7 +10,7 @@ By default, your {PrivateHubName} community repository directs to `galaxy.ansibl
 
 * You have *Modify Ansible repo content* permissions.
 //dcdacosta - since this content lives outside of this document, this should be added as a link once the URL known
-For more information on permissions, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Managing user access in automation hub].
+For more information on permissions, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Configuring user access for your {PrivateHubName}].
 * You have a `requirements.yml` file that identifies those collections to synchronize from {Galaxy} as in the following example:
 +
 .Requirements.yml example

--- a/downstream/modules/hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/hub/proc-set-rhcertified-remote.adoc
@@ -16,7 +16,7 @@ If you have collections `A`, `B`, and `C` in your requirements file, and a new c
 .Prerequisites
 
 * You have valid *Modify Ansible repo content* permissions.
-For more information on permissions, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Managing user access in automation hub].
+For more information on permissions, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Configuring user access for your {PrivateHubName}].
 * You have retrieved the Sync URL and API Token from the {HubName} hosted service on {Console}.
 * You have configured access to port 443. This is required for synchronizing certified collections. For more information, see the {HubName} table in the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/ref-network-ports-protocols_planning[Network ports and protocols] chapter of the {PlatformName} Planning Guide.
 


### PR DESCRIPTION
This PR backports the changes from [PR 1019](https://github.com/ansible/aap-docs/pull/1019) to the 2.4 branch. For the initial request see [AAP-19025](https://issues.redhat.com/browse/AAP-19025).