### PR TITLE
BP to 2.4: AAP-18084 adds collection count variable to ansible automation hub variables table in appendix

### DIFF
--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -40,13 +40,13 @@ Default = `false`.
 
 You can also set `automationhub_backup_collections` to false and the backup/restore process does not then backup or restore `/var/lib/pulp`.
 
-Default = `true`
+Default = `true`.
 | *`automationhub_collection_download_count`* | _Optional_
 
 Determines whether download count is displayed on the UI.
 
-Default = `false`
-| *`automationhub_collection_seed_repository`* a| When the bundle installer is run, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository.
+Default = `false`.
+| *`automationhub_collection_seed_repository`* a| When you run the bundle installer, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository.
 
 By default, both certified and validated content are uploaded.
 

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -40,13 +40,13 @@ Default = `false`.
 
 You can also set `automationhub_backup_collections` to false and the backup/restore process does not then backup or restore `/var/lib/pulp`.
 
-Default = `true`.
+Default = `true`
 | *`automationhub_collection_download_count`* | _Optional_
 
 Determines whether download count is displayed on the UI.
 
-Default = `false`.
-| *`automationhub_collection_seed_repository`* a| When you run the bundle installer, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository.
+Default = `false`
+| *`automationhub_collection_seed_repository`* a| When the bundle installer is run, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository.
 
 By default, both certified and validated content are uploaded.
 
@@ -320,7 +320,7 @@ If your configuration makes any references to LDAP groups, you must set this var
 Must be set when integrating {PrivateHubName} with LDAP, or the installation will fail.
 
 Default = `None`
-| *`automatiohub_ldap_group_search_filter`* | _Optional_
+| *`automationhub_ldap_group_search_filter`* | _Optional_
 
 Search filter for finding group membership.
 


### PR DESCRIPTION
This PR backports the changes from [PR 784](https://github.com/ansible/aap-docs/pull/784) to the 2.4 branch. See[ AAP-18084](https://issues.redhat.com/browse/AAP-18084) for more info.

* AAP-18084 adds collection count variable to ansible automation hub variables table in appendix

* edit based on peer review feedback