### PR TITLE
Correct heading level for installer 2.4-6 release notes

### DIFF
--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -26,7 +26,7 @@ include::topics/docs-24.adoc[leveloffset=+1]
 
 === Installer releases
 
-include::topics/installer-24-6.adoc[leveloffset=+2]
+include::topics/installer-24-6.adoc[leveloffset=+3]
 
 include::topics/installer-24-5.adoc[leveloffset=+3]
 


### PR DESCRIPTION
Correct heading level for installer 2.4-6 release notes

2.4 Release Notes - AAP 2.4-6 Installer Release

https://issues.redhat.com/browse/AAP-21131