### PR TITLE
Replace plain text with attributes for content in the hub module

### DIFF
--- a/downstream/modules/hub/proc-add-user-to-group.adoc
+++ b/downstream/modules/hub/proc-add-user-to-group.adoc
@@ -6,4 +6,4 @@
 
 You can add users to groups when you create a group. But, you can also manually add users to existing groups.
 
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_automation_hub/index#proc-add-users-to-group[Adding users to existing groups] in the Getting started with automation hub guide.
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_automation_hub/index#proc-add-users-to-group[Adding users to existing groups] in the Getting started with {HubName} guide.

--- a/downstream/modules/hub/proc-assigning-permissions.adoc
+++ b/downstream/modules/hub/proc-assigning-permissions.adoc
@@ -9,4 +9,4 @@ You can assign permissions to groups in {PrivateHubName} that enable users to ac
 
 You can add permissions when first creating a group or edit an existing group to add or remove permissions
 
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_automation_hub/index#proc-assigning-permissions[Assigning permissions to groups] in the Getting started with automation hub guide.
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_automation_hub/index#proc-assigning-permissions[Assigning permissions to groups] in the Getting started with {HubName} guide.

--- a/downstream/modules/hub/proc-configure-automation-hub-server-gui.adoc
+++ b/downstream/modules/hub/proc-configure-automation-hub-server-gui.adoc
@@ -30,7 +30,7 @@ Creating a new token revokes any previous tokens generated for {HubName}. Update
 .. Click btn:[Edit].
 .. Under Galaxy Credentials, click the btn:[Search] icon.
 .. Select the credential that you created for {HubName}, and place it at the beginning of the list.
-.. Optional: If you have a secondary source of content, such as Ansible Galaxy, place this credential after the credential that you created for {HubName}.
+.. Optional: If you have a secondary source of content, such as {Galaxy}, place this credential after the credential that you created for {HubName}.
 .. Click btn:[Select].
 .. Click btn:[Save].
 
@@ -48,5 +48,5 @@ You have now configured {HubName} as your primary server. You can begin to downl
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about server list configuration options and using Ansible Galaxy as an Ansible content source, see the link:https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client[Ansible Galaxy User Guide].
+* For more information about server list configuration options and using {Galaxy} as an Ansible content source, see the link:https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client[Ansible Galaxy User Guide].
 * For more information about creating and using credentials, see the link:https://docs.ansible.com/automation-controller/4.2.1/html/userguide/credentials.html[Credentials] section of Automation Controller User Guide v4.2.1.

--- a/downstream/modules/hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/hub/proc-configure-content-signing-on-pah.adoc
@@ -1,6 +1,6 @@
 [id="proc-configure-content-signing-on-pah"]
 
-= Configuring content signing on private automation hub
+= Configuring content signing on {PrivateHubName}
 
 To successfully sign and publish {CertifiedName}, you must configure {PrivateHubName} for signing.
 

--- a/downstream/modules/hub/proc-create-api-token.adoc
+++ b/downstream/modules/hub/proc-create-api-token.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
 [id="proc-create-api-token"]
-= Creating the API token in automation hub
+= Creating the API token in {HubName}
 
 In {HubName}, you can create an API token by using *Token management*. The API token is a secret token used to protect your content.
 

--- a/downstream/modules/hub/proc-create-credential.adoc
+++ b/downstream/modules/hub/proc-create-credential.adoc
@@ -2,7 +2,7 @@
 
 = Creating a credential in {ControllerName}
 
-To pull container images from a password or token-protected registry, you must create a credential in automation controller.
+To pull container images from a password or token-protected registry, you must create a credential in {ControllerName}.
 
 In earlier versions of {PlatformNameShort}, you were required to deploy a registry to store {ExecEnvShort} images. 
 On {PlatformNameShort} 2.0 and later, the system operates as if you already have a container registry up and running. 

--- a/downstream/modules/hub/proc-create-groups.adoc
+++ b/downstream/modules/hub/proc-create-groups.adoc
@@ -7,4 +7,4 @@
 You can create and assign permissions to a group in {PrivateHubName} that enables users to access specified features in the system.
 By default, the *Admin* group in the {HubName} has all permissions assigned and is available on initial login. Use the credentials created when installing {PrivateHubName}.
 
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_automation_hub/index#proc-create-group[Creating a new group in private automation hub] in the Getting started with automation hub guide.
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/getting_started_with_automation_hub/index#proc-create-group[Creating a new group in {PrivateHubName}] in the Getting started with {HubName} guide.

--- a/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
+++ b/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
@@ -3,7 +3,7 @@
 
 = Deploying your system for container signing
 
-{HubNameStart} implements image signing to provide better security for the execution environment container images.
+{HubNameStart} implements image signing to offer better security for the {ExecEnvShort} container images.
 
 To deploy your system so that it is ready for container signing, create a signing script.
 
@@ -13,7 +13,7 @@ Installer looks for the script and key on the same server where installer is loc
 ====
 
 .Procedure
-. From a terminal, create create a signing script, and pass the script path as an installer parameter.
+. From a terminal, create a signing script, and pass the script path as an installer parameter.
 +
 *Example*:
 +

--- a/downstream/modules/hub/proc-shared-filesystem.adoc
+++ b/downstream/modules/hub/proc-shared-filesystem.adoc
@@ -2,7 +2,7 @@
 
 = Setting up the shared filesystem
 
-You must mount the shared file system on each automation hub node:
+You must mount the shared file system on each {HubName} node:
 
 .Procedure
 

--- a/downstream/modules/hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/hub/proc-using-content-signing-services-in-pah.adoc
@@ -1,6 +1,6 @@
 [id="proc-using-content-signing-services-in-pah"]
 
-= Using content signing services in private automation hub
+= Using content signing services in {PrivateHubName}
 
 After you have configured content signing on your {PrivateHubName}, you can manually sign a new collection or replace an existing signature with a new one.
 When users download a specific collection, this signature indicates that the collection is for them and has not been modified after certification.


### PR DESCRIPTION
Affects the following titles:

```
./aap-operations-guide
./upgrade
./aap-operator-installation
./aap-installation-guide
./aap-planning-guide
./operator-mesh
./automation-mesh
./ocp_performance_guide
./controller/controller-user-guide
./controller/controller-admin-guide
./controller/controller-getting-started
./controller/controller-api-guide
./aap-operator-backup
./aap-containerized-install
./builder
./hub/managing-content
./hub/getting-started
```

Replace plain-text with attributes where appropriate

https://issues.redhat.com/browse/AAP-19894