### PR TITLE
Create section 1 of controller API guide

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-api-access-resources.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-access-resources.adoc
@@ -1,0 +1,13 @@
+[id="controller-api-access-resources"]
+
+= Access resources
+
+{ControllerNameStart} uses a primary key to access individual resource objects. 
+You can access {ControllerName} resources by using resource-specific, human-readable identifiers through the named URL feature. 
+
+The following example shows the named URL path where you can access a resource object without an auxiliary query string:
+
+----
+/api/v2/hosts/host_name++inv_name++org_name/
+----
+

--- a/downstream/assemblies/platform/assembly-controller-api-auth-methods.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-auth-methods.adoc
@@ -1,0 +1,10 @@
+[id="controller-api-auth-methods"]
+
+= Authentication methods using the API
+
+You can use the following authentication methods in the API:
+
+* Session authentication
+* Basic authentication
+* OAuth 2 token authentication
+* Single Sign-On authentication

--- a/downstream/assemblies/platform/assembly-controller-api-browsing-api.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-browsing-api.adoc
@@ -1,0 +1,8 @@
+[id="controller-api-browsing-api"]
+
+= Browsing with the API
+
+REST APIs give access to resources (data entities) through URI paths.
+
+
+

--- a/downstream/assemblies/platform/assembly-controller-api-conventions.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-conventions.adoc
@@ -1,0 +1,5 @@
+[id="controller-api-conventions"]
+
+= Use conventions in the API
+
+{ControllerNameStart} uses a standard REST API, rooted at `/api/` on the server.

--- a/downstream/assemblies/platform/assembly-controller-api-filter.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-filter.adoc
@@ -2,4 +2,4 @@
 
 = Filtering in the API
 
-Any collection is what the system calls a “queryset” and can be filtered via various operators.
+Any collection is what the system calls a “queryset” and can be filtered using various operators.

--- a/downstream/assemblies/platform/assembly-controller-api-filter.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-filter.adoc
@@ -1,0 +1,5 @@
+[id="controller-api-filter"]
+
+= Filtering in the API
+
+Any collection is what the system calls a “queryset” and can be filtered via various operators.

--- a/downstream/assemblies/platform/assembly-controller-api-pagination.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-pagination.adoc
@@ -1,0 +1,7 @@
+[id="controller-api-pagination"]
+
+= Using pagination in the API
+
+Responses for collections in the API are paginated. 
+This means that while a collection might contain tens or hundreds of thousands of objects, in each web request, only a limited number of results are returned for API performance reasons.
+

--- a/downstream/assemblies/platform/assembly-controller-api-readonly-fields.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-readonly-fields.adoc
@@ -1,0 +1,5 @@
+[id="controller-api-readonly-fields"]
+
+= Read-only fields
+
+Certain fields in the REST API are marked read-only.

--- a/downstream/assemblies/platform/assembly-controller-api-search.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-search.adoc
@@ -1,0 +1,5 @@
+[id="controller-api-search"]
+
+= Using the search query string parameter
+
+Use the search query string parameter to perform a non-case-sensitive search within all designated text fields of a model.

--- a/downstream/assemblies/platform/assembly-controller-api-sorting.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-sorting.adoc
@@ -1,0 +1,7 @@
+[id="controller-api-sorting"]
+
+= Sorting in the API
+
+To give examples that are easy to follow, we use the following URL throughout this guide:
+
+http://<server name>/api/v2/groups/

--- a/downstream/assemblies/platform/assembly-controller-api-tools.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-tools.adoc
@@ -1,0 +1,5 @@
+[id="controller-api-tools"]
+
+= Available tools with the API
+
+include::platform/ref-controller-api-tools.adoc[leveloffset=+1]

--- a/downstream/modules/platform/ref-controller-api-tools.adoc
+++ b/downstream/modules/platform/ref-controller-api-tools.adoc
@@ -1,0 +1,19 @@
+[id="ref-controller-api-tools"]
+
+REST stands for Representational State Transfer and is sometimes spelled as “ReST”. 
+It relies on a stateless, client-server, and cacheable communications protocol, usually the HTTP protocol.
+
+You might find it helpful to see which API calls the user interface makes in sequence. 
+To do this, you can use the UI from Firebug or Chrome with developer plugins.
+
+Another option is to use link:http://www.charlesproxy.com/[Charles Proxy]. 
+This offers a visualizer that you might find helpful. 
+While it is commercial software, it can insert itself as an operating system X proxy and intercept both requests from web browsers, curl and other API consumers.
+
+Further options include the following:
+
+* link:http://www.telerik.com/fiddler[Fiddler]
+* link:https://mitmproxy.org/[mitmproxy]
+* link:https://addons.mozilla.org/en-US/firefox/addon/live-http-headers/[Live HTTP headers FireFox extension]
+* link:http://sourceforge.net/projects/paros/[Paros]
+

--- a/downstream/modules/platform/ref-controller-api-tools.adoc
+++ b/downstream/modules/platform/ref-controller-api-tools.adoc
@@ -1,7 +1,6 @@
 [id="ref-controller-api-tools"]
 
-REST stands for Representational State Transfer and is sometimes spelled as “ReST”. 
-It relies on a stateless, client-server, and cacheable communications protocol, usually the HTTP protocol.
+Representational State Transfer (REST) relies on a stateless, client-server, and cacheable communications protocol, usually the HTTP protocol.
 
 You might find it helpful to see which API calls the user interface makes in sequence. 
 To do this, you can use the UI from Firebug or Chrome with developer plugins.

--- a/downstream/titles/controller/controller-api-guide/master.adoc
+++ b/downstream/titles/controller/controller-api-guide/master.adoc
@@ -17,3 +17,14 @@ The {ControllerName} API Guide focuses on helping you understand the {Controller
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::{DocumentationFeedback}[leveloffset=+1]
+
+include::platform/assembly-controller-api-tools.adoc[leveloffset=+1]
+include::platform/assembly-controller-api-browsing-api.adoc[leveloffset=+1]
+include::platform/assembly-controller-api-conventions.adoc[leveloffset=+1]
+include::platform/assembly-controller-api-sorting.adoc[leveloffset=+1]
+include::platform/assembly-controller-api-search.adoc[leveloffset=+1]
+include::platform/assembly-controller-api-filter.adoc[leveloffset=+1]
+include::platform/assembly-controller-api-pagination.adoc[leveloffset=+1]
+include::platform/assembly-controller-api-access-resources.adoc[leveloffset=+1]
+include::platform/assembly-controller-api-readonly-fields.adoc[leveloffset=+1]
+include::platform/assembly-controller-api-auth-methods.adoc[leveloffset=+1]


### PR DESCRIPTION
Adding content for section 1 as well as assemblies to master.adoc

Create section 1 of the Automation Controller API Guide

https://issues.redhat.com/browse/AAP-21361

Affects `titles/controller-api-guide`