### PR TITLE
AAP-15176: fixes broken links in getting started with ansible playbooks guide

### DIFF
--- a/downstream/modules/playbooks/ref-create-variables.adoc
+++ b/downstream/modules/playbooks/ref-create-variables.adoc
@@ -29,4 +29,4 @@ webservers:
   vars:
     ansible_user: my_server_user
 ----
-For more information about Inventories and Ansible Inventory variables, see link:{BaseURL}/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/about_the_installer_inventory_file[About the Installer Inventory file] and link:{BaseURL}/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars[Inventory file variables].
+For more information about Inventories and Ansible Inventory variables, see link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/about_the_installer_inventory_file[About the Installer Inventory file] and link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars[Inventory file variables].

--- a/downstream/modules/playbooks/ref-create-variables.adoc
+++ b/downstream/modules/playbooks/ref-create-variables.adoc
@@ -29,4 +29,4 @@ webservers:
   vars:
     ansible_user: my_server_user
 ----
-For more information about Inventories and Ansible Inventory variables, see link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/about_the_installer_inventory_file[About the Installer Inventory file] and link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars[Inventory file variables].
+For more information about inventories and Ansible inventory variables, see link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/about_the_installer_inventory_file[About the Installer Inventory file] and link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars[Inventory file variables].


### PR DESCRIPTION
See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more info. 

