### PR TITLE
Create sections 3, 4, 5, 6, and 7 of controller API guide

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-api-conventions.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-conventions.adoc
@@ -3,3 +3,5 @@
 = Use conventions in the API
 
 {ControllerNameStart} uses a standard REST API, rooted at `/api/` on the server.
+
+include::platform/ref-controller-api-conventions.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-api-filter.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-filter.adoc
@@ -2,4 +2,8 @@
 
 = Filtering in the API
 
-Any collection is what the system calls a “queryset” and can be filtered using various operators.
+Any collection is what the system calls a "queryset" that you can filter by using various operators.
+
+include::platform/proc-controller-api-filtering.adoc[leveloffset=+1]
+include::platform/ref-controller-api-advanced-queries.adoc[leveloffset=+1]
+include::platform/ref-controller-api-field-lookups.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-api-filter.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-filter.adoc
@@ -2,7 +2,8 @@
 
 = Filtering in the API
 
-Any collection is what the system calls a "queryset" that you can filter by using various operators.
+The system recognizes a collection as a "queryset".
+You can filter this by using various operators.
 
 include::platform/proc-controller-api-filtering.adoc[leveloffset=+1]
 include::platform/ref-controller-api-advanced-queries.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-api-pagination.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-pagination.adoc
@@ -2,6 +2,7 @@
 
 = Using pagination in the API
 
-Responses for collections in the API are paginated. 
+The API paginates responses for collections. 
 This means that while a collection might contain tens or hundreds of thousands of objects, in each web request, only a limited number of results are returned for API performance reasons.
 
+include::platform/proc-controller-api-using-pagination.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-api-search.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-search.adoc
@@ -2,4 +2,18 @@
 
 = Using the search query string parameter
 
-Use the search query string parameter to perform a non-case-sensitive search within all designated text fields of a model.
+.Procedure
+
+* Use the search query string parameter to perform a non-case-sensitive search within all designated text fields of a model:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+https://<server name>/api/v2/model_verbose_name?search=findme
+----
+
+* To search across related fields, use the following:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+https://<server name>/api/v2/model_verbose_name?related__search=findme
+----

--- a/downstream/assemblies/platform/assembly-controller-api-sorting.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-sorting.adoc
@@ -2,6 +2,12 @@
 
 = Sorting in the API
 
-To give examples that are easy to follow, we use the following URL throughout this guide:
+To give you examples that are easy to follow, we use the following URL throughout this guide:
 
-http://<server name>/api/v2/groups/
+[literal, options="nowrap" subs="+attributes"]
+----
+https://<server name>/api/v2/groups/
+----
+
+include::platform/proc-controller-api-sorting.adoc[leveloffset=+1]
+

--- a/downstream/modules/platform/proc-controller-api-browsing-api.adoc
+++ b/downstream/modules/platform/proc-controller-api-browsing-api.adoc
@@ -8,10 +8,9 @@
 +
 . Click the **"v2"** link next to **"current versions"** or **"available versions"**.
 {ControllerNameStart} supports version 2 of the API.
-. Perform a `GET` with just the `/api/` end point to get the `current_version`, which is the recommended version.
+. Perform a `GET` with just the `/api/` endpoint to get the `current_version`, which is the recommended version.
 . Click the image:api-questionmark.png[Copy,15,15] icon on the navigation menu, for documentation on the access methods for that particular API endpoint and what data is returned when using those methods.
-
-Use the `PUT` and `POST` verbs on the specific API pages by formatting JSON in the various text fields.
+. Use the `PUT` and `POST` verbs on the specific API pages by formatting JSON in the various text fields.
 
 You can also view changed settings from factory defaults at `/api/v2/settings/changed/` endpoint. 
 It reflects changes you made in the API browser, not changed settings that come from static settings files.

--- a/downstream/modules/platform/proc-controller-api-filtering.adoc
+++ b/downstream/modules/platform/proc-controller-api-filtering.adoc
@@ -1,0 +1,50 @@
+[id="controller-api-filtering-in-api"]
+
+.Procedure
+
+* To find groups that contain the name "foo", use the following:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+http://<controller server name>/api/v2/groups/?name__contains=foo
+----
++
+* To find an exact match, use the following:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+http://<controller server name>/api/v2/groups/?name=foo
+----
++
+* If a resource is of an integer type, you must add `\_\_int` to the end to cast your string input value to an integer, like the following:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+http://<controller server name>/api/v2/arbitrary_resource/?x__int=5
+----
++
+* You can query related resources with the following:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+http://<controller server name>/api/v2/users/?first_name__icontains=kim
+----
++
+This returns all users with names that include the string "Kim" in them.
++
+* You can also filter against many fields at once:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+http://<controller server name>/api/v2/groups/?name__icontains=test&has_active_failures=false
+----
+This finds all groups containing the name “test” that have no active failures.
+
+.Additional resources
+
+For more information about what types of operators are available, see link:https://docs.djangoproject.com/en/dev/ref/models/querysets/[QuerySet API reference].
+
+[NOTE]
+====
+You can also watch the API as the UI is being used to see how it is filtering on various criteria.
+====

--- a/downstream/modules/platform/proc-controller-api-filtering.adoc
+++ b/downstream/modules/platform/proc-controller-api-filtering.adoc
@@ -16,7 +16,7 @@ http://<controller server name>/api/v2/groups/?name__contains=foo
 http://<controller server name>/api/v2/groups/?name=foo
 ----
 +
-* If a resource is of an integer type, you must add `\_\_int` to the end to cast your string input value to an integer, like the following:
+* If a resource is of an integer type, you must add `\_\_int` to the end to cast your string input value to an integer, such as the following:
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
@@ -38,7 +38,7 @@ This returns all users with names that include the string "Kim" in them.
 ----
 http://<controller server name>/api/v2/groups/?name__icontains=test&has_active_failures=false
 ----
-This finds all groups containing the name “test” that have no active failures.
+This finds all groups containing the name "test" that have no active failures.
 
 .Additional resources
 

--- a/downstream/modules/platform/proc-controller-api-sorting.adoc
+++ b/downstream/modules/platform/proc-controller-api-sorting.adoc
@@ -1,0 +1,25 @@
+[id="controller-api-sorting-in-api"]
+
+.Procedure
+
+* To specify that {{ model_verbose_name_plural }} are returned in a particular order, use the `order_by` query string parameter on the `GET` request:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+https://<server name>/api/v2/model_verbose_name_plural?order_by={{ order_field }}
+----
++
+** Prefix the field name with a dash (`-`) to sort in reverse:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+https://<server name>/api/v2/model_verbose_name_plural?order_by=-{{ order_field }}
+----
++
+** You can specify the sorting fields by separating the field names with a comma (`,`):
++
+[literal, options="nowrap" subs="+attributes"]
+----
+https://<server name>/api/v2/model_verbose_name_plural?order_by={{ order_field }},some_other_field
+----
+

--- a/downstream/modules/platform/proc-controller-api-using-pagination.adoc
+++ b/downstream/modules/platform/proc-controller-api-using-pagination.adoc
@@ -1,0 +1,27 @@
+[id="controller-api-using-pagination"]
+
+When you receive the result for a collection, something similar to the following appears:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+{'count': 25, 'next': 'http://testserver/api/v2/some_resource?page=2', 'previous': None, 'results': [ ... ] }
+----
+
+.Procedure
+
+. Request the page given by the "next" sequential URL, to get to the next page.
+. Use the `page_size=XX` query string parameter to change the number of results returned for each request.
+** The `page_size` has a default maximum limit configured to 200, which is enforced when a user tries a value beyond it, for example, `?page_size=1000`. 
+However, you can change this limit by setting the value in `/etc/tower/conf.d/<some file>.py` to something higher. For example, `MAX_PAGE_SIZE=1000`.
+. Use the page query string parameter to retrieve a particular page of results:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+http://<server name>/api/v2/model_verbose_name?page_size=100&page=2
+----
+
+The preceding and following links returned with the results set these query string parameters automatically.
+
+We recommend that you do not request page sizes beyond a couple of hundred.
+
+The user interface uses smaller values to avoid scrolling.

--- a/downstream/modules/platform/proc-controller-api-using-pagination.adoc
+++ b/downstream/modules/platform/proc-controller-api-using-pagination.adoc
@@ -11,7 +11,7 @@ When you receive the result for a collection, something similar to the following
 
 . Request the page given by the "next" sequential URL, to get to the next page.
 . Use the `page_size=XX` query string parameter to change the number of results returned for each request.
-** The `page_size` has a default maximum limit configured to 200, which is enforced when a user tries a value beyond it, for example, `?page_size=1000`. 
+** The `page_size` has a default maximum limit of 200, which is enforced when a user tries a value beyond it, for example, `?page_size=1000`. 
 However, you can change this limit by setting the value in `/etc/tower/conf.d/<some file>.py` to something higher. For example, `MAX_PAGE_SIZE=1000`.
 . Use the page query string parameter to retrieve a particular page of results:
 +
@@ -22,6 +22,6 @@ http://<server name>/api/v2/model_verbose_name?page_size=100&page=2
 
 The preceding and following links returned with the results set these query string parameters automatically.
 
-We recommend that you do not request page sizes beyond a couple of hundred.
+Do not request page sizes greater than 200.
 
 The user interface uses smaller values to avoid scrolling.

--- a/downstream/modules/platform/ref-controller-api-advanced-queries.adoc
+++ b/downstream/modules/platform/ref-controller-api-advanced-queries.adoc
@@ -1,0 +1,49 @@
+[id="controller-api-advanced-queries"]
+
+= Advanced queries in the API
+
+You can use additional query string parameters used to filter the list of results returned to those matching a given value. 
+You can only use fields and relations that exist in the database for filtering. 
+Ensure that any special characters in the specified value are URL-encoded. 
+For example:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+?field=value%20xyz
+----
+
+Fields can also span relations, only for fields and relationships defined in the database:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+?other__field=value
+----
+
+To exclude results matching certain criteria, prefix the field parameter with `not__`:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+?not__field=value
+----
+
+By default, all query string filters are AND'ed together, so only the results matching all filters are returned. 
+To combine results matching any one of multiple criteria, prefix each query string parameter with `or__`:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+?or__field=value&or__field=othervalue
+?or__not__field=value&or__field=othervalue
+----
+
+The default AND filtering applies all filters simultaneously to each related object being filtered across database relationships. 
+The chain filter instead applies filters separately for each related object. 
+To use this, prefix the query string parameter with `chain__`:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+?chain__related__field=value&chain__related__field2=othervalue
+?chain__not__related__field=value&chain__related__field2=othervalue
+----
+
+If the first query were written as `?related__field=value&related__field2=othervalue`, it would return only the primary objects where the same related object satisfied both conditions. 
+As written by using the chain filter, it would return the intersection of primary objects matching each condition.

--- a/downstream/modules/platform/ref-controller-api-conventions.adoc
+++ b/downstream/modules/platform/ref-controller-api-conventions.adoc
@@ -1,0 +1,19 @@
+[id="controller-api-conventions-in-API"]
+
+The API is versioned for compatibility reasons. 
+You can see what API versions are available by querying `/api/`.
+
+You might have to specify the content or type on `POST` or `PUT` requests:
+
+* `PUT`: Update a specific resource (by an identifier) or a collection of resources. 
+You can also use `PUT` to create a specific resource if you know the resource identifier before-hand.
+* `POST`: Create a new resource. 
+Also acts as a catch-all verb for operations that do not fit into the other categories.
+
+All URIs not ending with "/" receive a 301 redirect.
+
+[NOTE]
+====
+The formatting of `extra_vars` attached to Job Template records is preserved. 
+YAML is returned as YAML with formatting and comments preserved, and JSON is returned as JSON.
+====

--- a/downstream/modules/platform/ref-controller-api-field-lookups.adoc
+++ b/downstream/modules/platform/ref-controller-api-field-lookups.adoc
@@ -1,0 +1,39 @@
+[id="controller-api-field-lookups"]
+
+= Field lookups
+
+You can use field lookups for more advanced queries, by appending the lookup to the field name:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+?field__lookup=value
+----
+
+The following field lookups are supported:
+
+* exact: Exact match (default lookup if not specified).
+* iexact: Case-insensitive version of exact.
+* contains: Field contains value.
+* icontains: Case-insensitive version of contains.
+* startswith: Field starts with value.
+* istartswith: Case-insensitive version of startswith.
+* endswith: Field ends with value.
+* iendswith: Case-insensitive version of endswith.
+* regex: Field matches the given regular expression.
+* iregex: Case-insensitive version of regular expression.
+* gt: Greater than comparison.
+* gte: Greater than or equal to comparison.
+* lt: Less than comparison.
+* lte: Less than or equal to comparison.
+* isnull: Check whether the given field or related object is null; expects a boolean value.
+* in: Check whether the given field's value is present in the list provided; expects a list of items.
+* You can specify boolean values can as `True` or `1` for true, `False` or `0` for false (both case-insensitive).
+
+For example, `?created__gte=2023-01-01` provides a list of items created after 1/1/2023.
+
+You can specify null values can as `None` or `Null` (both case-insensitive), though it we recommend to use the `isnull` lookup to explicitly check for null values.
+
+You can specify lists (for the `in` lookup) as a comma-separated list of values.
+Filtering based on the requesting user's level of access by query string parameter:
+
+* `role_level`: Level of role to filter on, such as `admin_role`

--- a/downstream/modules/platform/ref-controller-api-field-lookups.adoc
+++ b/downstream/modules/platform/ref-controller-api-field-lookups.adoc
@@ -31,7 +31,7 @@ The following field lookups are supported:
 
 For example, `?created__gte=2023-01-01` provides a list of items created after 1/1/2023.
 
-You can specify null values can as `None` or `Null` (both case-insensitive), though it we recommend to use the `isnull` lookup to explicitly check for null values.
+You can specify null values as `None` or `Null` (both case-insensitive), though we recommend using the `isnull` lookup to explicitly check for null values.
 
 You can specify lists (for the `in` lookup) as a comma-separated list of values.
 Filtering based on the requesting user's level of access by query string parameter:


### PR DESCRIPTION
Adding content for sections 3, 4, 5, 6, and 7

Create sections 3, 4, 5, 6, and 7 of the Automation Controller API Guide

https://issues.redhat.com/browse/AAP-21476

Affects `titles/controller-api-guide`