### PR TITLE
Backport to 2.4: AAP-20141: adds note about api token never expiring (#1077)

### DIFF
--- a/downstream/modules/hub/proc-create-api-token-pah.adoc
+++ b/downstream/modules/hub/proc-create-api-token-pah.adoc
@@ -23,3 +23,8 @@ The API token is a secret token used to protect your content. Store your API tok
 ====
 
 The API token is now available for configuring {HubName} as your default collections server or uploading collections using the `ansible-galaxy` command line tool.
+
+[NOTE]
+====
+The API token does not expire. 
+====

--- a/downstream/modules/hub/proc-create-api-token.adoc
+++ b/downstream/modules/hub/proc-create-api-token.adoc
@@ -19,3 +19,8 @@ The API token is a secret token used to protect your content. Store your API tok
 ====
 
 The API token is now available for configuring {HubName} as your default collections server or for uploading collections by using the `ansible-galaxy` command line tool.
+
+[NOTE]
+====
+The API token does not expire. 
+====


### PR DESCRIPTION
This PR ports the changes from[ PR 1077](https://github.com/ansible/aap-docs/pull/1077) to the 2.4 branch. See [AAP-20141](https://issues.redhat.com/browse/AAP-20141) for more info. 