### PR TITLE
Replace plain text with attributes for content in the navigator module

### DIFF
--- a/downstream/assemblies/navigator/assembly-review-ee-navigator.adoc
+++ b/downstream/assemblies/navigator/assembly-review-ee-navigator.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 :imagesdir: images
 
 [id="assembly-review-ee-navigator_{context}"]
-= Reviewing {ExecEnvNameStart} with {Navigator}
+= Reviewing {ExecEnvName} with {Navigator}
 
 :context: review-ee-navigator
 

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -89,6 +89,7 @@
 :ExecEnvNameStart: Automation execution environments
 :ExecEnvName: automation execution environments
 :ExecEnvNameSing: automation execution environment
+:ExecEnvNameStartSing: Automation execution environment
 :ExecEnvShort: execution environment
 :RHEL8: RHEL 8 UBI
 :RHEL9: RHEL 9 UBI

--- a/downstream/modules/navigator/con-navigator-collections.adoc
+++ b/downstream/modules/navigator/con-navigator-collections.adoc
@@ -11,4 +11,4 @@ SHADOWED:: Indicates that an additional copy of the collection is higher in the 
 TYPE:: Shows if the collection is contained within an {ExecEnvNameSing} or volume mounted on onto the {ExecEnvNameSing} as a `bind_mount`.
 PATH:: Reflects the collections location within the {ExecEnvNameSing} or local file system based on the collection TYPE field.
 
-image::navigator-collections-shadow.png[Automation content navigator collections display]
+image::navigator-collections-shadow.png[{Navigator} collections display]

--- a/downstream/modules/navigator/proc-browse-collections-tui.adoc
+++ b/downstream/modules/navigator/proc-browse-collections-tui.adoc
@@ -28,7 +28,7 @@ $ ansible-navigator
 $ :collections
 ----
 +
-image::navigator-collection-list.png[A list of Ansible collections shown in the Automation content navigator]
+image::navigator-collection-list.png[A list of Ansible collections shown in the {Navigator}]
 
 . Type the number of the collection you want to explore.
 +
@@ -36,7 +36,7 @@ image::navigator-collection-list.png[A list of Ansible collections shown in the 
 :4
 ----
 +
-image::navigator-plugin-list.png[A collection shown in the Automation content navigator]
+image::navigator-plugin-list.png[A collection shown in the {Navigator}]
 
 . Type the number corresponding to the module you want to delve into.
 +

--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -53,4 +53,4 @@ $ ansible-navigator --help
 
 The following example demonstrates a successful installation:
 
-image::navigator-stdout.png[Automation content navigator successful installation]
+image::navigator-stdout.png[{Navigator} successful installation]

--- a/downstream/modules/navigator/proc-review-ee-tui.adoc
+++ b/downstream/modules/navigator/proc-review-ee-tui.adoc
@@ -3,15 +3,15 @@
 
 
 
-= Reviewing {ExecEnvNameStart} from {Navigator}
+= Reviewing {ExecEnvName} from {Navigator}
 
 [role="_abstract"]
 
-You can review your {ExecEnvNameStart} with the {Navigator} text-based user interface.
+You can review your {ExecEnvName} with the {Navigator} text-based user interface.
 
 .Prerequisites
 
-* {ExecEnvName}
+* {ExecEnvNameStart}
 
 .Procedure
 
@@ -21,11 +21,11 @@ You can review your {ExecEnvNameStart} with the {Navigator} text-based user inte
 $ ansible-navigator images
 ----
 +
-image::navigator-images-list.png[List of automation execution environments]
+image::navigator-images-list.png[List of {ExecEnvName}]
 
 . Type the number of the {ExecEnvNameSing} you want to delve into for more details.
 +
-image::navigator-image-details.png[Automation execution environment details]
+image::navigator-image-details.png[{ExecEnvNameStartSing} details]
 +
 You can review the packages and versions of each installed {ExecEnvNameSing} and the Ansible version any included collections.
 
@@ -41,4 +41,4 @@ $ ansible-navigator images --eei registry.example.com/example-enterprise-ee:late
 
 * Review the {ExecEnvNameSing} output.
 +
-image::navigator-image-details.png[Automation execution environment output]
+image::navigator-image-details.png[{ExecEnvNameStartSing} output]

--- a/downstream/modules/navigator/ref-navigator-command-summary.adoc
+++ b/downstream/modules/navigator/ref-navigator-command-summary.adoc
@@ -10,9 +10,9 @@ The {Navigator} commands run familiar Ansible CLI commands in `-m stdout` mode. 
 |====
 |Command|Description|CLI example
 |collections|Explore available collections|`ansible-navigator collections --help`
-|config|Explore the current ansible configuration|`ansible-navigator config --help`
+|config|Explore the current Ansible configuration|`ansible-navigator config --help`
 |doc|Review documentation for a module or plugin|`ansible-navigator doc --help`
-|images|Explore execution environment images|`ansible-navigator images --help`
+|images|Explore {ExecEnvShort} images|`ansible-navigator images --help`
 |inventory|Explore an inventory|`ansible-navigator inventory --help`
 |replay|Explore a previous run using a playbook artifact|`ansible-navigator replay --help`
 |run|Run a playbook|`ansible-navigator run --help`


### PR DESCRIPTION
Affects the following titles:

```
./navigator-guide/navigator
./dev-guide/navigator
```

Replace plain-text with attributes where appropriate

https://issues.redhat.com/browse/AAP-19894