### PR TITLE
Backport-2.4-1050 AAP-18707 Updated procedure with EDA max running activations

### DIFF
--- a/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
+++ b/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
@@ -16,7 +16,26 @@
 
 . Under *Provided APIs*, locate the {EDAName} modal and click *Create instance*. 
 +
-This takes you to the Form View to customize your installation.
+This takes you to the Form View to customize your installation. 
++
+[IMPORTANT]
+====
+To ensure that you can run concurrent {EDAName} activations efficiently, you must set your maximum number of activations in proportion to the resources available on your cluster. You can do this by adjusting your {EDAName} settings in the YAML view. 
+
+When you activate an {EDAName} rulebook under standard conditions, it uses approximately 250 MB of memory. However, the actual memory consumption can vary significantly based on the complexity of your rules and the volume and size of the events processed. In scenarios where a large number of events are anticipated or the rulebook complexity is high, conduct a preliminary assessment of resource usage in a staging environment. This ensures that your maximum number of activations is based on the capacity of your resources. 
+====
++
+. Click btn:[YAML view] to update your YAML key values. 
+
+. Copy and paste the following string at the end of the `spec` key value section:
++
+----
+extra_settings:
+  - setting: EDA_MAX_RUNNING_ACTIVATIONS
+    value: '12'
+----
++
+. Click btn[Reload] and btn[Save]. Return to the Form view.
 
 . In the *Name* field, enter the name you want for your new {EDAcontroller} deployment. 
 +

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -40,6 +40,9 @@ Default = empty list
 | *`automationedacontroller_gunicorn_workers`* | Number of workers for the API served through gunicorn.
 
 Default = (# of cores or threads) * 2 + 1
+| *`automationedacontroller_max_running_activations`* | The number of maximum activations running concurrently per node.
+
+Default = 12
 | *`automationedacontroller_pg_database`* | The Postgres database used by {EDAController}.
 
 Default = `automtionedacontroller`.

--- a/downstream/modules/platform/ref-eda-system-requirements.adoc
+++ b/downstream/modules/platform/ref-eda-system-requirements.adoc
@@ -2,12 +2,8 @@
 
 = {EDAcontroller} system requirements
 
-The {EDAcontroller} is a single-node system capable of handling a variable number of long-running processes (such as, Rulebook activations) on-demand, depending on the number of CPU cores. Use the following minimum requirements to execute a maximum of 9 simultaneous activations:
+The {EDAcontroller} is a single-node system capable of handling a variable number of long-running processes (such as Rulebook activations) on-demand, depending on the number of CPU cores. Use the following minimum requirements to execute, by default, a maximum of 12 simultaneous activations:
 
-[NOTE]
-====
-If you are running {RHEL} 8 and want to set your memory limits, you must have cgroup v2 enabled before you install {EDAName}. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for {RHEL} 8 requires cgroupv2].
-====
 
 [cols="a,a",options="header"]
 |===
@@ -17,3 +13,10 @@ h| Requirement | Required
 | *Local disk* | 40 GB minimum
 |===
 
+[IMPORTANT]
+====
+* If you are running {RHEL} 8 and want to set your memory limits, you must have cgroup v2 enabled before you install {EDAName}. For specific instructions, see the Knowledge-Centered Support (KCS) article, link:https://access.redhat.com/solutions/7054905[Ansible Automation Platform Event-Driven Ansible controller for {RHEL} 8 requires cgroupv2].
+
+* When you activate an {EDAName} rulebook under standard conditions, it uses approximately 250 MB of memory. However, the actual memory consumption can vary significantly based on the complexity of your rules and the volume and size of the events processed. In scenarios where a large number of events are anticipated or the rulebook complexity is high, conduct a preliminary assessment of resource usage in a staging environment. This ensures that your maximum number of activations is based on the capacity of your resources. See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-single-controller-hub-eda-with-managed-db[Single {ControllerName}, single {HubName}, and single {EDAcontroller} node with external (installer managed) database] for an example on setting {EDAController} maximum
+running activations. 
+====

--- a/downstream/modules/platform/ref-single-controller-hub-eda-with-managed-db.adoc
+++ b/downstream/modules/platform/ref-single-controller-hub-eda-with-managed-db.adoc
@@ -1,6 +1,6 @@
 [id="ref-single-controller-hub-eda-with-managed-db"]
 
-=  Single {ControllerName}, single {HubName}, and single {EDAController} node with external (installer managed ) database
+=  Single {ControllerName}, single {HubName}, and single {EDAController} node with external (installer managed) database
 
 [role="_abstract"]
 Use this example to populate the inventory file to deploy single instances of {ControllerName}, {HubName}, and {EDAController} with an external (installer managed) database.
@@ -10,6 +10,9 @@ Use this example to populate the inventory file to deploy single instances of {C
 * This scenario requires a minimum of {ControllerName} 2.4 for successful deployment of {EDAcontroller}.
 
 * {EDAController} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
+
+* When you activate an {EDAName} rulebook under standard conditions, it uses approximately 250 MB of memory. However, the actual memory consumption can vary significantly based on the complexity of your rules and the volume and size of the events processed. In scenarios where a large number of events are anticipated or the rulebook complexity is high, conduct a preliminary assessment of resource usage in a staging environment. This ensures that your maximum number of activations is based on the capacity of your resources. In the following example, the default `automationedacontroller_max_running_activations` setting is 12, but you can adjust according to your capacity. 
+
 ====
 
 -----


### PR DESCRIPTION
Updates to address issue AAP-18707 include the following:

- Deploying AAP Operator on OCP guide

     - [Chapter 6](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/deploy-eda-controller-on-aap-operator-ocp) in the [Deploying AAP operator on OCP guide](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index).

- AAP Installation Guide

     - [Chapter 2.4 Event-Driven Ansible controller system requirements](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#event-driven-ansible-system-requirements)

     - [Chapter 3.2.1.5 Single automation controller, single automation hub, and single Event-Driven Ansible controller node with external (installer managed ) database](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-single-controller-hub-eda-with-managed-db)

     - [Appendix A.5. Event-Driven Ansible controller variables](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#event-driven-ansible-controller)