### PR TITLE
Replace plain text with attributes for content in the platform module…

### DIFF
--- a/downstream/modules/platform/con-aap-example-architecture.adoc
+++ b/downstream/modules/platform/con-aap-example-architecture.adoc
@@ -3,7 +3,7 @@
 [id='aap_example_architecture_{context}']
 = Example {PlatformNameShort} architecture
 
-The {PlatformName} {PlatformVers} reference architecture provides an example setup of a standard deployment of {PlatformNameShort} using automation mesh on Red Hat Enterprise Linux. The deployment shown takes advantage of the following key components to provide a simple, secure and flexible method of handling your automation workloads, a central location for content collections, and automated resolution of IT requests.
+The {PlatformName} {PlatformVers} reference architecture provides an example setup of a standard deployment of {PlatformNameShort} using {AutomationMesh} on {RHEL}. The deployment shown takes advantage of the following components to provide a simple, secure and flexible method of handling your automation workloads, a central location for content collections, and automated resolution of IT requests.
 
 {ControllerNameStart}:: Provides the control plane for automation through its UI, Restful API, RBAC workflows and CI/CD integrations.
 {AutomationMeshStart}:: Is an overlay network that provides the ability to ease the distribution of work across a large and dispersed collection of workers through nodes that establish peer-to-peer connections with each other using existing networks.
@@ -21,4 +21,4 @@ The architecture for this example consists of the following:
 
 .Example {PlatformNameShort} {PlatformVers} architecture
 // dcd - Image in progress with graphics team and will be added once complete.
-image::aap_ref_arch_2.4.png[Reference architecture for an example setup of a standard Ansible Automation Platform deployment]
+image::aap_ref_arch_2.4.png[Reference architecture for an example setup of a standard {PlatformNameShort} deployment]

--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -11,7 +11,7 @@ Before you begin the upgrade process, review the following considerations to pla
 == {ControllerNameStart}
 
 * Even if you have a valid license from a previous version, you must provide your credentials or a subscriptions manifest upon upgrading to the latest version of {ControllerName}.
-* If you need to upgrade Red Hat Enterprise Linux and {ControllerName}, you must first backup and restore your {ControllerName} data.
+* If you need to upgrade {RHEL} and {ControllerName}, you must first backup and restore your {ControllerName} data.
 * Clustered upgrades require special attention to instance and instance groups before upgrading.
 
 [role="_additional-resources"]

--- a/downstream/modules/platform/con-aap-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-prereq.adoc
@@ -14,7 +14,7 @@ The following specifications are required for the nodes involved in the {Platfor
 * 40 GB+ disk space for non-database nodes.
 * DHCP reservations use infinite leases to deploy the cluster with static IP addresses.
 * DNS records for all nodes.
-* Red Hat Enterprise Linux 8 or later 64-bit (x86) installed for all nodes.
+* {RHEL} 8 or later 64-bit (x86) installed for all nodes.
 * Chrony configured for all nodes.
 * Python 3.9 or later for all content dependencies.
 
@@ -66,7 +66,7 @@ Before you upgrade {PlatformNameShort}, it is recommended to create a non-root u
 * Passwordless authentication during installation.
 * Privilege escalation (sudo) permissions.
 
-The following example uses `ansible` to name this user. On all nodes used in the upgraded {PlatformNameShort} cluster, create a non-root user named `ansible` and generate an ssh key:
+The following example uses `ansible` to name this user. On all nodes used in the upgraded {PlatformNameShort} cluster, create a non-root user named `ansible` and generate an SSH key:
 
 . Create a non-root user:
 +
@@ -102,7 +102,7 @@ $ ssh-copy-id ansible@node-1.example.com
 NOTE: If running within a cloud provider, you might need to instead create an `~/.ssh/authorized_keys` file containing the public key for the `ansible` user on all your nodes and set the permissions to the `authorized_keys` file to only the owner (`ansible`) having read and write access (permissions 600).
 
 .Configuring firewall settings
-Configure the firewall settings on all the nodes used in the upgraded {PlatformNameShort} cluster to permit access to the appropriate services and ports for a successful {PlatformNameShort} upgrade. For Red Hat Enterprise Linux 8 or later, enable the `firewalld` daemon to enable the access needed for all nodes:
+Configure the firewall settings on all the nodes used in the upgraded {PlatformNameShort} cluster to allow access to the appropriate services and ports for a successful {PlatformNameShort} upgrade. For {RHEL} 8 or later, enable the `firewalld` daemon to enable the access needed for all nodes:
 
 . Install the `firewalld` package:
 +
@@ -126,7 +126,7 @@ The following {PlatformNameShort} configurations are required before you proceed
 
 .Configuring firewall settings for execution and hop nodes
 
-After upgrading your {PlatformName} instance, add the automation mesh port on the mesh nodes (execution and hop nodes) to enable automation mesh functionality. The default port used for the mesh networks on all nodes is `27199/tcp`. You can configure the mesh network to use a different port by specifying `recptor_listener_port` as the variable for each node within your inventory file.
+After upgrading your {PlatformName} instance, add the {AutomationMesh} port on the mesh nodes (execution and hop nodes) to enable {AutomationMesh} functionality. The default port used for the mesh networks on all nodes is `27199/tcp`. You can configure the mesh network to use a different port by specifying `recptor_listener_port` as the variable for each node within your inventory file.
 
 Within your hop and execution node set the `firewalld` port to be used for installation.
 

--- a/downstream/modules/platform/con-aap-upgrades-legacy.adoc
+++ b/downstream/modules/platform/con-aap-upgrades-legacy.adoc
@@ -8,7 +8,7 @@ Upgrading to version {PlatformVers} from {PlatformNameShort} 2.0 or earlier requ
 
 The following steps provide an overview of the legacy upgrade process:
 
-* Duplicate your custom virtual environments into automation execution environments using the `awx-manage` command.
+* Duplicate your custom virtual environments into {ExecEnvName} by using the `awx-manage` command.
 * Migrate data from isolated legacy nodes to execution nodes by performing a side-by-side upgrade so nodes are compatible with the latest {AutomationMesh} features.
 * Import or generate a new {HubName} API token.
 * Reconfigure your Ansible content to include Fully Qualified Collection Names (FQCN) for compatibility with `ansible-core` {AnsibleCoreVers}.

--- a/downstream/modules/platform/con-about-eda-controller.adoc
+++ b/downstream/modules/platform/con-about-eda-controller.adoc
@@ -1,9 +1,9 @@
 [id="about-event-driven-ansible-controller_{context}"]
 
-= Event-Driven Ansible controller
+= {EDAcontroller}
 
 [role="_abstract"]
-The Event-Driven Ansible controller is the interface for event-driven automation and introduces automated resolution of IT requests. This component helps you connect to sources of events and act on those events using rulebooks. This technology improves IT speed and agility, and enables consistency and resilience. With Event-Driven Ansible, you can: 
+The {EDAcontroller} is the interface for event-driven automation and introduces automated resolution of IT requests. {EDAcontroller} helps you connect to sources of events and act on those events by using rulebooks. This technology improves IT speed and agility, and enables consistency and resilience. With {EDAName}, you can: 
 
 * Automate decision making
 * Use numerous event sources

--- a/downstream/modules/platform/con-about-navigator.adoc
+++ b/downstream/modules/platform/con-about-navigator.adoc
@@ -3,4 +3,4 @@
 = {Navigator}
 
 [role="_abstract"]
-{Navigator} is a _textual user interface_ (TUI) that becomes the primary command line interface into the automation platform, covering use cases from content building, running automation locally in an execution environment, running automation in {PlatformNameShort}, and providing the foundation for future _integrated development environments_ (IDEs).
+{Navigator} is a _textual user interface_ (TUI) that becomes the primary command line interface into the automation platform, covering use cases from content building, running automation locally in an {ExecEnvShort}, running automation in {PlatformNameShort}, and providing the foundation for future _integrated development environments_ (IDEs).

--- a/downstream/modules/platform/con-about-operator.adoc
+++ b/downstream/modules/platform/con-about-operator.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 The {OperatorPlatform} provides cloud-native, push-button deployment of new {PlatformNameShort} instances in your OpenShift environment.
-The {OperatorPlatform} includes resource types to deploy and manage instances of {ControllerNameStart} and Private Automation hub.
+The {OperatorPlatform} includes resource types to deploy and manage instances of {ControllerNameStart} and {PrivateHubName}.
 It also includes {ControllerName} job resources for defining and launching jobs inside your {ControllerName} deployments.
 
 Deploying {PlatformNameShort} instances with a Kubernetes native operator offers several advantages over launching instances from a playbook deployed on {OCP}, including upgrades and full lifecycle support for your {PlatformName} deployments.

--- a/downstream/modules/platform/con-about-pa-hub.adoc
+++ b/downstream/modules/platform/con-about-pa-hub.adoc
@@ -3,7 +3,7 @@
 = {PrivateHubNameStart}
 
 [role="_abstract"]
-{PrivateHubNameStart} provides both disconnected and on premise solution for synchronizing content.
-You can synchronize collections and execution environment images from Red Hat cloud automation hub, storing and serving your own custom automation collections and execution images.
+{PrivateHubNameStart} provides both disconnected and on-premise solutions for synchronizing content.
+You can synchronize collections and {ExecEnvShort} images from Red Hat cloud {HubName}, storing and serving your own custom automation collections and execution images.
 You can also use other sources such as {Galaxy} or other container registries to provide content to your {PrivateHubName}.
 {PrivateHubNameStart} can integrate into your enterprise directory and your CI/CD pipelines.

--- a/downstream/modules/platform/con-controller-deprovision-instance-groups.adoc
+++ b/downstream/modules/platform/con-controller-deprovision-instance-groups.adoc
@@ -39,9 +39,9 @@ awx-manage unregister_queue --queuename=<name>
 Removing an instance's membership from an instance group in the inventory file and re-running the setup playbook does not ensure that the instance is not added back to a group. To be sure that an instance is not added back to a group, remove it through the API and also remove it in your inventory file. 
 You can also stop defining instance groups in the inventory file. 
 You can manage instance group topology through the {ControllerName} UI. 
-For more information on managing instance groups in the UI, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_user_guide/index#controller-instance-groups[Managing Instance Groups] in the _{ControllerUG}_.
+For more information about managing instance groups in the UI, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_user_guide/index#controller-instance-groups[Managing Instance Groups] in the _{ControllerUG}_.
 
 [NOTE]
 ====
-If you have isolated instance groups created in older versions of {ControllerName} (3.8.x and earlier) and want to migrate them to execution nodes to make them compatible for use with the automation mesh architecture, see link:https://docs.ansible.com/automation-controller/4.4/html/upgrade-migration-guide/upgrade_to_ees.html#migrate-iso-to-exe[Migrate isolated instances to execution nodes] in the _Ansible Automation Platform Upgrade and Migration Guide_.
+If you have isolated instance groups created in older versions of {ControllerName} (3.8.x and earlier) and want to migrate them to execution nodes to make them compatible for use with the {AutomationMesh} architecture, see link:https://docs.ansible.com/automation-controller/4.4/html/upgrade-migration-guide/upgrade_to_ees.html#migrate-iso-to-exe[Migrate isolated instances to execution nodes] in the _Ansible Automation Platform Upgrade and Migration Guide_.
 ====

--- a/downstream/modules/platform/con-install-scenario-recommendations.adoc
+++ b/downstream/modules/platform/con-install-scenario-recommendations.adoc
@@ -12,7 +12,7 @@ Before selecting your installation method for {PlatformNameShort}, review the fo
 This can cause contention issues and heavy resource use.
 * Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure users can sync and install content from {HubName} from a different node.
 Do not use 'localhost'.
-* `admin` is the default user ID for the initial log in to Ansible Automation Platform and cannot be changed in the inventory file.
+* `admin` is the default user ID for the initial log in to {PlatformNameShort} and cannot be changed in the inventory file.
 * Use of special characters for `pg_password` is limited. The `!`, `#`, `0` and `@` characters are supported. Use of other special characters can cause the setup to fail.
 * Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
 * The inventory file variables `registry_username` and `registry_password` are only required if a non-bundle installer is used.

--- a/downstream/modules/platform/con-operator-additional-resources.adoc
+++ b/downstream/modules/platform/con-operator-additional-resources.adoc
@@ -2,4 +2,4 @@
 
 = Additional resources
 
-* See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/operators/understanding-operators#olm-understanding-operatorhub[Understanding OperatorHub] to learn more about OpenShift Container Platform OperatorHub.
+* See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/operators/understanding-operators#olm-understanding-operatorhub[Understanding OperatorHub] to learn more about {OCPShort} OperatorHub.

--- a/downstream/modules/platform/con-persisting-data-from-auto-runs.adoc
+++ b/downstream/modules/platform/con-persisting-data-from-auto-runs.adoc
@@ -5,17 +5,17 @@
 [id="persisting-data-from-auto-runs_{context}"]
 = Persisting data from auto runs
 
-Consider the local Automation Controller filesystem as counterproductive since that ties the data to that host. If you have a multi-node cluster, then you can contact a different host each time causing issues if you are creating workflows that depend upon each other and created directories. For example, if a directory was only created in one node, while another node runs the playbook, the results would be inconsistent.
+Consider the local {ControllerName} filesystem as counterproductive since that ties the data to that host. If you have a multi-node cluster, then you can contact a different host each time, causing issues if you are creating workflows that depend on each other and created directories. For example, if a directory was only created in one node while another node runs the playbook, the results would be inconsistent.
 
-The solution is to use some form of shared storage solution, like Amazon S3, Gist, or a role to rsync data to your data endpoint. 
+The solution is to use some form of shared storage solution, such as Amazon S3, Gist, or a role to rsync data to your data endpoint. 
 
-The option exists of injecting data or a configuration into a container at runtime. This can be achieved using the automation controller’s isolated jobs path option.
+The option exists of injecting data or a configuration into a container at runtime. This can be achieved by using the {ControllerName}'s isolated jobs path option.
 
-This provides a way to mount directories and files into an execution environment at runtime. This is achieved through the automation mesh, utilizing ansible-runner to inject them into a Podman container to launch the automation. What follows are some of the use cases for using isolated job paths:
+This provides a way to mount directories and files into an {ExecEnvShort} at runtime. This is achieved through the {AutomationMesh}, using ansible-runner to inject them into a Podman container to start the automation. What follows are some of the use cases for using isolated job paths:
 
-* Providing SSL certificates at runtime, rather than baking them into an execution environment.
+* Providing SSL certificates at runtime, rather than baking them into an {ExecEnvShort}.
 
-* Passing runtime configuration data, such as SSH config settings, but could be anything you want to provide and use during automation.
+* Passing runtime configuration data, such as SSH config settings, but could be anything you want to use during automation.
 
 * Reading and writing to files used before, during and after automation runs.
 
@@ -23,11 +23,11 @@ There are caveats to utilization:
 
 * The volume mount has to pre-exist on all nodes capable of automation execution (so hybrid control plane nodes and all execution nodes).
 
-* Where SELinux is enabled (Ansible Automation Platform default) beware of file permissions.
+* Where SELinux is enabled ({PlatformNameShort} default) beware of file permissions.
 
-** This is important since rootless podman is run on non-OCP based installs.
+** This is important since rootless Podman is run on non-OCP based installs.
 
-The caveats need to be carefully observed. It is highly recommended to read up on rootless Podman and the Podman volume mount runtime options, the [:OPTIONS] part of the isolated job paths, as this is what is used inside Ansible Automation Platform 2. 
+The caveats need to be carefully observed. It is highly recommended to read up on rootless Podman and the Podman volume mount runtime options, the [:OPTIONS] part of the isolated job paths, as this is what is used inside {PlatformNameShort} 2. 
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/platform/con-single-eda-controller-with-internal-database.adoc
+++ b/downstream/modules/platform/con-single-eda-controller-with-internal-database.adoc
@@ -4,7 +4,7 @@
 
 = Single {EDAcontroller} node with internal database
 
-This scenario includes installation of {EDAcontroller} on a single machine with an internal database. It installs an installer managed PostgreSQL that is similar to the automation controller installation scenario.
+This scenario includes installation of {EDAcontroller} on a single machine with an internal database. It installs an installer managed PostgreSQL that is similar to the {ControllerName} installation scenario.
 
 [IMPORTANT]
 ====

--- a/downstream/modules/platform/con-why-ee.adoc
+++ b/downstream/modules/platform/con-why-ee.adoc
@@ -2,7 +2,7 @@
 
 = Why upgrade to {ExecEnvName}?
 
-{PlatformName} {PlatformVers} introduces {ExecEnvName}. {ExecEnvNameStart} are container images that allow for easier administration of Ansible by including everything needed to run Ansible automation within a single container. Automation execution environments include:
+{PlatformName} {PlatformVers} introduces {ExecEnvName}. {ExecEnvNameStart} are container images that allow for easier administration of Ansible by including everything needed to run Ansible automation within a single container. {ExecEnvNameStart} include:
 
 * RHEL UBI 8
 * Ansible 2.9 or Ansible Core 2.13

--- a/downstream/modules/platform/con-why-migrate-ansible-29.adoc
+++ b/downstream/modules/platform/con-why-migrate-ansible-29.adoc
@@ -6,4 +6,4 @@ To migrate Ansible Engine 2.9 images for use with {PlatformNameShort} {PlatformV
 
 [role="_additional-resources"]
 .Additional resources
-* See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments] for more information on using Ansible Builder to build execution environments.
+* See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments/index[Creating and Consuming Execution Environments] for more information about using {Builder} to build execution environments.


### PR DESCRIPTION
… (#1119)

* Replace plain text with attributes for content in the platform module

I'm breaking up platform module updates into mulitiple PRs to prevent merge conflicts.

Affects the following titles:

```
./aap-operations-guide/platform
./upgrade/platform
./aap-operator-installation/platform
./aap-installation-guide/platform
./aap-planning-guide/platform
./operator-mesh/platform
./automation-mesh/platform
./ocp_performance_guide/platform
./controller/controller-user-guide/platform
./controller/controller-admin-guide/platform
./controller/controller-getting-started/platform
./controller/controller-api-guide/platform
./aap-operator-backup/platform
./aap-containerized-install/platform
./builder/builder/
```

Replace plain-text with attributes where appropriate

https://issues.redhat.com/browse/AAP-19894

* updates based on peer review feedback