### PR TITLE
Adding missing info to extra vars section

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-awx-manage-utility.adoc
+++ b/downstream/assemblies/platform/assembly-controller-awx-manage-utility.adoc
@@ -2,8 +2,8 @@
 
 = The _awx-manage_ Utility
 
-The `awx-manage` utility is used to access detailed internal information of {ControllerName}.
-Commands for `awx-manage` must run as the `awx` or `root` user.
+Use the `awx-manage` utility to access detailed internal information of {ControllerName}.
+Commands for `awx-manage` must only run as the `awx` user.
 
 include::platform/ref-controller-inventory-import.adoc[leveloffset=+1]
 include::platform/ref-controller-cleanup-old-data.adoc[leveloffset=+1]

--- a/downstream/modules/platform/ref-controller-extra-variables.adoc
+++ b/downstream/modules/platform/ref-controller-extra-variables.adoc
@@ -8,7 +8,7 @@ However, passing extra variables to a job template (as you would do with a surve
 By default, `extra_vars` are marked as `!unsafe` unless you specify them on the Job Template's Extra Variables section. 
 These are trusted, because they can only be added by users with enough privileges to add or edit a Job Template. 
 For example, nested variables do not expand when entered as a prompt, as the Jinja brackets are treated as a string.
-For more information on unsafe variables, see: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings. 
+For more information about unsafe variables, see link:https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings[Unsafe or raw strings]. 
 
 [NOTE]
 ====

--- a/downstream/modules/platform/ref-controller-extra-variables.adoc
+++ b/downstream/modules/platform/ref-controller-extra-variables.adoc
@@ -20,7 +20,7 @@ It is possible that this variable, `debug = true`, can be overridden in a job te
 To ensure the variables that you pass are not overridden, ensure they are included by redefining them in the survey.
 Extra variables can be defined at the inventory, group, and host levels.
 
-If you are specifying the `ALLOW_JINJA_IN_EXTRA_VARS` parameter, see the link:http://docs.ansible.com/automation-controller/4.4/html/administration/tipsandtricks.html#ag-tips-jinja-extravars[Controller Tips and Tricks] section of the _{ControllerAG}_ to configure it in the *Jobs Settings* screen of the controller UI.
+If you are specifying the `ALLOW_JINJA_IN_EXTRA_VARS` parameter, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_administration_guide/index[Controller Tips and Tricks] section of the _{ControllerAG}_ to configure it in the *Jobs Settings* screen of the controller UI.
 
 The job template extra variables dictionary is merged with the survey variables.
 
@@ -53,7 +53,7 @@ The following table notes the behavior (hierarchy) of variable precedence in {Co
 |====
 | Ansible | {ControllerName}
 | role defaults | role defaults
-| dynamic inventory vaviables | dynamic inventory variables
+| dynamic inventory variables | dynamic inventory variables
 | inventory variables | {ControllerName} inventory variables
 | inventory `group_vars` | {ControllerName} group variables
 | inventory `host_vars` | {ControllerName} host variables
@@ -70,5 +70,5 @@ The following table notes the behavior (hierarchy) of variable precedence in {Co
 | task variables | task variables
 | extra variables | Job Template extra variables
 | | Job Template Survey (defaults)
-| | Job Launch exta variables
+| | Job Launch extra variables
 |====

--- a/downstream/modules/platform/ref-controller-extra-variables.adoc
+++ b/downstream/modules/platform/ref-controller-extra-variables.adoc
@@ -5,6 +5,11 @@
 When you pass survey variables, they are passed as extra variables (`extra_vars`) within {ControllerName}.
 However, passing extra variables to a job template (as you would do with a survey) can override other variables being passed from the inventory and project.
 
+By default, `extra_vars` are marked as `!unsafe` unless you specify them on the Job Template's Extra Variables section. 
+These are trusted, because they can only be added by users with enough privileges to add or edit a Job Template. 
+For example, nested variables do not expand when entered as a prompt, as the Jinja brackets are treated as a string.
+For more information on unsafe variables, see: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings. 
+
 [NOTE]
 ====
 `extra_vars` passed to the job launch API are only honored if one of the following is true:
@@ -24,7 +29,7 @@ If you are specifying the `ALLOW_JINJA_IN_EXTRA_VARS` parameter, see the link:ht
 
 The job template extra variables dictionary is merged with the survey variables.
 
-The following are some simplified examples of extra_vars in YAML and JSON formats:
+The following are some simplified examples of `extra_vars` in YAML and JSON formats:
 
 * The configuration in YAML format:
 ----


### PR DESCRIPTION
Missing documentation on job template's extra vars

https://issues.redhat.com/browse/AAP-4442

Affects `titles/controller-admin-guide` and `controller-user-guide`