### PR TITLE
AAP-20863: Adds EDA controller variables to procedure for changing SSL certification (#1130)

### DIFF
--- a/downstream/modules/platform/proc-change-ssl-installer.adoc
+++ b/downstream/modules/platform/proc-change-ssl-installer.adoc
@@ -9,14 +9,15 @@ The following procedure describes how to change the SSL certificate and key in t
 
 . Copy the new SSL certificates and keys to a path relative to the {PlatformNameShort} installer.
 . Add the absolute paths of the SSL certificates and keys to the inventory file. 
-Refer to the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index#ref-hub-variables[{ControllerNameStart} variables] and
-link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index#ref-controller-variables[{HubNameStart} variables] sections of the 
+Refer to the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index#ref-hub-variables[{ControllerNameStart} variables], 
+link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index#ref-controller-variables[{HubNameStart} variables], and link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the 
 link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} Installation Guide]
 for guidance on setting these variables.
 +
 --
 ** {ControllerNameStart}: `web_server_ssl_cert`, `web_server_ssl_key`, `custom_ca_cert`
 ** {HubNameStart}: `automationhub_ssl_cert`, `automationhub_ssl_key`, `custom_ca_cert`
+** {EDAcontroller}: `automationedacontroller_ssl_cert`, `automationedacontroller_ssl_key`, `custom_ca_cert`
 --
 +
 [NOTE]

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -60,5 +60,15 @@ Default = `5432`.
 Default = `automationedacontroller`.
 | *`automationedacontroller_rq_workers`* | Number of Redis Queue (RQ) workers used by {EDAcontroller}. RQ workers are Python processes that run in the background.
 
-Default =  2 * (# of cores or threads) + 1
+Default =  (# of cores or threads) * 2 + 1
+| *`automationedacontroller_ssl_cert`* | _Optional_
+
+`/root/ssl_certs/eda._<example>_.com.crt`
+
+Same as `automationhub_ssl_cert` but for {EDAcontroller} UI and API.
+| *`automationedacontroller_ssl_key`* | _Optional_
+
+`/root/ssl_certs/eda._<example>_.com.key`
+
+Same as `automationhub_server_ssl_key` but for {EDAcontroller} UI and API.
 |====


### PR DESCRIPTION
This PR ports the changes from [PR 1130](https://github.com/ansible/aap-docs/pull/1130) to the 2.4 branch. See [AAP-20863](https://issues.redhat.com/browse/AAP-20863) for more info. 

* Adds EDA controller variables to procedure for changing SSL certification

* adds eda controller ssl variables to variable index in installation guide

* edits based on technical SME feedback