### PR TITLE
AAP-19591: Added RH and IBM support links

### DIFF
--- a/lightspeed/modules/proc_provide-feedback.adoc
+++ b/lightspeed/modules/proc_provide-feedback.adoc
@@ -12,9 +12,9 @@ You can submit feedback through the following channels:
 +
 IMPORTANT: Red Hat Support cannot assist with the suggestion quality reports. Content quality issues are routed to IBM for resolution.
 
-* From link:access.redhat.com[the Red Hat customer portal]: Use this method to log bug reports and service disruption incidents, and feature requests.
+* From the link:access.redhat.com[Red Hat customer portal]: Use this method to log bug reports and service disruption incidents, and feature requests.
 
-NOTE: On the login screen of the link:https://c.ai.ansible.redhat.com/[Ansible Lightspeed Portal], there is a *Chat* link that redirects you to a Matrix channel. Use the Matrix channel to ask questions pertaining to your Ansible Lightspeed experience and request help to troubleshoot your issues. However, the Matrix channel is not an official Support channel, and issues raised in the Matrix chat would not be tracked through Red Hat Service Level Agreement (SLA). To raise a bug or a feature request, contact Red Hat Support and open a support ticket.  
+NOTE: On the login screen of the link:https://c.ai.ansible.redhat.com/[Ansible Lightspeed Portal], there is a *Chat* link that redirects you to a Matrix channel. Use the Matrix channel to ask questions pertaining to your Ansible Lightspeed experience and request help to troubleshoot your issues. However, the Matrix channel is not an official Support channel, and issues raised in the Matrix chat would not be tracked through Red Hat Service Level Agreement (SLA). To raise a bug or a feature request, contact link:https://access.redhat.com/support[Red Hat Support] and open a support ticket.  
 
 .Prerequisites
 
@@ -27,7 +27,7 @@ NOTE: On the login screen of the link:https://c.ai.ansible.redhat.com/[Ansible L
 . In the *Tell us why* field, provide your feedback. Here, provide feedback about what results you were expecting to receive, compared to what results were generated and the training match.
 . Select the issue type: *Bug report*, *Feature request*, or *Suggestion feedback*. 
 +
-NOTE: To raise a bug or feature request, contact Red Hat Support and open a support ticket. Bug features and feature requests made through Ansible Lightspeed feedback are not tracked through the Red Hat Service Level Agreement (SLA).
+NOTE: To raise a bug or feature request, contact link:https://access.redhat.com/support[Red Hat Support] and open a support ticket. Bug features and feature requests made through Ansible Lightspeed feedback are not tracked through the Red Hat Service Level Agreement (SLA).
 +
 . Select the *I understand that feedback is shared with Red Hat and IBM* checkbox. 
 . Click *Send*.

--- a/lightspeed/modules/proc_troubleshooting-lightspeed-config.adoc
+++ b/lightspeed/modules/proc_troubleshooting-lightspeed-config.adoc
@@ -17,7 +17,7 @@ When you enter the Watsonx Code Assistant (WCA) API key, authentication fails an
 
 `IBM Cloud API key is invalid`
 
-{LightspeedShortName} verifies the WCA API key by generating an associated access token. To resolve the error, ensure that you have not accidentally included any extra spaces when obtaining the WCA API key from {ibmwatsonxcodeassistant}. If you still cannot upload the WCA key, contact IBM support. 
+{LightspeedShortName} verifies the WCA API key by generating an associated access token. To resolve the error, ensure that you have not accidentally included any extra spaces when obtaining the WCA API key from {ibmwatsonxcodeassistant}. If you still cannot upload the WCA key, contact link:https://cloud.ibm.com/docs/get-support?topic=get-support-open-case[IBM Support].
 
 == Cannot configure the model ID due to authentication failure
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-19591. 

Changes made:

- Added links to contact both Red Hat and IBM Support. 