### PR TITLE
Replace plain text with attributes for content in the platform module

### DIFF
--- a/downstream/modules/platform/con-why-migrate-venvs-ee.adoc
+++ b/downstream/modules/platform/con-why-migrate-venvs-ee.adoc
@@ -2,7 +2,7 @@
 
 = Migrating from legacy virtual environments (venvs) to {ExecEnvName}
 
-{PlatformNameShort} {PlatformVers} moves you away from custom Python virtual environments (venvs) in favor of automation execution environments - containerized images that package the necessary components needed to execute and scale your Ansible automation. These components include Ansible Core, Ansible Content Collections, Python dependencies, Red Hat Enterprise Linux UBI 8, and any additional package dependencies.
+{PlatformNameShort} {PlatformVers} moves you away from custom Python virtual environments (venvs) in favor of {ExecEnvName} - containerized images that package the necessary components needed to run and scale your Ansible automation. These components include Ansible Core, Ansible Content Collections, Python dependencies, {RHEL} UBI 8, and any additional package dependencies.
 
 To migrate your venvs to execution environments, you must use the `awx-manage` command to list and export a list of venvs from your original instance, and then use `ansible-builder` to create execution environments.
 

--- a/downstream/modules/platform/proc-apply-selinux-context.adoc
+++ b/downstream/modules/platform/proc-apply-selinux-context.adoc
@@ -2,7 +2,7 @@
 
 = Applying the SELinux context
 
-After you have configured the inventory file, you must now apply the context to enable the high availability (HA) deployment of automation hub on SELinux.
+After you have configured the inventory file, you must now apply the context to enable the high availability (HA) deployment of {HubName} on SELinux.
 
 .Procedure 
 

--- a/downstream/modules/platform/proc-choosing-obtaining-installer.adoc
+++ b/downstream/modules/platform/proc-choosing-obtaining-installer.adoc
@@ -6,7 +6,7 @@
 = Choosing and obtaining a {PlatformName} installer
 
 [role="_abstract"]
-Choose the {PlatformName} installer you need based on your Red Hat Enterprise Linux environment internet connectivity. Review the scenarios below and determine which {PlatformName} installer meets your needs.
+Choose the {PlatformName} installer you need based on your {RHEL} environment internet connectivity. Review the following scenarios and decide on which {PlatformName} installer meets your needs.
 
 [NOTE]
 ====
@@ -15,7 +15,7 @@ A valid Red Hat customer account is required to access {PlatformName} installer 
 
 .Installing with internet access
 
-Choose the {PlatformName} installer if your Red Hat Enterprise Linux environment is connected to the internet. Installing with internet access retrieves the latest required repositories, packages, and dependencies. Choose one of the following ways to set up your {PlatformNameShort} installer.
+Choose the {PlatformName} installer if your {RHEL} environment is connected to the internet. Installing with internet access retrieves the latest required repositories, packages, and dependencies. Choose one of the following ways to set up your {PlatformNameShort} installer.
 
 *Tarball install*
 
@@ -29,7 +29,7 @@ $ tar xvzf ansible-automation-platform-setup-<latest-version>.tar.gz
 
 *RPM install*
 
-. Install Ansible Automation Platform Installer Package
+. Install {PlatformNameShort} Installer Package
 +
 v.{PlatformVers} for RHEL 8 for x86_64
 +

--- a/downstream/modules/platform/proc-configuring-controller-ldap-security.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-ldap-security.adoc
@@ -25,7 +25,7 @@ metadata:
   namespace: awx
 type: Opaque
 ----
-<1> Automation controller looks for the data field `ldap-ca.crt` in the specified secret when using the `ldap_cacert_secret`.
+<1> {ControllerNameStart} looks for the data field `ldap-ca.crt` in the specified secret when using the `ldap_cacert_secret`.
 +
 . Under *LDAP Certificate Authority Trust Bundle* click the drop-down menu and select your `ldap_cacert_secret`.
 . Under *LDAP Password Secret*, click the drop-down menu and select a secret.

--- a/downstream/modules/platform/proc-controller-awx-manage-utility.adoc
+++ b/downstream/modules/platform/proc-controller-awx-manage-utility.adoc
@@ -28,4 +28,4 @@ The following is an example of a configuration file:
 
 image:ug-host-metrics-awx-manage-config.png[Configuration file]
 
-This JSON file is what gets sent to and consumed by Automation Analytics.
+{Analytics} receives and consumes the JSON file.

--- a/downstream/modules/platform/proc-controller-importing-subscriptions.adoc
+++ b/downstream/modules/platform/proc-controller-importing-subscriptions.adoc
@@ -40,8 +40,8 @@ This option is checked by default, but you can opt out of any of the following:
 .. *User analytics*. Collects data from the controller UI.
 .. *Insights Analytics*. Provides a high level analysis of your automation with {ControllerName}. 
 It helps you to identify trends and anomalous use of the controller. 
-For opt-in of Automation Analytics to be effective, your instance of {ControllerName} must be running on Red Hat Enterprise Linux. 
-For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_administration_guide/index#ref-controller-automation-analytics[Automation Analytics] section.
+For opt-in of {Analytics} to be effective, your instance of {ControllerName} must be running on {RHEL}. 
+For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_administration_guide/index#ref-controller-automation-analytics[{Analytics}] section.
 +
 [NOTE]
 ====

--- a/downstream/modules/platform/proc-controller-use-an-exec-env.adoc
+++ b/downstream/modules/platform/proc-controller-use-an-exec-env.adoc
@@ -1,6 +1,6 @@
 [id="proc-controller-use-an-exec-env"]
 
-= Using an execution environment in jobs
+= Using an {ExecEnvShort} in jobs
 
 .Prerequisites
 
@@ -28,7 +28,7 @@ The image name requires its full location (repo), the registry, image name, and 
 * Optional: *Organization*: Assign the organization to specifically use this {ExecEnvShort}. To make the {ExecEnvShort} available for use across multiple organizations, leave this field blank.
 * *Registry credential*: If the image has a protected container registry, provide the credential to access it.
 +
-image:ee-new-ee-form-filled.png[New execution environment]
+image:ee-new-ee-form-filled.png[New {ExecEnvShort}]
 
 . Click btn:[Save].
 

--- a/downstream/modules/platform/proc-create-password-hashes.adoc
+++ b/downstream/modules/platform/proc-create-password-hashes.adoc
@@ -3,7 +3,7 @@
 = Creating PostgreSQL password hashes
 
 .Procedure
-. On your automation controller node, run the following:
+. On your {ControllerName} node, run the following:
 +
 [literal, options="nowrap" subs="+quotes,attributes"]
 ----
@@ -20,7 +20,7 @@
 +
 [NOTE]
 ====
-Replace the `$POSTGRES_PASS` variable with the actual plain text password you wish to encrypt.
+Replace the `$POSTGRES_PASS` variable with the actual plain text password you want to encrypt.
 ====
 +
 The output should resemble the following:
@@ -40,4 +40,4 @@ $encrypted$AESCBC$Z0FBQUFBQmNONU9BbGQ1VjJyNDJRVTRKaFRIR09Ib2U5TGdaYVRfcXFXRjlmdm
 +
 Note that the `$*_PASS` values are already in plain text in your inventory file.
 
-These steps supply the hash values that replace the plain text passwords within the automation controller configuration files. 
+These steps supply the hash values that replace the plain text passwords within the {ControllerName} configuration files. 

--- a/downstream/modules/platform/proc-customizing-pod-specs.adoc
+++ b/downstream/modules/platform/proc-customizing-pod-specs.adoc
@@ -5,12 +5,12 @@
 You can use the following procedure to customize the pod. 
 
 .Procedure
-. In the {ControllerName} UI, navigate to menu:Administration[Instance Groups].
+. In the {ControllerName} UI, go to menu:Administration[Instance Groups].
 . Check btn:[Customize pod specification].
 . In the *Pod Spec Override* field, specify the namespace by using the toggle to enable and expand the *Pod Spec Override* field.
 . Click btn:[Save].
 . Optional: Click btn:[Expand] to view the entire customization window if you want to provide additional customizations.
 
-The image used at job launch time is determined by the execution environment associated with the job. 
-If a Container Registry credential is associated with the execution environment, then {ControllerName} uses `ImagePullSecret` to pull the image. 
-If you prefer not to give the service account permission to manage secrets, you must pre-create the `ImagePullSecret`, specify it on the pod specification, and omit any credential from the execution environment used.
+The image used at job launch time is determined by the {ExecEnvShort} associated with the job. 
+If a Container Registry credential is associated with the {ExecEnvShort}, then {ControllerName} uses `ImagePullSecret` to pull the image. 
+If you prefer not to give the service account permission to manage secrets, you must pre-create the `ImagePullSecret`, specify it on the pod specification, and omit any credential from the {ExecEnvShort} used.

--- a/downstream/modules/platform/proc-deprovisioning-mesh-nodes.adoc
+++ b/downstream/modules/platform/proc-deprovisioning-mesh-nodes.adoc
@@ -18,7 +18,7 @@ You can deprovision any of your inventory’s hosts except for the first host sp
 
 .Example
 
-This example inventory file deprovisions two nodes from an automation mesh configuration.
+This example inventory file deprovisions two nodes from an {AutomationMesh} configuration.
 
 
 -----

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -63,7 +63,7 @@ This file creates a `Subscription` object called `_ansible-automation-platform_`
 +
 It then creates an `AutomationController` object called `_example_` in the `ansible-automation-platform` namespace.
 +
-To change the Automation controller name from `_example_`, edit the _name_ field in the `kind: AutomationController` section of [filename]`sub.yaml` and replace `_<automation_controller_name>_` with the name you want to use:
+To change the {ControllerName} name from `_example_`, edit the _name_ field in the `kind: AutomationController` section of [filename]`sub.yaml` and replace `_<automation_controller_name>_` with the name you want to use:
 +
 [subs="+quotes"]
 -----

--- a/downstream/modules/platform/proc-installing-with-internet.adoc
+++ b/downstream/modules/platform/proc-installing-with-internet.adoc
@@ -20,7 +20,7 @@ $ tar xvzf ansible-automation-platform-setup-<latest-version>.tar.gz
 
 .RPM install
 
-. Install Ansible Automation Platform Installer Package
+. Install {PlatformNameShort} Installer Package
 +
 v.{PlatformVers} for RHEL 8 for x86_64
 +

--- a/downstream/modules/platform/proc-update-ee-image-locations.adoc
+++ b/downstream/modules/platform/proc-update-ee-image-locations.adoc
@@ -5,13 +5,13 @@
 
 [id="updating-ee-image-locations"]
 
-= Updating execution environment image locations
+= Updating {ExecEnvShort} image locations
 
 [role="_abstract"]
-If you installed {PrivateHubName} separately from {PlatformNameShort}, you can update your execution environment image locations to point to your {PrivateHubName}.
+If you installed {PrivateHubName} separately from {PlatformNameShort}, you can update your {ExecEnvShort} image locations to point to your {PrivateHubName}.
 
 .Procedure
-. Navigate to the directory that contains `setup.sh`
+. Go to the directory that contains `setup.sh`
 . Create `./group_vars/automationcontroller` by running the following command: 
 +
 ----
@@ -47,9 +47,9 @@ $ ./setup.sh
 
 .Verification
 
-. Log into {PlatformNameShort} as a user with system administrator access. 
-. Navigate to menu:Administration[Execution Environments].
-. In the *Image* column, confirm that the execution environment image location has changed from the default value of `<registry url>/ansible-automation-platform-<version>/<image name>:<tag>` to `<automation hub url>/<image name>:<tag>`. 
+. Log in to {PlatformNameShort} as a user with system administrator access. 
+. Go to menu:Administration[Execution Environments].
+. In the *Image* column, confirm that the {ExecEnvShort} image location has changed from the default value of `<registry url>/ansible-automation-platform-<version>/<image name>:<tag>` to `<automation hub url>/<image name>:<tag>`. 
 
 
 

--- a/downstream/modules/platform/proc-update-rhsso-client.adoc
+++ b/downstream/modules/platform/proc-update-rhsso-client.adoc
@@ -1,6 +1,6 @@
 [id="proc-update-rhsso-client_{context}"]
 
-= Updating the Red Hat Single Sign-On client
+= Updating the {RHSSO} client
 
 When {HubName} is installed and you know the URL of the instance, you must update the {RHSSO} to set the Valid Redirect URIs and Web Origins settings.
 

--- a/downstream/modules/platform/proc-upgrade-installer.adoc
+++ b/downstream/modules/platform/proc-upgrade-installer.adoc
@@ -34,7 +34,7 @@ The setup script pauses and indicates that a "pre-2.x" inventory file was detect
 . Open `inventory.new.ini` with a text editor.
 +
 NOTE: By running the setup script, the Installer modified a few fields from your original inventory file, such as renaming [tower] to [automationcontroller].
-. Modify the newly generated `inventory.new.ini` file to configure your automation mesh by assigning relevant variables, nodes, and relevant node-to-node peer connections:
+. Update the newly generated `inventory.new.ini` file to configure your {AutomationMesh} by assigning relevant variables, nodes, and relevant node-to-node peer connections:
 +
 [NOTE]
 ====
@@ -92,10 +92,10 @@ generate_automationhub_token=True
 ----
 $ ./setup.sh -i inventory.new.ini -e @credentials.yml -- --ask-vault-pass
 ----
-. Once the installation completes, verify that your {PlatformNameShort} has been installed successfully by logging in to the {PlatformNameShort} dashboard UI across all automation controller nodes.
+. Once the installation completes, verify that your {PlatformNameShort} has been installed successfully by logging in to the {PlatformNameShort} dashboard UI across all {ControllerName} nodes.
 
 .Additional resources
-* For general information on using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} installation guide].
+* For general information about using the {PlatformNameShort} installer, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} installation guide].
 // Remove comments once 2.2 version of the docs are published.
 //* For more information about automation mesh, see the https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide/index[{PlatformNameShort} automation mesh guide]
 

--- a/downstream/modules/platform/proc-verify-controller-installation.adoc
+++ b/downstream/modules/platform/proc-verify-controller-installation.adoc
@@ -3,13 +3,13 @@
 = Verifying installation of {ControllerName}
 
 [role="_abstract"]
-Verify that you installed automation controller successfully by logging in with the admin credentials you inserted in the `inventory` file.
+Verify that you installed {ControllerName} successfully by logging in with the admin credentials you inserted in the `inventory` file.
 
 .Prerequisite
 * Port 443 is available
 
 .Procedure
-. Navigate to the IP address specified for the {ControllerName} node in the `inventory` file.
+. Go to the IP address specified for the {ControllerName} node in the `inventory` file.
 . Log in with the user ID `admin` and the password credentials you set in the `inventory` file.
 
 [NOTE]

--- a/downstream/modules/platform/ref-container-resource-requirements.adoc
+++ b/downstream/modules/platform/ref-container-resource-requirements.adoc
@@ -2,7 +2,7 @@
 
 = Containers resource requirements
 
-You can configure the resource requirements of tasks and the web containers, at both the lower end (requests) and the upper end (limits). The execution environment control plane is used for project updates, but is normally the same as the default execution environment for jobs.
+You can configure the resource requirements of tasks and the web containers, at both the lower end (requests) and the upper end (limits). The {ExecEnvShort} control plane is used for project updates, but is normally the same as the default {ExecEnvShort} for jobs.
 
 Setting resource requests and limits is a best practice because a container that has both defined is given a higher _Quality of Service_ class. 
 This means that if the underlying node is resource constrained and the cluster has to reap a pod to prevent running memory or other failure, the control plane pod is less likely to be reaped.

--- a/downstream/modules/platform/ref-controller-amazon-web-services.adoc
+++ b/downstream/modules/platform/ref-controller-amazon-web-services.adoc
@@ -1,6 +1,6 @@
 [id="controller-amazon-web-services"]
 
-= Amazon Web Services EC2
+= {AWS} EC2
 
 [literal, options="nowrap" subs="+attributes"]
 ----

--- a/downstream/modules/platform/ref-controller-automation-analytics.adoc
+++ b/downstream/modules/platform/ref-controller-automation-analytics.adoc
@@ -1,6 +1,6 @@
 [id="ref-controller-automation-analytics"]
 
-= Automation Analytics
+= {Analytics}
 
 When you imported your license for the first time, you were given options related to the collection of data that powers {Analytics}, a cloud service that is part of the {PlatformNameShort} subscription. 
 

--- a/downstream/modules/platform/ref-controller-aws-cloud.adoc
+++ b/downstream/modules/platform/ref-controller-aws-cloud.adoc
@@ -1,8 +1,8 @@
 [id="controller-aws-cloud"]
 
-= Amazon Web Services
+= {AWS}
 
-Amazon Web Services (AWS) cloud credentials are exposed as the following environment variables during playbook execution (in the job template, choose the cloud credential needed for your setup):
+{AWS} (AWS) cloud credentials are exposed as the following environment variables during playbook execution (in the job template, choose the cloud credential needed for your setup):
 
 * `AWS_ACCESS_KEY_ID`
 * `AWS-SECRET_ACCESS_KEY`


### PR DESCRIPTION
I'm breaking up platform module updates into mulitiple PRs to prevent merge conflicts.

Affects the following titles:

```
./aap-operations-guide/platform
./upgrade/platform
./aap-operator-installation/platform
./aap-installation-guide/platform
./aap-planning-guide/platform
./operator-mesh/platform
./automation-mesh/platform
./ocp_performance_guide/platform
./controller/controller-user-guide/platform
./controller/controller-admin-guide/platform
./controller/controller-getting-started/platform
./controller/controller-api-guide/platform
./aap-operator-backup/platform
./aap-containerized-install/platform
```

Replace plain-text with attributes where appropriate

https://issues.redhat.com/browse/AAP-19894