### PR TITLE
Correction to The _awx-manage_ Utility section (#1149)

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-awx-manage-utility.adoc
+++ b/downstream/assemblies/platform/assembly-controller-awx-manage-utility.adoc
@@ -3,7 +3,7 @@
 = The _awx-manage_ Utility
 
 Use the `awx-manage` utility to access detailed internal information of {ControllerName}.
-Commands for `awx-manage` must only run as the `awx` user.
+Commands for `awx-manage` must run as the `awx` user only.
 
 include::platform/ref-controller-inventory-import.adoc[leveloffset=+1]
 include::platform/ref-controller-cleanup-old-data.adoc[leveloffset=+1]


### PR DESCRIPTION
Minor syntax edit

https://issues.redhat.com/browse/AAP-4442

Affects `controller-admin-guide`