### PR TITLE
Setting up controller resource operator assembly

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-resource-operator.adoc
+++ b/downstream/assemblies/platform/assembly-controller-resource-operator.adoc
@@ -1,0 +1,13 @@
+ifdef::context[:parent-context: {context}]
+
+:context: performance-considerations
+
+[id="assembly-controller-resource-operator"]
+= Automation Controller Resource Operator
+
+include::platform/con-controller-resource-operator.adoc[leveloffset=+1]
+include::platform/proc-use-controller-resource-operator.adoc[leveloffset=+1]
+include::platform/proc-add-controller-access-token.adoc[leveloffset=+1]
+include::platform/proc-create-a-connection-secret.adoc[leveloffset=+1]
+include::platform/proc-create-an-ansiblejob.adoc[leveloffset=+1]
+include::platform/proc-create-a-jobtemplate.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-resource-operator.adoc
+++ b/downstream/assemblies/platform/assembly-controller-resource-operator.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 :context: performance-considerations
 
 [id="assembly-controller-resource-operator"]
-= Automation Controller Resource Operator
+= {ControllerNameStart} Resource Operator
 
 include::platform/con-controller-resource-operator.adoc[leveloffset=+1]
 include::platform/proc-use-controller-resource-operator.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-controller-resource-operator.adoc
+++ b/downstream/modules/platform/con-controller-resource-operator.adoc
@@ -1,0 +1,10 @@
+[id="con-controller-resource-operator_{context}"]
+
+= Introduction
+
+Resource Operator is a customer resource (CR) that you can deploy after you have created your {ControllerName} deployment. Resource Operator allows you to define projects, job templates, and inventories through the use of YAML files. These YAML files are then used by {ControllerName} to create these resources. You can create the YAML through a form view that prompts you for keys and values for your YAML code. Alternatively, to work with  YAML directly, you can select YAML view. 
+
+There are currently two custom resources provided by the resource-operator-controller-manager:
+
+* AnsibleJob: launches a job in the {ControllerName} instance specified in the Kubernetes secret ({ControllerName} host url, token).
+* JobTemplate: creates a job template in the {ControllerName} instance specified.

--- a/downstream/modules/platform/proc-add-controller-access-token.adoc
+++ b/downstream/modules/platform/proc-add-controller-access-token.adoc
@@ -1,3 +1,24 @@
 [id="proc-add-controller-access-token_{context}"]
 
 = Adding an {ControllerName} access token
+
+To connect Resource Operator with {ControllerName} you need to create a k8s secret with the connection information for your {ControllerName} instance.
+
+.Procedure
+To create an OAuth2 token for your user in the Automation Controller UI:
+. In the navigation panel, select *Access -> Users*
+. Select the username you wish to create a token for
+. Click on btn:[Tokens], then click btn:[Add]
+. You can leave *Applications* empty. Add a description and select *Read* or *Write* for the *Scope*
+
+Alternatively, you can create a OAuth2 token at the command-line by using the `create_oauth2_token` manage command:
+
+----
+$ controller-manage create_oauth2_token --user example_user
+New OAuth2 token for example_user: j89ia8OO79te6IAZ97L7E8bMgXCON2
+----
+
+[NOTE]
+====
+Make sure you provide a valid user when creating tokens. Otherwise, you will get an error message that you tried to issue the command without specifying a user, or supplying a username that does not exist.
+====

--- a/downstream/modules/platform/proc-add-controller-access-token.adoc
+++ b/downstream/modules/platform/proc-add-controller-access-token.adoc
@@ -6,6 +6,7 @@ To connect Resource Operator with {ControllerName} you need to create a k8s secr
 
 .Procedure
 To create an OAuth2 token for your user in the Automation Controller UI:
+
 . In the navigation panel, select *Access -> Users*
 . Select the username you wish to create a token for
 . Click on btn:[Tokens], then click btn:[Add]

--- a/downstream/modules/platform/proc-add-controller-access-token.adoc
+++ b/downstream/modules/platform/proc-add-controller-access-token.adoc
@@ -1,0 +1,3 @@
+[id="proc-add-controller-access-token_{context}"]
+
+= Adding an {ControllerName} access token

--- a/downstream/modules/platform/proc-create-a-connection-secret.adoc
+++ b/downstream/modules/platform/proc-create-a-connection-secret.adoc
@@ -1,3 +1,24 @@
 [id="proc-create-connection-secret_{context}"]
 
 = Creating a connection secret
+To make your connection information available to the operator, create a k8s secret with the token and host value. 
+
+.Procedure
+. The following is an example of the YAML for the connection secret. Save the following example to a file, for example, `automation-controller-connection-secret.yml`
++
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: controller-access
+  type: Opaque
+stringData:
+  token: <generated-token>
+  host: https://my-controller-host.example.com/
+----
++
+. Edit the file with your host and token value
+. Apply it to your cluster using the `kubectl create` command: 
+----
+kubectl create -f controller-connection-secret.yml
+----

--- a/downstream/modules/platform/proc-create-a-connection-secret.adoc
+++ b/downstream/modules/platform/proc-create-a-connection-secret.adoc
@@ -1,0 +1,3 @@
+[id="proc-create-connection-secret_{context}"]
+
+= Creating a connection secret

--- a/downstream/modules/platform/proc-create-a-jobtemplate.adoc
+++ b/downstream/modules/platform/proc-create-a-jobtemplate.adoc
@@ -1,3 +1,18 @@
 [id="proc-create-a-jobtemplate_{context}"]
 
 = Creating a JobTemplate 
+
+* Create a job template on {ControllerName} by creating a JobTemplate resource:
++
+----
+apiVersion: tower.ansible.com/v1alpha1
+kind: JobTemplate
+metadata:
+  name: jobtemplate-4
+spec:
+  connection_secret: controller-access
+  job_template_name: ExampleJobTemplate4
+  job_template_project: Demo Project
+  job_template_playbook: hello_world.yml
+  job_template_inventory: Demo Inventory
+----

--- a/downstream/modules/platform/proc-create-a-jobtemplate.adoc
+++ b/downstream/modules/platform/proc-create-a-jobtemplate.adoc
@@ -1,0 +1,3 @@
+[id="proc-create-a-jobtemplate_{context}"]
+
+= Creating a JobTemplate 

--- a/downstream/modules/platform/proc-create-an-ansiblejob.adoc
+++ b/downstream/modules/platform/proc-create-an-ansiblejob.adoc
@@ -1,3 +1,52 @@
 [id="proc-create-an-ansiblejob_{context}"]
 
 = Creating an AnsibleJob 
+Launch an automation job on [ControllerName] by creating an AnsibleJob resource.
+
+.Procedure
+. Specify the connection secret and job template you want to launch.
++
+----
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  generateName: demo-job-1 # generate a unique suffix per 'kubectl create'
+spec:
+  connection_secret: controller-access
+  job_template_name: Demo Job Template
+----
++
+. Configure features such as, inventory, extra variables, and time to live for the job.
++
+----
+spec:
+  connection_secret: controller-access
+  job_template_name: Demo Job Template
+  inventory: Demo Inventory                    # Inventory prompt on launch needs to be enabled
+  runner_image: quay.io/ansible/controller-resource-runner
+  runner_version: latest
+  job_ttl: 100
+
+  extra_vars:                                  # Extra variables prompt on launch needs to be enabled
+     test_var: test
+
+  job_tags: "provision,install,configuration"  # Specify tags to run
+  skip_tags: "configuration,restart"           # Skip tasks with a given tag
+----
++
+[NOTE]
+====
+You must enable  prompt on launch for inventories and extra variables if you are configuring those. To enable *Prompt on launch*, within the {ControllerName} UI:
+From the *Resources -> Templates* page, select your template and select the *Prompt on launch* checkbox next to *Inventory* and *Variables* sections.
+====
+. Launch a workflow job template with an AnsibleJob object by specifying the `workflow_template_name` instead of `job_template_name`:
++
+----
+apiVersion: tower.ansible.com/v1alpha1
+kind: AnsibleJob
+metadata:
+  generateName: demo-job-1 # generate a unique suffix per 'kubectl create'
+spec:
+  connection_secret: controller-access
+  workflow_template_name: Demo Workflow Template
+----

--- a/downstream/modules/platform/proc-create-an-ansiblejob.adoc
+++ b/downstream/modules/platform/proc-create-an-ansiblejob.adoc
@@ -1,0 +1,3 @@
+[id="proc-create-an-ansiblejob_{context}"]
+
+= Creating an AnsibleJob 

--- a/downstream/modules/platform/proc-use-controller-resource-operator.adoc
+++ b/downstream/modules/platform/proc-use-controller-resource-operator.adoc
@@ -1,3 +1,11 @@
 [id="proc-use-controller-resource-operator_{context}"]
 
-= Using {ControllerName} resource operator 
+= Using {ControllerName} Resource Operator 
+
+The {ControllerName} Resource Operator itself does not do anything until the user creates an object. So as soon as the user creates an AutomationControllerProject or AnsibleJob resource, the resource operator will start processing that object. 
+
+.Prerequisites
+* Install the Kubernetes-based cluster of your choice
+* Deploy {ControllerName} using the `automation-controller-operator`
+
+After installing the `automation-controller-resource-operator` in your cluster, you must create a Kubernetes (k8s) secret with the connection information for your {ControllerName} instance. Then you can use Resource Operator to create a k8s resource to manage your {ControllerName} instance.

--- a/downstream/modules/platform/proc-use-controller-resource-operator.adoc
+++ b/downstream/modules/platform/proc-use-controller-resource-operator.adoc
@@ -1,0 +1,3 @@
+[id="proc-use-controller-resource-operator_{context}"]
+
+= Using {ControllerName} resource operator 

--- a/downstream/modules/platform/proc-use-controller-resource-operator.adoc
+++ b/downstream/modules/platform/proc-use-controller-resource-operator.adoc
@@ -2,7 +2,7 @@
 
 = Using {ControllerName} Resource Operator 
 
-The {ControllerName} Resource Operator itself does not do anything until the user creates an object. So as soon as the user creates an AutomationControllerProject or AnsibleJob resource, the resource operator will start processing that object. 
+The {ControllerName} Resource Operator itself does not do anything until the user creates an object. As soon as the user creates an AutomationControllerProject or AnsibleJob resource, the resource operator will start processing that object. 
 
 .Prerequisites
 * Install the Kubernetes-based cluster of your choice


### PR DESCRIPTION
[AAP-14684](https://issues.redhat.com/browse/AAP-14684
): 
Converting upstream controller resource operator to downstream

[Red Hat Ansible Automation Platform Performance Considerations for Operator Based Installations](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_performance_considerations_for_operator_based_installations/index)
Doc location  : Ocp_performance_guide (tbc)