### PR TITLE
Replace plain text with attributes for content in the platform module…

### DIFF
--- a/downstream/modules/platform/ref-controller-build-arg-defaults.adoc
+++ b/downstream/modules/platform/ref-controller-build-arg-defaults.adoc
@@ -19,8 +19,7 @@ If the value is `always`, the cache is never cleared.
 Any other value forces the cache to be cleared only after the system dependencies are installed in the final build stage.
 |====
 
-Ansible Builder hard-codes values given inside of `build_arg_defaults` into the build instruction file, so they persist if you run your
-container build manually.
+{Builder} hard-codes values given inside of `build_arg_defaults` into the build instruction file, so they persist if you run your container build manually.
 
 If you specify the same variable in the definition and at the command line with the CLI `build-arg` flag, the CLI value takes higher
 precedence, that is, the CLI value overrides the value in the definition.

--- a/downstream/modules/platform/ref-controller-building-exec-env.adoc
+++ b/downstream/modules/platform/ref-controller-building-exec-env.adoc
@@ -7,7 +7,7 @@ Ansible-builder is used to create an {ExecEnvShort}.
 An {ExecEnvShort} is expected to contain:
 
 * Ansible
-* Ansible Runner
+* {Runner}
 * Ansible Collections
 * Python and system dependencies of:
 ** modules or plugins in collections

--- a/downstream/modules/platform/ref-controller-cluster-install.adoc
+++ b/downstream/modules/platform/ref-controller-cluster-install.adoc
@@ -55,7 +55,7 @@ hostC routable_hostname=10.1.0.4
 routable_hostname
 ----
 
-For more information on `routable_hostname`, see link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#ref-genera-inventory-variables[General variables] in the _Red Hat Ansible Automation Platform Installation Guide_.
+For more information about `routable_hostname`, see link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#ref-genera-inventory-variables[General variables] in the _{PlatformName} Installation Guide_.
 
 [IMPORTANT]
 ====

--- a/downstream/modules/platform/ref-controller-config-options.adoc
+++ b/downstream/modules/platform/ref-controller-config-options.adoc
@@ -27,7 +27,7 @@ The default value is `dumb-init==1.2.5`.
 * *package_manager_path*: string with the path to the package manager (dnf or microdnf) to use. 
 The default is `/usr/bin/dnf`. 
 This value is used to install a Python interpreter, if specified in `dependencies`, and during the build phase by the `assemble` script.
-* *skip_ansible_check*: This boolean value controls whether or not the check for an installation of Ansible and Ansible Runner is performed on the final image. 
+* *skip_ansible_check*: This boolean value controls whether or not the check for an installation of Ansible and {Runner} is performed on the final image. 
 +
 Set this value to `True` to not perform this check. 
 +

--- a/downstream/modules/platform/ref-controller-config-version.adoc
+++ b/downstream/modules/platform/ref-controller-config-version.adoc
@@ -6,4 +6,4 @@ An integer value that sets the schema version of the {ExecEnvShort} definition f
 
 Defaults to `1`. 
 
-The value must be `3` if you are using Ansible Builder 3.x.
+The value must be `3` if you are using {Builder} 3.x.

--- a/downstream/modules/platform/ref-controller-credential-GCE.adoc
+++ b/downstream/modules/platform/ref-controller-credential-GCE.adoc
@@ -22,11 +22,11 @@ GCE credentials require the following inputs:
 * *Service Account Email Address*: The email address assigned to the Google Compute Engine *service account*.
 * Optional: *Project*: Provide the GCE assigned identification or the unique project ID you provided at project creation time.
 * Optional: *Service Account JSON File*: Upload a GCE service account file. 
-Click btn:[Browse] to browse for the file that contains the special account information that can be used by services and applications running on your GCE instance to interact with other Google Cloud Platform APIs.
+Click btn:[Browse] to browse for the file that contains the special account information that can be used by services and applications running on your GCE instance to interact with other {GCP} APIs.
 This grants permissions to the service account and virtual machine instances.
 * *RSA Private Key*: The PEM file associated with the service account email.
 
-== Access Google Compute Engine credentials in an ansible playbook
+== Access Google Compute Engine credentials in an Ansible Playbook
 
 You can get GCE credential parameters from a job runtime environment:
 

--- a/downstream/modules/platform/ref-controller-credential-aws.adoc
+++ b/downstream/modules/platform/ref-controller-credential-aws.adoc
@@ -1,8 +1,8 @@
 [id="ref-controller-credential-aws"]
 
-= Amazon Web Services
+= {AWS}
 
-Select this credential to enable synchronization of cloud inventory with Amazon Web Services.
+Select this credential to enable synchronization of cloud inventory with {AWS}.
 
 {ControllerNamestart} uses the following environment variables for AWS credentials: 
 
@@ -17,7 +17,7 @@ These are fields prompted in the user interface.
 
 //image:credentials-create-aws-credential.png[Credentials- create AWS credential]
 
-Amazon Web Services credentials consist of the AWS *Access Key* and *Secret Key*.
+{AWS} credentials consist of the AWS *Access Key* and *Secret Key*.
 
 {ControllerNameStart} provides support for EC2 STS tokens (sometimes referred to as IAM STS credentials). 
 _Security Token Service_ (STS) is a web service that enables you to request temporary, limited-privilege credentials for AWS
@@ -37,7 +37,7 @@ To use implicit IAM role credentials, do not attach AWS cloud credentials in {Co
 Attaching your AWS cloud credential to your job template forces the use of your AWS credentials and will not "fall through" to use your IAM role credentials (this is due to the use of the boto library.)
 ====
 
-== Access Amazon EC2 credentials in an ansible playbook
+== Access Amazon EC2 credentials in an Ansible Playbook
 
 You can get AWS credential parameters from a job runtime environment:
 

--- a/downstream/modules/platform/ref-controller-dependencies.adoc
+++ b/downstream/modules/platform/ref-controller-dependencies.adoc
@@ -4,7 +4,7 @@
 
 Specifies dependencies to install into the final image, including `ansible-core`, `ansible-runner`, Python packages, system packages, and
 Ansible Collections. 
-Ansible Builder automatically installs dependencies for any Ansible Collections you install.
+{Builder} automatically installs dependencies for any Ansible Collections you install.
 
 In general, you can use standard syntax to constrain package versions.
 Use the same syntax you would pass to `dnf`, `pip`, `ansible-galaxy`, or any other package management utility. 
@@ -29,7 +29,7 @@ ansible_core:
 ansible_core:
     package_pip: https://github.com/example_user/ansible/archive/refs/heads/ansible.tar.gz
 ----
-| *ansible_runner* a| The version of the Ansible Runner Python package to be installed. 
+| *ansible_runner* a| The version of the {Runner} Python package to be installed. 
 This value is a dictionary with a single key, `package_pip`. 
 The `package_pip` value is passed directly to pip for installation and can be in any format that pip supports. 
 The following are some example values:
@@ -50,14 +50,14 @@ For more information about the requirements file format, see the link:https://do
 | *python* | The Python installation requirements. 
 
 This can be a filename, or a list of requirements. 
-Ansible Builder combines all the Python requirements files from all collections into a single file using the `requirements-parser` library. 
+{Builder} combines all the Python requirements files from all collections into a single file using the `requirements-parser` library. 
 
 This library supports complex syntax, including references to other files. 
-If multiple collections require the same _package name_, Ansible Builder combines them into a single entry and combines the constraints.
+If multiple collections require the same _package name_, {Builder} combines them into a single entry and combines the constraints.
 
-Certain package names are specifically _ignored_ by `ansible-builder`, meaning that Ansible Builder does not include them in the combined
+Certain package names are specifically _ignored_ by `ansible-builder`, meaning that {Builder} does not include them in the combined
 file of Python dependencies, even if a collection lists them as dependencies. These include test packages and packages that provide
-Ansible itself. The full list can be found in `EXCLUDE_REQUIREMENTS` in `src/ansible_builder/_target_scripts/introspect.py`. 
+Ansible itself. The full list can is available under `EXCLUDE_REQUIREMENTS` in `src/ansible_builder/_target_scripts/introspect.py`. 
 
 If you need to include one of these ignored package names, use the `--user-pip` option of the `introspect` command to list it in the user requirements file. 
 
@@ -68,9 +68,9 @@ This can be a filename, or a list of requirements.
 
 For more information about bindep, see the link:https://docs.opendev.org/opendev/bindep/latest/readme.html[OpenDev documentation]. 
 
-For system packages, use the `bindep` format to specify cross-platform requirements, so they can be installed by whichever package management system the execution environment uses.
+For system packages, use the `bindep` format to specify cross-platform requirements, so they can be installed by whichever package management system the {ExecEnvShort} uses.
 Collections must specify necessary requirements for `[platform:rpm]`. 
-Ansible Builder combines system package entries from multiple collections into a single file. 
+{Builder} combines system package entries from multiple collections into a single file. 
 Only requirements with no profiles (runtime requirements) are installed to the image. 
 Entries from multiple collections which are outright duplicates of each other can be consolidated in the combined file.
 |====
@@ -117,7 +117,7 @@ dependencies:
 
 [NOTE]
 ====
-If any of these dependency files (`requirementa.txt, bindep.txt, and requirements.yml`) are in the `build_ignore` of the collection, it does not work correctly.
+If any of these dependency files (`requirements.txt, bindep.txt, and requirements.yml`) are in the `build_ignore` of the collection, it does not work correctly.
 
 Collection maintainers can verify that ansible-builder recognizes the requirements they expect by using the `introspect` command, for example:
 

--- a/downstream/modules/platform/ref-controller-ee-configuration-options.adoc
+++ b/downstream/modules/platform/ref-controller-ee-configuration-options.adoc
@@ -4,7 +4,7 @@
 
 Use the configuration YAML keys listed here in your v3 definition file. 
 
-The Ansible Builder 3.x {ExecEnvShort} definition file accepts seven top-level sections:
+The {Builder} 3.x {ExecEnvShort} definition file accepts seven top-level sections:
 
 * xref:ref-controller-additional-build-files[additional_build_files]
 * xref:ref-controller-additional-build-steps[additional_build_steps]

--- a/downstream/modules/platform/ref-controller-ee-definition.adoc
+++ b/downstream/modules/platform/ref-controller-ee-definition.adoc
@@ -4,7 +4,7 @@
 
 A definition file is a `.yml` file that is required to build an image for an {ExecEnvShort}. 
 The following is a sample version 3 {ExecEnvShort} definition schema file. 
-To use Ansible Builder 3.x, you must specify the schema version. 
+To use {Builder} 3.x, you must specify the schema version. 
 If your {ExecEnvShort} file does not specify version 3, version 1 is supplied.
 
 [literal, options="nowrap" subs="+attributes"]

--- a/downstream/modules/platform/ref-controller-images.adoc
+++ b/downstream/modules/platform/ref-controller-images.adoc
@@ -12,7 +12,7 @@ Valid keys for this section are:
 
 [cols="15%,40%"]
 |====
-| *base_image* | A dictionary defining the parent image for the execution environment.
+| *base_image* | A dictionary defining the parent image for the {ExecEnvShort}.
 
 A `name` key must be supplied with the container image to use. 
 Use the `signature_original_name` key if the image is mirrored within your repository, but signed with the original image's signature key.

--- a/downstream/modules/platform/ref-controller-notification-email.adoc
+++ b/downstream/modules/platform/ref-controller-notification-email.adoc
@@ -2,9 +2,9 @@
 
 = Email
 
-The email notification type supports a wide variety of SMTP servers and has support for TLS/SSL connections.
+The {email} type supports a wide variety of SMTP servers and has support for SSL/TLS connections.
 
-Provide the following details to set up an email notification:
+Provide the following details to set up an {email}:
 
 * *Host*
 * *Recipient list*

--- a/downstream/modules/platform/ref-controller-setup-considerations.adoc
+++ b/downstream/modules/platform/ref-controller-setup-considerations.adoc
@@ -3,7 +3,7 @@
 = Setup considerations
 
 Learn about the initial setup of clusters. 
-To upgrade an existing cluster, see link:https://docs.ansible.com/automation-controller/4.4/html/upgrade-migration-guide/upgrade_considerations.html#upgrade-planning[Upgrade Planning] of the _Ansible Automation Platform Upgrade and Migration Guide_.
+To upgrade an existing cluster, see link:https://docs.ansible.com/automation-controller/4.4/html/upgrade-migration-guide/upgrade_considerations.html#upgrade-planning[Upgrade Planning] in the _{PlatformNameShort} Upgrade and Migration Guide_.
 
 Note the following important considerations in the new clustering environment:
 

--- a/downstream/modules/platform/ref-controller-supported-oses.adoc
+++ b/downstream/modules/platform/ref-controller-supported-oses.adoc
@@ -4,14 +4,14 @@
 
 If you use the `scan_facts.yml` playbook with use fact cache, ensure that you are using one of the following supported operating systems:
 
-* Red Hat Enterprise Linux 5, 6, 7, 8 & 9
+* {RHEL} 5, 6, 7, 8, and 9
 * Ubuntu 23.04 (Support for Ubuntu is deprecated and will be removed in a future release)
-* OEL 6 & 7
-* SLES 11 & 12
-* Debian 6, 7, 8, 9, 10, 11, & 12
-* Fedora 22, 23, 24
+* OEL 6 and 7
+* SLES 11 and 12
+* Debian 6, 7, 8, 9, 10, 11, and 12
+* Fedora 22, 23, and 24
 * Amazon Linux 2023.1.20230912
 * Windows Server 2008 and later
 
-Some of these operating systems require initial configuration to run python or have access to the python packages, such as `python-apt`, that the scan modules depend on.
+Some of these operating systems require initial configuration to run python or have access to the python packages, such as `python-apt`, which the scan modules depend on.
 

--- a/downstream/modules/platform/ref-controller-system-requirements.adoc
+++ b/downstream/modules/platform/ref-controller-system-requirements.adoc
@@ -9,7 +9,7 @@ Use the following recommendations for node sizing:
 
 [NOTE]
 ====
-On control and hybrid nodes, allocate a minimum of 20 GB to `/var/lib/awx` for execution environment storage.
+On control and hybrid nodes, allocate a minimum of 20 GB to `/var/lib/awx` for {ExecEnvShort} storage.
 ====
 
 *Execution nodes* 

--- a/downstream/modules/platform/ref-converting-playbook-examples.adoc
+++ b/downstream/modules/platform/ref-converting-playbook-examples.adoc
@@ -58,7 +58,7 @@ You will use a simple playbook to launch the automation with sleep defined to al
 
 ----
 
-In Ansible Automation Platform 2 from the Settings menu, select menu:Job Settings[Jobs].
+In {PlatformNameShort} 2, from the Settings menu, select menu:Job Settings[Jobs].
 
 Paths to expose isolated jobs:
 
@@ -81,7 +81,7 @@ $ podman exec -it 'podman ps -q' /bin/bash
 bash-4.4#
 ----
 
-You are now inside the running execution environment container.
+You are now inside the running {ExecEnvShort} container.
 
 Look at the permissions, you will see that *awx* has become ‘root’, but this is not really root as in the superuser, as you are using rootless Podman, which maps users into a kernel namespace similar to a sandbox. Learn more about link:https://opensource.com/article/19/2/how-does-rootless-podman-work[How does rootless Podman work?] for shadow-utils.
 
@@ -147,7 +147,7 @@ ok: [localhost] =>  {
 
 Back on the underlying execution node host, we have the newly written out contents.
 
-NOTE: If you are using container groups to launch automation jobs inside Red Hat OpenShift, we can also tell Ansible Automation Platform 2 to expose the same paths to that environment, but you must toggle the default to On under settings.
+NOTE: If you are using container groups to launch automation jobs inside Red Hat OpenShift, you can also tell {PlatformNameShort} 2 to expose the same paths to that environment, but you must toggle the default to `On` under settings.
 
 Once enabled, this will inject this as _volumeMounts_ and _volumes_ inside the pod spec that will be used for execution. It will look like this:
 
@@ -156,7 +156,7 @@ apiVersion: v1
 kind: Pod
 Spec:
    containers:
-   - image: registry.redhat.io/ansible-automatoin-platform-24/ee-minimal-rhel8
+   - image: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel8
   args:
     - ansible runner
     - worker
@@ -165,7 +165,7 @@ Spec:
 mountPath: /mnt2
 name: volume-0
 readOnly: true
-mouuntPath: /mnt3
+mountPath: /mnt3
 name: volume-1
 readOnly: true
 mountPath: /mnt4

--- a/downstream/modules/platform/ref-enabling-automation-hub-collection-and-container-signing.adoc
+++ b/downstream/modules/platform/ref-enabling-automation-hub-collection-and-container-signing.adoc
@@ -7,7 +7,7 @@
 = Enabling {HubNameStart} collection and container signing
 
 [role="_abstract"]
-Automation hub allows you to sign ansible collections and container images. This feature is not enabled by default, and you must provide the GPG key.
+{HubNameStart} allows you to sign Ansible collections and container images. This feature is not enabled by default, and you must provide the GPG key.
 
 ----
 hub_collection_signing=true

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -175,7 +175,7 @@ Set value to `true` if {HubName} must validate certificates when requesting itse
 Default = `false`.
 | *`automationhub_upgrade`* | *Deprecated*
 
-For Ansible Automation Platform 2.2.1 and later, the value of this has been fixed at true.
+For {PlatformNameShort} 2.2.1 and later, the value of this has been fixed at `true`.
 
 {HubNameStart} always updates with the latest packages.
 | *`automationhub_user_headers`* | List of nginx headers for {HubNameMain}'s web server. 
@@ -183,11 +183,11 @@ For Ansible Automation Platform 2.2.1 and later, the value of this has been fixe
 Each element in the list is provided to the web server's nginx configuration as a separate line. 
 
 Default = empty list
-| *`ee_from_hub_only`* | When deployed with {HubName} the installer pushes execution environment images to {HubName} and configures {ControllerName} to pull images from the {HubName} registry.
+| *`ee_from_hub_only`* | When deployed with {HubName} the installer pushes {ExecEnvShort} images to {HubName} and configures {ControllerName} to pull images from the {HubName} registry.
 
-To make {HubName} the only registry to pull execution environment images from, set this variable to `true`.
+To make {HubName} the only registry to pull {ExecEnvShort} images from, set this variable to `true`.
 
-If set to `false`, execution environment images are also taken directly from Red Hat.
+If set to `false`, {ExecEnvShort} images are also taken directly from Red Hat.
 
 Default = `true` when the bundle installer is used.
 | *`generate_automationhub_token`* a| If upgrading from {PlatformName} 2.0 or earlier, choose one of the following options:


### PR DESCRIPTION
… (#1151)

I'm breaking up platform module updates into mulitiple PRs to prevent merge conflicts.

Affects the following titles:

```
./aap-operations-guide/platform
./upgrade/platform
./aap-operator-installation/platform
./aap-installation-guide/platform
./aap-planning-guide/platform
./operator-mesh/platform
./automation-mesh/platform
./ocp_performance_guide/platform
./controller/controller-user-guide/platform
./controller/controller-admin-guide/platform
./controller/controller-getting-started/platform
./controller/controller-api-guide/platform
./aap-operator-backup/platform
./aap-containerized-install/platform
```

Replace plain-text with attributes where appropriate

https://issues.redhat.com/browse/AAP-19894