### PR TITLE
Replace plain text with attributes for content in the core module (#1…

### DIFF
--- a/downstream/modules/core/con-ansible-roles.adoc
+++ b/downstream/modules/core/con-ansible-roles.adoc
@@ -7,7 +7,7 @@
 
 A role is Ansible’s way of bundling automation content as well as loading related vars, files, tasks, handlers, and other artifacts automatically by utilizing a known file structure. Instead of creating huge playbooks with hundreds of tasks, you can use roles to break the tasks apart into smaller, more discrete and composable units of work.
 
-You can find roles for provisioning infrastructure, deploying applications, and all of the tasks you do every day on Ansible Galaxy. Filter your search by *Type* and select *Role*. Once you find a role that you're interested in, you can download it by using the `ansible-galaxy` command that comes bundled with Ansible:
+You can find roles for provisioning infrastructure, deploying applications, and all of the tasks you do every day on {Galaxy}. Filter your search by *Type* and select *Role*. Once you find a role that you're interested in, you can download it by using the `ansible-galaxy` command that comes bundled with Ansible:
 
 -----
 $ ansible-galaxy role install username.rolename

--- a/downstream/modules/core/con-content-collections.adoc
+++ b/downstream/modules/core/con-content-collections.adoc
@@ -39,4 +39,4 @@ collection/
     └── unit/
 ....
 
-In {PlatformName}, {HubName} serves as the source for Ansible Certified Content Collections.
+In {PlatformName}, {HubName} serves as the source for {CertifiedName}.

--- a/downstream/modules/core/con-execution-environments.adoc
+++ b/downstream/modules/core/con-execution-environments.adoc
@@ -15,13 +15,13 @@ The `context` attribute enables module reuse. Every module ID includes {context}
 {ExecEnvNameStart} contain:
 
 * Ansible Core
-* Ansible Runner
+* {Runner}
 * Ansible Collections
 * Python libraries
 * System dependencies
 * Custom user needs
 
-You can define and create an automation execution environment using {Builder}.
+You can define and create an {ExecEnvNameSing} using {Builder}.
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
…168)

Replace plain text with attributes for content in the core module. Affects `/titles/dev-guide`

Replace plain-text with attributes where appropriate

https://issues.redhat.com/browse/AAP-19894