### PR TITLE
AAP-21516 Update links to use BaseURL attribute in platform assemblies

### DIFF
--- a/downstream/assemblies/platform/assembly-ag-controller-backup-and-restore.adoc
+++ b/downstream/assemblies/platform/assembly-ag-controller-backup-and-restore.adoc
@@ -12,7 +12,7 @@ However, you must use the most recent minor version of a release to backup or re
 For example, if the current {PlatformNameShort} version you are on is 2.0.x, use only the latest 2.0 installer.
 
 Backup and restore only works on PostgreSQL versions supported by your current platform version. 
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#red_hat_ansible_automation_platform_system_requirements[{PlatformName} system requirements] in the _{PlatformName} Installation Guide_.
+For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_installation_guide/index#red_hat_ansible_automation_platform_system_requirements[{PlatformName} system requirements] in the _{PlatformName} Installation Guide_.
 ====
 
 The {PlatformNameShort} setup playbook is invoked as `setup.sh` from the path where you unpacked the platform installer tarball. 

--- a/downstream/assemblies/platform/assembly-ag-controller-security-best-practices.adoc
+++ b/downstream/assemblies/platform/assembly-ag-controller-security-best-practices.adoc
@@ -7,9 +7,9 @@ However, managing certain operating system environments, automation, and automat
 
 To secure {RHEL}  start with the following release-appropriate security guide:
 
-* For Red Hat Enterprise Linux 8, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/index[Security hardening].
+* For Red Hat Enterprise Linux 8, see link:{BaseURL}/red_hat_enterprise_linux/8/html/security_hardening/index[Security hardening].
 
-* For Red Hat Enterprise Linux 9, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening[Security hardening].
+* For Red Hat Enterprise Linux 9, see link:{BaseURL}/red_hat_enterprise_linux/9/html/security_hardening[Security hardening].
 
 include::platform/con-controller-understand-architecture.adoc[leveloffset=+1]
 include::platform/con-controller-minimize-administrative-accounts.adoc[leveloffset=+2]

--- a/downstream/assemblies/platform/assembly-ag-instance-and-container-groups.adoc
+++ b/downstream/assemblies/platform/assembly-ag-instance-and-container-groups.adoc
@@ -7,7 +7,7 @@ This is called a container group.
 You can execute jobs in a container group only as-needed per playbook. 
 For more information, see xref:controller-container-groups[Container groups].
 
-For {ExecEnvShort}s, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_user_guide/index#assembly-controller-execution-environments[Execution environments] in the _{ControllerUG}_.
+For {ExecEnvShort}s, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_user_guide/index#assembly-controller-execution-environments[Execution environments] in the _{ControllerUG}_.
 
 include::platform/con-controller-instance-groups.adoc[leveloffset=+1]
 include::platform/ref-controller-group-policies-automationcontroller.adoc[leveloffset=+2]

--- a/downstream/assemblies/platform/assembly-automation-mesh-operator-aap.adoc
+++ b/downstream/assemblies/platform/assembly-automation-mesh-operator-aap.adoc
@@ -12,7 +12,7 @@ To manage instances from the {ControllerName} UI, you must have System Administr
 
 In general, the more processor cores (CPU) and memory (RAM) a node has, the more jobs that can be scheduled to run on that node at once. 
 
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-jobs#controller-capacity-determination[Automation controller capacity determination and job impact]. 
+For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_user_guide/controller-jobs#controller-capacity-determination[Automation controller capacity determination and job impact]. 
 
 include::platform/ref-operator-mesh-prerequisites.adoc[leveloffset=+1]
 include::platform/proc-set-up-virtual-machines.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-credentials.adoc
+++ b/downstream/assemblies/platform/assembly-controller-credentials.adoc
@@ -21,7 +21,7 @@ If a user moves to a different team or leaves the organization, you do not have 
 [NOTE]
 ====
 {ControllerNameStart} encrypts passwords and key information in the database and never makes secret information visible through the API. 
-For further information, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_administration_guide/index#doc-wrapper[_{ControllerAG}_].
+For further information, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_administration_guide/index#doc-wrapper[_{ControllerAG}_].
 ====
 
 == How Credentials Work

--- a/downstream/assemblies/platform/assembly-controller-instances.adoc
+++ b/downstream/assemblies/platform/assembly-controller-instances.adoc
@@ -12,7 +12,7 @@ To manage instances from the {ControllerName} UI, you must have System Administr
 
 In general, the more processor cores (CPU) and memory (RAM) a node has, the more jobs that can be scheduled to run on that node at once. 
 
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-jobs#controller-capacity-determination[Automation controller capacity determination and job impact]. 
+For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_user_guide/controller-jobs#controller-capacity-determination[Automation controller capacity determination and job impact]. 
 
 //include::platform/ref-instances-prerequisites.adoc[leveloffset=+1]
 include::platform/ref-operator-mesh-prerequisites.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-inventories.adoc
+++ b/downstream/assemblies/platform/assembly-controller-inventories.adoc
@@ -13,9 +13,9 @@ Organizations are assigned to inventories, while permissions to launch playbooks
 
 For more information, see the following documentation:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_user_guide/index#proc-controller-user-permissions[Adding and removing user permissions] 
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_user_guide/index#proc-controller-team-add-user[Adding or removing a user] 
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_planning_guide/index#about_the_installer_inventory_file[About the installer inventory file]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_user_guide/index#proc-controller-user-permissions[Adding and removing user permissions] 
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_user_guide/index#proc-controller-team-add-user[Adding or removing a user] 
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_planning_guide/index#about_the_installer_inventory_file[About the installer inventory file]
 
 include::platform/proc-controller-create-inventory.adoc[leveloffset=+1]
 include::platform/con-controller-groups-hosts.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-job-templates.adoc
+++ b/downstream/assemblies/platform/assembly-controller-job-templates.adoc
@@ -4,7 +4,7 @@
 
 A job template combines an Ansible playbook from a project and the settings required to launch it. 
 Job templates are useful to run the same job many times. Job templates also encourage the reuse of Ansible playbook content and collaboration between teams. 
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_user_guide/index#controller-job-templates[Job Templates] in the _{ControllerUG}_. 
+For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_user_guide/index#controller-job-templates[Job Templates] in the _{ControllerUG}_. 
 
 include::platform/proc-controller-getting-started-with-job-templates.adoc[leveloffset=+1]
 include::platform/proc-controller-edit-job-template.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-disconnected-installation.adoc
+++ b/downstream/assemblies/platform/assembly-disconnected-installation.adoc
@@ -13,7 +13,7 @@ If you are not connected to the internet or do not have access to online reposit
 
 Before installing {PlatformNameShort} on a disconnected network, you must meet the following prerequisites:
 
-. A created subscription manifest. See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#doc-wrapper[Obtaining a manifest file] for more information.
+. A created subscription manifest. See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#doc-wrapper[Obtaining a manifest file] for more information.
 
 . The {PlatformNameShort}setup bundle at link:{PlatformDownloadUrl}[Customer Portal] is downloaded.
 

--- a/downstream/assemblies/platform/assembly-install-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-install-aap-operator.adoc
@@ -11,9 +11,9 @@ ifdef::context[:parent-context: {context}]
 
 .Prerequisites
 * You have installed the {PlatformName} catalog in OperatorHub.
-* You have created a `StorageClass` object for your platform and a persistent volume claim (PVC) with `ReadWriteMany` access mode. See link:https://docs.openshift.com/container-platform/4.10/storage/dynamic-provisioning.html[Dynamic provisioning] for details.
+* You have created a `StorageClass` object for your platform and a persistent volume claim (PVC) with `ReadWriteMany` access mode. See link:https://docs.openshift.com/container-platform/{OCPLatest}/storage/dynamic-provisioning.html[Dynamic provisioning] for details.
 * To run {OCP} clusters on Amazon Web Services (AWS) with `ReadWriteMany` access mode, you must add NFS or other storage.
-** For information about the AWS Elastic Block Store (EBS) or to use the `aws-ebs` storage class, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/storage/index#persistent-storage-aws[Persistent storage using AWS Elastic Block Store].
+** For information about the AWS Elastic Block Store (EBS) or to use the `aws-ebs` storage class, see link:{BaseURL}/openshift_container_platform/4.10/html-single/storage/index#persistent-storage-aws[Persistent storage using AWS Elastic Block Store].
 ** To use multi-attach `ReadWriteMany` access mode for AWS EBS, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volumes-multi.html[Attaching a volume to multiple instances with Amazon EBS Multi-Attach].
 
 

--- a/downstream/assemblies/platform/assembly-install-upgrade-pah.adoc
+++ b/downstream/assemblies/platform/assembly-install-upgrade-pah.adoc
@@ -157,8 +157,8 @@ When the installation completes, you can verify your {PrivateHubName} has been i
 
 Your {PrivateHubName} is now ready for initial configuration. See the following administration guides for more:
 
-* https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/managing_user_access_in_private_automation_hub/index[Managing user access in Private Automation Hub]
-* https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansible Galaxy collections in Automation Hub]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_user_access_in_private_automation_hub/index[Managing user access in Private Automation Hub]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index[Managing Red Hat Certified and Ansible Galaxy collections in Automation Hub]
 
 == Upgrading to the latest version
 

--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -19,7 +19,7 @@ Use these instructions to install the {OperatorPlatform} on {OCP} from the {OCPS
 == Prerequisites
 
 * Access to {OCP} using an account with operator installation permissions.
-* The {OCPShort} CLI [command]`oc` command is installed on your local system. Refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI] in the {OCP} product documentation for further information.
+* The {OCPShort} CLI [command]`oc` command is installed on your local system. Refer to link:{BaseURL}/openshift_container_platform/{OCPLatest}/html/cli_tools/openshift-cli-oc#installing-openshift-cli[Installing the OpenShift CLI] in the {OCP} product documentation for further information.
 
 
 include::platform/proc-install-cli-aap-operator.adoc[leveloffset=+1]
@@ -32,7 +32,7 @@ include::platform/proc-cli-get-controller-pwd.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
+* For more information on running operators on OpenShift Container Platform, navigate to the link:{BaseURL}/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
@@ -56,7 +56,7 @@ include::platform/proc-find-delete-PVCs.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
+* For more information on running operators on OpenShift Container Platform, navigate to the link:{BaseURL}/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -53,7 +53,7 @@ include::platform/ref-ocp-additional-configs.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on running operators on OpenShift Container Platform, navigate to the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
+* For more information on running operators on OpenShift Container Platform, navigate to the link:{BaseURL}/openshift_container_platform/[OpenShift Container Platform product documentation] and click the _Operators - Working with Operators in OpenShift Container Platform_ guide.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-inventory-file-importing.adoc
+++ b/downstream/assemblies/platform/assembly-inventory-file-importing.adoc
@@ -21,7 +21,7 @@ For example, if importing from a sourced `.ini` file, you can add the following 
 
 Similarly, group descriptions also default to _imported_, but can also be overridden by `_awx_description`.
 
-To use old inventory scripts in source control, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-inventories#ref-controller-export-old-scripts[Export old inventory scripts] in the _{ControllerUG}_.
+To use old inventory scripts in source control, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_user_guide/controller-inventories#ref-controller-export-old-scripts[Export old inventory scripts] in the _{ControllerUG}_.
 
 include::platform/con-controller-custom-dynamic-inv-scripts.adoc[leveloffset=+1]
 include::platform/ref-controller-scm-inv-source-fields.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
@@ -34,7 +34,7 @@ include::dev-guide/assembly-virt-env-to-ee.adoc[leveloffset=+1]
 // Remove comments once 2.2 version of the docs are published.
 //== Additional resources
 
-//* See the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide/index[Red Hat Ansible Automation Platform Creator Guide] for more information on migrating to {ExecEnvName}.
+//* See the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide/index[Red Hat Ansible Automation Platform Creator Guide] for more information on migrating to {ExecEnvName}.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-planning-installation.adoc
+++ b/downstream/assemblies/platform/assembly-planning-installation.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 {PlatformName} is supported on both {RHEL} and Red Hat OpenShift. Use this guide to plan your {PlatformName} installation on {RHEL}.
 
-To install {PlatformName} on your {OCP} environment, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform].
+To install {PlatformName} on your {OCP} environment, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform].
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-platform-install-overview.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-overview.adoc
@@ -27,7 +27,7 @@ xref:proc-verify-eda-controller-installation_platform-install-scenario[Verifying
 
 [role="_additional-resources"]
 .Additional resources
-For more information about the supported installation scenarios, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/index[{PlatformName} Planning Guide].
+For more information about the supported installation scenarios, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/index[{PlatformName} Planning Guide].
 
 include::platform/con-aap-installation-prereqs.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 :context: platform-install-scenario
 
 [role="_abstract"]
-{PlatformNameShort} is a modular platform. You can deploy {ControllerName} with other automation platform components, such as {HubName} and {EDAcontroller}. For more information about the components provided with {PlatformNameShort}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#ref-platform-components[{PlatformName} components] in the {PlatformName} Planning Guide.
+{PlatformNameShort} is a modular platform. You can deploy {ControllerName} with other automation platform components, such as {HubName} and {EDAcontroller}. For more information about the components provided with {PlatformNameShort}, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#ref-platform-components[{PlatformName} components] in the {PlatformName} Planning Guide.
 
 There are several supported installation scenarios for {PlatformName}. To install {PlatformName}, you must edit the inventory file parameters to specify your installation scenario. You can use one of the following as a basis for your own inventory file:
 

--- a/downstream/assemblies/platform/assembly-setting-up-automation-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-setting-up-automation-mesh.adoc
@@ -19,7 +19,7 @@ include::platform/proc-import-mesh-ca.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/platform-system-requirements[{PlatformName} System Requirements]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/platform-system-requirements[{PlatformName} System Requirements]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-supported-installation-scenarios.adoc
+++ b/downstream/assemblies/platform/assembly-supported-installation-scenarios.adoc
@@ -6,20 +6,20 @@ Red Hat supports the following installations scenarios for {PlatformName}:
 
 [role="_additional-resources"]
 .Additional resources
-To edit inventory file parameters to specify a supported installation scenario, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#con-install-scenario-examples[Inventory file examples based on installation scenarios] in the _{PlatformName} Installation Guide_.
+To edit inventory file parameters to specify a supported installation scenario, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#con-install-scenario-examples[Inventory file examples based on installation scenarios] in the _{PlatformName} Installation Guide_.
 
 //[dcd 12/8/2022 Removing links until new guides are published because some topics were removed and others were added.]
 include::platform/con-SM-standalone-contr-non-inst-database.adoc[leveloffset=+1]
 
 //[dcd 12/7/22] Changing xrefs to links because information is in a separate document due to restructuring.
 
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] to get started.
+//See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] to get started.
 
 //See xref:standalone-controller-non-inst-database[Installing {ControllerName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-SM-standalone-contr-ext-database.adoc[leveloffset=+1]
 
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] to get started.
+//See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] to get started.
 
 //See xref:assembly-standalone-controller-ext-database[Installing {ControllerName} with an external managed database] in _Installing {PlatformName} components on a single machine_ to get started.
 
@@ -27,30 +27,30 @@ include::platform/con-single-eda-controller-with-internal-database.adoc[leveloff
 
 include::platform/con-SM-standalone-hub-non-inst-database.adoc[leveloffset=+1]
 
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] to get started.
+//See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] to get started.
 
 //See xref:assembly-standalone-hub-non-inst-database[Installing {HubName} with a database on the same node] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-SM-standalone-hub-ext-database.adoc[leveloffset=+1]
 
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-ext-database[Installing {HubName} with an external database] to get started.
+//See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/single-machine-scenario#assembly-standalone-hub-ext-database[Installing {HubName} with an external database] to get started.
 
 //See xref:assembly-standalone-hub-ext-database[Installing {HubName} with an external database] in _Installing {PlatformName} components on a single machine_ to get started.
 
 include::platform/con-platform-non-inst-database.adoc[leveloffset=+1]
 
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] to get started.
+//See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] to get started.
 
 //See xref:assembly-platform-non-inst-database[Installing {PlatformName} with a database on the {ControllerName} node or non-installer managed database] in _Installing {PlatformName}_ to get started.
 
 include::platform/con-platform-ext-database.adoc[leveloffset=+1]
 
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-ext-database[Installing {PlatformName} with an external managed database] to get started.
+//See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#assembly-platform-ext-database[Installing {PlatformName} with an external managed database] to get started.
 
 //See xref:assembly-platform-ext-database[Installing {PlatformName} with an external managed database] in _Installing {PlatformName}_ to get started.
 
 include::platform/con-cluster-platform-ext-database.adoc[leveloffset=+1]
 
-//See link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] to get started.
+//See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] to get started.
 
 //See xref:assembly-multi-machine-cluster-scenario[Installing a multi-node {PlatformName} with an external managed database] in _Multi-machine cluster installation_ to get started.

--- a/downstream/assemblies/platform/assembly-system-requirements.adoc
+++ b/downstream/assemblies/platform/assembly-system-requirements.adoc
@@ -11,7 +11,7 @@ Use this information when planning your {PlatformName} installations and designi
 
 * You can obtain root access either through the `sudo` command, or through privilege escalation. For more on privilege escalation see link:https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_privilege_escalation.html[Understanding Privilege Escalation].
 * You can de-escalate privileges from root to users such as: AWX, PostgreSQL, {EDAName}, or Pulp.
-* You have configured an NTP client on all nodes. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/migrate-isolated-execution-nodes#automation_controller_configuration_requirements[Configuring NTP server using Chrony].
+* You have configured an NTP client on all nodes. For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/migrate-isolated-execution-nodes#automation_controller_configuration_requirements[Configuring NTP server using Chrony].
 
 include::platform/ref-system-requirements.adoc[leveloffset=+1]
 include::platform/ref-controller-system-requirements.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-using-rhsso-operator-with-automation-hub.adoc
+++ b/downstream/assemblies/platform/assembly-using-rhsso-operator-with-automation-hub.adoc
@@ -22,7 +22,7 @@ This chapter describes the process to configure {RHSSO} and integrate it with {P
 * You have access to {OCP} using an account with operator installation permissions.
 * You have installed the catalog containing the {PlatformName} operators.
 * You have installed the {OperatorRHSSO}.
-To install the {OperatorRHSSO}, follow the procedure in link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.6/html/server_installation_and_configuration_guide/operator#doc-wrapper[Installing {RHSSO} using a custom resource] in the {RHSSO} documentation.
+To install the {OperatorRHSSO}, follow the procedure in link:{BaseURL}/red_hat_single_sign-on/{RHSSOVers}/html/server_installation_and_configuration_guide/operator#doc-wrapper[Installing {RHSSO} using a custom resource] in the {RHSSO} documentation.
 
 include::platform/proc-create-keycloak-instance.adoc[leveloffset=2]
 include::platform/proc-create-keycloak-realm.adoc[leveloffset=2]
@@ -36,7 +36,7 @@ include::platform/proc-update-rhsso-client.adoc[leveloffset=2]
 
 == Additional resources
 
-* For more information on running operators on {OCPShort}, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{OCPLatest}/html/operators/index[Working with Operators in {OCPShort}] in the {OCPShort} product documentation.
+* For more information on running operators on {OCPShort}, see link:{BaseURL}/openshift_container_platform/{OCPLatest}/html/operators/index[Working with Operators in {OCPShort}] in the {OCPShort} product documentation.
 
 
 ifdef::parent-context[:context: {parent-context}]


### PR DESCRIPTION
AAP-21516 Update links to use `BaseURL` attribute in platform assemblies