### PR TITLE
Replace plain text with attributes for content in the dev-guide module.

### DIFF
--- a/downstream/modules/dev-guide/proc-create-collections.adoc
+++ b/downstream/modules/dev-guide/proc-create-collections.adoc
@@ -5,7 +5,7 @@
 = Creating collections
 
 [role="_abstract"]
-You can create your own Collections locally with the Ansible Galaxy CLI tool. All of the Collection-specific commands can be activated by using the `collection` subcommand.
+You can create your own Collections locally with the {Galaxy} CLI tool. All of the Collection-specific commands can be activated by using the `collection` subcommand.
 
 
 .Prerequisites
@@ -29,14 +29,14 @@ Make sure you have the proper permissions to upload to a namespace by checking u
 
 The above command will create a directory named from the namespace argument above (if one does not already exist) and then create a directory under that with the Collection name. Inside of that directory will be the default or "skeleton" Collection. This is where you can add your roles or plugins and start working on developing your own Collection.
 
-In relation to execution environments, Collection developers can declare requirements for their content by providing the appropriate metadata via Ansible Builder.
+In relation to {ExecEnvShort}s, Collection developers can declare requirements for their content by providing the appropriate metadata in {Builder}.
 
 Requirements from a Collection can be recognized in these ways:
 
 * A file `meta/execution-environment.yml` references the Python and/or `bindep` requirements files
 * A file named `requirements.txt`, which contains information on the Python dependencies and can sometimes be found at the root level of the Collection
 * A file named `bindep.txt`, which contains system-level dependencies and can be sometimes found in the root level of the Collection
-* If any of these files are in the `build_ignore` of the Collection, Ansible Builder will not pick up on these since this section is used to filter any files or directories that should not be included in the build artifact
+* If any of these files are in the `build_ignore` of the Collection, {Builder} will not pick up on these since this section is used to filter any files or directories that should not be included in the build artifact
 
 Collection maintainers can verify that ansible-builder recognizes the requirements they expect by using the introspect command:
 
@@ -47,4 +47,4 @@ $ ansible-builder introspect --sanitize ~/.ansible/collections/
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on creating collections, see link:https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html#creating-collections[Creating collections] in the Ansible _Developer Guide_.
+* For more information about creating collections, see link:https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html#creating-collections[Creating collections] in the Ansible _Developer Guide_.

--- a/downstream/modules/dev-guide/proc-create-role.adoc
+++ b/downstream/modules/dev-guide/proc-create-role.adoc
@@ -5,7 +5,7 @@
 = Creating roles
 
 [role="_abstract"]
-You can create roles using the Ansible Galaxy CLI tool. Role-specific commands can be accessed from the `roles` subcommand.
+You can create roles by using the {Galaxy} CLI tool. Role-specific commands can be accessed from the `roles` subcommand.
 
 -----
 ansible-galaxy role init <role_name>
@@ -58,4 +58,4 @@ This will create a role named `my_role` by copying the contents of `~/role_skele
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on creating roles, see link:https://galaxy.ansible.com/docs/contributing/creating_role.html[Creating roles] in the Ansible Galaxy documentation.
+* For more information about creating roles, see link:https://galaxy.ansible.com/docs/contributing/creating_role.html[Creating roles] in the {Galaxy} documentation.


### PR DESCRIPTION
This PR is specific to the 2.3 branch and version of our docs. The main PR is #1044

Replace plain-text with attributes where appropriate

Affects the following titles:

```
./aap-operations-guide/platform/dev-guide
./upgrade/platform/dev-guide
./aap-operator-installation/platform/dev-guide
./aap-installation-guide/platform/dev-guide
./aap-planning-guide/platform/dev-guide
./automation-mesh/platform/dev-guide
./ocp_performance_guide/platform/dev-guide
./controller/controller-user-guide/platform/dev-guide
./controller/controller-admin-guide/platform/dev-guide
./controller/controller-getting-started/platform/dev-guide
./aap-operator-backup/platform/dev-guide
./aap-containerized-install/platform/dev-guide
./dev-guide/dev-guide
```

https://issues.redhat.com/browse/AAP-19894