### PR TITLE
Replace plain text with attributes for content in the automation-hub …

### DIFF
--- a/downstream/modules/automation-hub/con-about-automation-hub.adoc
+++ b/downstream/modules/automation-hub/con-about-automation-hub.adoc
@@ -4,11 +4,11 @@
 
 [id="con-about-automation-hub_{context}"]
 
-= About Automation Hub
+= About {HubName}
 
-Automation Hub provides a place for Red Hat subscribers to quickly find and use content that is supported by Red Hat and our technology partners to deliver additional reassurance for the most demanding environments.
+{HubNameStart} provides a place for Red Hat subscribers to quickly find and use content that is supported by Red Hat and our technology partners to deliver additional reassurance for the most demanding environments.
 
-At a high level, Automation Hub provides an overview of all partners participating and providing certified, supported content.
+At a high level, {HubName} provides an overview of all partners participating and providing certified, supported content.
 
 From a central view, users can dive deeper into each partner and check out the collections.
 

--- a/downstream/modules/automation-hub/con-ansible-galaxy-client.adoc
+++ b/downstream/modules/automation-hub/con-ansible-galaxy-client.adoc
@@ -3,9 +3,9 @@
 
 [id="con-ansible-galaxy-client_{context}"]
 
-= Ansible Galaxy client
+= {Galaxy} client
 
-The Ansible Galaxy client `ansible-galaxy` is a command-line interface used to perform various roles and collections related operations. Configure the 'ansible-galaxy' client to use Red Hat Automation Hub.
+The {Galaxy} client `ansible-galaxy` is a command-line interface used to perform various roles and collections related operations. Configure the 'ansible-galaxy' client to use Red Hat {HubName}.
 
 // .Additional resources
 // * A bulleted list of links to other material closely related to the contents of the procedure module.

--- a/downstream/modules/automation-hub/con-collections.adoc
+++ b/downstream/modules/automation-hub/con-collections.adoc
@@ -6,4 +6,4 @@
 
 = Collections
 
-Collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. You can install and use collections through Ansible Galaxy.
+Collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. You can install and use collections through {Galaxy}.

--- a/downstream/modules/automation-hub/con-user-access.adoc
+++ b/downstream/modules/automation-hub/con-user-access.adoc
@@ -2,7 +2,7 @@
 
 = About user access
 
-You can manage user access to content and features in Automation Hub by creating groups of users that have specific permissions.
+You can manage user access to content and features in {HubName} by creating groups of users that have specific permissions.
 
 == How to implement user access
 
@@ -10,14 +10,14 @@ User access is based on managing permissions to system objects (users, groups, n
 
 You assign permissions to the groups you create. You can then assign users to these groups. This means that each user in a group has the permissions assigned to that group.
 
-Groups created in Automation Hub can range from system administrators responsible for governing internal collections, configuring user access, and repository management to groups with access to organize and upload internally developed content to Automation Hub.
+Groups created in {HubName} can range from system administrators responsible for governing internal collections, configuring user access, and repository management to groups with access to organize and upload internally developed content to {HubName}.
 
 *  See xref:ref-permissions[Automation Hub permissions] for information on system permissions.
 
 == Default user access
 
-When you install Automation hub, the default *admin* user is created in the *Admin* group. This group is assigned all permissions in the system.
+When you install {HubName}, the default *admin* user is created in the *Admin* group. This group is assigned all permissions in the system.
 
 == Getting started
 
-Log in to your local Automation Hub using credentials for the *admin* user configured during installation.
+Log in to your local {HubName} using credentials for the *admin* user configured during installation.

--- a/downstream/modules/automation-hub/proc-configure-automation-hub-server-cli.adoc
+++ b/downstream/modules/automation-hub/proc-configure-automation-hub-server-cli.adoc
@@ -1,11 +1,11 @@
 [id="proc-configure-automation-hub-server-cli"]
 = Configuring Red Hat {HubName} as the primary source for content
 
-Configure Red Hat automation hub as your primary source of content to access Ansible Certified Content Collections. You can configure automation hub in the command-line interface (CLI) or the web console.
+Configure Red Hat {HubName} as your primary source of content to access {CertifiedName}. You can configure {HubName} in the command-line interface (CLI) or the web console.
 
-== Configuring Red Hat automation hub as the primary source for content using the CLI
+== Configuring Red Hat {HubName} as the primary source for content using the CLI
 
-Configure Red Hat automation hub as your primary source of content by using the CLI. To configure automation hub, you must modify the `ansible.cfg` configuration file. With automation hub, you have access to certified, supported collections.
+Configure Red Hat {HubName} as your primary source of content by using the CLI. To configure {HubName}, you must modify the `ansible.cfg` configuration file. With {HubName}, you have access to certified, supported collections.
 
 .Prerequisites
 
@@ -13,7 +13,7 @@ Configure Red Hat automation hub as your primary source of content by using the 
 [IMPORTANT]
 ====
 	Creating a new token revokes any previous tokens 
-	generated for Private Automation Hub. Ensure that you update any Controller or scripts that you created with the previous token.
+	generated for {PrivateHubName}. Ensure that you update any Controller or scripts that you created with the previous token.
 ====
 
 .Procedure
@@ -31,10 +31,10 @@ Configure Red Hat automation hub as your primary source of content by using the 
 -----
 https://__<server_fully_qualified_domain_name>__/api/galaxy/
 -----
-. Optional: Set the `auth_url` option. The community Ansible Galaxy does not require an `auth_url`.
+. Optional: Set the `auth_url` option. The community {Galaxy} does not require an `auth_url`.
 . Set the API token for the {HubName} server.
 
-The following `ansible.cfg` configuration file example shows how to configure multiple servers in prioritized order, with {HubName} configured as your primary source and an Ansible Galaxy server as a secondary source:
+The following `ansible.cfg` configuration file example shows how to configure multiple servers in prioritized order, with {HubName} configured as your primary source and an {Galaxy} server as a secondary source:
 
 .ansible.cfg
 -----
@@ -53,13 +53,13 @@ username=my_user
 password=my_pass
 -----
 <1> Include a trailing slash */* after the server URL.
-<2> Include the `/api/galaxy/` subdirectory in the Ansible Galaxy server URL.
+<2> Include the `/api/galaxy/` subdirectory in the {Galaxy} server URL.
 <3> Include the `/api/galaxy/` subdirectory in the {HubName} server URL.
 
-NOTE: All API URLs must end with a trailing slash */* in order to prevent receiving a 301 redirect.
+NOTE: All API URLs must end with a trailing slash */* to prevent receiving a 301 redirect.
 
-You have now configured automation hub as your primary server using CLI, and can proceed to download and install supported collections.
+You have now configured {HubName} as your primary server using CLI, and can proceed to download and install supported collections.
 
 [role="_additional-resources"]
 .Additional resources
-For more information on server list configuration options and using Ansible Galaxy as an Ansible content source, see the link:https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client[Ansible Galaxy User Guide].
+For more information about server list configuration options and using {Galaxy} as an Ansible content source, see the link:https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client[{Galaxy} User Guide].

--- a/downstream/modules/automation-hub/proc-configure-automation-hub-server-gui.adoc
+++ b/downstream/modules/automation-hub/proc-configure-automation-hub-server-gui.adoc
@@ -1,7 +1,7 @@
 [id="proc-configure-automation-hub-server-gui"]
 == Configuring Red Hat {HubName} as the primary source for content using the web console
 
-Configure Red Hat automation hub as your primary source of content by using the web console. To configure automation hub, you must create a credential and add it to the Organization’s Galaxy Credentials field. With automation hub, you have access to certified, supported collections.
+Configure Red Hat {HubName} as your primary source of content by using the web console. To configure {HubName}, you must create a credential and add it to the Organization's Galaxy Credentials field. With {HubName}, you have access to certified, supported collections.
 
 .Prerequisites
 
@@ -9,12 +9,12 @@ Configure Red Hat automation hub as your primary source of content by using the 
 [IMPORTANT]
 ====
 	Creating a new token revokes any previous tokens 
-	generated for Private Automation Hub. Ensure that you update any Controller or scripts that you created with the previous token.
+	generated for {PrivateHubName}. Ensure that you update any Controller or scripts that you created with the previous token.
 ====
 
 .Procedure
 
-. Navigate to your Automation Controller. 
+. Go to your {ControllerName}. 
 . Create a new credential.
 .. Click btn:[Add] from the **Credentials** screen.
 .. Enter the name for your new credential in the **Name** field.
@@ -28,8 +28,8 @@ Configure Red Hat automation hub as your primary source of content by using the 
 .. Select the organization where you’d like to add your Galaxy credentials.
 .. Click btn:[Edit].
 .. Under Galaxy Credentials, click the **Search** icon.
-.. Select the credential you created for automation hub, and place it at the beginning of the list.
-.. Optional: If you have a secondary source of content, such as Ansible Galaxy, place this credential after the credential you created for automation hub. 
+.. Select the credential you created for {HubName}, and place it at the beginning of the list.
+.. Optional: If you have a secondary source of content, such as {Galaxy}, place this credential after the credential you created for {HubName}. 
 .. Click btn:[Select].
 .. Click btn:[Save].
 
@@ -43,9 +43,9 @@ To validate the credential, update an existing source control management (SCM)-b
 
 If the status of the project is **Successful**, then the credential is valid. 
 
-You have now configured automation hub as your primary server using the web console, and you can proceed to download and install supported collections.
+You have now configured {HubName} as your primary server using the web console, and you can proceed to download and install supported collections.
 
 [role="_additional-resources"]
 .Additional resources
-. For more information on server list configuration options and using Ansible Galaxy as an Ansible content source, see the link:https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client[Ansible Galaxy User Guide].
-. For more information on creating and using credentials, see the link:https://docs.ansible.com/automation-controller/4.2.1/html/userguide/credentials.html[Credentials] section of Automation Controller User Guide v4.2.1.
+. For more information about server list configuration options and using {Galaxy} as an Ansible content source, see the link:https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client[{Galaxy} User Guide].
+. For more information about creating and using credentials, see the link:https://docs.ansible.com/automation-controller/4.2.1/html/userguide/credentials.html[Credentials] section of {ControllerName} User Guide v4.2.1.

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -1,6 +1,6 @@
 [id="proc-configure-content-signing-on-pah"]
 
-= Configuring content signing on private automation hub
+= Configuring content signing on {PrivateHubName}
 
 To successfully sign and publish {CertifiedName}, you must configure {PrivateHubName} for signing.
 

--- a/downstream/modules/automation-hub/proc-create-super-users.adoc
+++ b/downstream/modules/automation-hub/proc-create-super-users.adoc
@@ -4,15 +4,15 @@
 
 = Creating a super user
 
-You can create a super user in automation hub and spread administration work across your team. 
+You can create a super user in {HubName} and spread administration work across your team. 
 
 .Prerequisites
 
-* You have *Super user* permissions and can create users in automation hub.  
+* You have *Super user* permissions and can create users in {HubName}.  
 
 .Procedure
-. Log in to your local automation hub.
-. Navigate to menu:User Access[].
+. Log in to your local {HubName}.
+. Go to menu:User Access[].
 . Click btn:[Users].
 . Select the user you want to be a super user to see the User details page.
 . Select *Super User* under User type.

--- a/downstream/modules/automation-hub/proc-create-users.adoc
+++ b/downstream/modules/automation-hub/proc-create-users.adoc
@@ -4,15 +4,15 @@
 
 = Creating a new user
 
-You can create a user in Automation Hub and add them to groups that can access features in the system associated by the level of assigned permissions.
+You can create a user in {HubName} and add them to groups that can access features in the system associated by the level of assigned permissions.
 
 .Prerequisites
 
-* You have *user* permissions and can create users in Automation Hub.  
+* You have *user* permissions and can create users in {HubName}.  
 
 .Procedure
-. Log in to your local Automation Hub.
-. Navigate to menu:Users[].
+. Log in to your local {HubName}.
+. Go to menu:Users[].
 . Click btn:[Create user].
 . Provide information in each of the fields. *Username* and *Password* are required.
 . [Optional] Assign the user to a group by clicking in the *Groups* field and selecting from the list of groups.

--- a/downstream/modules/automation-hub/proc-set-community-remote.adoc
+++ b/downstream/modules/automation-hub/proc-set-community-remote.adoc
@@ -16,7 +16,7 @@ See example below.
 .Requirements.yml example
 -----
 collections:
-  # Install a collection from Ansible Galaxy.
+  # Install a collection from {Galaxy}.
   - name: community.aws
     version: 5.2.0
     source: https://galaxy.ansible.com

--- a/downstream/modules/automation-hub/proc-upload-collection.adoc
+++ b/downstream/modules/automation-hub/proc-upload-collection.adoc
@@ -3,17 +3,17 @@
 
 .Prerequisites
 
-* You have configured the `ansible-galaxy` client for Red Hat Automation Hub.
+* You have configured the `ansible-galaxy` client for {HubName}.
 * You have at least one namespace.
 * You have run all content through `ansible-test sanity`.
 * You are a Red Hat Connect Partner. Learn more at https://connect.redhat.com/[Red Hat Partner Connect].
 
 .Procedure
 
-To upload your collection using the Automation Hub user interface:
+To upload your collection using the {HubName} user interface:
 
-. Log in to Red Hat Ansible Automation platform.
-. Navigate to menu:Automation Hub[My Namespaces].
+. Log in to {PlatformName}.
+. Go to menu:Automation Hub[My Namespaces].
 . Click a namespace.
 . Click btn:[Upload collection].
 . In the *New collection* modal, click btn:[Select file]. Locate the file on your system.

--- a/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
@@ -1,6 +1,6 @@
 [id="proc-using-content-signing-services-in-pah"]
 
-= Using content signing services in private automation hub
+= Using content signing services in {PrivateHubName}
 
 After you have configured content signing on your {PrivateHubName}, you can manually sign a new collection or replace an existing signature with a new one so that users who want to download a specific collection have the assurance that the collection is intended for them and has not been modified after certification.
 

--- a/downstream/modules/automation-hub/ref-permissions.adoc
+++ b/downstream/modules/automation-hub/ref-permissions.adoc
@@ -1,6 +1,6 @@
 [id="ref-permissions"]
 
-= Automation Hub permissions
+= {HubName} permissions
 
 Permissions provide a defined set of actions each group performs on a given object. Determine the required level of access for your groups based on the following permissions:
 


### PR DESCRIPTION
…module (#1179)

This PR is specific to the 2.3 branch and version of our docs. The main PR is #1073.

Affects the following titles:

```
./aap-operations-guide
./upgrade
./aap-operator-installation
./aap-installation-guide
./aap-planning-guide
./automation-mesh
./ocp_performance_guide
./controller/controller-user-guide
./controller/controller-getting-started
./aap-operator-backup
./aap-containerized-install
./builder
./hub/managing-content
./hub/getting-started
```

Replace plain-text with attributes where appropriate

https://issues.redhat.com/browse/AAP-19894