### PR TITLE
Replacing variables (#1181)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -1,6 +1,6 @@
 ifdef::context[:parent-context-of-aap-containerized-installation: {context}]
 
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 
 ifndef::context[]
 [id="aap-containerized-installation"]

--- a/downstream/modules/hub/proc-sync-image.adoc
+++ b/downstream/modules/hub/proc-sync-image.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="proc-sync-image-adoc_{context}"]
 = Syncing images from a container repository

--- a/downstream/modules/platform/con-aap-example-architecture.adoc
+++ b/downstream/modules/platform/con-aap-example-architecture.adoc
@@ -1,4 +1,4 @@
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 // This module is included in assembly-aap-architecture.adoc
 [id='aap_example_architecture_{context}']
 = Example {PlatformNameShort} architecture

--- a/downstream/modules/platform/con-persisting-data-from-auto-runs.adoc
+++ b/downstream/modules/platform/con-persisting-data-from-auto-runs.adoc
@@ -1,6 +1,6 @@
 //Can be found in /platform/asssemlbly/converting-playbooks-for-AAP2
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 
 [id="persisting-data-from-auto-runs_{context}"]
 = Persisting data from auto runs

--- a/downstream/modules/platform/con-single-eda-controller-with-internal-database.adoc
+++ b/downstream/modules/platform/con-single-eda-controller-with-internal-database.adoc
@@ -1,4 +1,4 @@
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 
 [id="single-eda-controller-with-internal-database"]
 

--- a/downstream/modules/platform/proc-downloading-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-downloading-containerized-aap.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="downloading-containerizzed-aap_{context}"]
 

--- a/downstream/modules/platform/proc-install-ansible-colls.adoc
+++ b/downstream/modules/platform/proc-install-ansible-colls.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="install-ansible-colls_{context}"]
 

--- a/downstream/modules/platform/proc-installing-ansible-core.adoc
+++ b/downstream/modules/platform/proc-installing-ansible-core.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="installing-ansible-core_{context}"]
 

--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="installing-containerized-aap_{context}"]
 

--- a/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="preparing-the-rhel-host-for-containerized-installation_{context}"]
 

--- a/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="uninstalling-containerized-aap_{context}"]
 = Uninstalling containerized {PlatformNameShort}

--- a/downstream/modules/platform/proc-update-ee-image-locations.adoc
+++ b/downstream/modules/platform/proc-update-ee-image-locations.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies: 
 // assembly-platform-whats-next.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="updating-ee-image-locations"]
 

--- a/downstream/modules/platform/proc-using-postinstall.adoc
+++ b/downstream/modules/platform/proc-using-postinstall.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="using-postinstall_{context}"]
 

--- a/downstream/modules/platform/ref-aap-containerized-dns-config.adoc
+++ b/downstream/modules/platform/ref-aap-containerized-dns-config.adoc
@@ -1,4 +1,4 @@
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="aap-containerized-dns-config_{context}"]
 

--- a/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
+++ b/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
@@ -1,4 +1,4 @@
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="accessing-control-auto-hub-eda-control_{context}"]
 

--- a/downstream/modules/platform/ref-ldap-config-on-pah.adoc
+++ b/downstream/modules/platform/ref-ldap-config-on-pah.adoc
@@ -1,4 +1,4 @@
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="ref-ldap-config-on-pah_{context}"]
 = LDAP configuration on {PrivateHubName}


### PR DESCRIPTION
rename :_content-type: variable
Replace the :_content-type: variable with the :_mod-docs-content-type: variable.
Modular Documentation: rename :_content-type: variable
https://issues.redhat.com/browse/AAP-17451