### PR TITLE
rename :_content-type: variable

### DIFF
--- a/downstream/modules/automation-hub/proc-sync-image.adoc
+++ b/downstream/modules/automation-hub/proc-sync-image.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="proc-sync-image-adoc_{context}"]
 = Syncing images from a container repository

--- a/downstream/modules/platform/con-aap-example-architecture.adoc
+++ b/downstream/modules/platform/con-aap-example-architecture.adoc
@@ -1,4 +1,4 @@
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 // This module is included in assembly-aap-architecture.adoc
 [id='aap_example_architecture_{context}']
 = Example {PlatformNameShort} architecture

--- a/downstream/modules/platform/proc-update-ee-image-locations.adoc
+++ b/downstream/modules/platform/proc-update-ee-image-locations.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies: 
 // assembly-platform-whats-next.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="updating-ee-image-locations_{context}"]
 

--- a/downstream/modules/platform/proc_configuring-tls-with-aap-operator.adoc
+++ b/downstream/modules/platform/proc_configuring-tls-with-aap-operator.adoc
@@ -11,7 +11,7 @@ ways:
 Add the prefix proc- or proc_ to the file name.
 Add the following attribute before the module ID:
 ////
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="proc_configuring-tls-with-aap-operator_{context}"]
 = configuring-tls-with-aap-operator

--- a/downstream/modules/platform/ref-ldap-config-on-pah.adoc
+++ b/downstream/modules/platform/ref-ldap-config-on-pah.adoc
@@ -1,4 +1,4 @@
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="ref-ldap-config-on-pah_{context}"]
 = LDAP configuration on {PrivateHubName}


### PR DESCRIPTION
rename :_content-type: variable
Replace the :_content-type: variable with the :_mod-docs-content-type: variable.
Modular Documentation: rename :_content-type: variable
https://issues.redhat.com/browse/AAP-17451