### PR TITLE
rename :_content-type: variable

### DIFF
--- a/downstream/modules/platform/proc_configuring-tls-with-aap-operator.adoc
+++ b/downstream/modules/platform/proc_configuring-tls-with-aap-operator.adoc
@@ -11,7 +11,7 @@ ways:
 Add the prefix proc- or proc_ to the file name.
 Add the following attribute before the module ID:
 ////
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 
 [id="proc_configuring-tls-with-aap-operator_{context}"]
 = configuring-tls-with-aap-operator

--- a/downstream/modules/platform/ref-ldap-config-on-pah.adoc
+++ b/downstream/modules/platform/ref-ldap-config-on-pah.adoc
@@ -1,4 +1,4 @@
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="ref-ldap-config-on-pah_{context}"]
 = LDAP configuration on {PrivateHubName}


### PR DESCRIPTION
Replace the :_content-type: variable with the :_mod-docs-content-type: variable. Modular Documentation: rename :_content-type: variable https://issues.redhat.com/browse/AAP-17451