### PR TITLE
AAP-18088: adds info on download count configuration; fixes a namesapce error (#915)

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -48,6 +48,7 @@ include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
 include::platform/proc-operator-external-db-hub.adoc[leveloffset=+1]
 include::platform/proc-enable-hstore-extension.adoc[leveloffset=+2]
 include::platform/proc-find-delete-PVCs.adoc[leveloffset=+1]
+include::platform/ref-ocp-additional-configs.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/modules/platform/proc-installing-hub-using-operator.adoc
+++ b/downstream/modules/platform/proc-installing-hub-using-operator.adoc
@@ -18,7 +18,7 @@ apiVersion: automationhub.ansible.com/v1beta1
 kind: AutomationHub
 metadata:
   name: private-ah                              <1>
-  namespace: ansible-automation-platform
+  namespace: aap
 spec:
   sso_secret: automation-hub-sso                <2>
   pulp_settings:

--- a/downstream/modules/platform/ref-ocp-additional-configs.adoc
+++ b/downstream/modules/platform/ref-ocp-additional-configs.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ocp-additional-configs_{context}"]
+= Additional configurations
+
+[role="_abstract"]
+
+A collection download count can help you understand collection usage. To add a collection download count to {HubName}, set the following configuration:
+
+-----
+spec:
+  pulp_settings:
+    ansible_collect_download_count: true 
+-----
+
+When `ansible_collect_download_count` is enabled, {HubName} will display a download count by the collection.


### PR DESCRIPTION
This PR backports the changes from [PR 915](https://github.com/ansible/aap-docs/pull/915) to the 2.4 branch. See [AAP-18088](https://issues.redhat.com/browse/AAP-18088) for more info. 

* AAP-18088: adds info on download count configuration; fixes a namespace error

* edit based on SME feedback--removed api_root setting from sample yaml