### PR TITLE
Correct typo in Red Hat Ansible Automation Platform Installation Guid…

### DIFF
--- a/downstream/assemblies/platform/assembly-disconnected-installation.adoc
+++ b/downstream/assemblies/platform/assembly-disconnected-installation.adoc
@@ -15,7 +15,7 @@ Before installing {PlatformNameShort} on a disconnected network, you must meet t
 
 . A created subscription manifest. See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#doc-wrapper[Obtaining a manifest file] for more information.
 
-. The {PlatformNameShort}setup bundle at link:{PlatformDownloadUrl}[Customer Portal] is downloaded.
+. The {PlatformNameShort} setup bundle at link:{PlatformDownloadUrl}[Customer Portal] is downloaded.
 
 . The link:https://docs.ansible.com/ansible/latest/collections/community/general/nsupdate_module.html[DNS records] for the {ControllerName} and {PrivateHubName} servers are created.
 


### PR DESCRIPTION
…e (#1195)

Fixed a typo in the Red Hat Ansible Automation Platform Installation Guide Correct typo in Red Hat Ansible Automation Platform Installation Guide https://issues.redhat.com/browse/AAP-22151