### PR TITLE
Creating new section to operator deploy guide as part of AAP-20779

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-add-execution-nodes.adoc
+++ b/downstream/assemblies/platform/assembly-operator-add-execution-nodes.adoc
@@ -1,0 +1,15 @@
+ifdef::context[:parent-context: {context}]
+
+[id="operator-add-execution-nodes_{context}"]
+
+= Adding execution nodes to {PlatformNameShort} Operator
+
+:context: operator-upgrade
+
+You can enable the {PlatformNameShort} (AAP) Operator with execution nodes by downloading and installing the install bundle. The steps outlined in this document are also applicable to virtual machines (VMs).  
+
+
+include::platform/proc-add-operator-execution-nodes.adoc[][leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/proc-add-operator-execution-nodes.adoc
+++ b/downstream/modules/platform/proc-add-operator-execution-nodes.adoc
@@ -7,12 +7,12 @@
 
 .Procedure
 . Log in to {PlatformName}.
-. In the navigation panel, select *Administration -> Instances*.
+. In the navigation panel, select menu:Administration[Instances].
 . Click btn:[Add].
 . Input the VM name in the *Host Name* field.
-. *Optional:* Input the port number in the *Listner Port* field.
+. Optional: Input the port number in the *Listner Port* field.
 . Click btn:[Save].
-. Click the download icon next to *Install Bundle*. This will start a download, take note of where you save the file
+. Click the download icon image:download.png[download]next to *Install Bundle*. This will start a download, take note of where you save the file
 . Untar the gz file.
 +
 [NOTE]
@@ -20,7 +20,7 @@
 To run the `install_receptor.yml` playbook you need to install  the receptor collection from {Galaxy}:
 `Ansible-galaxy collection install -r requirements.txt`
 ====
-. Update the playbook with your user name and SSH private key file. Note that `ansible_host` will pre-populate with the hostname you input earlier.
+. Update the playbook with your user name and SSH private key file. Note that `ansible_host` pre-populates with the hostname you input earlier.
 +
 ----
 all:
@@ -36,7 +36,7 @@ all:
 ----
 ansible-playbook install_receptor.yml -i inventory
 ----
-. Once installed you can now upgrade your execution node by downloading and re-running the playbook for the instance you created
+. When installed you can now upgrade your execution node by downloading and re-running the playbook for the instance you created
 
 .Verification 
 To verify if your playbook runs correctly on your new node run the following command:
@@ -45,4 +45,4 @@ watch podman ps
 ====
 
 .Additional resources
-* For more information about managing instance groups see the Managing Instance Groups section of the Automation Controller User Guide.
+* For more information about managing instance groups see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-instance-groups[Managing Instance Groups] section of the Automation Controller User Guide.

--- a/downstream/modules/platform/proc-add-operator-execution-nodes.adoc
+++ b/downstream/modules/platform/proc-add-operator-execution-nodes.adoc
@@ -1,0 +1,48 @@
+[id="add-operator-execution-nodes_{context}"]
+
+.Prerequisites
+* An {ControllerName} instance
+* The receptor collection package is installed
+* The `ansible-runner` package is installed
+
+.Procedure
+. Log in to {PlatformName}.
+. In the navigation panel, select *Administration -> Instances*.
+. Click btn:[Add].
+. Input the VM name in the *Host Name* field.
+. *Optional:* Input the port number in the *Listner Port* field.
+. Click btn:[Save].
+. Click the download icon next to *Install Bundle*. This will start a download, take note of where you save the file
+. Untar the gz file.
++
+[NOTE]
+====
+To run the `install_receptor.yml` playbook you need to install  the receptor collection from {Galaxy}:
+`Ansible-galaxy collection install -r requirements.txt`
+====
+. Update the playbook with your user name and SSH private key file. Note that `ansible_host` will pre-populate with the hostname you input earlier.
++
+----
+all:
+   hosts:
+      remote-execution:
+	        ansible_host: example_host_name
+	        ansible_user: <username> #user provided
+	        Ansible_ssh_private_key_file: ~/.ssh/id_example
+----
+. Open your terminal, and navigate to the directory where you saved the playbook.
+. To install the bundle run:
++
+----
+ansible-playbook install_receptor.yml -i inventory
+----
+. Once installed you can now upgrade your execution node by downloading and re-running the playbook for the instance you created
+
+.Verification 
+To verify if your playbook runs correctly on your new node run the following command:
+====
+watch podman ps
+====
+
+.Additional resources
+* For more information about managing instance groups see the Managing Instance Groups section of the Automation Controller User Guide.

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -39,3 +39,5 @@ include::platform/assembly-using-rhsso-operator-with-automation-hub.adoc[levelof
 include::platform/assembly-aap-migration.adoc[leveloffset=+1]
 
 include::platform/assembly-operator-upgrade.adoc[leveloffset=+1]
+
+include::platform/assembly-operator-add-execution-nodes.adoc[leveloffset=+1]


### PR DESCRIPTION
[AAP-20279](https://issues.redhat.com/browse/AAP-20779)

"Need a detailed document for upgrading AAP operator with on premise execution nodes"

[Red Hat Ansible Automation Platform Performance Considerations for Operator Based Installations](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_performance_considerations_for_operator_based_installations/index)

Created a new assembly and procedure and linked them to the master.adoc. 

Downstream>titles>aap-operator-installation

