### PR TITLE
Backport to 2.4: AAP 19094 fixed formatting to make API link inactive (#1208)

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -17,6 +17,6 @@ The following procedures form the user configuration:
 
 ====
 
-API documentation for {EDAcontroller} is available at https://<eda-server-host>/api/eda/v1/docs
+API documentation for {EDAcontroller} is available at \https://<eda-server-host>/api/eda/v1/docs
 
 ====


### PR DESCRIPTION
This PR ports the changes from[ PR 1208](https://github.com/ansible/aap-docs/pull/1208) to the 2.4 branch. See [AAP-19094](https://issues.redhat.com/browse/AAP-19094) for more info. 