### PR TITLE
Update links to use BaseURL attribute in assemblies

### DIFF
--- a/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-add-user-storage.adoc
@@ -13,7 +13,7 @@
 
 [NOTE]
 ====
-When using an LDAP User Federation in {RHSSOshort}, a group mapper must be added to the client configuration, ansible-automation-platform, to expose the identity provider (IDP) groups to the SAML authentication. Refer to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html-single/server_administration_guide/index#protocol-mappers[OIDC Token and SAML Assertion Mappings] for more information on SAML assertion mappers.
+When using an LDAP User Federation in {RHSSOshort}, a group mapper must be added to the client configuration, ansible-automation-platform, to expose the identity provider (IDP) groups to the SAML authentication. Refer to link:{BaseURL}/red_hat_single_sign-on/{RHSSOVers}/html-single/server_administration_guide/index#protocol-mappers[OIDC Token and SAML Assertion Mappings] for more information on SAML assertion mappers.
 ====
 
 . Using the dropdown menu labeled _Add provider_, select your LDAP provider to proceed to the LDAP configuration page.
@@ -22,10 +22,10 @@ The following table lists the available options for your LDAP configuration:
 [cols="a,a"]
 |===
 h|Configuration Option h|Description
-|Storage mode| Set to *On* if you want to import users into the {CentralAuth} user database. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/user-storage-federation#storage_mode[Storage Mode] for more information.
-|Edit mode| Determines the types of modifications that admins can make on user metadata. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/user-storage-federation#edit_mode[Edit Mode] for more information.
+|Storage mode| Set to *On* if you want to import users into the {CentralAuth} user database. See link:{BaseURL}/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/user-storage-federation#storage_mode[Storage Mode] for more information.
+|Edit mode| Determines the types of modifications that admins can make on user metadata. See link:{BaseURL}/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/user-storage-federation#edit_mode[Edit Mode] for more information.
 |Console Display Name |Name used when this provider is referenced in the admin console
 |Priority |The priority of this provider when looking up users or adding a user
 |Sync Registrations |Enable if you want new users created by {AAPCentralAuth} in the admin console or the registration page to be added to LDAP
-|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/authentication#kerberos[Kerberos] for more information.
+|Allow Kerberos authentication|Enable Kerberos/SPNEGO authentication in the realm with users data provisioned from LDAP. See link:{BaseURL}/red_hat_single_sign-on/{RHSSOVers}/html/server_administration_guide/authentication#kerberos[Kerberos] for more information.
 |===

--- a/downstream/assemblies/central-auth/assembly-central-auth-hub.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-hub.adoc
@@ -7,7 +7,7 @@ To enable {AAPCentralAuth} for your {HubName}, start by downloading the {Platfor
 [IMPORTANT]
 The installer in this guide will install {CentralAuth} for a basic standalone deployment. Standalone mode only runs one {CentralAuth} server instance, and thus will not be usable for clustered deployments. Standalone mode can be useful to test drive and play with the features of {CentralAuth}, but it is not recommended that you use standalone mode in production as you will only have a single point of failure.
 
-To install {CentralAuth} in a different deployment mode, please see https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_installation_and_configuration_guide/operating-mode[this guide] for more deployment options.
+To install {CentralAuth} in a different deployment mode, please see {BaseURL}/red_hat_single_sign-on/7.4/html/server_installation_and_configuration_guide/operating-mode[this guide] for more deployment options.
 
 include::central-auth/con-central-auth-reqs.adoc[leveloffset=+1]
 include::assembly-install-central-auth-hub.adoc[leveloffset=+1]

--- a/downstream/assemblies/central-auth/assembly-central-auth-identity-broker.adoc
+++ b/downstream/assemblies/central-auth/assembly-central-auth-identity-broker.adoc
@@ -5,7 +5,7 @@
 {AAPCentralAuth} supports both social and protocol-based providers. You can add an identity broker to {CentralAuth} to enable social authentication for your realm, allowing users to log in using an existing social network account, such as Google, Facebook, GitHub etc.
 
 [NOTE]
-For a list of supported social networks and for more information to enable them, please see this https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/identity_broker#social_identity_providers[section].
+For a list of supported social networks and for more information to enable them, please see this {BaseURL}/red_hat_single_sign-on/7.4/html/server_administration_guide/identity_broker#social_identity_providers[section].
 
 Protocol-based providers are those that rely on a specific protocol in order to authenticate and authorize users. They allow you to connect to any identity provider compliant with a specific protocol. {AAPCentralAuth} provides support for SAML v2.0 and OpenID Connect v1.0 protocols.
 

--- a/downstream/assemblies/dev-guide/assembly-tools-components.adoc
+++ b/downstream/assemblies/dev-guide/assembly-tools-components.adoc
@@ -29,7 +29,7 @@ include::core/con-about-ansible-cli.adoc[leveloffset=+1]
 == Additional resources
 
 * For more information on how to use Ansible as a command line tool, refer to link:https://docs.ansible.com/ansible/latest/command_guide/command_line_tools.html[Working with command line tools] in the Ansible _User Guide_.
-* To upload content to {HubName}, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/getting_started_with_automation_hub/uploading-content-hub[Uploading content to automation hub] in the {PlatformNameShort} product documentation.
+* To upload content to {HubName}, see link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/getting_started_with_automation_hub/uploading-content-hub[Uploading content to automation hub] in the {PlatformNameShort} product documentation.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/eda/assembly-ansible-rulebooks.adoc
+++ b/downstream/assemblies/eda/assembly-ansible-rulebooks.adoc
@@ -11,7 +11,7 @@ include::eda/con-rulebook-actions.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* For more information on using rulebooks, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/event-driven_ansible_controller_user_guide/index[Event-Driven Ansible controller User's Guide].
+* For more information on using rulebooks, see the link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/event-driven_ansible_controller_user_guide/index[Event-Driven Ansible controller User's Guide].
 * For more detailed information on Ansible rulebooks, see the section on link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html[Rulebooks] in the link:https://ansible.readthedocs.io/projects/rulebook/en/latest/[Ansible Rulebook documentation]. 
 
 

--- a/downstream/assemblies/eda/assembly-installation-eda-controller.adoc
+++ b/downstream/assemblies/eda/assembly-installation-eda-controller.adoc
@@ -21,9 +21,9 @@ include::eda/ref-deploy-eda-controller-with-aap-operator-on-ocp.adoc[leveloffset
 
 [role="_additional-resources"]
 .Additional resources
-* For more detailed information on planning, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/index[Red Hat Ansible Automation Platform Planning Guide].
-* For a comprehensive list of predefined variables for the Event-Driven Ansible controller, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Red Hat Ansible Automation Platform Installation Guide].
-* For more information about deployment on Ansible Automation Platform operator, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform Guide]
+* For more detailed information on planning, see the link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_planning_guide/index[Red Hat Ansible Automation Platform Planning Guide].
+* For a comprehensive list of predefined variables for the Event-Driven Ansible controller, see the link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Red Hat Ansible Automation Platform Installation Guide].
+* For more information about deployment on Ansible Automation Platform operator, see the link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform Guide]
 
 
 

--- a/downstream/assemblies/eda/assembly-using-eda-controller.adoc
+++ b/downstream/assemblies/eda/assembly-using-eda-controller.adoc
@@ -8,4 +8,4 @@ include::eda/ref-eda-controller-tasks.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Next steps
-* For further details on using Event-Driven Ansible controller, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html/event-driven_ansible_controller_user_guide/index[Event-Driven Ansible controller User's Guide].
+* For further details on using Event-Driven Ansible controller, see the link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/event-driven_ansible_controller_user_guide/index[Event-Driven Ansible controller User's Guide].


### PR DESCRIPTION
AAP-21516 Update links to use `BaseURL` attribute in assemblies.