### PR TITLE
AAP-21516 Update URLs in Lightspeed docs to use BaseURL

### DIFF
--- a/lightspeed/attributes/attributes.adoc
+++ b/lightspeed/attributes/attributes.adoc
@@ -10,6 +10,7 @@
 :AnsibleCoreVers: 2.15
 :AnsibleInstallVers: 2.4-1
 :PlatformDownloadUrl: https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software
+:BaseURL: https://access.redhat.com/documentation/en-us
 
 // Ansible Lightspeed
 :LightspeedFullName: Red Hat Ansible Lightspeed with IBM watsonx Code Assistant

--- a/lightspeed/modules/proc_multi-task-recs.adoc
+++ b/lightspeed/modules/proc_multi-task-recs.adoc
@@ -43,7 +43,7 @@ image::lightspeed-multitask-vs-code.png[Settings show Lightspeed as selected lan
 
 . Create a playbook or use an existing playbook. 
 +
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_creator_guide/index#creating-playbooks[Creating playbooks] in the {PlatformNameShort} Creator Guide.
+For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_creator_guide/index#creating-playbooks[Creating playbooks] in the {PlatformNameShort} Creator Guide.
 
 . In the playbook, provide the following information to request multitask code recommendations:
 ... Start a new YAML file comment by entering a Pound key (#) at the correct indentation.

--- a/lightspeed/modules/proc_single-task-recs.adoc
+++ b/lightspeed/modules/proc_single-task-recs.adoc
@@ -42,7 +42,7 @@ image::lightspeed-vs-code.png[Settings show Ansible and Lightspeed as selected l
 
 . Create a playbook or use an existing playbook. 
 +
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_creator_guide/index#creating-playbooks[Creating playbooks] in the {PlatformNameShort} Creator Guide.
+For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_creator_guide/index#creating-playbooks[Creating playbooks] in the {PlatformNameShort} Creator Guide.
 +
 . In the playbook, provide the following information to request code recommendations for a single task:
 ... Add a new Ansible task by starting a new line with `- name:` at the correct indentation.


### PR DESCRIPTION
AAP-21516 Update URLs in Lightspeed docs to use the `BaseURL` attribute