### PR TITLE
AAP-22950 updated figure 2.2 (#1239)

### DIFF
--- a/downstream/modules/aap-hardening/con-network-firewall-services-planning.adoc
+++ b/downstream/modules/aap-hardening/con-network-firewall-services-planning.adoc
@@ -10,7 +10,7 @@
 {PlatformNameShort} requires access to a network to integrate to external auxiliary services and to manage target environments and resources such as hosts, other network devices, applications, cloud services. The link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_planning_guide/index#ref-network-ports-protocols_planning[network ports and protocols] section of the {PlatformNameShort} planning guide describes how {PlatformNameShort} components interact on the network as well as which ports and protocols are used, as shown in the following diagram:
 
 .{PlatformNameShort} Network ports and protocols
-image::aap-network-ports-protocols-314.png[Interaction of {PlatformNameShort} components on the network with information about the ports and protocols that are used.]
+image::aap-network-ports-protocols.png[Interaction of {PlatformNameShort} components on the network with information about the ports and protocols that are used.]
 
 When planning firewall or cloud network security group configurations related to {PlatformNameShort}, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_planning_guide/index#ref-network-ports-protocols_planning[Network ports and protocols] section of the {PlatformNameShort} Planning Guide to understand what network ports need to be opened on a firewall or security group.
 


### PR DESCRIPTION
2.4 backport of [PR 1239](https://github.com/ansible/aap-docs/pull/1239)

[AAP-22950](https://issues.redhat.com/browse/AAP-22950)

Updated Figure 2.2. Ansible Automation Platform Network ports and protocols within [2.1.2. Network, firewall, and network services planning for Ansible Automation Platform](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_hardening_guide/index#con-network-firewall-services_hardening-aap)
with new diagram (see [DXD-637](https://issues.redhat.com/browse/DXD-637) for information on updates).