### PR TITLE
Automation Controller Administration Guide/ User Guide typos/Link error?

### DIFF
--- a/downstream/modules/platform/proc-controller-adding-gpg-key.adoc
+++ b/downstream/modules/platform/proc-controller-adding-gpg-key.adoc
@@ -2,7 +2,7 @@
 
 = Adding a GPG key to {ControllerName}
 
-To use the GPG key for content singing and validation in {ControllerName}, add it by running the following command in the CLI:
+To use the GPG key for content signing and validation in {ControllerName}, add it by running the following command in the CLI:
 
 [literal, options="nowrap" subs="+attributes"]
 ----

--- a/downstream/modules/platform/ref-controller-metrics-monitoring.adoc
+++ b/downstream/modules/platform/ref-controller-metrics-monitoring.adoc
@@ -15,7 +15,7 @@ The metrics endpoint includes descriptions of each metric. Metrics of particular
 ** colloquially called “job events lag”.
 ** Running average of the lag time between when a task occurred in ansible and when the user is able to see it. This indicates how far behind the callback receiver is in processing events. When this number is very high, users can consider scaling up the control plane or using the capacity adjustment feature to reduce the number of jobs a control node controls.
 * `callback_receiver_events_insert_db`
-** Counter of events that have been inserted by a node. Can be used to calculate the job even insertion rate over a given time period.
+** Counter of events that have been inserted by a node. Can be used to calculate the job event insertion rate over a given time period.
 * `callback_receiver_events_queue_size_redis`
 ** Indicator of how far behind callback receiver is in processing events. If too high, Redis can cause the control node to run out of memory (OOM).
  


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-20052

affects `titles/controller-admin-guide` and `controller-user-guide`