### PR TITLE
Update documentation links (#1276)

### DIFF
--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -16,9 +16,9 @@ Before you begin the upgrade process, review the following considerations to pla
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.ansible.com/automation-controller/latest/html/userguide/import_license.html[Import a subscription]
-* link:https://docs.ansible.com/automation-controller/latest/html/administration/backup_restore.html#ag-backup-restore[Backing up and restoring Controller]
-* link:https://docs.ansible.com/automation-controller/latest/html/administration/clustering.html#ag-clustering[Clustering]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_user_guide/controller-managing-subscriptions#controller-importing-subscriptions[Importing a subscription]
+* link:{BaseURL/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_administration_guide/controller-backup-and-restore[Backup and restore]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_administration_guide/controller-clustering[Clustering]
 
 [discrete]
 == {HubNameStart}


### PR DESCRIPTION
Documentation for "Upgrading to Red Hat Ansible Automation Platform 2.4" has wrong link

https://issues.redhat.com/browse/AAP-23273