### PR TITLE
Update documentation links

### DIFF
--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -17,7 +17,7 @@ Before you begin the upgrade process, review the following considerations to pla
 [role="_additional-resources"]
 .Additional resources
 * link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_user_guide/controller-managing-subscriptions#controller-importing-subscriptions[Importing a subscription]
-* link:{BaseURL/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_administration_guide/controller-backup-and-restore[Backup and restore]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_administration_guide/controller-backup-and-restore[Backup and restore]
 * link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_administration_guide/controller-clustering[Clustering]
 
 [discrete]


### PR DESCRIPTION
Correction

Documentation for "Upgrading to Red Hat Ansible Automation Platform 2.4" has wrong link

https://issues.redhat.com/browse/AAP-23273