### PR TITLE
[AAP-22627] Commenting out Chapter 9. Not to be included in 2.5

### DIFF
--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -38,6 +38,7 @@ include::platform/assembly-using-rhsso-operator-with-automation-hub.adoc[levelof
 
 include::platform/assembly-aap-migration.adoc[leveloffset=+1]
 
-include::platform/assembly-operator-upgrade.adoc[leveloffset=+1]
+// [gmurray] Commenting out this module as part of AAP-22627. Upgrade is not supported in the initial 2.5 release. 
+// include::platform/assembly-operator-upgrade.adoc[leveloffset=+1]
 
 include::platform/assembly-operator-add-execution-nodes.adoc[leveloffset=+1]


### PR DESCRIPTION
[AAP-23500](https://issues.redhat.com/browse/AAP-23500) Deploying the AAP operator on OCP – remove content related to upgrades.

Commenting out Chapter 9. Not to be included in 2.5

location downstream > titles > aap-operator-installation > master.adoc