### PR TITLE
Add NavigatorStart attribute and update Navigator attribute

### DIFF
--- a/downstream/assemblies/navigator/assembly-executing-content.adoc
+++ b/downstream/assemblies/navigator/assembly-executing-content.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-Now that you have your {ExecEnvName} built, you can use automation content navigator to validate that the content will be run in the same manner as the automation controller will run it.
+Now that you have your {ExecEnvName} built, you can use {Navigator} to validate that the content will run in the same manner as the {ControllerName} will run it.
 
 
 // include::navigator/con-about-ansible-navigator.adoc[leveloffset=+1]

--- a/downstream/assemblies/navigator/assembly-intro-navigator.adoc
+++ b/downstream/assemblies/navigator/assembly-intro-navigator.adoc
@@ -15,7 +15,7 @@ As a content creator, you can use {Navigator} to develop Ansible playbooks, coll
 * Local development machines
 * {ExecEnvNameStart}
 
-{Navigator} also produces an artifact file you can use to help you develop your playbooks and troubleshoot problem areas.
+{NavigatorStart} also produces an artifact file you can use to help you develop your playbooks and troubleshoot problem areas.
 
 include::navigator/con-about-ansible-navigator.adoc[leveloffset=+1]
 include::navigator/con-navigator-modes.adoc[leveloffset=+1]

--- a/downstream/assemblies/navigator/assembly-review-ee-navigator.adoc
+++ b/downstream/assemblies/navigator/assembly-review-ee-navigator.adoc
@@ -9,7 +9,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-As a content developer, you can review your {ExecEnvNameSing} with {Navigator} and display the packages and collections included in the {ExecEnvName}. {Navigator} runs a playbook to extract and display the results.
+As a content developer, you can review your {ExecEnvNameSing} with {Navigator} and display the packages and collections included in the {ExecEnvName}. {NavigatorStart} runs a playbook to extract and display the results.
 
 include::navigator/proc-review-ee-tui.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/navigator/assembly-settings-navigator.adoc
+++ b/downstream/assemblies/navigator/assembly-settings-navigator.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 :imagesdir: images
 
 [id="assembly-settings-navigator_{context}"]
-= {Navigator} configuration settings
+= {NavigatorStart} configuration settings
 
 :context: settings-navigator
 

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -101,7 +101,8 @@
 :ToolsName: Ansible developer tools
 :Test: Ansible-test
 :Builder: Ansible Builder
-:Navigator: Automation content navigator
+:Navigator: automation content navigator
+:NavigatorStart: Automation content navigator
 :IDEplugin: Ansible IDE plugins
 :IDEcollection: Ansible IDE collection explorer
 :IDElanguage: Ansible IDE language server

--- a/downstream/modules/navigator/con-about-ansible-navigator.adoc
+++ b/downstream/modules/navigator/con-about-ansible-navigator.adoc
@@ -6,7 +6,7 @@
 
 [role="_abstract"]
 
-{Navigator} is a command line, content-creator-focused tool with a text-based user interface. You can use {Navigator} to:
+{NavigatorStart} is a command line, content-creator-focused tool with a text-based user interface. You can use {Navigator} to:
 
 * Launch and watch jobs and playbooks.
 * Share stored, completed playbook and job run artifacts in JSON format.

--- a/downstream/modules/navigator/con-about-navigator-settings.adoc
+++ b/downstream/modules/navigator/con-about-navigator-settings.adoc
@@ -9,7 +9,7 @@ You can alter the default {Navigator} settings through:
 * Within a settings file
 * As an environment variable
 
-{Navigator} checks for a settings file in the following order and uses the first match:
+{NavigatorStart} checks for a settings file in the following order and uses the first match:
 
 * `ANSIBLE_NAVIGATOR_CONFIG` - The settings file path environment variable if set.
 * `./ansible-navigator.<ext>` - The settings file within the current project directory, with no dot in the file name.

--- a/downstream/modules/navigator/con-navigator-collections.adoc
+++ b/downstream/modules/navigator/con-navigator-collections.adoc
@@ -1,14 +1,14 @@
 
 [id="con-navigator-collections_{context}"]
 
-= {Navigator} collections display
+= {NavigatorStart} collections display
 
 [role="_abstract"]
 
-{Navigator} displays information about your collections with the following details for each collection:
+{NavigatorStart} displays information about your collections with the following details for each collection:
 
 SHADOWED:: Indicates that an additional copy of the collection is higher in the search order, and playbooks prefer that collection.
 TYPE:: Shows if the collection is contained within an {ExecEnvNameSing} or volume mounted on onto the {ExecEnvNameSing} as a `bind_mount`.
 PATH:: Reflects the collections location within the {ExecEnvNameSing} or local file system based on the collection TYPE field.
 
-image::navigator-collections-shadow.png[{Navigator} collections display]
+image::navigator-collections-shadow.png[{NavigatorStart} collections display]

--- a/downstream/modules/navigator/con-navigator-modes.adoc
+++ b/downstream/modules/navigator/con-navigator-modes.adoc
@@ -1,9 +1,9 @@
 
 [id="con-navigator-mode_{context}"]
 
-= {Navigator} modes
+= {NavigatorStart} modes
 
-{Navigator} operates in two modes:
+{NavigatorStart} operates in two modes:
 
 [role="_abstract"]
 
@@ -14,7 +14,7 @@ text-based user interface mode:: Provides an interactive, text-based interface t
 
 Use the `-m stdout` subcommand with {Navigator} to use the familiar Ansible commands, such as `ansible-playbook` within {ExecEnvName} or on your local development environment. You can use commands you are familiar with for quick tasks.
 
-{Navigator} also provides extensive help in this mode:
+{NavigatorStart} also provides extensive help in this mode:
 
 `--help`:: Accessible from `ansible-navigator` command or from any subcommand, such as `ansible-navigator config --help`.
 subcommand help:: Accessible from the subcommand, for example `ansible-navigator config --help-config`. This help displays the details of all the parameters supported from the related Ansible command. 

--- a/downstream/modules/navigator/proc-review-ansible-config-tui.adoc
+++ b/downstream/modules/navigator/proc-review-ansible-config-tui.adoc
@@ -7,7 +7,7 @@
 
 [role="_abstract"]
 
-You can review your Ansible configuration with the {Navigator} text-based user interface in interactive mode and delve into the settings. {Navigator} pulls in the results from an accessible Ansible configuration file, or returns the defaults if no configuration file is present.
+You can review your Ansible configuration with the {Navigator} text-based user interface in interactive mode and delve into the settings. {NavigatorStart} pulls in the results from an accessible Ansible configuration file, or returns the defaults if no configuration file is present.
 
 .Prerequisites
 

--- a/downstream/modules/navigator/proc-review-artifact.adoc
+++ b/downstream/modules/navigator/proc-review-artifact.adoc
@@ -7,7 +7,7 @@
 
 [role="_abstract"]
 
-{Navigator} saves the results of the playbook run in a JSON artifact file. You can use this file to share the playbook results with someone else, save it for security or compliance reasons, or review and troubleshoot later. You only need the artifact file to review the playbook run. You do not need access to the playbook itself or inventory access.
+{NavigatorStart} saves the results of the playbook run in a JSON artifact file. You can use this file to share the playbook results with someone else, save it for security or compliance reasons, or review and troubleshoot later. You only need the artifact file to review the playbook run. You do not need access to the playbook itself or inventory access.
 
 .Prerequisites
 

--- a/downstream/modules/navigator/ref-faq-navigator.adoc
+++ b/downstream/modules/navigator/ref-faq-navigator.adoc
@@ -20,16 +20,16 @@ Where should Ansible collections be placed when not using an {ExecEnvNameSing}?:
 
 Why does the playbook hang when `vars_prompt` or `pause/prompt` is used?:: By default, {Navigator} runs the playbook in the same manner that {ControllerName} runs the playbook. This helps content creators author playbooks that are production ready. If you cannot avoid the use of `vars_prompt` or `pause\prompt`, disabling `playbook-artifact` creation causes {Navigator} to run the playbook in a manner that is compatible with `ansible-playbook` and allows for user interaction.
 
-Why does {Navigator} change the terminal colors or look terrible?:: {Navigator} queries the terminal for its OSC4 compatibility. OSC4, 10, 11, 104, 110, 111 indicate the terminal supports color changing and reverting. It is possible that the terminal is misrepresenting its ability.
-You can disable OSC4 detection by setting `--osc4 false`. (See xref:ref-navigator-general-settings_settings-navigator[Automation content navigator general settings] for how to handle this with an environment variable or in the settings file).
+Why does {Navigator} change the terminal colors or look terrible?:: {NavigatorStart} queries the terminal for its OSC4 compatibility. OSC4, 10, 11, 104, 110, 111 indicate the terminal supports color changing and reverting. It is possible that the terminal is misrepresenting its ability.
+You can disable OSC4 detection by setting `--osc4 false`. (See xref:ref-navigator-general-settings_settings-navigator[{NavigatorStart} general settings] for how to handle this with an environment variable or in the settings file).
 
-How can I change the colors used by {Navigator}?:: Use `--osc4 false` to force {Navigator} to use the terminal defined colors. (See xref:ref-navigator-general-settings_settings-navigator[Automation content navigator general settings] for how to handle this with an environment variable or in the settings file).
+How can I change the colors used by {Navigator}?:: Use `--osc4 false` to force {Navigator} to use the terminal defined colors. (See xref:ref-navigator-general-settings_settings-navigator[{NavigatorStart} general settings] for how to handle this with an environment variable or in the settings file).
 
-What's with all these `site-artifact-2021-06-02T16:02:33.911259+00:00.json` files in the playbook directory?:: {Navigator} creates a playbook artifact for every playbook run. These can be helpful for reviewing the outcome of automation after it is complete, sharing and troubleshooting with a colleague, or keeping for compliance or change-control purposes.
-The playbook artifact file has the detailed information about every play and task, and the `stdout` from the playbook run. You can review playbook artifacts with `ansible-navigator replay <filename>` or `:replay <filename>` while in an {Navigator} session. You can review all playbook artifacts with both `--mode stdout` and `--mode interactive`, depending on the desired view.
-You can disable playbook artifacts writing and the default file naming convention. (See xref:ref-navigator-general-settings_settings-navigator[Automation content navigator general settings] for how to handle this with an environment variable or in the settings file).
+What is with all these `site-artifact-2021-06-02T16:02:33.911259+00:00.json` files in the playbook directory?:: {NavigatorStart} creates a playbook artifact for every playbook run. These can be helpful for reviewing the outcome of automation after it is complete, sharing and troubleshooting with a colleague, or keeping for compliance or change-control purposes.
+The playbook artifact file has the detailed information about every play and task, and the `stdout` from the playbook run. You can review playbook artifacts with `ansible-navigator replay <filename>` or `:replay <filename>` while in an {Navigator} session. You can review all playbook artifacts with both `--mode stdout` and `--mode interactive`, depending on the required view.
+You can disable playbook artifacts writing and the default file naming convention. (See xref:ref-navigator-general-settings_settings-navigator[{NavigatorStart} general settings] for how to handle this with an environment variable or in the settings file).
 
-Why does `vi` open when I use `:open`?:: {Navigator} opens anything showing in the terminal in the default editor. The default is set to either `vi +{line_number} {filename}` or the current value of the `EDITOR` environment variable. Related to this is the `editor-console` setting which indicates if the editor is console or terminal based. Here are examples of alternate settings that might be useful:
+Why does `vi` open when I use `:open`?:: {NavigatorStart} opens anything showing in the terminal in the default editor. The default is set to either `vi +{line_number} {filename}` or the current value of the `EDITOR` environment variable. Related to this is the `editor-console` setting which indicates if the editor is console or terminal based. Here are examples of alternate settings that might be useful:
 +
 [source,yaml]
 ----
@@ -66,4 +66,4 @@ What is the order in which configuration settings are applied?:: The {Navigator}
 . Flags and arguments specified on the command line
 . While issuing `:` commands within the text-based user interface
 
-Something didn't work, how can I troubleshoot it?:: {Navigator} has reasonable logging messages. You can enable `debug` logging with `--log-level debug`. If you think you might have found a bug, log an issue and include the details from the log file.
+Something did not work, how can I troubleshoot it?:: {NavigatorStart} has reasonable logging messages. You can enable `debug` logging with `--log-level debug`. If you think you might have found a bug, log an issue and include the details from the log file.

--- a/downstream/modules/navigator/ref-navigator-command-summary.adoc
+++ b/downstream/modules/navigator/ref-navigator-command-summary.adoc
@@ -1,11 +1,11 @@
 [id="ref-navigator-command-summary{context}"]
 
-= {Navigator} commands
+= {NavigatorStart} commands
 
 [role="_abstract"]
 The {Navigator} commands run familiar Ansible CLI commands in `-m stdout` mode. You can use all the subcommands and options from the related Ansible CLI command. Use `ansible-navigator --help` for details.
 
-.{Navigator} commands
+.{NavigatorStart} commands
 [options="header"]
 |====
 |Command|Description|CLI example

--- a/downstream/modules/navigator/ref-navigator-config-settings.adoc
+++ b/downstream/modules/navigator/ref-navigator-config-settings.adoc
@@ -1,12 +1,12 @@
 [id="ref-navigator-config-settings_{context}"]
 
-= {Navigator} `config` subcommand settings
+= {NavigatorStart} `config` subcommand settings
 
 [role="_abstract"]
 
 The following table describes each parameter and setting options for the {Navigator} `config` subcommand.
 
-.{Navigator} `config` subcommand parameters settings
+.{NavigatorStart} `config` subcommand parameters settings
 [options="header"]
 [cols='1,1a,1a']
 |====

--- a/downstream/modules/navigator/ref-navigator-general-settings.adoc
+++ b/downstream/modules/navigator/ref-navigator-general-settings.adoc
@@ -1,12 +1,12 @@
 [id="ref-navigator-general-settings_{context}"]
 
-= {Navigator} general settings
+= {NavigatorStart} general settings
 
 [role="_abstract"]
 
 The following table describes each general parameter and setting options for {Navigator}.
 
-.{Navigator} general parameters settings
+.{NavigatorStart} general parameters settings
 [options="header"]
 [cols='1,1a,1a']
 |====

--- a/downstream/modules/navigator/ref-navigator-inventory-settings.adoc
+++ b/downstream/modules/navigator/ref-navigator-inventory-settings.adoc
@@ -1,12 +1,12 @@
 [id="ref-navigator-inventory-settings_{context}"]
 
-= {Navigator} `inventory` subcommand settings
+= {NavigatorStart} `inventory` subcommand settings
 
 [role="_abstract"]
 
 The following table describes each parameter and setting options for the {Navigator} `inventory` subcommand.
 
-.{Navigator} `inventory` subcommand parameters settings
+.{NavigatorStart} `inventory` subcommand parameters settings
 [options="header"]
 [cols='1,1a,1a']
 |====

--- a/downstream/modules/navigator/ref-navigator-replay-settings.adoc
+++ b/downstream/modules/navigator/ref-navigator-replay-settings.adoc
@@ -1,12 +1,12 @@
 [id="ref-navigator-replay-settings_{context}"]
 
-= {Navigator} `replay` subcommand settings
+= {NavigatorStart} `replay` subcommand settings
 
 [role="_abstract"]
 
 The following table describes each parameter and setting options for the {Navigator} `replay` subcommand.
 
-.{Navigator} `replay` subcommand parameters settings
+.{NavigatorStart} `replay` subcommand parameters settings
 [options="header"]
 [cols='1,1a,1a']
 |====

--- a/downstream/modules/navigator/ref-navigator-run-settings.adoc
+++ b/downstream/modules/navigator/ref-navigator-run-settings.adoc
@@ -1,12 +1,12 @@
 [id="ref-navigator-run-settings_{context}"]
 
-= {Navigator} `run` subcommand settings
+= {NavigatorStart} `run` subcommand settings
 
 [role="_abstract"]
 
 The following table describes each parameter and setting options for the {Navigator} `run` subcommand.
 
-.{Navigator} `run` subcommand parameters settings
+.{NavigatorStart} `run` subcommand parameters settings
 [options="header"]
 [cols='1,1a,1a']
 |====

--- a/downstream/modules/platform/con-about-navigator.adoc
+++ b/downstream/modules/platform/con-about-navigator.adoc
@@ -1,6 +1,6 @@
 [id="con-about-navigator_{context}"]
 
-= {Navigator}
+= {NavigatorStart}
 
 [role="_abstract"]
-{Navigator} is a _textual user interface_ (TUI) that becomes the primary command line interface into the automation platform, covering use cases from content building, running automation locally in an {ExecEnvShort}, running automation in {PlatformNameShort}, and providing the foundation for future _integrated development environments_ (IDEs).
+{NavigatorStart} is a _textual user interface_ (TUI) that becomes the primary command line interface into the automation platform, covering use cases from content building, running automation locally in an {ExecEnvShort}, running automation in {PlatformNameShort}, and providing the foundation for future _integrated development environments_ (IDEs).


### PR DESCRIPTION
According to Official Red Hat product names list (OPL), the correct usage is "automation content navigator".

It would be helpful to set the attributes like this:

- :Navigator: automation content navigator
- :NavigatorStart: Automation content navigator

Additionally, the usage of these attributes should be reviewed throughout the docs set to ensure it's used correctly.

Update Navigator attribute and add NavigatorStart attribute

https://issues.redhat.com/browse/AAP-21433