### PR TITLE
Remove snippets for tertiary menus

### DIFF
--- a/downstream/snippets/snip_menu-top-ac.adoc
+++ b/downstream/snippets/snip_menu-top-ac.adoc
@@ -1,1 +1,0 @@
-. From the *{MenuAC}* menu on the navigation panel, select

--- a/downstream/snippets/snip_menu-top-ae.adoc
+++ b/downstream/snippets/snip_menu-top-ae.adoc
@@ -1,1 +1,0 @@
-. From the *{MenuAE}* menu on the navigation panel, select


### PR DESCRIPTION
This PR deletes the snippets for tertiary menus because the new docs experience allows them to be coded with the menu:selection1[selection2 > selection3] and makes the snippets an unnecessary workaround. 