### PR TITLE
Add and update Ansible-core attributes in aap-docs (#1339)

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -7,8 +7,10 @@
 :CentralAuthStart: Central authentication
 :CentralAuth: central authentication
 :PlatformVers: 2.4
-:AnsibleCoreVers: 2.15
-:AnsibleInstallVers: 2.4-1
+//The Ansible-core version required to install AAP
+:CoreInstVers: 2.14 
+//The Ansible-core version used by the AAP control plane and EEs
+:CoreUseVers: 2.15 
 :PlatformDownloadUrl: https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software
 :BaseURL: https://access.redhat.com/documentation/en-us
 :VMBase: VM-based installation

--- a/downstream/modules/platform/con-aap-upgrades-legacy.adoc
+++ b/downstream/modules/platform/con-aap-upgrades-legacy.adoc
@@ -11,7 +11,7 @@ The following steps provide an overview of the legacy upgrade process:
 * Duplicate your custom virtual environments into {ExecEnvName} by using the `awx-manage` command.
 * Migrate data from isolated legacy nodes to execution nodes by performing a side-by-side upgrade so nodes are compatible with the latest {AutomationMesh} features.
 * Import or generate a new {HubName} API token.
-* Reconfigure your Ansible content to include Fully Qualified Collection Names (FQCN) for compatibility with `ansible-core` {AnsibleCoreVers}.
+* Reconfigure your Ansible content to include Fully Qualified Collection Names (FQCN) for compatibility with `ansible-core` {CoreUseVers}.
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -16,7 +16,7 @@ h| Subscription | Valid {PlatformName} |
 
 h| OS | {RHEL} 8.6 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
-h| Ansible | version 2.15 | {PlatformNameShort} ships with execution environments that contain ansible-core {AnsibleCoreVers}.
+h| Ansible-core | Ansible-core version {CoreInstVers} or later | {PlatformNameShort} includes execution environments that contain ansible-core {CoreUseVers}.
 
 h| Python | 3.9 or later |
 


### PR DESCRIPTION
- Added CoreInstVers. This is the Ansible-core version required to install AAP
- Added CoreUseVers. This is the Ansible-core version used by the AAP control plane and EEs
- Removed AnsibleCoreVers. This is replaced by CoreUseVers
- Removed AnsibleInstallVers. This is replaced by CoreInstVers

Add and update Ansible-core attributes in aap-docs

https://issues.redhat.com/browse/AAP-23165