### PR TITLE
Add CPU and RAM requirements for Postgres in planning guide (#1341)

### DIFF
--- a/downstream/modules/platform/ref-postgresql-requirements.adoc
+++ b/downstream/modules/platform/ref-postgresql-requirements.adoc
@@ -21,7 +21,11 @@ h| Service |Required |Notes
 // | *Each {HubName}* | 60 GB dedicated hard disk space |
 
 //Storage volume must be rated for a minimum baseline of 1500 IOPS.
-| *Database* | 20 GB dedicated hard disk space |
+| *Database* | 
+
+* 20 GB dedicated hard disk space 
+* 4 CPUs 
+* 16 GB RAM |
 
 * 150 GB+ recommended
 * Storage volume must be rated for a high baseline IOPS (1500 or more).


### PR DESCRIPTION
[Docs] Planning Guide should have the RAM and CPU requirement for Postgres system.

https://issues.redhat.com/browse/AAP-20172