### PR TITLE
Update BaseURL attribute to docs.redhat.com site

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -12,7 +12,7 @@
 //The Ansible-core version used by the AAP control plane and EEs
 :CoreUseVers: 2.15 
 :PlatformDownloadUrl: https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software
-:BaseURL: https://access.redhat.com/documentation/en-us
+:BaseURL: https://docs.redhat.com/en/documentation
 :VMBase: VM-based installation
 :OperatorBase: operator-based installation
 :ContainerBase: container-based installation


### PR DESCRIPTION
Update the {BaseURL} attribute so that links to Red Hat docs point to docs.redhat.com instead of access.redhat.com