### PR TITLE
Plus symbols not rendering correctly in asciidoc (#1343)

### DIFF
--- a/downstream/modules/platform/ref-controller-api-config-settings.adoc
+++ b/downstream/modules/platform/ref-controller-api-config-settings.adoc
@@ -51,7 +51,7 @@ To compose a named URL for this specific resource object by using `NAMED_URL_FOR
 
 * The first part of the URL format is `<name>`, which indicates that you can find the label resource detail in `/api/v2/labels/5/`, and look for `name` field in returned JSON. 
 If you have the `name` field with value `Foo`, then the first part of the unique identifier is `Foo`.
-* The second part of the format is double pluses "++". 
+* The second part of the format is double plus sign {plus}{plus}. 
 That is the delimiter that separates different parts of a unique identifier. 
 Append them to the unique identifier to get `Foo++`.
 * The third part of the format is `<organization.name>`, which indicates that the field is not in the current label object under investigation, but in an organization that the label object points to. 
@@ -61,7 +61,7 @@ If it exists, follow the URL given in that field, for example, `/api/v2/organiza
 +
 In the case where an organization does not exist in the related field of the label object detail, append an empty string instead. 
 This does not alter the current identifier. 
-Therefore, "Foo++" becomes the final unique identifier and the resulting generated named URL becomes `/api/v2/labels/Foo++/`.
+Therefore, `Foo++` becomes the final unique identifier and the resulting generated named URL becomes `/api/v2/labels/Foo{plus}{plus}/`.
 
 An important aspect of generating a unique identifier for named URL has to do with reserved characters. 
 As the identifier is part of a URL, the following reserved characters by URL standard are encoded by percentage symbols: `;/?:@=&[]`. 


### PR DESCRIPTION
* Plus symbols not rendering correctly in asciidoc

Automation Controller API Overview typo

https://issues.redhat.com/browse/AAP-23917

Affects `titles/controller-api-overview`

* Peer review edit