### PR TITLE
Added mesh ingress section back into doc for 2.5

### DIFF
--- a/downstream/assemblies/platform/assembly-automation-mesh-operator-aap.adoc
+++ b/downstream/assemblies/platform/assembly-automation-mesh-operator-aap.adoc
@@ -20,7 +20,7 @@ include::platform/proc-define-mesh-node-types.adoc[leveloffset=+1]
 include::platform/proc-controller-create-instance-group.adoc[leveloffset=+1]
 include::platform/proc-controller-associate-instances-to-instance-group.adoc[leveloffset=+1]
 include::platform/proc-run-jobs-on-execution-nodes.adoc[leveloffset=+1]
-//include::platform/proc-connecting-nodes-through-mesh-ingress.adoc[leveloffset=+1]
+include::platform/proc-connecting-nodes-through-mesh-ingress.adoc[leveloffset=+1]
 include::platform/proc-pulling-the-secret.adoc[leveloffset=+1]
 include::platform/ref-removing-instances.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Replace Mesh Ingress section in Operator-mesh guide

https://issues.redhat.com/browse/AAP-22845