### PR TITLE
Adding modules for planning Assembly (AAP-23356)

### DIFF
--- a/stories/assembly-saas-planning.adoc
+++ b/stories/assembly-saas-planning.adoc
@@ -1,6 +1,11 @@
 ifdef::context[:parent-context: {context}]
 
 [id="saas-planning"]
-= Planning your {SaaSonAWS}
+= Planning for {SaaSonAWS}
+Before setting up your {SaaSonAWS} review the following sections for a comprehensive understanding of the required configurations to plan your deployment effectively. 
 
+
+include::topics/con-saas-intro.adoc[leveloffset=+1]
+include::topics/ref-saas-default-configs.adoc[leveloffset=+1]
+include::topics/ref-saas-planning-configs.adoc[leveloffset=+1]
 :context: saas-planning

--- a/stories/topics/con-saas-intro.adoc
+++ b/stories/topics/con-saas-intro.adoc
@@ -1,0 +1,11 @@
+[id="con-saas-intro"]
+= Introduction 
+{SaaSonAWS} links your {AWS} (AWS) offering to your Red{nbsp}Hat account which enables access to {PlatformNameShort}. 
+When you subscribe to {SaaSonAWSShort}, Red{nbsp}Hat deploys and configures a cluster for you on the {PlatformNameShort}. 
+
+From here you can access the control plane which allows you to run and manage your automation. You can run automation through mesh ingress or self-managed hop nodes. 
+You can connect execution nodes through an egress model from your environment using mesh ingress.
+Alternatively, mesh ingress sets up hop nodes on the controller and then you can peer execution nodes to them.
+
+
+//Insert diagram here when ready DXD-716

--- a/stories/topics/ref-saas-default-configs.adoc
+++ b/stories/topics/ref-saas-default-configs.adoc
@@ -1,0 +1,5 @@
+[id="ref-saas-default-configs"]
+= Default configurations in {SaaSonAWSShort}
+The initial configuration of {PlatformNameShort} includes the control node container group and mesh ingress hop nodes. 
+It does not include execution nodes or connectivity to an OpenShift cluster that operates as the execution plane. 
+By default the only automation job available and supported is the *Demo Job Template* provided for simple testing.

--- a/stories/topics/ref-saas-planning-configs.adoc
+++ b/stories/topics/ref-saas-planning-configs.adoc
@@ -1,0 +1,5 @@
+[id="ref-saas-planning-configs"]
+= Planning the required configurations for {SaaSonAWSShort}
+After accessing your {PlatformNameShort} instance, you can confirm that there is only a control node, and mesh ingress hop nodes on the *Instances* page or *Topology* page. 
+Before you can start automation jobs you must add remote execution nodes to the cluster, or connect an OpenShift cluster as a container group. 
+For help with configuring execution nodes see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_automation_mesh_for_operator-based_installations/index[Red Hat Ansible Automation Platform Automation Mesh for operator-based installations]


### PR DESCRIPTION
[AAP-23356 ](https://issues.redhat.com/browse/AAP-23356 )SaaS documentation - Add planning chapter

Cretaing and linking the modules for the Planning chapter assembly

Location : aap-clouds-latest > stories > topics
