### PR TITLE
AAP-24195: Added info. about languages supported for Ansible Lightspeed prompts

### DIFF
--- a/lightspeed/modules/con-lightspeed-about.adoc
+++ b/lightspeed/modules/con-lightspeed-about.adoc
@@ -22,7 +22,7 @@ To use {LightspeedFullName}, your organization must have:
 
 * *Reduces the onboarding learning period for Ansible developers*
 +
-With just a basic understanding of YAML syntax, Ansible developers can use natural language prompts to describe the automation goal. {LightspeedShortName} then offers Ansible code recommendations to help achieve the automation goal more efficiently. This combination of content and best practice suggestions reduces the learning curve and offers a smoother onboarding experience for new Ansible users. 
+With just a basic understanding of YAML syntax, Ansible developers can use natural language prompts in English language to describe the automation goal. {LightspeedShortName} then offers Ansible code recommendations to help achieve the automation goal more efficiently. This combination of content and best practice suggestions reduces the learning curve and offers a smoother onboarding experience for new Ansible users. 
 +
 For example, to get a multitask code recommendation, you can enter the prompt `Install postgresql-server & run postgresql-setup command`. The Ansible Lightspeed service reads the text, interacts with {ibmwatsonxcodeassistant}, and generates code recommendations to automate a multitask that installs a PostgreSQL server and sets up a PostgreSQL database. You can then view and accept the code recommendations to create tasks in an Ansible YAML file. 
 

--- a/lightspeed/modules/con_lightspeed-key-features.adoc
+++ b/lightspeed/modules/con_lightspeed-key-features.adoc
@@ -12,6 +12,8 @@
 * *Single tasks and multitask generation*
 +
 Using natural language prompts, you can generate single task or multiple task recommendations for Ansible task files and playbooks. To request multitask code recommendations, you can enter a sequence of natural language task prompts in a YAML file comment separated by ampersand (*&*) symbols.
++
+Currently, {LightspeedShortName} supports user prompts in English language only. However, there could be instances where the training data that was used to train the {ibmwatsonxcodeassistant} models included non-English language. In such scenarios, the model can generate code recommendations for prompts made in the same non-English language, but the generated code recommendations might or might not be accurate.
 
 * *Content source matching*
 +

--- a/lightspeed/modules/con_overview-and-best-practices.adoc
+++ b/lightspeed/modules/con_overview-and-best-practices.adoc
@@ -15,8 +15,14 @@ Write a description of your task in the `- name:` key of a new task line in your
 Place your cursor on a new line in your Ansible YAML file at the correct indentation, and start your prompt with a Pound key (#).
 +
 Write the descriptions of your tasks, separating each prompt by using Ampersand symbols (&). For example, to automate a multitask of installing PostgreSQL server and running the initial PostgreSQL setup command, you can enter the prompt `# Install postgresql-server & run postgresql-setup command`.
-
++
 The Ansible Lightspeed service reads the text, interacts with the {ibmwatsonxcodeassistant} model, and generates Ansible task recommendations based on your natural language prompt.
++
+[NOTE]
++
+====
+Currently, {LightspeedShortName} supports user prompts in English language only. However, there could be instances where the training data that was used to train the {ibmwatsonxcodeassistant} models included non-English language. In such scenarios, the model can generate code recommendations for prompts made in the same non-English language, but the generated code recommendations might or might not be accurate.
+====
 
 * *View the content source matching results*
 +


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-24195. 

Changes made:

- Added info. that Lightspeed supports user prompts in English language only, along with a corner case. 