### PR TITLE
[DOCS] - mistake in AAP 2.4 install docs - 2.5.2. Enabling the hstore…

### DIFF
--- a/downstream/modules/platform/proc-enable-hstore-extension.adoc
+++ b/downstream/modules/platform/proc-enable-hstore-extension.adoc
@@ -53,7 +53,7 @@ dnf install postgresql-contrib
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-$ psql -d <{HubName} database> -c "CREATE EXTENSION hstore"
+$ psql -d <{HubName} database> -c "CREATE EXTENSION hstore;"
 ----
 +
 The output of which is:


### PR DESCRIPTION
… extension for the automation hub PostgreSQL database

Added a semicolon at the end of the command

AAP-24305

https://issues.redhat.com/browse/AAP-24305