### PR TITLE
Updating the info for private dns zone being customer managable.

### DIFF
--- a/stories/assembly-azure-support.adoc
+++ b/stories/assembly-azure-support.adoc
@@ -13,7 +13,7 @@ Due to the architecture of the application and the deployment strategy in Azure,
 As an {AAPonAzureNameShort} user, you can configure the {PlatformNameShort} network to peer your own network.
 By doing so, you can grant access from the {PlatformNameShort} instance to all the assets associated with your own network that you want to manage.
 Also, you can route all the {PlatformNameShort} traffic to your own Virtual Network Appliances to control, audit, or block traffic from the {PlatformNameShort} instance to the internet.
-To do this, you must consider the URLs that need to be allowlisted for {PlatformNameShort} to work properly.
+To do this, you must consider the URLs that must be allowlisted for {PlatformNameShort} to work properly.
 
 For more information about Azure Virtual Appliance Routing, see the link:https://access.redhat.com/articles/6972355[Azure Virtual Appliance Routing with Ansible Automation Platform on Azure] article on the Red Hat customer portal.
 
@@ -24,7 +24,7 @@ For more information about Azure Virtual Appliance Routing, see the link:https:/
 To use private DNS records that cannot be resolved publicly, you can either use Azure Private DNS zones that are peered to the managed application VNET, or you can make a submit request to Red Hat to submit DNS zones that should be forwarded to a customer-managed private DNS server.
 
 A limitation of Private DNS zones is that only one instance of a given zone may be linked to a Virtual Network.
-Attempting to link zones that match the names of Private DNS zones in the managed resource group will cause conflicts.
+Attempting to link zones that match the names of Private DNS zones in the managed resource group causes conflicts.
 Microsoft recommends consolidating DNS records into a single zone to work around this limitation.
 
 You can replicate the records from the zones in the managed resource group into your own instance of the Private DNS zone.
@@ -34,7 +34,7 @@ Failure to properly maintain the records in the Private DNS zone can prevent the
 
 The AKS Private DNS zone cannot be customer managed and still allow Red Hat to update or upgrade the managed AKS that is a part of this offering.
 To allow Red Hat to upgrade the customer AKS to the latest version during the maintenance windows, do not unlink the `<GUID>.privatelink.<region>.azmk8s.io` Private DNS zone.
-For more information on this limitation, see https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/createorupdatevirtualnetworklinkfailed-error["CreateOrUpdateVirtualNetworkLinkFailed" error when updating or upgrading an AKS cluster] in the Microsoft Azure documentation.
+For more information on this limitation, see link:https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/createorupdatevirtualnetworklinkfailed-error["CreateOrUpdateVirtualNetworkLinkFailed" error when updating or upgrading an AKS cluster] in the Microsoft Azure documentation.
 
 To work around this limitation, Red Hat allows you to manage A and CNAME records in the Private DNS zones in the managed resource group.
 Any records that you put in the Private DNS zones in the managed resource group are visible to the Red Hat SREs.

--- a/stories/assembly-azure-support.adoc
+++ b/stories/assembly-azure-support.adoc
@@ -13,7 +13,7 @@ Due to the architecture of the application and the deployment strategy in Azure,
 As an {AAPonAzureNameShort} user, you can configure the {PlatformNameShort} network to peer your own network.
 By doing so, you can grant access from the {PlatformNameShort} instance to all the assets associated with your own network that you want to manage.
 Also, you can route all the {PlatformNameShort} traffic to your own Virtual Network Appliances to control, audit, or block traffic from the {PlatformNameShort} instance to the internet.
-To do this, you must consider the URLs that need to be allowlisted for {PlatformNameShort} to work properly. 
+To do this, you must consider the URLs that need to be allowlisted for {PlatformNameShort} to work properly.
 
 For more information about Azure Virtual Appliance Routing, see the link:https://access.redhat.com/articles/6972355[Azure Virtual Appliance Routing with Ansible Automation Platform on Azure] article on the Red Hat customer portal.
 
@@ -21,18 +21,29 @@ For more information about Azure Virtual Appliance Routing, see the link:https:/
 
 {AAPonAzureNameShort} uses Azure's managed DNS services when deployed.
 
-To use private DNS records that cannot be resolved publicly, you can either use Azure Private DNS Zones that are peered to the managed application VNET, or you can make a submit request to Red Hat to submit DNS zones that should be forwarded to a customer-managed private DNS server.
+To use private DNS records that cannot be resolved publicly, you can either use Azure Private DNS zones that are peered to the managed application VNET, or you can make a submit request to Red Hat to submit DNS zones that should be forwarded to a customer-managed private DNS server.
 
-A limitation of Private DNS Zones is that only one instance of a given zone may be linked to a Virtual Network.
-Attempting to link zones that match the names of Private DNS Zones in the managed resource group will cause conflicts.
+A limitation of Private DNS zones is that only one instance of a given zone may be linked to a Virtual Network.
+Attempting to link zones that match the names of Private DNS zones in the managed resource group will cause conflicts.
 Microsoft recommends consolidating DNS records into a single zone to work around this limitation.
 
-You can replicate the records from the zones in the managed resource group into your own instance of the Private DNS Zone.
-You can then unlink Private DNS Zones in the managed resource group from the Virtual Network and replace it with your own instance of the Private DNS Zone.
+You can replicate the records from the zones in the managed resource group into your own instance of the Private DNS zone.
+You can then unlink Private DNS zones in the managed resource group from the Virtual Network and replace it with your own instance of the Private DNS zone.
 
-Failure to properly maintain the records in the Private DNS Zone can prevent the managed application from operating.
+Failure to properly maintain the records in the Private DNS zone can prevent the managed application from operating.
 
-For more information about working with Private DNS Zones, see the link:https://access.redhat.com/articles/6983525[Private DNS with Red Hat Ansible Automation Platform on Microsoft Azure] article on the Red Hat customer portal.
+The AKS Private DNS zone cannot be customer managed and still allow Red Hat to update or upgrade the managed AKS that is a part of this offering.
+That means that customers should not unlink the `<GUID>.privatelink.<region>.azmk8s.io` Private DNS zone to allow Red Hat to upgrade the customer AKS to the latest version during the maintenance windows.
+See the following link for more information on this limitation: https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/createorupdatevirtualnetworklinkfailed-error["CreateOrUpdateVirtualNetworkLinkFailed" error when updating or upgrading an AKS cluster]
+
+To work around the above limitations, Red Hat has allowed customers to manage A and CNAME records in the Private DNS zones in the managed resource group.
+Any records put in the Private DNS zones in the managed resource group will be visible to the Red Hat SREs.
+If you decide to use the Private DNS zones in the managed resource group, you will be responsible for updating them with the records you need.
+Customer supplied records will not be backed up as a part of the disaster recovery process.
+Removal of any Azure supplied records could result in network connectivity issues with {AAPonAzureNameShort}.
+
+
+For more information about working with Private DNS zones, see the link:https://access.redhat.com/articles/6983525[Private DNS with Red Hat Ansible Automation Platform on Microsoft Azure] article on the Red Hat customer portal.
 
 .Microsoft Azure Policy
 
@@ -42,6 +53,3 @@ These situations are identified by Red Hat during maintenance or daily operation
 You must exclude the enforcement of Azure Policy, for example by using exceptions, on resources associated with the managed application.
 
 For more information about working with Azure Policy, see the link:https://access.redhat.com/articles/7013454[Azure Policy and Ansible on Azure] article on the Red Hat customer portal.
-
-
-

--- a/stories/assembly-azure-support.adoc
+++ b/stories/assembly-azure-support.adoc
@@ -33,17 +33,17 @@ You can then unlink Private DNS zones in the managed resource group from the Vir
 Failure to properly maintain the records in the Private DNS zone can prevent the managed application from operating.
 
 The AKS Private DNS zone cannot be customer managed and still allow Red Hat to update or upgrade the managed AKS that is a part of this offering.
-That means that customers should not unlink the `<GUID>.privatelink.<region>.azmk8s.io` Private DNS zone to allow Red Hat to upgrade the customer AKS to the latest version during the maintenance windows.
-See the following link for more information on this limitation: https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/createorupdatevirtualnetworklinkfailed-error["CreateOrUpdateVirtualNetworkLinkFailed" error when updating or upgrading an AKS cluster]
+To allow Red Hat to upgrade the customer AKS to the latest version during the maintenance windows, do not unlink the `<GUID>.privatelink.<region>.azmk8s.io` Private DNS zone.
+For more information on this limitation, see https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/createorupdatevirtualnetworklinkfailed-error["CreateOrUpdateVirtualNetworkLinkFailed" error when updating or upgrading an AKS cluster] in the Microsoft Azure documentation.
 
-To work around the above limitations, Red Hat has allowed customers to manage A and CNAME records in the Private DNS zones in the managed resource group.
-Any records put in the Private DNS zones in the managed resource group will be visible to the Red Hat SREs.
-If you decide to use the Private DNS zones in the managed resource group, you will be responsible for updating them with the records you need.
-Customer supplied records will not be backed up as a part of the disaster recovery process.
-Removal of any Azure supplied records could result in network connectivity issues with {AAPonAzureNameShort}.
+To work around this limitation, Red Hat allows you to manage A and CNAME records in the Private DNS zones in the managed resource group.
+Any records that you put in the Private DNS zones in the managed resource group are visible to the Red Hat SREs.
+If you decide to use the Private DNS zones in the managed resource group, you are responsible for updating them with the records you need.
+Customer supplied records are not backed up as a part of the disaster recovery process.
+Removing any Azure supplied records can cause network connectivity issues with {AAPonAzureNameShort}.
 
 
-For more information about working with Private DNS zones, see the link:https://access.redhat.com/articles/6983525[Private DNS with Red Hat Ansible Automation Platform on Microsoft Azure] article on the Red Hat customer portal.
+For more information about working with Private DNS zones, see link:https://access.redhat.com/articles/6983525[Private DNS with Red Hat Ansible Automation Platform on Microsoft Azure] on the Red Hat customer portal.
 
 .Microsoft Azure Policy
 


### PR DESCRIPTION
This PR adds information about the AKS Private DNS zone, the customers soon having the ability to partially manage the Private DNS zones in the managed resource group, and cleans up the capitalization to match Azure docs.

Draft for now until we're live with these changes.