### PR TITLE
Formatting issue in Controller UG Glossary section (#1370)

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-glossary.adoc
+++ b/downstream/assemblies/platform/assembly-controller-glossary.adoc
@@ -231,7 +231,7 @@ The calendar of dates and times for which a job should run automatically.
 See *Distributed Job*.
 
 [discrete]
-=== Source Credential::
+=== Source Credential
 An external credential that is linked to the field of a target credential.
 
 [discrete]


### PR DESCRIPTION
* Formatting issue in Controller UG Glossary section

This should show up as a bold term but is displaying with 3 = like this: === Source Credential

AAP-24465

https://issues.redhat.com/browse/AAP-24465

* Formatting issue in Controller UG Glossary section

This should show up as a bold term but is displaying with 3 = like this: === Source Credential

AAP-24465

https://issues.redhat.com/browse/AAP-24465