### PR TITLE
AAP-24694 Added note about rulebook activations shutting down and canceling jobs on controller.

### DIFF
--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -42,7 +42,7 @@ Your rulebook activation is now created and can be managed on the *Rulebook Acti
 
 After saving the new rulebook activation, the rulebook activation's details page is displayed.
 From there or the *Rulebook Activations* list view, you can edit or delete it.
-+
+
 [IMPORTANT]
 ====
 When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -45,5 +45,5 @@ From there or the *Rulebook Activations* list view, you can edit or delete it.
 
 [IMPORTANT]
 ====
-When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
+Occasionally, when a source plugin shuts down, it causes a rulebook to exit gracefully after a certain amount of time.When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
 ====

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -40,7 +40,7 @@ The content would be equivalent to the file passed through the `--vars` flag of 
 +
 [IMPORTANT]
 ====
-When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. This is expected behavior. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
+When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
 ====
 
 Your rulebook activation is now created and can be managed on the *Rulebook Activations* page.

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -43,7 +43,7 @@ Your rulebook activation is now created and can be managed on the *Rulebook Acti
 After saving the new rulebook activation, the rulebook activation's details page is displayed.
 From there or the *Rulebook Activations* list view, you can edit or delete it.
 
-[IMPORTANT]
+[NOTE]
 ====
 Occasionally, when a source plugin shuts down, it causes a rulebook to exit gracefully after a certain amount of time. When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
 ====

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -37,13 +37,13 @@ Variables:: The variables for the rulebook are in a JSON/YAML format.
 The content would be equivalent to the file passed through the `--vars` flag of ansible-rulebook command.
 
 . Click btn:[Create rulebook activation].
-+
-[IMPORTANT]
-====
-When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
-====
 
 Your rulebook activation is now created and can be managed on the *Rulebook Activations* page.
 
 After saving the new rulebook activation, the rulebook activation's details page is displayed.
 From there or the *Rulebook Activations* list view, you can edit or delete it.
++
+[IMPORTANT]
+====
+When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
+====

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -37,6 +37,11 @@ Variables:: The variables for the rulebook are in a JSON/YAML format.
 The content would be equivalent to the file passed through the `--vars` flag of ansible-rulebook command.
 
 . Click btn:[Create rulebook activation].
++
+[IMPORTANT]
+====
+When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. This is expected behavior. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
+====
 
 Your rulebook activation is now created and can be managed in the *Rulebook Activations* screen.
 

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -43,7 +43,7 @@ The content would be equivalent to the file passed through the `--vars` flag of 
 When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. This is expected behavior. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
 ====
 
-Your rulebook activation is now created and can be managed in the *Rulebook Activations* screen.
+Your rulebook activation is now created and can be managed on the *Rulebook Activations* page.
 
 After saving the new rulebook activation, the rulebook activation's details page is displayed.
-From there or the *Rulebook Activations* list view you can edit or delete it.
+From there or the *Rulebook Activations* list view, you can edit or delete it.

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -45,5 +45,5 @@ From there or the *Rulebook Activations* list view, you can edit or delete it.
 
 [IMPORTANT]
 ====
-Occasionally, when a source plugin shuts down, it causes a rulebook to exit gracefully after a certain amount of time.When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
+Occasionally, when a source plugin shuts down, it causes a rulebook to exit gracefully after a certain amount of time. When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
 ====


### PR DESCRIPTION
Added a note at the end of [section 6.1 Setting up a rulebook activation](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/event-driven_ansible_controller_user_guide/index#eda-set-up-rulebook-activation) in the EDA controller user guide to inform users that when an activation shuts down, any tasks that are waiting to be performed will be canceled and an info level message will be sent to the activation log. Tracked in jira [AAP-24694](https://issues.redhat.com/browse/AAP-24694). 