### PR TITLE
AAP-17190 Remove molecule chapter from devtools guide

### DIFF
--- a/downstream/assemblies/devtools/assembly-testing-playbooks.adoc
+++ b/downstream/assemblies/devtools/assembly-testing-playbooks.adoc
@@ -1,6 +1,8 @@
 ifdef::context[:parent-context: {context}]
 [id="testing-playbook-project"]
 
+// Used in /titles/develop-automation-content/
+//
 = Testing a playbook project
 
 :context: testing-playbook-project

--- a/downstream/titles/develop-automation-content/master.adoc
+++ b/downstream/titles/develop-automation-content/master.adoc
@@ -23,5 +23,5 @@ include::devtools/assembly-devtools-install.adoc[leveloffset=+1]
 include::devtools/assembly-devtools-setup.adoc[leveloffset=+1]
 include::devtools/assembly-creating-playbook-project.adoc[leveloffset=+1]
 include::devtools/assembly-writing-running-playbook.adoc[leveloffset=+1]
-include::devtools/assembly-testing-playbooks.adoc[leveloffset=+1]
+// include::devtools/assembly-testing-playbooks.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Remove chapter about molecule from Devtools book. 
Add it back in when molecule examples are added to the community documentation.

Affects `/titles/develop-automation-content/`