### PR TITLE
Add async release note templates

### DIFF
--- a/downstream/templates/installer-rn-template.adoc
+++ b/downstream/templates/installer-rn-template.adoc
@@ -1,0 +1,11 @@
+// This is the release notes for x.x-x bundle installer release
+
+[id="installer-xx-xx"]
+
+= RHSA-XXXX:XXXX - bundle installer release x.x-x - <month date, year>
+
+link:https://access.redhat.com/errata/<errata advisory link>[RHSA-XXXX:XXXX]
+
+== Related RPM releases
+
+* 

--- a/downstream/templates/rpm-rn-template.adoc
+++ b/downstream/templates/rpm-rn-template.adoc
@@ -1,0 +1,28 @@
+// This is the release notes for x.x-x async installer release
+
+[id="rpm-xx-xx"]
+
+= RHSA-XXXX:XXXX - security advisory - <month date, year>
+
+link:https://access.redhat.com/errata/<errata advisory link>[RHSA-XXXX:XXXX]
+
+== General
+
+With this update, the following CVEs have been addressed:
+
+* 
+
+// Automation controller
+== {ControllerNameStart}
+
+* 
+
+// Automation hub
+== {HubNameStart}
+
+* 
+
+// Event-Driven Ansible
+== {EDAName}
+
+* 


### PR DESCRIPTION
Add `installer-rn-template.adoc` and `rpm-rn-template.adoc` for use when creating async release notes.

Automate generation of async release notes

https://issues.redhat.com/browse/AAP-19076