### PR TITLE
AAP-25067 removing incorrect sentence (#1401)

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-add-execution-nodes.adoc
+++ b/downstream/assemblies/platform/assembly-operator-add-execution-nodes.adoc
@@ -6,10 +6,10 @@ ifdef::context[:parent-context: {context}]
 
 :context: operator-upgrade
 
-You can enable the {PlatformNameShort} Operator with execution nodes by downloading and installing the install bundle. The steps outlined in this document are also applicable to virtual machines (VMs).  
+You can enable the {PlatformNameShort} Operator with execution nodes by downloading and installing the install bundle.  
 
 
-include::platform/proc-add-operator-execution-nodes.adoc[][leveloffset=+1]
+include::platform/proc-add-operator-execution-nodes.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
[AAP-25067](https://issues.redhat.com/browse/AAP-25067)

Removing an incorrect sentence that was causing confusion

Doc location: downstream > titles > assembly-operator-add-execution-nodes.adoc