### PR TITLE
adding assembly and modules as part of AAP-20941

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-deploy-gateway.adoc
+++ b/downstream/assemblies/platform/assembly-operator-deploy-gateway.adoc
@@ -1,0 +1,14 @@
+ifdef::context[:parent-context: {context}]
+
+[id="operator-deploy-gateway_{context}"]
+
+= Deploying the AnsibleAutomationPlatform user interface
+
+:context: gateway-deploy
+
+include::platform/proc-operator-link-components.adoc[leveloffset=+1]
+include::platform/proc-operator-access-aap.adoc[leveloffset=+1]
+include::platform/proc-operator-aap-troubleshooting.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/proc-operator-aap-troubleshooting.adoc
+++ b/downstream/modules/platform/proc-operator-aap-troubleshooting.adoc
@@ -1,0 +1,3 @@
+[id="operator-aap-troubleshooting_{context}"]
+
+= Troubleshooting AnsibleAutomationPlatform issues  

--- a/downstream/modules/platform/proc-operator-access-aap.adoc
+++ b/downstream/modules/platform/proc-operator-access-aap.adoc
@@ -1,0 +1,3 @@
+[id="operator-access-aap_{context}"]
+
+= Accessing your AnsibleAutomationPlatform  

--- a/downstream/modules/platform/proc-operator-link-components.adoc
+++ b/downstream/modules/platform/proc-operator-link-components.adoc
@@ -1,0 +1,3 @@
+[id="operator-link-components_{context}"]
+
+= Linking your components to AnsibleAutomationPlatform  


### PR DESCRIPTION
[AAP-20941](https://issues.redhat.com/browse/AAP-20941)

Tech review is still ongoing for this request, but adding in Assembly and modules now so I can hit the ground running next week. 

doc location: downstream > titles > aap-operator-installation

doc titles:
- assembly-operator-deploy-gateway.adoc
- proc-operator-link-components.adoc
- proc-operator-access-aap.adoc
- proc-operator-aap-troubleshooting.adoc