### PR TITLE
Removing AAP acronyms

### DIFF
--- a/downstream/archive/archived-modules/platform/ref-network-ports-protocols.adoc
+++ b/downstream/archive/archived-modules/platform/ref-network-ports-protocols.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 
-{PlatformName} (AAP) uses several ports to communicate with its services. These ports must be open and available for incoming connections to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
+{PlatformName} uses several ports to communicate with its services. These ports must be open and available for incoming connections to the {PlatformName} server in order for it to work. Ensure that these ports are available and are not being blocked by the server firewall.
 
 The following tables show the default {PlatformName} destination ports required for each application.
 


### PR DESCRIPTION
Removing the incorrect use of AAP acroynms from "ref-network-ports-protocols.adoc"