### PR TITLE
2.4 Add boilerplate module (#1426)

### DIFF
--- a/downstream/aap-common/boilerplate.adoc
+++ b/downstream/aap-common/boilerplate.adoc
@@ -1,0 +1,4 @@
+// Removing the following module from AAP docs front matter because the
+// docs.redhat.com site already includes a similar statement.
+// include::making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::{DocumentationFeedback}[leveloffset=+1]

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -149,7 +149,8 @@
 :SettingsIcon: &#9881;
 
 // Feedback module
-:DocumentationFeedback: aap-common/providing-feedback.adoc
+:DocumentationFeedback: providing-feedback.adoc
+:Boilerplate: aap-common/boilerplate.adoc
 
 // Linux platforms
 :RHEL: Red Hat Enterprise Linux

--- a/downstream/titles/aap-containerized-install/master.adoc
+++ b/downstream/titles/aap-containerized-install/master.adoc
@@ -8,7 +8,6 @@ include::attributes/attributes.adoc[]
 // Book Title
 = Containerized Ansible Automation Platform Installation Guide
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-aap-containerized-installation.adoc[leveloffset=+1]

--- a/downstream/titles/aap-hardening/master.adoc
+++ b/downstream/titles/aap-hardening/master.adoc
@@ -12,8 +12,7 @@ include::attributes/attributes.adoc[]
 
 This guide provides recommended practices for various processes needed to install, configure, and maintain {PlatformNameShort} on Red Hat Enterprise Linux in a secure manner.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 include::aap-hardening/assembly-intro-to-aap-hardening.adoc[leveloffset=+1]
 include::aap-hardening/assembly-hardening-aap.adoc[leveloffset=+1]
 // include::aap-hardening/assembly-aap-compliance.adoc[leveloffset=+1]

--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -6,7 +6,6 @@
 
 include::attributes/attributes.adoc[]
 
-
 // Book Title
 = {PlatformName} Installation Guide
 
@@ -14,8 +13,7 @@ Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commerci
 
 This guide helps you to understand the installation requirements and processes behind installing {PlatformNameShort}. This document has been updated to include information for the latest release of {PlatformNameShort}.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 //12/2/22 [dcd: moved following assembly to new planning guide]
 //include::platform/assembly-planning-installation.adoc[leveloffset=+1]

--- a/downstream/titles/aap-operations-guide/master.adoc
+++ b/downstream/titles/aap-operations-guide/master.adoc
@@ -12,8 +12,7 @@ include::attributes/attributes.adoc[]
 
 After installing Red Hat Ansible Automation Platform, your system might need extra configuration to ensure your deployment runs smoothly. This guide provides procedures for configuration tasks that you can perform after installing {PlatformName}.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 include::platform/assembly-aap-activate.adoc[leveloffset=+1]
 include::platform/assembly-aap-manifest-files.adoc[leveloffset=+1]
 //ifowler assembly transferred from installation guide as part of AAP-18700

--- a/downstream/titles/aap-operator-backup/master.adoc
+++ b/downstream/titles/aap-operator-backup/master.adoc
@@ -15,8 +15,7 @@ Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commerci
 Use the procedures in this guide to create backup resources that can be used for recovering your {PlatformName} deployment in the event of a failure.
 
 //Downstream only content
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-aap-backup-recovery.adoc[leveloffset=+1]
 

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -15,8 +15,7 @@ Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commerci
 
 This guide helps you to understand the installation, migration and upgrade requirements for deploying the {OperatorPlatform} on {OCPShort}.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-operator-install-planning.adoc[leveloffset=+1]
 

--- a/downstream/titles/aap-planning-guide/master.adoc
+++ b/downstream/titles/aap-planning-guide/master.adoc
@@ -14,8 +14,7 @@ Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commerci
 
 Use the information in this guide to plan your {PlatformName} installation.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 include::platform/assembly-planning-installation.adoc[leveloffset=+1]
 include::platform/assembly-aap-architecture.adoc[leveloffset=+1]
 include::platform/assembly-aap-platform-components.adoc[leveloffset=+1]

--- a/downstream/titles/analytics/automation-savings-planner/master.adoc
+++ b/downstream/titles/analytics/automation-savings-planner/master.adoc
@@ -10,8 +10,7 @@ include::attributes/attributes.adoc[]
 = Planning your automation jobs using the automation savings planner
 
 //Downstream only content
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 // Contents
 include::analytics/assembly-automation-savings-planner.adoc[leveloffset=+1]

--- a/downstream/titles/analytics/automation-savings/master.adoc
+++ b/downstream/titles/analytics/automation-savings/master.adoc
@@ -12,8 +12,7 @@ include::attributes/attributes.adoc[]
 = Using the Automation Calculator
 
 //Downstream only content
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 // Contents
 include::analytics/assembly-evaluating-automation-return.adoc[leveloffset=+1]

--- a/downstream/titles/analytics/job-explorer/master.adoc
+++ b/downstream/titles/analytics/job-explorer/master.adoc
@@ -9,8 +9,7 @@ include::attributes/attributes.adoc[]
 [[analytics_automation_savings]]
 = Evaluating your Automation controller job runs using the Job Explorer
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 // Contents
 include::analytics/assembly-using-job-explorer.adoc[leveloffset=+1]

--- a/downstream/titles/analytics/reports/master.adoc
+++ b/downstream/titles/analytics/reports/master.adoc
@@ -8,8 +8,7 @@ include::attributes/attributes.adoc[]
 [[insights_reports]]
 = Viewing reports about your Ansible automation environment
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 // Contents
 include::analytics/assembly-insights-reports.adoc[leveloffset=+1]

--- a/downstream/titles/automation-mesh/master.adoc
+++ b/downstream/titles/automation-mesh/master.adoc
@@ -17,8 +17,7 @@ Thank you for your interest in {PlatformName}.
 This guide helps you to understand the requirements and processes behind setting up an automation mesh on a VM-based installation of {PlatformName}. 
 This document has been updated to include information for the latest release of {PlatformNameShort}.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-planning-mesh.adoc[leveloffset=+1]
 

--- a/downstream/titles/builder/master.adoc
+++ b/downstream/titles/builder/master.adoc
@@ -11,8 +11,7 @@ include::attributes/attributes.adoc[]
 
 Use {Builder} to create consistent and reproducible {ExecEnvName} for your {PlatformName} needs.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::builder/assembly-intro-to-builder.adoc[leveloffset=+1]
 include::builder/assembly-using-builder.adoc[leveloffset=+1]

--- a/downstream/titles/central-auth/master.adoc
+++ b/downstream/titles/central-auth/master.adoc
@@ -11,8 +11,7 @@ include::attributes/attributes.adoc[]
 
 {AAPCentralAuth} is a third-party identity provider (idP) solution, allowing for a simplified single sign-on solution that can be used across the {PlatformNameShort}. Platform administrators can utilize {CentralAuth} to test connectivity and authentication, as well as onboard new users and manage user permissions by configuring and assigning them to groups. Along with OpenID Connect-based and LDAP support, {CentralAuth} also provides a supported REST API which can be used to bootstrap customer usage.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::central-auth/assembly-central-auth-hub.adoc[leveloffset=+1]
 include::central-auth/assembly-central-auth-add-user-storage.adoc[leveloffset=+1]

--- a/downstream/titles/controller/controller-admin-guide/master.adoc
+++ b/downstream/titles/controller/controller-admin-guide/master.adoc
@@ -14,8 +14,7 @@ include::attributes/attributes.adoc[]
 The {ControllerName} Administration Guide describes the administration of {ControllerName} through custom scripts, management jobs, and more. 
 Written for DevOps engineers and administrators, the {ControllerName} Administration Guide assumes a basic understanding of the systems requiring management with {ControllerName}s easy-to-use graphical interface. 
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-controller-licensing.adoc[leveloffset=+1]
 include::platform/assembly-ag-controller-start-stop-controller.adoc[leveloffset=+1]

--- a/downstream/titles/controller/controller-api-overview/master.adoc
+++ b/downstream/titles/controller/controller-api-overview/master.adoc
@@ -15,8 +15,7 @@ Thank you for your interest in {PlatformName}.
 
 The {ControllerName} API Overview focuses on helping you understand the {ControllerName} API.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-controller-api-tools.adoc[leveloffset=+1]
 include::platform/assembly-controller-api-browsing-api.adoc[leveloffset=+1]

--- a/downstream/titles/controller/controller-getting-started/master.adoc
+++ b/downstream/titles/controller/controller-getting-started/master.adoc
@@ -24,8 +24,7 @@ These subscriptions vary in price and support-levels.
 For more information about subscriptions and features, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_user_guide/index#ref-controller-subscription-types[Subscription Types].
 ====
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-controller-login.adoc[leveloffset=+1]
 include::platform/assembly-controller-managing-subscriptions.adoc[leveloffset=+1]

--- a/downstream/titles/controller/controller-user-guide/master.adoc
+++ b/downstream/titles/controller/controller-user-guide/master.adoc
@@ -18,8 +18,7 @@ The {ControllerNameStart} User Guide describes all of the functionality availabl
 It assumes moderate familiarity with Ansible, including concepts such as playbooks, variables, and tags.
 For more information about these and other Ansible concepts, see the link:https://docs.ansible.com/[Ansible documentation].
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-UG-overview.adoc[leveloffset=+1]
 include::platform/assembly-controller-licensing.adoc[leveloffset=+1]

--- a/downstream/titles/dev-guide/master.adoc
+++ b/downstream/titles/dev-guide/master.adoc
@@ -9,8 +9,7 @@ include::attributes/attributes.adoc[]
 // Book Title
 = {PlatformName} Creator Guide
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 == Preface
 

--- a/downstream/titles/develop-automation-content/master.adoc
+++ b/downstream/titles/develop-automation-content/master.adoc
@@ -14,8 +14,7 @@ Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commerci
 This guide describes how to develop Ansible automation content and how to use it to run automation jobs from {PlatformName}.
 This document has been updated to include information for the latest release of {PlatformNameShort}.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::devtools/assembly-devtools-intro.adoc[leveloffset=+1]
 include::devtools/assembly-developer-workflow.adoc[leveloffset=+1]

--- a/downstream/titles/eda/eda-getting-started-guide/master.adoc
+++ b/downstream/titles/eda/eda-getting-started-guide/master.adoc
@@ -15,8 +15,7 @@ Thank you for your interest in {EDAname}. {EDAname} is a new way to enhance and 
 
 This guide provides the conceptual framework of {EDAname} and links you to information on installing and using {EDAcontroller}.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::eda/assembly-about-event-driven-ansible-automation.adoc[leveloffset=+1]
 include::eda/assembly-ansible-rulebooks.adoc[leveloffset=+1]

--- a/downstream/titles/eda/eda-user-guide/master.adoc
+++ b/downstream/titles/eda/eda-user-guide/master.adoc
@@ -11,8 +11,7 @@ include::attributes/attributes.adoc[]
 {EDAcontroller} is a new way to enhance and expand automation by improving IT speed and agility while enabling consistency and resilience. 
 Developed by Red Hat, this feature is designed for simplicity and flexibility. 
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 include::eda/assembly-eda-user-guide-overview.adoc[leveloffset=+1]
 include::eda/assembly-eda-credentials.adoc[leveloffset=+1]
 include::eda/assembly-eda-projects.adoc[leveloffset=+1]

--- a/downstream/titles/hub/getting-started/master.adoc
+++ b/downstream/titles/hub/getting-started/master.adoc
@@ -15,8 +15,7 @@ Red Hat Ansible {HubName} provides a place for Red Hat subscribers to quickly fi
 The {Galaxy} client, `ansible-galaxy`, manages roles and collections from the command line.
 To ensure that the `ansible-galaxy` client uses certified, supported Ansible collections whenever possible, update your `ansible.cfg` file to use Red Hat {HubName} as your primary source of Ansible collections.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::hub/assembly-hub-overview.adoc[leveloffset=+1]
 include::hub/assembly-hub-create-api-token.adoc[leveloffset=+1]

--- a/downstream/titles/hub/managing-content/master.adoc
+++ b/downstream/titles/hub/managing-content/master.adoc
@@ -7,8 +7,7 @@ include::attributes/attributes.adoc[]
 = Managing content in automation hub
 
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::hub/assembly-managing-cert-valid-content.adoc[leveloffset=+1]
 

--- a/downstream/titles/navigator-guide/master.adoc
+++ b/downstream/titles/navigator-guide/master.adoc
@@ -9,8 +9,7 @@ include::attributes/attributes.adoc[]
 // Book Title
 = Automation Content Navigator Creator Guide
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::navigator/assembly-intro-navigator.adoc[leveloffset=+1]
 include::navigator/assembly-installing-on-rhel.adoc[leveloffset=+1]

--- a/downstream/titles/ocp_performance_guide/master.adoc
+++ b/downstream/titles/ocp_performance_guide/master.adoc
@@ -19,8 +19,7 @@ Although application and operator developers can provide many options to {OCPSho
 For example, use of node labels in the Openshift cluster can help ensure different workloads are run on specific nodes. 
 This type of configuration must be provided by the user as the {PlatformNameShort} Operator has no way of inferring this.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-pod-spec-modifications.adoc[leveloffset=+1]
 include::platform/assembly-control-plane-adjustments.adoc[leveloffset=+1]

--- a/downstream/titles/operator-mesh/master.adoc
+++ b/downstream/titles/operator-mesh/master.adoc
@@ -16,8 +16,7 @@ Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commerci
 This guide helps you to understand the requirements and processes behind setting up an automation mesh on a operator-based installation of {PlatformName}. 
 This document has been updated to include information for the latest release of {PlatformNameShort}.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-planning-mesh.adoc[leveloffset=+1]
 

--- a/downstream/titles/playbooks/playbooks-getting-started/master.adoc
+++ b/downstream/titles/playbooks/playbooks-getting-started/master.adoc
@@ -14,8 +14,7 @@ Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commerci
 
 This guide provides an introduction to the use of Ansible Playbooks..
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 //include::playbooks/assembly-playbook-gs.adoc[leveloffset=+1]
 include::playbooks/assembly-intro-to-playbooks.adoc[leveloffset=+1]

--- a/downstream/titles/playbooks/playbooks-reference/master.adoc
+++ b/downstream/titles/playbooks/playbooks-reference/master.adoc
@@ -14,7 +14,6 @@ Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commerci
 
 This guide provides a reference for the differing approaches to the creating of Ansible playbooks.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::playbooks/assembly-reference-test.adoc[leveloffset=+1]

--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -4,9 +4,8 @@ include::attributes/attributes.adoc[]
 
 = {PlatformName} Release Notes
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::topics/platform-intro.adoc[leveloffset=+1]
 

--- a/downstream/titles/security-guide/master.adoc
+++ b/downstream/titles/security-guide/master.adoc
@@ -9,8 +9,7 @@ include::attributes/attributes.adoc[]
 // Book Title
 = Red Hat Ansible Security Automation Guide
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::security/assembly-firewall-policy-manage.adoc[leveloffset=+1]
 

--- a/downstream/titles/troubleshooting-aap/master.adoc
+++ b/downstream/titles/troubleshooting-aap/master.adoc
@@ -10,8 +10,7 @@ include::attributes/attributes.adoc[]
 
 Use the Troubleshooting {PlatformNameShort} guide to troubleshoot your {PlatformNameShort} installation.
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::troubleshooting-aap/assembly-diagnosing-the-problem.adoc[leveloffset=+1]
 include::troubleshooting-aap/assembly-troubleshoot-controller.adoc[leveloffset=+1]

--- a/downstream/titles/upgrade/master.adoc
+++ b/downstream/titles/upgrade/master.adoc
@@ -8,8 +8,7 @@ include::attributes/attributes.adoc[]
 // Book Title
 = Red Hat Ansible Automation Platform Upgrade and Migration Guide
 
-include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
-include::{DocumentationFeedback}[leveloffset=+1]
+include::{Boilerplate}[]
 
 include::platform/assembly-aap-upgrades.adoc[leveloffset=+1]
 include::platform/assembly-aap-upgrading-platform.adoc[leveloffset=+1]


### PR DESCRIPTION
Create a boilerplate module that contains the front matter for all AAP docs,
so that
we can edit this content in one place and have it replicated in all docs.