### PR TITLE
Add 2.4-7 bundle installer release to release notes

### DIFF
--- a/downstream/templates/installer-rn-template.adoc
+++ b/downstream/templates/installer-rn-template.adoc
@@ -2,9 +2,9 @@
 
 [id="installer-xx-xx"]
 
-= RHSA-XXXX:XXXX - bundle installer release x.x-x - <month date, year>
+= RHBA-XXXX:XXXX - bundle installer release x.x-x - <month date, year>
 
-link:https://access.redhat.com/errata/<errata advisory link>[RHSA-XXXX:XXXX]
+link:https://access.redhat.com/errata/<errata advisory link>[RHBA-XXXX:XXXX]
 
 == Related RPM releases
 

--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -41,6 +41,10 @@ include::topics/rpm-24-2.adoc[leveloffset=+3]
 
 === Installer releases
 
+include::topics/installer-version-table.adoc[leveloffset=+3]
+
+include::topics/installer-24-7.adoc[leveloffset=+3]
+
 include::topics/installer-24-62.adoc[leveloffset=+3]
 
 include::topics/installer-24-61.adoc[leveloffset=+3]

--- a/downstream/titles/release-notes/topics/installer-24-7.adoc
+++ b/downstream/titles/release-notes/topics/installer-24-7.adoc
@@ -1,0 +1,15 @@
+// This is the release notes for 2.4-7 bundle installer release
+
+[id="installer-24-7"]
+
+= RHBA-2024:3871 - bundle installer release 2.4-7 - June 12, 2024
+
+link:https://access.redhat.com/errata/RHBA-2024:3871[RHBA-2024:3871]
+
+== Related RPM releases
+
+* xref:rpm-24-7[RHSA-2024:3781 - Security Advisory - June 10, 2024]
+
+== Related container releases
+
+* link:https://access.redhat.com/errata/RHBA-2024:3782[RHBA-2024:3782 - Bug Fix Advisory - June 10, 2024]

--- a/downstream/titles/release-notes/topics/installer-version-table.adoc
+++ b/downstream/titles/release-notes/topics/installer-version-table.adoc
@@ -1,0 +1,17 @@
+// This table contains the component/package versions per bundle installer release 
+
+.Component versions per installation bundle
+//cols="a,a" formats the columns as AsciiDoc allowing for AsciiDoc syntax
+[cols="2a,3a", options="header"]
+|===
+| Installation bundle | Component versions
+
+| xref:installer-24-7[2.4-7] + 
+June 12, 2024  | 
+* `ansible-automation-platform-setup` 2.4-7
+* `ansible-core` 2.15.11
+* {ControllerNameStart} 4.5.7
+* {HubNameStart} 4.9.2
+* {EDAName} 1.0.7
+
+|===

--- a/downstream/titles/release-notes/topics/rpm-version-table.adoc
+++ b/downstream/titles/release-notes/topics/rpm-version-table.adoc
@@ -2,7 +2,7 @@
 
 .Component versions per errata advisory
 //cols="a,a" formats the columns as AsciiDoc allowing for AsciiDoc syntax
-[cols="a,a",options="header"]
+[cols="2a,3a", options="header"]
 |===
 | Errata advisory | Component versions
 


### PR DESCRIPTION
2.4 Release Notes - AAP 2.4-7 Bundle installer release

https://issues.redhat.com/browse/AAP-24793