### PR TITLE
Update CVE python packages to include each version

### DIFF
--- a/downstream/titles/release-notes/topics/rpm-24-7.adoc
+++ b/downstream/titles/release-notes/topics/rpm-24-7.adoc
@@ -20,55 +20,55 @@ With this update, the following CVEs have been addressed:
 ** Packages updated: `receptor: golang: net/http`.
 //AAP-19153 & AAP-19156
 * link:https://access.redhat.com/security/cve/CVE-2023-49083[CVE-2023-49083] - null-pointer dereference when loading PKCS7 certificates.
-** Packages updated: `python-cryptography` and `python3x-cryptography: python-cryptography`.
+** Packages updated: `python3-cryptography` and `python39-cryptography`.
 //AAP-19723 
 * link:https://access.redhat.com/security/cve/CVE-2023-50447[CVE-2023-50447] - arbitrary code execution with the environment parameter.
-** Packages updated: `python-pillow: pillow`.
+** Packages updated: `python3-pillow` and `python39-pillow`.
 //AAP-22945 
 * link:https://access.redhat.com/security/cve/CVE-2024-1135[CVE-2024-1135] - HTTP Request Smuggling due to improper validation of Transfer-Encoding headers.
-** Packages updated: `python-gunicorn`.
+** Packages updated: `python3-gunicorn` and `python39-gunicorn`.
 //AAP-21885 & AAP-21886 
 * link:https://access.redhat.com/security/cve/CVE-2024-21503[CVE-2024-21503] - regular expression denial of service (ReDoS) with the `lines_with_leading_tabs_expanded()` function within the `strings.py` file.
-** Packages updated: `python-black: psf/black` and `python3x-black: psf/black`.
+** Packages updated: `python3-black` and `python39-black`.
 //AAP-21552 
 * link:https://access.redhat.com/security/cve/CVE-2024-24783[CVE-2024-24783] - verify panics on certificates with an unknown public key algorithm.
 ** Packages updated: `receptor: golang: crypto/x509`.
 //AAP-21823 
 * link:https://access.redhat.com/security/cve/CVE-2024-26130[CVE-2024-26130] - NULL pointer dereference with `pkcs12.serialize_key_and_certificates` when called with a non-matching certificate and private key and an `hmac_hash` override.
-** Packages updated: `python-cryptography`.
+** Packages updated: `python3-cryptography` and `python39-cryptography`.
 //AAP-23106 & AAP-23269
 * link:https://access.redhat.com/security/cve/CVE-2024-27306[CVE-2024-27306] - cross-site scripting (XSS) on index pages for static file handling.
-** Packages updated: `python-aiohttp: aiohttp` and `python3x-aiohttp: aiohttp`.
+** Packages updated: `python3-aiohttp` and `python39-aiohttp`.
 //AAP-21133 
 * link:https://access.redhat.com/security/cve/CVE-2024-27351[CVE-2024-27351] - potential ReDoS in `django.utils.text.Truncator.words()`.
-** Packages updated: `automation-controller: python-django`.
+** Packages updated: `automation-controller: Django`.
 //AAP-22332 
 * link:https://access.redhat.com/security/cve/CVE-2024-28219[CVE-2024-28219] - buffer overflow in `_imagingcms.c`.
-** Packages updated: `python-pillow`.
+** Packages updated: `python3-pillow` and `python39-pillow`.
 //AAP-21817 & AAP-21818 & AAP-21816
 * link:https://access.redhat.com/security/cve/CVE-2024-28849[CVE-2024-28849] - possible credential leak.
-** Packages updated: `python-galaxy-ng: follow-redirects`, `python3x-galaxy-ng: follow-redirects`, and `automation-hub: follow-redirects`.
+** Packages updated: `python3-galaxy-ng: follow-redirects`, `python39-galaxy-ng: follow-redirects`, and `automation-hub: follow-redirects`.
 //AAP-23660 & AAP-23653
 * link:https://access.redhat.com/security/cve/CVE-2024-30251[CVE-2024-30251] - DoS when trying to parse malformed POST requests. 
-** Packages updated: `python-aiohttp: aiohttp` and `automation-controller: aiohttp`.
+** Packages updated: `python3-aiohttp`, `python39-aiohttp`, and `automation-controller: aiohttp`.
 //AAP-23393 & AAP-23394
 * link:https://access.redhat.com/security/cve/CVE-2024-32879[CVE-2024-32879] - improper handling of case sensitivity in `social-auth-app-django`.
-** Packages updated: `python-social-auth-app-django: python-social-auth` and `python3x-social-auth-app-django: python-social-auth`.
+** Packages updated: `python3-social-auth-app-django` and `python39-social-auth-app-django`.
 //AAP-23795 & AAP-23797
 * link:https://access.redhat.com/security/cve/CVE-2024-34064[CVE-2024-34064] - `xmlattr` filter accepts keys containing non-attribute characters.
-** Packages updated: `python-jinja2: jinja2` and `python3x-jinja2: jinja2`.
+** Packages updated: `python3-jinja2` and `python39-jinja2`.
 //AAP-24453 
 * link:https://access.redhat.com/security/cve/CVE-2024-35195[CVE-2024-35195] - additional requests to the same host ignore cert verification.
-** Packages updated: `python-requests: requests`.
+** Packages updated: `python3-requests` and `python39-requests`.
 //AAP-22832 
 * link:https://access.redhat.com/security/cve/CVE-2024-3651[CVE-2024-3651] - potential DoS with resource consumption through specially crafted inputs to `idna.encode()`.
-** Packages updated: `python-idna`.
+** Packages updated: `python3-idna` and `python39-idna`.
 //AAP-22858 & AAP-22857 & AAP-22856
 * link:https://access.redhat.com/security/cve/CVE-2024-3772[CVE-2024-3772] - ReDoS with a crafted email string.
-** Packages updated: `python-pydantic`, `python3x-pydantic: python-pydantic`, and `automation-controller: python-pydantic`.
+** Packages updated: `python3-pydantic`, `python39-pydantic`, and `automation-controller: python-pydantic`.
 //AAP-23574 & AAP-24423
 * link:https://access.redhat.com/security/cve/CVE-2024-4340[CVE-2024-4340] - parsing a heavily nested list leads to a DoS.
-** Packages updated: `python-sqlparse: sqlparse` and `python3x-sqlparse: sqlparse`.
+** Packages updated: `python3-sqlparse` and `python39-sqlparse`.
 //AAP-18435 
 * link:https://access.redhat.com/security/cve/CVE-2023-5752[CVE-2023-5752] - Mercurial configuration injection in repository revision when installing with `pip`.
 ** Packages updated: `automation-controller: pip`.


### PR DESCRIPTION
2.4 Release Notes - AAP 2.4-7 Bundle installer release

https://issues.redhat.com/browse/AAP-24793