### PR TITLE
Fixed mismatch in docinfo and master

### DIFF
--- a/downstream/titles/aap-planning-guide/master.adoc
+++ b/downstream/titles/aap-planning-guide/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Ansible Automation Platform planning guide
+= Red Hat Ansible Automation Platform planning guide
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multitiered deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/ocp_performance_guide/docinfo.xml
+++ b/downstream/titles/ocp_performance_guide/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Red Hat Ansible Automation Platform performance considerations for operator-based installations</title>
+<title>Red Hat Ansible Automation Platform performance considerations for operator based installations</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.4</productnumber>
 <subtitle>

--- a/downstream/titles/ocp_performance_guide/master.adoc
+++ b/downstream/titles/ocp_performance_guide/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 :context: ocp-performance
 
 // Book Title
-= Red Hat Ansible Automation Platform performance considerations for operator-based installations
+= Red Hat Ansible Automation Platform performance considerations for operator based installations
 
 Deploying applications to a container orchestration platform such as {OCP} provides a number of advantages from an operational perspective.
 For example, an update to the base image of an application can be made through a simple in-place upgrade with little to no disruption.


### PR DESCRIPTION
Fixing a mismatch between master.adoc and docinfo.xml and removing the dash in operator-based because it's causing issues with Pantheon. 