### PR TITLE
Fix title issue in AAP install guide

### DIFF
--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -7,7 +7,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Ansible Automation Platform installation guide
+= Red Hat Ansible Automation Platform installation guide
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 


### PR DESCRIPTION
This PR fixes a mismatch between the master.adoc and docinfo.xml file in the installation guide. 