### PR TITLE
Typo-fix

### DIFF
--- a/stories/topics/proc-saas-set-up-public.adoc
+++ b/stories/topics/proc-saas-set-up-public.adoc
@@ -12,7 +12,7 @@ As an AWS customer you can search for and subscribe to {SaaSonAWS} from the AWS 
 . In the search bar, search for "{SaaSonAWS}." 
 ** Depending on your region select one of the following: 
 *** For EMEA, select *Red{nbsp}Hat Limited*.
-*** For the rest of world, select *Red{nbsp}Hat*.
+*** For the rest of the world, select *Red{nbsp}Hat*.
 . Click btn:[View purchase options].
 . Select your desired contract duration.
 . Click btn:[auto renewal settings] if you would like your contract to auto renew.


### PR DESCRIPTION
Missing the article "the" 

aap-docs > aap-clouds-latest > stories > proc-saas-set-up-public.adoc