### PR TITLE
AAP-20958 Lightspeed Set grandparent-context for assembly with nesting

### DIFF
--- a/lightspeed/assemblies/assembly_setting-up-lightspeed.adoc
+++ b/lightspeed/assemblies/assembly_setting-up-lightspeed.adoc
@@ -1,3 +1,8 @@
+// This assembly contains nested assemblies.
+// Store the value of context as grandparent-context because
+// the nested assemblies will change the value of parent-context.
+ifdef::context[:grandparent-context: {context}]
+//
 ifdef::context[:parent-context: {context}]
 
 :_content-type: ASSEMBLY
@@ -17,6 +22,11 @@ include::modules/con_wca-key-model-id.adoc[leveloffset=+1]
 include::assembly_configure-code-assistant.adoc[leveloffset=+1]
 include::assembly_configuring-lightspeed-onpremise.adoc[leveloffset=+1]
 include::assembly_configuring-custom-models.adoc[leveloffset=+1]
+
+// The nested assemblies use this current assembly as their parent,
+// so the value of parent-context was changed.
+// Reset the value of parent-context to the parent of this assembly, ie grandparent-context.
+ifdef::grandparent-context[:parent-context: {grandparent-context}]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
AAP-20958 Lightspeed Set `grandparent-context` value for assembly that contains nested assemblies.

When an assembly contains nested assemblies, the `parent-context` variable is set by the nested assemblies.
After the nested assemblies, you need to restore the context to the original `parent-context` (ie the value before the nesting).
This PR does this by creating a variable called `grandparent-context`.