### PR TITLE
AAP-25663: Update IBM WCA on-premise doc links in Lightspeed on-premise docs

### DIFF
--- a/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
+++ b/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
@@ -28,7 +28,7 @@ To see the rest of the {PlatformName} system requirements, see _Chapter 4. Syste
 
 [NOTE]
 ====
-You must also have a trial or paid subscription to {ibmwatsonxcodeassistant}, and have a model in the {ibmwatsonxcodeassistant} deployment space. For information about creating a {ibmwatsonxcodeassistant} model, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation].
+You must also have a trial or paid subscription to {ibmwatsonxcodeassistant}, and have a model in the {ibmwatsonxcodeassistant} deployment space. For information about creating a {ibmwatsonxcodeassistant} model, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/en/cloud-paks/cp-data/5.0.x?topic=services-watsonx-code-assistant-red-hat-ansible-lightspeed[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation]. 
 ====
 
 == Prerequisites
@@ -41,7 +41,7 @@ You must also have a trial or paid subscription to {ibmwatsonxcodeassistant}, an
 
 * You have obtained an API key and a model ID from {ibmwatsonxcodeassistant}. 
 +
-For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation].
+For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/en/cloud-paks/cp-data/5.0.x?topic=services-watsonx-code-assistant-red-hat-ansible-lightspeed[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
 
 * You have an existing external PostgreSQL database configured for the {PlatformName}, or have a database created for you when configuring the {LightspeedshortName} on-premise deployment. 
 

--- a/lightspeed/modules/proc_create-connection-secrets.adoc
+++ b/lightspeed/modules/proc_create-connection-secrets.adoc
@@ -11,7 +11,7 @@ Use this procedure to create secrets to connect to {PlatformName} and {ibmwatson
 * You have created an OAuth application in the {ControllerName}.
 * You have obtained an API key and a model ID from {ibmwatsonxcodeassistant}. 
 +
-For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation].
+For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/en/cloud-paks/cp-data/5.0.x?topic=services-watsonx-code-assistant-red-hat-ansible-lightspeed[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
 
 .Procedure
 . Go to the {OCP}. 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-25663.

Changes made:
IBM released its WCA on-premise docs yesterday. In this PR, I'm adding the relevant WCA on-premise doc links to Red Hat Ansible Lightspeed on-premise deployment docs. 