### PR TITLE
Updated system requirements for planning guide. Updated attributes fi…

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -8,7 +8,7 @@
 :CentralAuth: central authentication
 :PlatformVers: 2.5
 //The Ansible-core version required to install AAP
-:CoreInstVers: 2.14
+:CoreInstVers: 2.15
 //The Ansible-core version used by the AAP control plane and EEs
 :CoreUseVers: 2.15
 :PlatformDownloadUrl: https://access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.4/x86_64/product-software

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -14,15 +14,19 @@ Your system must meet the following minimum system requirements to install and r
 
 h| Subscription | Valid {PlatformName} |
 
-h| OS | {RHEL} 8.6 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
+h| OS | {RHEL} 8.8 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
 h| Ansible-core | Ansible-core version {CoreInstVers} or later | {PlatformNameShort} includes execution environments that contain ansible-core {CoreUseVers}.
 
-h| Python | 3.9 or later |
+h| Python | 3.11 or later |
 
 h| Browser | A currently supported version of Mozilla FireFox or Google Chrome |
 
-h| Database | PostgreSQL version 13 |
+h| Database | PostgreSQL version 15 |
+
+h| RAM  | 16 GB minimum |
+
+h| CPUs | 4 |
 |===
 
 The following are necessary for you to work with project updates and collections:


### PR DESCRIPTION
…le. (#1478)

These changes are for AAP-22715 to update the system requirements for the Planning Guide.

A change has also been made to the 'attributes.adoc' file to update {CoreInstVers} from 2.14 to 2.15 to concide with the new system requirments for 2.5 EA.

Resolves: AAP-22715
Also Resolves: AAP-22628