### PR TITLE
Adding proc content (AAP-22718)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-backup.adoc
+++ b/downstream/assemblies/platform/assembly-aap-backup.adoc
@@ -9,7 +9,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-Backing up your {PlatformName} deployment involves creating backup resources for your deployed instances. Use these procedures to create backup resources for your {PlatformName} deployment.
+Backing up your {PlatformName} deployment involves creating backup resources for your deployed instances. Use the following procedures to create backup resources for your {PlatformName} deployment.
 
 //part of 2.5 release, (AAP-22178) uncomment when publishing [gmurray]
 //include::platform/proc-aap-platform-gateway-backup.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-aap-backup.adoc
+++ b/downstream/assemblies/platform/assembly-aap-backup.adoc
@@ -9,10 +9,10 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-Backing up your {PlatformName} deployment involves creating backup resources for your deployed {HubName} and {ControllerName} instances. Use these procedures to create backup resources for your {PlatformName} deployment.
+Backing up your {PlatformName} deployment involves creating backup resources for your deployed instances. Use these procedures to create backup resources for your {PlatformName} deployment.
 
 //part of 2.5 release, (AAP-22178) uncomment when publishing [gmurray]
-include::platform/proc-aap-platform-gateway-backup.adoc[leveloffset=+1]
+//include::platform/proc-aap-platform-gateway-backup.adoc[leveloffset=+1]
 
 include::platform/proc-aap-controller-backup.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-aap-recovery.adoc
+++ b/downstream/assemblies/platform/assembly-aap-recovery.adoc
@@ -7,7 +7,8 @@ ifdef::context[:parent-context: {context}]
 :context: aap-recovery
 
 [role="_abstract"]
-If you lose information on your system or issues with an upgrade, you can use the backup resources of your deployment instances. Use these procedures to recover your {ControllerName} and {HubName} deployment files.
+If you lose information on your system or experience issues with an upgrade, you can use the backup resources of your deployment instances. Use these procedures to recover your {PlatformNameShort} deployment files.
+
 //part of 2.5 release, (AAP-22178) uncomment when publishing [gmurray]
 //include::platform/proc-aap-platform-gateway-restore.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-aap-recovery.adoc
+++ b/downstream/assemblies/platform/assembly-aap-recovery.adoc
@@ -7,7 +7,7 @@ ifdef::context[:parent-context: {context}]
 :context: aap-recovery
 
 [role="_abstract"]
-If you lose information on your system or experience issues with an upgrade, you can use the backup resources of your deployment instances. Use these procedures to recover your {PlatformNameShort} deployment files.
+If you lose information on your system or experience issues with an upgrade, you can use the backup resources of your deployment instances. Use the following procedures to recover your {PlatformNameShort} deployment files.
 
 //part of 2.5 release, (AAP-22178) uncomment when publishing [gmurray]
 //include::platform/proc-aap-platform-gateway-restore.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-aap-platform-gateway-backup.adoc
+++ b/downstream/modules/platform/proc-aap-platform-gateway-backup.adoc
@@ -4,21 +4,21 @@
 Regularly backing up your *AnsibleAutomationPlatform* deployment is vital to protect against unexpected data loss and application errors. *AnsibleAutomationPlatform* hosts any enabled components (such as, {ControllerName}, {HubName}, {EDAName}, and {LightspeedShortName}), when you back up *AnsibleAutomationPlatform* you also back up these components.
 
 .Prerequisites
-* You must be authenticated with an Openshift cluster.
-* The {OperatorPlatform} has been installed to the cluster.
+* You must be authenticated on Openshift cluster.
+* The {OperatorPlatform} has been installed on the cluster.
 * The *AnsibleAutomationPlatform* instance is deployed using the {OperatorPlatform}.
 
 .Procedure 
 . Log in to {OCP}.
 . Go to menu:Operators[Installed Operators].
 . Select the {OperatorPlatform} installed on your project namespace.
-. Go to your btn:[All Instances] tab, and click btn:[Create New].
+. Go to your *All Instances* tab, and click btn:[Create New].
 . Select *Ansible Automation Platform Backup* from the list.
 +
-NOTE: When creating the *Ansible Automation Platform Backup* resource it will also create backup resources for each of the nested components that are enabled.
+NOTE: When creating the *Ansible Automation Platform Backup* resource it also creates backup resources for each of the nested components that are enabled.
 +
-. For *Name* enter a name for the backup.
-. For *Deployment name* enter the name of the deployed {PlatformNameShort} instance being backed up. For example if your {PlatformNameShort} deployment must be backed up and the deployment name is myaap, enter 'myaap' in the *Deployment name* field.
+. In the *Name* field, enter a name for the backup.
+. In the *Deployment name* field, enter the name of the deployed {PlatformNameShort} instance being backed up. For example if your {PlatformNameShort} deployment must be backed up and the deployment name is myaap, enter 'myaap' in the *Deployment name* field.
 . Click btn:[Create].
 
 .Verification 
@@ -27,7 +27,7 @@ To verify that your backup was successful you can:
 . Log in to {OCP}.
 . Go to menu:Operators[Installed Operators].
 . Select the {OperatorPlatform} installed on your project namespace.
-. Click btn:[All Instances].
+. Click *All Instances*.
 
-Here, you should see your main backup and the backups for each component with the name you specified when creating your backup resource. The status for these instances should state *Running* or *Successful*.
+The *All Instances* page displays the main backup and the backups for each component with the name you specified when creating your backup resource. The status for these instances should state *Running* or *Successful*.
 

--- a/downstream/modules/platform/proc-aap-platform-gateway-backup.adoc
+++ b/downstream/modules/platform/proc-aap-platform-gateway-backup.adoc
@@ -1,3 +1,33 @@
 [id="aap-platform-gateway-backup_{context}"]
 
-= Backing up your AnsibleAutomationPlatform resource
+= Backing up your AnsibleAutomationPlatform deployment
+Regularly backing up your *AnsibleAutomationPlatform* deployment is vital to protect against unexpected data loss and application errors. *AnsibleAutomationPlatform* hosts any enabled components (such as, {ControllerName}, {HubName}, {EDAName}, and {LightspeedShortName}), when you back up *AnsibleAutomationPlatform* you also back up these components.
+
+.Prerequisites
+* You must be authenticated with an Openshift cluster.
+* The {OperatorPlatform} has been installed to the cluster.
+* The *AnsibleAutomationPlatform* instance is deployed using the {OperatorPlatform}.
+
+.Procedure 
+. Log in to {OCP}.
+. Go to menu:Operators[Installed Operators].
+. Select the {OperatorPlatform} installed on your project namespace.
+. Go to your btn:[All Instances] tab, and click btn:[Create New].
+. Select *Ansible Automation Platform Backup* from the list.
++
+NOTE: When creating the *Ansible Automation Platform Backup* resource it will also create backup resources for each of the nested components that are enabled.
++
+. For *Name* enter a name for the backup.
+. For *Deployment name* enter the name of the deployed {PlatformNameShort} instance being backed up. For example if your {PlatformNameShort} deployment must be backed up and the deployment name is myaap, enter 'myaap' in the *Deployment name* field.
+. Click btn:[Create].
+
+.Verification 
+To verify that your backup was successful you can:
+
+. Log in to {OCP}.
+. Go to menu:Operators[Installed Operators].
+. Select the {OperatorPlatform} installed on your project namespace.
+. Click btn:[All Instances].
+
+Here, you should see your main backup and the backups for each component with the name you specified when creating your backup resource. The status for these instances should state *Running* or *Successful*.
+

--- a/downstream/modules/platform/proc-aap-platform-gateway-restore.adoc
+++ b/downstream/modules/platform/proc-aap-platform-gateway-restore.adoc
@@ -1,18 +1,18 @@
 [id="aap-platform-gateway-restore_{context}"]
 
 = Recovering your AnsibleAutomationPlatform deployment
-The *AnsibleAutomationPlatform* hosts any enabled components (such as, {ControllerName}, {HubName}, {EDAName}, and {LightspeedShortName}), when you recover *AnsibleAutomationPlatform* you also restore these components.
+*AnsibleAutomationPlatform* hosts any enabled components (such as, {ControllerName}, {HubName}, {EDAName}, and {LightspeedShortName}), when you recover *AnsibleAutomationPlatform* you also restore these components.
 
 .Prerequisites
 * You must be authenticated with an Openshift cluster.
-* The {OperatorPlatform} has been installed to the cluster.
+* You have installed the {OperatorPlatform} on the cluster.
 * The *AnsibleAutomationPlatformBackups* deployment is available in your cluster.
 
 .Procedure 
 . Log in to {OCP}.
 . Go to menu:Operators[Installed Operators].
 . Select the {OperatorPlatform} installed on your project namespace.
-. Go to your btn:[All Instances] tab, and click btn:[Create New].
+. Go to your *All Instances* tab, and click btn:[Create New].
 . Select *Ansible Automation Platform Restore* from the list.
 . For *Name* enter the name for the recovery deployment. 
 . For *New Ansible Automation Platform Name* enter the new name for your {PlatformNameShort} instance. 
@@ -20,9 +20,9 @@ The *AnsibleAutomationPlatform* hosts any enabled components (such as, {Controll
 . For *Backup name* enter the name your chose when creating the backup. 
 . Click btn:[Create].
 
-Your backups will start restoring under the *AnsibleAutomationPlatformRestores* tab.
+Your backups starts restoring under the *AnsibleAutomationPlatformRestores* tab.
 
-NOTE: The recovery is not complete until all the resources are successfully restored. Depending on the size of your database this typically takes between 10-30 minutes.
+NOTE: The recovery is not complete until all the resources are successfully restored. Depending on the size of your database this this can take some time.
 
 .Verification
 To verify that your recovery was successful you can:

--- a/downstream/modules/platform/proc-aap-platform-gateway-restore.adoc
+++ b/downstream/modules/platform/proc-aap-platform-gateway-restore.adoc
@@ -1,3 +1,31 @@
-[id="aap-platform-gateway-restore"]
+[id="aap-platform-gateway-restore_{context}"]
 
-= Recovering your AnsibleAutomationPlatform resource
+= Recovering your AnsibleAutomationPlatform deployment
+The *AnsibleAutomationPlatform* hosts any enabled components (such as, {ControllerName}, {HubName}, {EDAName}, and {LightspeedShortName}), when you recover *AnsibleAutomationPlatform* you also restore these components.
+
+.Prerequisites
+* You must be authenticated with an Openshift cluster.
+* The {OperatorPlatform} has been installed to the cluster.
+* The *AnsibleAutomationPlatformBackups* deployment is available in your cluster.
+
+.Procedure 
+. Log in to {OCP}.
+. Go to menu:Operators[Installed Operators].
+. Select the {OperatorPlatform} installed on your project namespace.
+. Go to your btn:[All Instances] tab, and click btn:[Create New].
+. Select *Ansible Automation Platform Restore* from the list.
+. For *Name* enter the name for the recovery deployment. 
+. For *New Ansible Automation Platform Name* enter the new name for your {PlatformNameShort} instance. 
+. *Backup Source* defaults to *CR*.
+. For *Backup name* enter the name your chose when creating the backup. 
+. Click btn:[Create].
+
+Your backups will start restoring under the *AnsibleAutomationPlatformRestores* tab.
+
+NOTE: The recovery is not complete until all the resources are successfully restored. Depending on the size of your database this typically takes between 10-30 minutes.
+
+.Verification
+To verify that your recovery was successful you can:
+
+. Go to menu:Workloads[Pods].
+. Confirm that all pods are in a *Running* or *Completed* state.


### PR DESCRIPTION
Preparing 2.5 content 
[AAP-22718](https://issues.redhat.com/browse/AAP-22718)

Adding content to proc modules:

- downstream/assemblies/platform/assembly-aap-backup.adoc
- downstream/assemblies/platform/assembly-aap-recovery.adoc