### PR TITLE
Adding manifest deprication warning to execution environments doc

### DIFF
--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -32,7 +32,7 @@ Use the hostnames instead of IP addresses when configuring firewall rules.
 
 After making this change you can continue to pull images from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
 
-However, manifests, sometimes called “subscription allocations”, on the web-based Red Hat Subscription Management are no longer supported as of early 2024 with one exception: If a system is part of a closed network or “air gapped” system that does not receive its updates from Red Hat’s servers directly, manifests are supported until the release of Red Hat Satellite 6.16. Keep up to date with link://access.redhat.com/articles/1365633[Red Hat Satellite Release Dates] for the announcement for Red Hat Satellite 6.16's release date announcement.
+However, manifests, sometimes called “subscription allocations”, on the web-based Red Hat Subscription Management are no longer supported as of early 2024 with one exception: If a system is part of a closed network or “air gapped” system that does not receive its updates from Red Hat’s servers directly, manifests are supported until the release of Red Hat Satellite 6.16. Keep up to date with link:access.redhat.com/articles/1365633[Red Hat Satellite Release Dates] for the announcement for Red Hat Satellite 6.16's release date announcement.
 ====
 
 include::hub/proc-obtain-images.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -10,10 +10,10 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-By default, {PrivateHubName} does not include container images. 
-To populate your container registry, you must push a container image to it. 
+By default, {PrivateHubName} does not include container images.
+To populate your container registry, you must push a container image to it.
 
-You must follow a specific workflow to populate your {PrivateHubName} container registry: 
+You must follow a specific workflow to populate your {PrivateHubName} container registry:
 
 * Pull images from the Red Hat Ecosystem Catalog (registry.redhat.io)
 * Tag them
@@ -21,16 +21,18 @@ You must follow a specific workflow to populate your {PrivateHubName} container 
 
 [IMPORTANT]
 ====
-Image manifests and filesystem blobs were both originally served directly from `registry.redhat.io` and `registry.access.redhat.com`. 
-As of 1 May 2023, filesystem blobs are served from `quay.io` instead. 
+Image manifests and filesystem blobs were both originally served directly from `registry.redhat.io` and `registry.access.redhat.com`.
+As of 1 May 2023, filesystem blobs are served from `quay.io` instead.
 
 * Ensure that the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/ref-network-ports-protocols_planning[Network ports and protocols] listed in _Table 5.10. Execution Environments (EE)_ are available to avoid problems pulling container images.
 
 Make this change to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
 
-Use the hostnames instead of IP addresses when configuring firewall rules. 
+Use the hostnames instead of IP addresses when configuring firewall rules.
 
 After making this change you can continue to pull images from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+
+However, manifests, sometimes called “subscription allocations”, on the web-based Red Hat Subscription Management are no longer supported as of early 2024 with one exception: If a system is part of a closed network or “air gapped” system that does not receive its updates from Red Hat’s servers directly, manifests are supported until the release of Red Hat Satellite 6.16. Keep up to date with link://access.redhat.com/articles/1365633[Red Hat Satellite Release Dates] for the announcement for Red Hat Satellite 6.16's release date announcement.
 ====
 
 include::hub/proc-obtain-images.adoc[leveloffset=+1]

--- a/downstream/modules/hub/proc-obtain-images.adoc
+++ b/downstream/modules/hub/proc-obtain-images.adoc
@@ -24,9 +24,9 @@ New Red Hat accounts automatically use Simple Content Access for their subscript
 
 .Procedure
 
-. If you need to access your manifest for your container images log in to link:https://console.redhat.com/subscriptions/manifests[Red Hat Console].
+. If you need to access your manifest for your container images log in to link:console.redhat.com/subscriptions/manifests[Red Hat Console].
 
-. Click the three-dot menu for the manifest you need for your container images, and click *Export manifest*.
+. Click the three-dot menu for the manifest you need for your container images, and click btn:[Export manifest].
 
 . Log in to Podman by using your registry.redhat.io credentials:
 +
@@ -58,6 +58,6 @@ $ podman images
 [role="_additional-resources"]
 .Additional resources
 
-* See link:https://redhat-connect.gitbook.io/catalog-help/[Red Hat Ecosystem Catalog Help] for information on registering and getting images.
+* See link:redhat-connect.gitbook.io/catalog-help/[Red Hat Ecosystem Catalog Help] for information on registering and getting images.
 
-* See link:https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] to learn more about the changes coming to Red Hat subscription tooling
+* See link:{BaseURL}subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] to learn more about the changes coming to Red Hat subscription tooling

--- a/downstream/modules/hub/proc-obtain-images.adoc
+++ b/downstream/modules/hub/proc-obtain-images.adoc
@@ -8,10 +8,25 @@
 [role="_abstract"]
 Before you can push container images to your {PrivateHubName}, you must first pull them from an existing registry and tag them for use. The following example details how to pull an image from the Red Hat Ecosystem Catalog (registry.redhat.io).
 
+[IMPORTANT]
+====
+As of early 2024, Red Hat no longer supports manifests or manifest lists on the Red Hat Subscription Management web platform, which has also been used interchangeably with “subscription allocations.” Red Hat also no longer supports most manifest functionality in Red Hat Satellite with one exception:
+* Red Hat Satellite users in closed network or “air gapped” networks that do not receive their updates directly from Red Hat servers can currently still use `access.redhat.com` until the release of Red Hat Satellite 6.16.
+
+New Red Hat accounts automatically use Simple Content Access for their subscription tooling. New Red Hat accounts and existing Satellite customers who can connect to Red Hat’s servers can find their manifests at `console.redhat.com`.
+====
+
 .Prerequisites
-You have permissions to pull images from registry.redhat.io.
+
+* You have permissions to pull images from registry.redhat.io.
+
+* A Red Hat account with Simple Account Access enabled.
 
 .Procedure
+
+. If you need to access your manifest for your container images log in to link:https://console.redhat.com/subscriptions/manifests[Red Hat Console].
+
+. Click the three-dot menu for the manifest you need for your container images, and click *Export manifest*.
 
 . Log in to Podman by using your registry.redhat.io credentials:
 +
@@ -44,3 +59,5 @@ $ podman images
 .Additional resources
 
 * See link:https://redhat-connect.gitbook.io/catalog-help/[Red Hat Ecosystem Catalog Help] for information on registering and getting images.
+
+* See link:https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] to learn more about the changes coming to Red Hat subscription tooling

--- a/downstream/modules/hub/proc-obtain-images.adoc
+++ b/downstream/modules/hub/proc-obtain-images.adoc
@@ -20,7 +20,7 @@ New Red Hat accounts automatically use Simple Content Access for their subscript
 
 * You have permissions to pull images from registry.redhat.io.
 
-* A Red Hat account with Simple Account Access enabled.
+* A Red Hat account with Simple Content Access enabled.
 
 .Procedure
 
@@ -60,4 +60,4 @@ $ podman images
 
 * See link:redhat-connect.gitbook.io/catalog-help/[Red Hat Ecosystem Catalog Help] for information on registering and getting images.
 
-* See link:{BaseURL}subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] to learn more about the changes coming to Red Hat subscription tooling
+* See link:{BaseURL}/subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] to learn more about the changes coming to Red Hat subscription tooling


### PR DESCRIPTION
Added warnings about the depreciation of RHSM manifests & manifest lists, interchangeably called subscription allocations, to:

- Assembly chapters 5. Populating your private automation hub container registry
- Procedure chapter 5.1 Pulling images for use in automation hub

In 5.1, I also added reference links for
- Added links for Satellite Release Dates, as it relates to the one exception to the currently existing depreciation
- Transition of Red Hat's subscription services to console.redhat.com from the Customer Portal

Because the use of consoleDOT is new to the user potentially, I have also added two steps to the procedure in 5.1 addressing that.