### PR TITLE
AAP-25889 Azure - link to kcs article for list of domains

### DIFF
--- a/stories/topics/proc-azure-update-route-tables.adoc
+++ b/stories/topics/proc-azure-update-route-tables.adoc
@@ -55,28 +55,7 @@ If you choose not to allow all outbound traffic from  port 443, you must configu
 
 * For Red Hat to manage and upgrade {AAPonAzureNameShort} and execute security patching, any machine in the Azure Kubernetes service (AKS) cluster must be allowed to submit a request to pull updates for containers used by {PlatformNameShort}.
 +
-Add routes in the {PlatformNameShort} route table for outbound traffic from the full CIDR range of the {AAPonAzureNameShort} managed application to the following domains:
-
-** `redhat.com`
-** `*.redhat.com`
-** `{Registry}`
-** `*.{Registry}`
-** `quay.io`
-** `*.quay.io`
-** `letsencrypt.org`
-** `*.letsencrypt.org`
-** `gcr.io`
-** `*.gcr.io`
-** `docker.com`
-** `*.docker.com`
-** `docker.io`
-** `*.docker.io`
-** `googleapis.com`
-** `*.googleapis.com`
-** `mcr.microsoft.com`
-** `*.mcr.microsoft.com`
-** `dynatrace.com` - Port 443 and 9999
-** `*.dynatrace.com` - Port 443 and 9999
+Add routes in the {PlatformNameShort} route table for outbound traffic from the full CIDR range of the {AAPonAzureNameShort} managed application to the domains listed in the link:https://access.redhat.com/articles/6972355[Azure Virtual Appliance Routing with Ansible Automation Platform on Azure] article on the Red Hat Customer Portal.
 
 * You must also allow traffic from your firewall to any other external domain or IP address that you want {PlatformNameShort} to run automation jobs against.
 Otherwise, your firewall will block connectivity between {PlatformNameShort} and destinations for automation.


### PR DESCRIPTION
AAP-25889 Azure - link to a KCS article that customers / support can refer to for the list of domains to allow, instead of listing the domains in the docs, because this list is frequently updated.