### PR TITLE
AAP-25853: Update on-premise deployment docs to include IBM CPD requirement

### DIFF
--- a/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
+++ b/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
@@ -28,20 +28,20 @@ To see the rest of the {PlatformName} system requirements, see _Chapter 4. Syste
 
 [NOTE]
 ====
-You must also have a trial or paid subscription to {ibmwatsonxcodeassistant}, and have a model in the {ibmwatsonxcodeassistant} deployment space. For information about creating a {ibmwatsonxcodeassistant} model, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/en/cloud-paks/cp-data/5.0.x?topic=services-watsonx-code-assistant-red-hat-ansible-lightspeed[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation]. 
+You must also have installed {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data. The installation includes a base model that you can use to set up your {LightspeedshortName} on-premise deployment. For installation information, see the link:https://www.ibm.com/docs/SSQNUZ_5.0.x/svc-welcome/wxca-ansible.html[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation]. 
 ====
 
 == Prerequisites
 
 * You have administrator privileges for {PlatformName}.
 
-* Your organization has a trial or paid subscription to both {PlatformName} and {ibmwatsonxcodeassistant}.
+* You have installed {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data.
 
 * Your system meets the minimum system requirements to set up {LightspeedshortName} on-premise deployment.
 
 * You have obtained an API key and a model ID from {ibmwatsonxcodeassistant}. 
 +
-For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/en/cloud-paks/cp-data/5.0.x?topic=services-watsonx-code-assistant-red-hat-ansible-lightspeed[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
+For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/SSQNUZ_5.0.x/svc-welcome/wxca-ansible.html[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
 
 * You have an existing external PostgreSQL database configured for the {PlatformName}, or have a database created for you when configuring the {LightspeedshortName} on-premise deployment. 
 

--- a/lightspeed/modules/con_wca-key-model-id.adoc
+++ b/lightspeed/modules/con_wca-key-model-id.adoc
@@ -3,11 +3,17 @@
 [id="wca-key-model-id_{context}"]
 = Configuration requirements
 
-To use {LightspeedFullName}, your organization must have the following subscriptions:
+To use the {LightspeedShortName} cloud service, your organization must have the following subscriptions:
 
 * A trial or paid subscription to {PlatformName} 
 
 * A trial or paid subscription to {ibmwatsonxcodeassistant}
+
+To use an on-premise deployment of {LightspeedShortName}, your organization must have the following subscriptions:
+
+* A trial or paid subscription to {PlatformName} 
+
+* An installation of {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data
 
 You need the following {ibmwatsonxcodeassistant} information:
 

--- a/lightspeed/modules/proc_create-connection-secrets.adoc
+++ b/lightspeed/modules/proc_create-connection-secrets.adoc
@@ -11,7 +11,7 @@ Use this procedure to create secrets to connect to {PlatformName} and {ibmwatson
 * You have created an OAuth application in the {ControllerName}.
 * You have obtained an API key and a model ID from {ibmwatsonxcodeassistant}. 
 +
-For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/en/cloud-paks/cp-data/5.0.x?topic=services-watsonx-code-assistant-red-hat-ansible-lightspeed[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
+For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/SSQNUZ_5.0.x/svc-welcome/wxca-ansible.html[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
 
 .Procedure
 . Go to the {OCP}. 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-25853.

Changes made:
#1: Updated the prerequisites and other places where we've mentioned the info. about needing IBM watsonx Code Assistant trial and paid plans. Replaced them with needing "IBM watsonx Code Assistant for Red Hat Ansible Lightspeed on Cloud Pak for Data" .. I know..the name is a mouthful! Here's the IBM doc link for your reference: https://www.ibm.com/docs/SSQNUZ_5.0.x/svc-welcome/wxca-ansible.html

#2: The hyperlinks currently pointing to IBM WCA docs are now updated to point to the relevant IBM watsonx Code Assistant for Red Hat Ansible Lightspeed on Cloud Pak for Data docs. 