### PR TITLE
AAP-25608: Lightspeed doc improvements

### DIFF
--- a/lightspeed/assemblies/assembly_configuring-vscode-extension.adoc
+++ b/lightspeed/assemblies/assembly_configuring-vscode-extension.adoc
@@ -15,6 +15,15 @@ To access {LightspeedShortName}, all Ansible users must install and configure th
 
 You can also use a custom, fine-tuned model if your organization administrator has created a custom model and has shared the model ID with you separately. Use the *model-override* setting in the Ansible VS Code extension to override the default model, and use the custom model instead. Using a custom model enables you to improve the code recommendation experience and tune the model to your organizational automation patterns. For example, if you are using {LightspeedShortName} both as an organization administrator and a user, you can test the custom model for select Ansible users before making it available for all users in your organization. For more information, see xref:configuring-custom-models_set-up-lightspeed[Configuring custom models]. 
 
+== Connectivity requirements
+To generate code recommendations, the Ansible Lightspeed service in Visual Studio (VS) Code editor requires access to the following outbound domains:
+
+* https://c.ai.ansible.redhat.com
+* https://console.redhat.com
+* https://access.redhat.com
+
+The outbound connections are encrypted on TCP protocol port 443.
+
 include::modules/proc_install-vscode-extension.adoc[leveloffset=+1]
 include::modules/proc_configure-vscode-extension.adoc[leveloffset=+1]
 include::modules/proc_login-vscode-extension.adoc[leveloffset=+1]

--- a/lightspeed/modules/con_lightspeed-key-features.adoc
+++ b/lightspeed/modules/con_lightspeed-key-features.adoc
@@ -9,7 +9,27 @@
 +
 {LightspeedFullName} uses Ansible-specific IBM watsonx Granite models unique to your organization, which are provided, managed, and maintained by IBM.
 
-* *Single tasks and multitask generation*
+* *Model customization*
++
+Organization administrators can now create and use fine-tuned, custom models that are trained on your organization's existing Ansible content. With this capability, you can tune the models to your organization's automation patterns and improve the code recommendation experience. 
++
+You can configure multiple custom models for your organization. For example, you can create a custom model for your corporate IT automation team and a different one for your engineering team's infrastructure. You can also configure a custom model to make it available for all Ansible users or select Ansible users in your organization.
+
+* *{LightspeedShortName} cloud service and on-premise deployments*
++
+{LightspeedShortName} is available both as a cloud service and as an on-premise deployment. 
+{LightspeedShortName} on-premise deployments provide the {PlatformName} customers more control over their data and supports compliance with enterprise security policies. For example, organizations in sensitive industries with data privacy or air-gapped requirements can use on-premise deployments of both {LightspeedShortName} and {ibmwatsonxcodeassistant} for {LightspeedShortName} on Cloud Pak for Data. {LightspeedShortName} on-premise deployments are supported on {PlatformName} version 2.4.
+
+* *Playbook and task generation*
+
++
+This includes the following capabilities:
+
+** *Playbook generation and explanations*
++
+Using the Ansible VS Code extension, you can create Ansible playbooks using a natural language interface in English. {LightspeedShortName} with {ibmwatsonxcodeassistant} reads the natural language prompts and generates an entire playbook recommendation based on your intent. You can also view the explanations for new or existing playbooks. The playbook explanations describe what the playbook or task within the playbook does and contextualize its impact. 
+
+** *Single and multitask generation*
 +
 Using natural language prompts, you can generate single task or multiple task recommendations for Ansible task files and playbooks. To request multitask code recommendations, you can enter a sequence of natural language task prompts in a YAML file comment separated by ampersand (*&*) symbols.
 +
@@ -26,3 +46,7 @@ For each generated code recommendation, {LightspeedShortName} lists content sour
 * *Content maintenance and modernization*
 +
 The {AnsibleCodeBot} scans existing content collections, roles, and playbooks through Git repositories, and proactively creates pull requests whenever best practices or quality improvement recommendations are available. The bot automatically submits pull requests to the repository, which proactively alerts the repository owner to a recommended change to their content. 
+
+* *Telemetry data collection on the Admin dashboard*
++
+{LightspeedShortName} now collects Admin dashboard telemetry data that provides insight into how your organization users are using the Ansible Lightspeed service, and displays the metrics on the Admin dashboard. If you no longer want to collect and manage the Admin dashboard telemetry, you can disable it for your organization.

--- a/lightspeed/modules/con_lightspeed-process.adoc
+++ b/lightspeed/modules/con_lightspeed-process.adoc
@@ -4,12 +4,28 @@
 
 = Using {LightspeedShortName} with {ibmwatsonxcodeassistant}
 
-.Prerequisites
+== Prerequisites
 
-To use {LightspeedShortName}, ensure that you have the following components:
+To use {LightspeedShortName} cloud service, ensure that you have the following components:
 
 * Trial or paid subscription to {PlatformNameShort}
 * Trial or paid subscription to {ibmwatsonxcodeassistant}
 * VS Code version 1.70.1 or later
 * The Ansible extension for VS Code version 2.8 or later
+
+To use an on-premise deployment of {LightspeedShortName}, your organization must have the following subscriptions:
+
+* A trial or paid subscription to {PlatformName} 
+
+* An installation of {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data
+
+== Connectivity requirements
+To generate code recommendations, the Ansible Lightspeed service in Visual Studio (VS) Code editor requires access to the following outbound domains:
+
+* https://c.ai.ansible.redhat.com
+* https://console.redhat.com
+* https://access.redhat.com
+
+The outbound connections are encrypted on TCP protocol port 443.
+
 

--- a/lightspeed/modules/proc_create-connection-secrets.adoc
+++ b/lightspeed/modules/proc_create-connection-secrets.adoc
@@ -15,11 +15,11 @@ For information about obtaining an API key and model ID from {ibmwatsonxcodeassi
 
 .Procedure
 . Go to the {OCP}. 
-. Select Select menu:Workloads[Secrets].
-. Click *Create → Key/value secret*.
+. Select menu:Workloads[Secrets].
+. Click menu:Create[Key/value secret].
 . From the *Projects* list, select the namespace that you created when you installed the {PlatformName} operator.
 . Create an *authorization secret* to connect to the {PlatformName}:
-.. Click *Create → Key/value secret*.
+.. Click menu:Create[Key/value secret].
 .. In *Secret name*, enter a unique name for the secret. For example, `auth-aiconnect`.
 .. Add the following keys and their associated values individually:
 +
@@ -57,7 +57,7 @@ The following image is an example of an authorization secret:
 image::aiconnect-auth-secret.png[{Example of an authorization secret]
 
 . Similarly, create a *model secret* to connect to an {ibmwatsonxcodeassistant} model:
-.. Click *Create → Key/value secret*.
+.. Click menu:Create[Key/value secret].
 .. In *Secret name*, enter a unique name for the secret. For example, `model-aiconnect`.
 .. Add the following keys and their associated values individually:
 +

--- a/lightspeed/modules/proc_create-lightspeed-instance.adoc
+++ b/lightspeed/modules/proc_create-lightspeed-instance.adoc
@@ -12,10 +12,10 @@ Use this procedure to create and deploy a {LightspeedShortName} instance to your
 .Procedure
 
 . Go to {OCP}.
-. Select *Operators → Installed Operators*.
+. Select menu:Operators[Installed Operators].
 . From the *Projects* list, select the namespace where you want to install the {LightspeedShortName} instance and where you created the connection secrets.
 . Locate and select the *{PlatformNameShort} (provided by Red Hat)* operator that you installed earlier.
-. Select *All instances → Create new*.
+. Select menu:All instances[Create new].
 . From the *Create new* list, select the *Ansible Lightspeed* modal.
 . Ensure that you have selected *Form view* as the configuration mode. 
 . Provide the following information:
@@ -24,4 +24,4 @@ Use this procedure to create and deploy a {LightspeedShortName} instance to your
 .. *Secret where the model configuration can be found*: Select the model secret that you created to connect to {ibmwatsonxcodeassistant}.
 . Click *Create*. 
 +
-The {LightspeedShortName} instance takes a few minutes to deploy to your namespace. After the installation status is displayed as *Successful*, the Ansible Lightspeed portal URL is available under *Networking → Routes* in {OCP}.
+The {LightspeedShortName} instance takes a few minutes to deploy to your namespace. After the installation status is displayed as *Successful*, the Ansible Lightspeed portal URL is available under menu:Networking[Routes] in {OCP}.

--- a/lightspeed/modules/proc_create-oauth-app.adoc
+++ b/lightspeed/modules/proc_create-oauth-app.adoc
@@ -11,7 +11,7 @@ Use this procedure to create an OAuth application for your {LightspeedShortName}
 
 .Procedure
 . Log in to the {ControllerName} as an administrator.
-. Under *Administration*, click *Applications > Add*. 
+. Under *Administration*, click menu:Applications[Add].
 . Enter the following information:
 .. *Name*: Specify a unique name for your application.
 .. *Organization*: Select a preferred organization.

--- a/lightspeed/modules/proc_install-aap-lightspeed-operator.adoc
+++ b/lightspeed/modules/proc_install-aap-lightspeed-operator.adoc
@@ -14,13 +14,13 @@ Use this procedure to install the {PlatformNameShort} operator on the {OCP}.
 . Log in to the {OCP} as an administrator.
 
 . Create a namespace:
-.. Go to *Administration → Namespaces*.
+.. Go to menu:Administration[Namespaces].
 .. Click *Create Namespace*.
 .. Enter a unique name for the namespace.
 .. Click *Create*. 
 
 . Install the operator:
-.. Go to *Operators → OperatorHub*.
+.. Go to menu:Operators[OperatorHub].
 .. Select the namespace where you want to install the {PlatformName} operator.
 .. Search for the {PlatformNameShort} operator. 
 .. From the search results, select the {PlatformNameShort} (provided by Red Hat) tile. 

--- a/lightspeed/modules/proc_login-vscode-extension.adoc
+++ b/lightspeed/modules/proc_login-vscode-extension.adoc
@@ -13,7 +13,7 @@ After installing and configuring the VS Code extension, you can log in to the An
 .. From the navigation menu, click the *Ansible* icon. 
 .. Under Ansible Lightspeed Login, click *Connect*.
 ** Using the *Accounts* button:
-.. From the navigation menu, click *Accounts icon > Sign in with Ansible Lightspeed*.
+.. From the navigation menu, click the *Accounts* icon and select *Sign in with Ansible Lightspeed*.
 +
 [NOTE]
 +
@@ -24,7 +24,7 @@ This option is displayed when the VS Code extension is in an active state. The e
 . When prompted, click *Allow* to sign in. 
 . In the *Authorize Ansible Lightspeed for VS Code* window, click *Authorize*.
 . In the *Do you want Code to open the external website?* window, click *Open*. The link:https://c.ai.ansible.redhat.com/[Ansible Lightspeed portal login page] is displayed.
-. Click *Log in → Log in with Red Hat*.
+. Click menu:Log in[Log in with Red Hat].
 . Enter your Red Hat account username and password. 
 +
 On successful authentication, the login screen is displayed along with your username and your assigned user role. The VS code extension is now connected with Ansible Lightspeed service. 

--- a/lightspeed/modules/proc_update-connection-secrets.adoc
+++ b/lightspeed/modules/proc_update-connection-secrets.adoc
@@ -13,12 +13,12 @@ After you have set up the {LightspeedShortName} on-premise deployment successful
 
 .Procedure
 . Go to the {OCP}. 
-. Select *Operators → Installed Operators*.
+. Select menu:Operators[Installed Operators].
 . From the *Projects* list, select the namespace where you installed the {LightspeedShortName} instance.
 . Locate and select the *Ansible Automation Platform (provided by Red Hat)* operator that you installed earlier.
 . Select the *Ansible Lightspeed* tab.
 . Find and select the instance you want to update.
-. Click *Actions > Edit AnsibleLightspeed*. The editor will switch to a text or YAML view.
+. Click menu:Actions[Edit AnsibleLightspeed]. The editor switches to a text or YAML view.
 . Scroll the text to find the `spec:` section.
 +
 image:update-connection-secrets.png[Setting to update the connection secrets])

--- a/lightspeed/modules/proc_update-redirect-uri.adoc
+++ b/lightspeed/modules/proc_update-redirect-uri.adoc
@@ -12,12 +12,12 @@ When Ansible users log in or log out of Ansible Lightspeed service, the {Platfor
 .Procedure
 . Get the URL of the Ansible Lightspeed instance:
 .. Go to {OCP}.
-.. Select *Networking → Routes*.
+.. Select menu:Networking[Routes].
 .. Locate the {LightspeedShortName} instance that you created. 
 .. Copy the Location URL of the {LightspeedShortName} instance.
 
 . Update the *login* redirect URI:
-.. In the automation controller, go to *Administration → Applications*.
+.. In the automation controller, go to menu:Administration[Applications].
 .. Select the Lightspeed Oauth application that you created.
 .. In the *Redirect URIs* field of the Oauth application, enter the URL in the following format:
 +

--- a/lightspeed/modules/proc_view-playbook-explanation.adoc
+++ b/lightspeed/modules/proc_view-playbook-explanation.adoc
@@ -19,7 +19,7 @@ You can request explanations for a newly created playbook as well as an existing
 . Use one of the following methods to view the playbook explanation:
 * *From an active playbook YAML file*:
 .. Place your cursor anywhere within the playbook file.
-.. Right-click > Select *Explain the playbook with Ansible Lightspeed*. 
+.. Right-click and select *Explain the playbook with Ansible Lightspeed*. 
 * *From the Ansible panel*:
 .. From the navigation menu, click the *Ansible* icon.
 .. Select *Explain the current playbook*.


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-25608.

Changes made:
#1: Specified VS code connection URLs (outbound domains). 
$2: Checked all instances throughout the Lightspeed docs and use Asciidoc button macro for consistency in places where the menu wasn't used as expected.
$3: Updated 'Key features' section to include new updates namely: model customization, telemetry and admin dashboard, on-premise deployment and playbook generation. **Content is reused from release notes**, no changes made to the blurbs. Release notes are here for your reference: https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html-single/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_release_notes/index


