### PR TITLE
AAP-25848 Change Azure Active Directory (AD) to Microsoft Entra ID

### DIFF
--- a/attributes/attributes.adoc
+++ b/attributes/attributes.adoc
@@ -13,6 +13,7 @@
 // AAP on Clouds
 :AAPonAzureName: Red Hat Ansible Automation Platform on Microsoft Azure
 :AAPonAzureNameShort: Ansible Automation Platform on Microsoft Azure
+:MSEntraID: Microsoft Entra ID
 :Azure: Microsoft Azure
 :AWS: Amazon Web Services
 :Market: AWS Marketplace

--- a/stories/topics/con-azure-security.adoc
+++ b/stories/topics/con-azure-security.adoc
@@ -25,6 +25,6 @@ It is accessible to SREs from the kubernetes API and can be reset by the SREs up
 ** Any parts of the {PlatformNameShort} APIs that could leak any sensitive information are only accessible via authenticating as a known {PlatformNameShort} user and require that user to have the right level of authorization to use those APIs.
 In a private deployment, access to the {PlatformNameShort} APIs is only accessible to the customer via the route they choose to connect to the private deployment.
 ** The Kubernetes API is private and only accessible from a private endpoint
-** Workload identity is enabled and it allows Kubernetes applications to access Azure cloud resources securely with Azure AD.
+** Workload identity is enabled and it allows Kubernetes applications to access Azure cloud resources securely with {MSEntraID}.
 * Updates and patching
 ** The Red Hat SREs regularly update the Kubernetes version, underlying node OS, and {PlatformNameShort} version to the latest available stable versions to get the latest features, bug fixes, and security fixes.

--- a/stories/topics/proc-azure-configure-ad-sso.adoc
+++ b/stories/topics/proc-azure-configure-ad-sso.adoc
@@ -1,9 +1,9 @@
 [id="proc-azure-configure-ad-sso_{context}"]
 
-= Azure Active Directory (Azure AD) SSO configuration
+= {MSEntraID} SSO configuration
 
 [role="_abstract"]
-Follow the procedures below to configure SSO with Azure Active Directory (Azure AD). If your organization does not use Azure AD for application authorization, you can create users in the user management system in {PlatformNameShort}.
+Follow the procedures below to configure SSO with {MSEntraID}. If your organization does not use {MSEntraID} for application authorization, you can create users in the user management system in {PlatformNameShort}.
 
 .Configuring the base URL for the {PlatformNameShort} deployment
 
@@ -17,7 +17,7 @@ Follow the procedures below to configure SSO with Azure Active Directory (Azure 
 
 .Configuring authentication for {PlatformNameShort}
 
-To set up enterprise authentication for Microsoft Azure Active Directory (Azure AD), you must obtain an OAuth2 key and secret by registering your {PlatformNameShort} deployment in Azure.
+To set up enterprise authentication for {MSEntraID}, you must obtain an OAuth2 key and secret by registering your {PlatformNameShort} deployment in Azure.
 
 To register the {ControllerName} instance in Azure, you must supply the _Azure AD OAuth2 Callback URL_ from the {ControllerName} settings.
 
@@ -26,14 +26,14 @@ To register the {ControllerName} instance in Azure, you must supply the _Azure A
 . In a web browser, open the {ControllerName} console.
 . Click *Settings* in the menu to open the main settings page.
 . Click *Azure AD settings* in the *Authentication* category to open the *Details* page.
-. Copy the value for _Azure AD OAuth2 Callback URL_. You will need this value when you register your deployed application in Azure AD.
+. Copy the value for _Azure AD OAuth2 Callback URL_. You will need this value when you register your deployed application in {MSEntraID}.
 
-.Creating a registered application in Azure AD
+.Creating a registered application in {MSEntraID}
 
 . In a web browser, open the Azure portal.
 . Ensure that you are using the tenant where you deployed {PlatformNameShort}.
-. Type `Azure Active Directory` in the search bar.
-. Select *Azure Active Directory* from the search results.
+. Type `Microsoft Entra ID` in the search bar.
+. Select *{MSEntraID}* from the search results.
 . Under *Manage* in the menu options, click *App registrations*.
 . In the *App registrations* page, click *+ New registration*.
 . Configure the new registration as follows:
@@ -70,7 +70,7 @@ Add the key _(Application (client) ID)_ and value (_Value_) of the secret that y
 . Open the {ControllerName} console in a web browser.
 . Click menu:Settings[Azure AD settings].
 . Click *Edit*.
-. Enter the information for the secret that you generated in Azure AD:
+. Enter the information for the secret that you generated in {MSEntraID}:
   . In *Azure AD OAuth2 Key*, paste the _Application (client) ID_.
   . In *Azure AD OAuth2 Secret*, paste the secret _Value_.
 . Click *Save*.

--- a/stories/topics/proc-azure-create-service-principal.adoc
+++ b/stories/topics/proc-azure-create-service-principal.adoc
@@ -15,7 +15,7 @@ Your {AAPonAzureNameShort} deployment will be provisioned in the same Subscripti
 -----
 az account set --subscription <your_subscription_id>
 -----
-. Run the following command using the Azure CLI to create a privileged service principal in Azure AD:
+. Run the following command using the Azure CLI to create a privileged service principal in {MSEntraID}:
 +
 -----
 az ad sp create-for-rbac --name ansible --role Contributor
@@ -36,7 +36,7 @@ The output displays the _appID_ and _tenant_ keys for the service principal:
 
 == Maintaining your service principals
 
-Service principal credentials have a limited lifetime that is set in your Azure AD configuration.
+Service principal credentials have a limited lifetime that is set in your {MSEntraID} configuration.
 Track the lifespan of the service principal if you intend to automate against Azure for an extended period of time.
 You can create a new one when needed.
 


### PR DESCRIPTION

Update the Azure docs: Microsoft Entra ID is replacing Azure Active Directory (Azure AD).
However, the AAP UI still contains Azure AD references, so these have not been changed.