### PR TITLE
AAP-22995: Reused logout procedure in VS Code chapter

### DIFF
--- a/lightspeed/assemblies/assembly_configuring-vscode-extension.adoc
+++ b/lightspeed/assemblies/assembly_configuring-vscode-extension.adoc
@@ -18,6 +18,7 @@ You can also use a custom, fine-tuned model if your organization administrator h
 include::modules/proc_install-vscode-extension.adoc[leveloffset=+1]
 include::modules/proc_configure-vscode-extension.adoc[leveloffset=+1]
 include::modules/proc_login-vscode-extension.adoc[leveloffset=+1]
+include::modules/proc_log-out-of-portal.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/lightspeed/modules/proc_log-out-of-portal.adoc
+++ b/lightspeed/modules/proc_log-out-of-portal.adoc
@@ -2,7 +2,7 @@
 
 [id="log-out-of-portal_{context}"]
 
-= Logging out of the Ansible Lightspeed portal
+= Logging out of the Ansible Lightspeed Service
 
 [role="_abstract"]
 To log out of the Ansible Lightspeed Service, you must log out of both the Ansible Lightspeed VS Code extension and the Ansible Lightspeed portal. 


### PR DESCRIPTION
This PR addresses an older JIRA https://github.com/sayjadha/aap-docs/pull/new/AAP-22995. The docs were published earlier [on here](https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html-single/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/index#log-out-of-portal_logging-in-out-lightspeed-portal), but I simply missed updating the JIRA. 

Updates made:

- Reused the logout module in 'Chapter 5. Installing and configuring the Ansible VS Code extension'
-  Changed 'Ansible Lightspeed Portal' to Ansible Lightspeed Service 