### PR TITLE
added a second step to verification modules about satellite login

### DIFF
--- a/downstream/modules/platform/proc-verify-controller-installation.adoc
+++ b/downstream/modules/platform/proc-verify-controller-installation.adoc
@@ -10,6 +10,7 @@ Verify that you installed {ControllerName} successfully by logging in with the a
 
 .Procedure
 . Go to the IP address specified for the {ControllerName} node in the `inventory` file.
+. Enter your Red Hat Satellite credentials. If this is your first time logging in after installation, upload your `manifest` file.
 . Log in with the user ID `admin` and the password credentials you set in the `inventory` file.
 
 [NOTE]

--- a/downstream/modules/platform/proc-verify-eda-controller-installation.adoc
+++ b/downstream/modules/platform/proc-verify-eda-controller-installation.adoc
@@ -10,6 +10,8 @@ Verify that you installed {EDAcontroller} successfully by logging in with the ad
 
 . Navigate to the IP address specified for the {EDAcontroller} node in the `inventory` file.
 
+. Enter your Red Hat Satellite credentials. If this is your first time logging in after installation, upload your `manifest` file.
+
 . Log in with the user ID `admin` and the password credentials you set in the `inventory` file.
 
 [IMPORTANT]

--- a/downstream/modules/platform/proc-verify-hub-installation.adoc
+++ b/downstream/modules/platform/proc-verify-hub-installation.adoc
@@ -7,6 +7,7 @@ Verify that you installed your {HubName} successfully by logging in with the adm
 
 .Procedure
 . Navigate to the IP address specified for the {HubName} node in the `inventory` file.
+. Enter your Red Hat Satellite credentials. If this is your first time logging in after installation, upload your `manifest` file.
 . Log in with the user ID `admin` and the password credentials you set in the `inventory` file.
 
 


### PR DESCRIPTION
As per AAP-16427 and its comments, I have added a step (now step 2) that instructs users to login with their Satellite credentials and, if it is the first time they are logging in since installation, upload their manifest file in:

1. [3.5 Verifying installation of automation hub](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#proc-verify-hub-installation_platform-install-scenario)
2. [3.4 Verifying installation of automation controller](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#proc-verify-controller-installation_platform-install-scenario)
3. [3.6. Verifying Event-Driven Ansible controller installation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario#proc-verify-eda-controller-installation_platform-install-scenario)