### PR TITLE
AAP-26616: Added info. that code bot doesn't need IBM watsonx Code Assistant

### DIFF
--- a/lightspeed/assemblies/assembly_using-code-bot-for-suggestions.adoc
+++ b/lightspeed/assemblies/assembly_using-code-bot-for-suggestions.adoc
@@ -12,7 +12,12 @@ ifdef::context[:parent-context: {context}]
 
 The {AnsibleCodeBot} scans existing content collections, roles, and playbooks hosted in GitHub repositories, and proactively creates pull requests whenever best practices or quality improvement recommendations are available. 
 
-{AnsibleCodeBot} scans your code repositories to recommend code quality improvements. It promotes Ansible best practices while avoiding common errors that can lead to bugs or make code harder to maintain. The bot automatically submits pull requests to the repository, which proactively alerts the repository owner to a recommended change to their content. You can configure {AnsibleCodeBot} to scan your existing Git repositories (both public and private). Your organization must have an active subscription to {PlatformName} to use the {AnsibleCodeBot}. 
+{AnsibleCodeBot} scans your code repositories to recommend code quality improvements. It promotes Ansible best practices while avoiding common errors that can lead to bugs or make code harder to maintain. The bot automatically submits pull requests to the repository, which proactively alerts the repository owner to a recommended change to their content. You can configure {AnsibleCodeBot} to scan your existing Git repositories (both public and private).  
+
+[NOTE]
+====
+Your organization must have an active subscription to {PlatformName} to use the {AnsibleCodeBot}. However, {ibmwatsonxcodeassistant} is not required to use the {AnsibleCodeBot}.
+====
 
 After you install the {AnsibleCodeBot}, you can access the {AnsibleCodeBot} dashboard that displays all your repositories that have the bot installed along with their scan status. From the dashboard, you can start a manual scan, view the scan history, and view the repository. From GitHub, you can configure a schedule to scan your repository at regular intervals, and add or remove a repository from being scanned. For more information, see xref:manage-repo-scans_using-code-bot-for-suggestions[Managing repository scans]. 
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-26616. 

Change made:
Added a note stating 'Ansible code bot doesn't need IBM watsonx Code Assistant'