### PR TITLE
AAP-23395: Reused  known issue about using remote SSH extension from existing inline troubleshooting doc

### DIFF
--- a/lightspeed/modules/proc_troubleshooting-vscode.adoc
+++ b/lightspeed/modules/proc_troubleshooting-vscode.adoc
@@ -20,6 +20,10 @@ To resolve this error, ensure that:
 +
 If you are part of an organization that has a trial or paid subscription to both {PlatformNameShort} and {ibmwatsonxcodeassistant}, but your organization administrator has not configured an {ibmwatsonxcodeassistant} model for your organization, you will encounter a `Failure on completion requests` error when you make inference requests in VS Code. 
 
+* You receive an `Ansible Lightspeed encountered an error. Try again after some time.` error message when you make single-task or multitask requests.
++
+This error occurs when you use a remote SSH extension with VS Code to request single or multitask recommendations in playbooks. However, the task recommendations are generated when using a role. This error occurs in workspaces that contain a large number of roles.  
+
 * Your VS Code Workspace settings override user settings.
 +
 If your Workspace settings are configured, they can override our user settings even if you have configured the Ansible VS Code extension correctly. The Workspace settings can disable your VS Code extension settings, and therefore you cannot access the Ansible Lightspeed service. 


### PR DESCRIPTION
This PR addresses AAP-23395, which was originally added to ongoing troubleshooting inline messages (AAP-22335) effort, but reusing it here because the troubleshooting activity is still WIP and delayed than originally planned. Content was reviewed as part of the ongoing error messaging effort. 

Change made:
Added error message about Ansible Lightspeed Task Generation in Playbooks does not work with Remote SSH Extension for workspaces with large number of roles.