### PR TITLE
Fixed naming content with proper attribute. (#1527)

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -9,7 +9,7 @@
 
 Passwords must be enclosed in quotes when they are provided in plain text in the inventory file.
 
-| *`automation_controller_main_url`* | The full routeable URL used by EDA to connect to a controller host. This URL is required if there is no Automation Controller configured in inventory.
+| *`automation_controller_main_url`* | The full routeable URL used by {EDAName} to connect to a controller host. This URL is required if there is no {ControllerName} configured in inventory.
 
 Format example: `automation_controller_main_url='https://<hostname>'`
 


### PR DESCRIPTION
Replaced Automation controller with {ControllerName}, and EDA with {EDAName}.