### PR TITLE
Fixed spelling error in Controller User Guide (#1531)

### DIFF
--- a/downstream/modules/platform/proc-controller-use-an-exec-env.adoc
+++ b/downstream/modules/platform/proc-controller-use-an-exec-env.adoc
@@ -27,7 +27,7 @@ The image name requires its full location (repository), the registry, image name
 +
 [NOTE]
 ====
-If you do not set a typing error for pull, the value defaults to *Only pull the image if not present before running*.
+If you do not set a type for pull, the value defaults to *Only pull the image if not present before running*.
 ====
 +
 * Optional: *Description*:


### PR DESCRIPTION
Fixed "typing error" to "type" in the Controller User Guide

AAP-24968

https://issues.redhat.com/browse/AAP-24968