### PR TITLE
Preparing the AAP Operator  guides for EA

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-backup.adoc
+++ b/downstream/assemblies/platform/assembly-aap-backup.adoc
@@ -15,8 +15,7 @@ We recommend taking backups before upgrading the {OperatorPlatform}.
 Take a backup regularly in case you want to restore the platform to a previous state.
 
 
-//part of 2.5 release, (AAP-22178) uncomment when publishing [gmurray]
-//include::platform/proc-aap-platform-gateway-backup.adoc[leveloffset=+1]
+include::platform/proc-aap-platform-gateway-backup.adoc[leveloffset=+1]
 
 include::platform/proc-aap-controller-backup.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-aap-recovery.adoc
+++ b/downstream/assemblies/platform/assembly-aap-recovery.adoc
@@ -9,8 +9,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 If you lose information on your system or experience issues with an upgrade, you can use the backup resources of your deployment instances. Use the following procedures to recover your {PlatformNameShort} deployment files.
 
-//part of 2.5 release, (AAP-22178) uncomment when publishing [gmurray]
-//include::platform/proc-aap-platform-gateway-restore.adoc[leveloffset=+1]
+include::platform/proc-aap-platform-gateway-restore.adoc[leveloffset=+1]
 
 include::platform/proc-aap-controller-restore.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 
 = Configuring the Red Hat {OperatorPlatform} on {OCP}
 
-The platform gateway for {PlaformNameShort} enables you to manage the following {PlatformNameShort} components to form a single user interface:
+The platform gateway for {PlatformNameShort} enables you to manage the following {PlatformNameShort} components to form a single user interface:
 
 * {ControllerNameStart}
 * {HubNameStart}

--- a/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
@@ -8,14 +8,13 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="installing-controller-operator"]
-= Installing and configuring {ControllerName} on {OCP} web console
-
+= Configuring {ControllerName} on {OCP} web console
 
 :context: installing-contr-operator
 
 
 [role="_abstract"]
-You can use these instructions to install the {ControllerName} operator on {OCP}, specify custom resources, and deploy {PlatformNameShort} with an external database.
+You can use these instructions to configure the {ControllerName} operator on {OCP}, specify custom resources, and deploy {PlatformNameShort} with an external database.
 
 {ControllerNameStart} configuration can be done through the {ControllerName} extra_settings or directly in the user interface after deployment. However, it is important to note that configurations made in extra_settings take precedence over settings made in the user interface.
 
@@ -30,23 +29,26 @@ When an instance of {ControllerName} is removed, the associated PVCs are not aut
 == Prerequisites
 
 * You have installed the {PlatformName} catalog in Operator Hub.
-* For Controller, a default StorageClass must be configured on the cluster for the operator to dynamically create needed PVCs. This is not necessary if an external PostgreSQL database is configured.
+* For {ControllerName}, a default StorageClass must be configured on the cluster for the operator to dynamically create needed PVCs. This is not necessary if an external PostgreSQL database is configured.
 * For Hub a StorageClass that supports ReadWriteMany must be available on the cluster to dynamically created the PVC needed for the content, redis and api pods. If it is not the default StorageClass on the cluster, you can specify it when creating your AutomationHub object.
 
-== Installing the {ControllerName} operator
-Use this procedure to install the {ControllerName} operator.
+//Not relevant for 2.5 EA, commenting out section [gmurray]
+//== Installing the {ControllerName} operator
+//Use this procedure to install the {ControllerName} operator.
 
-.Procedure
+//.Procedure
 
-. Navigate to menu:Operators[Installed Operators], then click on the *Ansible Automation Platform* operator.
-. Locate the *Automation controller* tab, then click btn:[Create instance].
+//. Navigate to menu:Operators[Installed Operators], then click on the *Ansible Automation Platform* operator.
+//. Locate the *Automation controller* tab, then click btn:[Create instance].
 
-You can proceed with configuring the instance using either the Form View or YAML view.
+//You can proceed with configuring the instance using either the Form View or YAML view.
 
 
-include::platform/proc-creating-controller-form-view.adoc[leveloffset=+2]
+//include::platform/proc-creating-controller-form-view.adoc[leveloffset=+2]
 include::platform/proc-configuring-controller-image-pull-policy.adoc[leveloffset=+2]
-include::platform/proc-configuring-controller-ldap-security.adoc[leveloffset=+2]
+
+// removing this section until we add the new guide for gateway specific
+//include::platform/proc-configuring-controller-ldap-security.adoc[leveloffset=+2]
 include::platform/proc-configuring-controller-route-options.adoc[leveloffset=+2]
 include::platform/proc-controller-ingress-options.adoc[leveloffset=+2]
 include::platform/proc-operator-external-db-controller.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -8,12 +8,12 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="installing-hub-operator"]
-= Installing and configuring {HubName} on {OCP} web console
+= Configuring {HubName} on {OCP} web console
 
 :context: installing-hub-operator
 
 [role="_abstract"]
-You can use these instructions to install the {HubName} operator on {OCP}, specify custom resources, and deploy {PlatformNameShort} with an external database.
+You can use these instructions to configure the {HubName} operator on {OCP}, specify custom resources, and deploy {PlatformNameShort} with an external database.
 
 {HubNameStart} configuration can be done through the {HubName} pulp_settings or directly in the user interface after deployment. However, it is important to note that configurations made in pulp_settings take precedence over settings made in the user interface. Hub settings should always be set as lowercase on the Hub custom resource specification.
 

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -7,7 +7,7 @@ You can use the OperatorHub on the {OCP} web console to install {OperatorPlatfor
 
 Alternatively, you can install {OperatorPlatform} from the {OCPShort} command-line interface (CLI), `oc`.
 
-After you have installed {OperatorPlatform} you must create an *AnsibleAutomationPlatform* custom resource (CR). This allows you to manage {PlatformNameShort} components from a single unified interface known as the platform gateway. As of version 2.5, you must create an {PlatformNameShort} CR, even if you have an existing {ControllerName},  {HubName}, or {{EDAName}}, components.
+After you have installed {OperatorPlatform} you must create an *AnsibleAutomationPlatform* custom resource (CR). This allows you to manage {PlatformNameShort} components from a single unified interface known as the platform gateway. As of version 2.5, you must create an {PlatformNameShort} CR, even if you have an existing {ControllerName},  {HubName}, or {EDAName}, components.
 
 If existing components have already been deployed, you must specify these components on the {PlatformNameShort} CR. You must create the custom resource in the same namespace as the existing components.
 

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -7,7 +7,7 @@ You can use the OperatorHub on the {OCP} web console to install {OperatorPlatfor
 
 Alternatively, you can install {OperatorPlatform} from the {OCPShort} command-line interface (CLI), `oc`.
 
-After you have installed {OperatorPlatform} you must create an *AnsibleAutomationPlatform* custom resource (CR). This allows you to manage {PlatformNameShort} components from a single unified interface known as the platform gateway. As of version 2.5, you must create an {PlatformNameShort} CR, even if you have an existing automation controller,  automation hub, or Event-driven Ansible (EDA), components.
+After you have installed {OperatorPlatform} you must create an *AnsibleAutomationPlatform* custom resource (CR). This allows you to manage {PlatformNameShort} components from a single unified interface known as the platform gateway. As of version 2.5, you must create an {PlatformNameShort} CR, even if you have an existing {ControllerName},  {HubName}, or {{EDAName}}, components.
 
 If existing components have already been deployed, you must specify these components on the {PlatformNameShort} CR. You must create the custom resource in the same namespace as the existing components.
 
@@ -15,21 +15,21 @@ If existing components have already been deployed, you must specify these compon
 |===
 | *Supported scenarios* | *Supported scenarios with existing components*
 |
-* {PlatformNameShort} CR for blank slate install with automation controller, automation hub, and EDA enabled
+* {PlatformNameShort} CR for blank slate install with {ControllerName}, {HubName}, and {EDAName} enabled
 
-* {PlatformNameShort} CR with just automation controller enabled
+* {PlatformNameShort} CR with just {ControllerName} enabled
 
-* {PlatformNameShort} CR with just automation controller, automation hub enabled
+* {PlatformNameShort} CR with just {ControllerName}, {HubName} enabled
 
-* {PlatformNameShort} CR with just automation controller, EDA enabled
+* {PlatformNameShort} CR with just {ControllerName}, {EDAName} enabled
  |
- * {PlatformNameShort} CR created in the same namespace as an existing automation controller CR with the automation controller name specified on the {PlatformNameShort} CR spec
+ * {PlatformNameShort} CR created in the same namespace as an existing {ControllerName} CR with the {ControllerName} name specified on the {PlatformNameShort} CR spec
 
-* Same with automation controller and automation hub
+* Same with {ControllerName} and {HubName}
 
-* Same with automation controller, automation hub, and EDA
+* Same with {ControllerName}, {HubName}, and {EDAName}
 
-* Same with automation controller and EDA
+* Same with {ControllerName} and {EDAName}
 |===
 
 // Commenting out as upgrade is not included in EA [gmurray]

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -7,9 +7,30 @@ You can use the OperatorHub on the {OCP} web console to install {OperatorPlatfor
 
 Alternatively, you can install {OperatorPlatform} from the {OCPShort} command-line interface (CLI), `oc`.
 
-Follow one of the workflows below to install the {OperatorPlatform} and use it to install the components of {PlatformNameShort} that you require.
+After you have installed {OperatorPlatform} you must create an *AnsibleAutomationPlatform* custom resource (CR). This allows you to manage {PlatformNameShort} components from a single unified interface known as the platform gateway. As of version 2.5, you must create an {PlatformNameShort} CR, even if you have an existing automation controller,  automation hub, or Event-driven Ansible (EDA), components.
 
-* {ControllerNameStart} custom resources first, then {HubName} custom resources;
-* {HubNameStart} custom resources first, then {ControllerName} custom resources;
-* {ControllerNameStart} custom resources;
-* {HubNameStart} custom resources.
+If existing components have already been deployed, you must specify these components on the {PlatformNameShort} CR. You must create the custom resource in the same namespace as the existing components.
+
+[cols=2*a,options="header"]
+|===
+| *Supported scenarios* | *Supported scenarios with existing components*
+|
+* {PlatformNameShort} CR for blank slate install with automation controller, automation hub, and EDA enabled
+
+* {PlatformNameShort} CR with just automation controller enabled
+
+* {PlatformNameShort} CR with just automation controller, automation hub enabled
+
+* {PlatformNameShort} CR with just automation controller, EDA enabled
+ |
+ * {PlatformNameShort} CR created in the same namespace as an existing automation controller CR with the automation controller name specified on the {PlatformNameShort} CR spec
+
+* Same with automation controller and automation hub
+
+* Same with automation controller, automation hub, and EDA
+
+* Same with automation controller and EDA
+|===
+
+// Commenting out as upgrade is not included in EA [gmurray]
+// NOTE: The stand-alone EDA user interface will not work upon upgrade. After you configure {PlatformNameShort}, other stand-alone user interfaces will not work.

--- a/downstream/modules/platform/con-resource-operator-overview.adoc
+++ b/downstream/modules/platform/con-resource-operator-overview.adoc
@@ -1,7 +1,7 @@
 [id="con-controller-resource-operator_{context}"]
 
 = {OperatorResourceShort} overview
-{OperatorResourceShort} is a custom resource (CR) that you can deploy after you have created your {ControllerName} deployment.
+{OperatorResourceShort} is a custom resource (CR) that you can deploy after you have created your platform gateway deployment.
  With {OperatorResourceShort} you can define projects, job templates, and inventories through the use of YAML files. 
  These YAML files are then used by {ControllerName} to create these resources. 
  You can create the YAML through the *Form view* that prompts you for keys and values for your YAML code. 

--- a/downstream/modules/platform/proc-access-hub-operator-ui.adoc
+++ b/downstream/modules/platform/proc-access-hub-operator-ui.adoc
@@ -1,8 +1,8 @@
 [id="proc-access-hub-operator-ui_{context}"]
 
-= Accessing the {HubName} user interface
+= Finding the {HubName} route
 
-You can access the {HubName} interface once all pods have successfully launched.
+You can access the {HubName} through the platform gateway or through the following procedure. 
 
 .Procedure
 . Navigate to menu:Networking[Routes].

--- a/downstream/modules/platform/proc-add-controller-access-token.adoc
+++ b/downstream/modules/platform/proc-add-controller-access-token.adoc
@@ -1,23 +1,19 @@
 [id="proc-add-controller-access-token_{context}"]
 
-= Connecting {OperatorResourceShort} to {ControllerName}
+= Connecting {OperatorResourceShort} to platform gateway
 
-To connect {OperatorResourceShort} with {ControllerName} you need to create a k8s secret with the connection information for your {ControllerName} instance.
+To connect {OperatorResourceShort} with platform gateway you need to create a k8s secret with the connection information for your {ControllerName} instance.
+
+NOTE: You can only create OAuth 2 Tokens for your own user through the API or UI, which means you can only configure or view tokens from your own user profile.
 
 .Procedure
-To create an OAuth2 token for your user in the {ControllerName} UI:
+To create an OAuth2 token for your user in the platform gateway UI:
 
-. In the navigation panel, select menu:Access[Users].
+. In the navigation panel, select menu:Access Management[Users].
 . Select the username you want to create a token for.
-. Click on btn:[Tokens], then click btn:[Add].
+. Select menu:Tokens[Automation Execution]
+. Click btn:[Create Token].
 . You can leave *Applications* empty. Add a description and select *Read* or *Write* for the *Scope*.
-
-Alternatively, you can create a OAuth2 token at the command-line by using the `create_oauth2_token` manage command:
-
-----
-$ controller-manage create_oauth2_token --user example_user
-New OAuth2 token for example_user: j89ia8OO79te6IAZ97L7E8bMgXCON2
-----
 
 [NOTE]
 ====

--- a/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
+++ b/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
@@ -4,24 +4,24 @@
 
 [id="proc-cli-get-controller-pwd{context}"]
 
-= Fetching {ControllerNameStart} login details from the {OCPShort} CLI
+= Fetching platform gateway login details from the {OCPShort} CLI
 
-To login to the {ControllerNameStart}, you need the web address and the password.
+To login to the platform gateway, you need the web address and the password.
 
-== Fetching the {ControllerName} web address
+== Fetching the platform gateway web address
 
 A {OCP} route exposes a service at a host name, so that external clients can reach it by name.
-When you created the {ControllerName} instance, a route was created for it.
-The route inherits the name that you assigned to the {ControllerName} object in the YAML file.
+When you created the platform gateway instance, a route was created for it.
+The route inherits the name that you assigned to the platform gateway object in the YAML file.
 
 Use the following command to fetch the routes:
 
 [subs="+quotes"]
 -----
-oc get routes -n __<controller_namespace>__
+oc get routes -n __<platform_namespace>__
 -----
 
-In the following example, the `_example_` {ControllerName} is running in the `_ansible-automation-platform_` namespace.
+In the following example, the `_example_` platform gateway is running in the `_ansible-automation-platform_` namespace.
 
 -----
 $ oc get routes -n ansible-automation-platform
@@ -30,26 +30,26 @@ NAME      HOST/PORT                                              PATH   SERVICES
 example   example-ansible-automation-platform.apps-crc.testing          example-service   http   edge/Redirect   None
 -----
 
-The address for the {ControllerName} instance is `example-ansible-automation-platform.apps-crc.testing`.
+The address for the platform gateway instance is `example-ansible-automation-platform.apps-crc.testing`.
 
-== Fetching the {ControllerName} password
+== Fetching the platform gateway password
 
-The YAML block for the {ControllerName} instance in [filename]`sub.yaml` assigns values to the _name_ and _admin_user_ keys.
-Use these values in the following command to fetch the password for the {ControllerName} instance.
+The YAML block for the platform gateway instance in [filename]`sub.yaml` assigns values to the _name_ and _admin_user_ keys.
+Use these values in the following command to fetch the password for the platform gateway instance.
 
 -----
-oc get secret/<controller_name>-<admin_user>-password -o yaml
+oc get secret/<your instance name>-<admin_user>-password -o yaml
 -----
 
 The default value for _admin_user_ is `_admin_`. Modify the command if you changed the admin username in [filename]`sub.yaml`.
 
-The following example retrieves the password for an {ControllerName} object called `_example_`: 
+The following example retrieves the password for a platform gateway object called `_example_`: 
 
 -----
 oc get secret/example-admin-password -o yaml
 -----
 
-The password for the {ControllerName} instance is listed in the `metadata` field in the output:
+The password for the platform gateway instance is listed in the `metadata` field in the output:
 
 -----
 $ oc get secret/example-admin-password -o yaml

--- a/downstream/modules/platform/proc-configuring-controller-image-pull-policy.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-image-pull-policy.adoc
@@ -5,7 +5,12 @@ Use this procedure to configure the image pull policy on your {ControllerName}.
 
 .Procedure
 
-. Under *Image Pull Policy*, click on the radio button to select
+. Go to menu:Operators[Installed Operators].
+. Locate the *Automation Controller* tab. 
+. For new instances, click btn:[Create AutomationController].
+.. For existing instances, you can edit the YAML view by clicking {MoreActionsIcon} and then btn:[Edit AutomationController].
+. Click btn:[advanced Configuration].
+Under *Image Pull Policy*, click on the radio button to select
 * *Always*
 * *Never*
 * *IfNotPresent*

--- a/downstream/modules/platform/proc-configuring-controller-ldap-security.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-ldap-security.adoc
@@ -1,7 +1,13 @@
 [id="proc_configuring-controller-ldap-security_{context}"]
 
 = Configuring your controller LDAP security
-Use this procedure to configure LDAP security for your {ControllerName}.
+
+You can configure your LDAP security for {ControllerName} through any of the following options:
+
+* The automation controller user interface.
+//Need to add a link to Donna's Auth doc when finished.
+* The platform gateway user interface. See Authentication doc for additional steps.
+* The following procedure steps.
 
 .Procedure
 . If you do not have a `ldap_cacert_secret`, you can create one with the following command:

--- a/downstream/modules/platform/proc-configuring-controller-route-options.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-route-options.adoc
@@ -5,6 +5,10 @@
 The {PlatformName} operator installation form allows you to further configure your {ControllerName} operator route options under *Advanced configuration*.
 
 .Procedure
+. Go to menu:Operators[Installed Operators].
+. Locate the *Automation Controller* tab. 
+. For new instances, click btn:[Create AutomationController].
+.. For existing instances, you can edit the YAML view by clicking {MoreActionsIcon} and then btn:[Edit AutomationController].
 . Click btn:[Advanced configuration].
 . Under *Ingress type*, click the drop-down menu and select *Route*.
 . Under *Route DNS host*, enter a common host name that the route answers to.

--- a/downstream/modules/platform/proc-controller-ingress-options.adoc
+++ b/downstream/modules/platform/proc-controller-ingress-options.adoc
@@ -6,7 +6,11 @@ The {PlatformName} operator installation form allows you to further configure yo
 
 .Procedure
 
-. Click btn:[Advanced Configuration].
+. Go to menu:Operators[Installed Operators].
+. Locate the *Automation Controller* tab. 
+. For new instances, click btn:[Create AutomationController].
+.. For existing instances, you can edit the YAML view by clicking {MoreActionsIcon} and then btn:[Edit AutomationController].
+. Click btn:[Advanced configuration].
 . Under *Ingress type*, click the drop-down menu and select *Ingress*.
 . Under *Ingress annotations*, enter any annotations to add to the ingress.
 . Under *Ingress TLS secret*, click the drop-down menu and select a secret from the list.

--- a/downstream/modules/platform/proc-enable-hstore-extension.adoc
+++ b/downstream/modules/platform/proc-enable-hstore-extension.adoc
@@ -2,7 +2,7 @@
 
 = Enabling the hstore extension for the {HubName} PostgreSQL database
 
-From {PlatformNameShort} {PlatformVers}, the database migration script uses `hstore` fields to store information, therefore the `hstore` extension to the {HubName} PostgreSQL database must be enabled.
+Added in {PlatformNameShort} {PlatformVers}, the database migration script uses `hstore` fields to store information, therefore the `hstore` extension to the {HubName} PostgreSQL database must be enabled.
 
 This process is automatic when using the {PlatformNameShort} installer and a managed PostgreSQL server.
 

--- a/downstream/modules/platform/proc-hub-ingress-options.adoc
+++ b/downstream/modules/platform/proc-hub-ingress-options.adoc
@@ -6,6 +6,10 @@ The {PlatformName} operator installation form allows you to further configure yo
 
 .Procedure
 
+. Go to menu:Operators[Installed Operators].
+. Locate the *Automation Hub* tab. 
+. For new instances, click btn:[Create AutomationHub].
+.. For existing instances, you can edit the YAML view by clicking {MoreActionsIcon} and then btn:[Edit AutomationHub].
 . Click btn:[Advanced Configuration].
 . Under *Ingress type*, click the drop-down menu and select *Ingress*.
 . Under *Ingress annotations*, enter any annotations to add to the ingress.

--- a/downstream/modules/platform/proc-hub-route-options.adoc
+++ b/downstream/modules/platform/proc-hub-route-options.adoc
@@ -6,6 +6,10 @@ The {PlatformName} operator installation form allows you to further configure yo
 
 .Procedure
 
+. Go to menu:Operators[Installed Operators].
+. Locate the *Automation Hub* tab. 
+. For new instances, click btn:[Create AutomationHub].
+.. For existing instances, you can edit the YAML view by clicking {MoreActionsIcon} and then btn:[Edit AutomationHub].
 . Click btn:[Advanced configuration].
 . Under *Ingress type*, click the drop-down menu and select *Route*.
 . Under *Route DNS host*, enter a common host name that the route answers to.

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -43,7 +43,7 @@ metadata:
   name: ansible-automation-platform
   namespace: ansible-automation-platform
 spec:
-  channel: 'stable-2.4'
+  channel: 'stable-2.5'
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators

--- a/downstream/modules/platform/proc-operator-access-aap.adoc
+++ b/downstream/modules/platform/proc-operator-access-aap.adoc
@@ -20,8 +20,8 @@ To access your *AnsibleAutomationPlatform* instance:
 .. Click btn:[Subscription manifest] or btn:[Username/password].
 .. Upload your manifest or enter your username and password.
 .. Select  your subscription from the *Subscription* list.
-.. Click btn:[Next]. 
-+ This redirects you to the *Analytics* page.
+.. Click btn:[Next]. +
+This redirects you to the *Analytics* page.
 . Click btn:[Next].
 . Select the *I agree to the terms of the license agreement* checkbox.
 . Click btn:[Next].

--- a/downstream/modules/platform/proc-operator-external-db-controller.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-controller.adoc
@@ -22,7 +22,7 @@ The external database must be a PostgreSQL database that is the version supporte
 
 [NOTE]
 ====
-{PlatformNameShort} {PlatformVers} supports PostgreSQL 13.
+{PlatformNameShort} {PlatformVers} supports {PostgresVers}.
 ====
 
 .Procedure

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -22,7 +22,7 @@ The external database must be a PostgreSQL database that is the version supporte
 
 [NOTE]
 ====
-{PlatformNameShort} {PlatformVers} supports PostgreSQL 13.
+{PlatformNameShort} {PlatformVers} supports PostgreSQL 15.
 ====
 
 .Procedure

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -22,7 +22,7 @@ The external database must be a PostgreSQL database that is the version supporte
 
 [NOTE]
 ====
-{PlatformNameShort} {PlatformVers} supports PostgreSQL 15.
+{PlatformNameShort} {PlatformVers} supports {PostgresVers}.
 ====
 
 .Procedure

--- a/downstream/modules/platform/proc-provision-ocp-storage-with-readwritemany.adoc
+++ b/downstream/modules/platform/proc-provision-ocp-storage-with-readwritemany.adoc
@@ -7,6 +7,8 @@ To ensure successful installation of {OperatorPlatform}, you must provision your
 
 .Procedure
 
-. Click link:{BaseURL}/openshift_container_platform/4.10/html-single/storage/index#persistent-storage-nfs-provisioning_persistent-storage-nfs[Provisioning] to update the access mode.
+. Go to menu:Storage[PersistentVolume].
+. Click btn: Create PersistentVolume.
 . In the first step, update the `accessModes` from the default `ReadWriteOnce` to `ReadWriteMany`.
+.. See link:{BaseURL}/openshift_container_platform/4.10/html-single/storage/index#persistent-storage-nfs-provisioning_persistent-storage-nfs[Provisioning] to update the access mode. for a detailed overview.
 . Complete the additional steps in this section to create the persistent volume claim (PVC).

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -21,7 +21,8 @@ include::platform/assembly-operator-install-planning.adoc[leveloffset=+1]
 
 include::platform/assembly-install-aap-operator.adoc[leveloffset=+1]
 
-// Part of the 2.5 release commenting out until live
+include::platform/assembly-installing-aap-operator-cli.adoc[leveloffset=+1]
+
 include::platform/assembly-configure-aap-operator.adoc[leveloffset=+1]
 
 include::platform/assembly-installing-controller-operator.adoc[leveloffset=+1]
@@ -32,15 +33,16 @@ include::platform/assembly-installing-hub-operator.adoc[leveloffset=+1]
 
 // include::platform/assembly-installing-controller-operator-local-db.adoc[leveloffset=+1]
 
-include::platform/assembly-installing-aap-operator-cli.adoc[leveloffset=+1]
 
-include::platform/assembly-deploy-eda-controller-on-aap-operator.adoc[leveloffset=+1]
+// [gmurray] Commenting out this module as covered in assembly-configure-aap-operator.adoc
+// include::platform/assembly-deploy-eda-controller-on-aap-operator.adoc[leveloffset=+1]
 
 include::platform/assembly-using-rhsso-operator-with-automation-hub.adoc[leveloffset=+1]
 
-include::platform/assembly-aap-migration.adoc[leveloffset=+1]
+// [gmurray] Commenting out this module as  migration is not supported for  2.5 EA. 
+// include::platform/assembly-aap-migration.adoc[leveloffset=+1]
 
-// [gmurray] Commenting out this module as part of AAP-22627. Upgrade is not supported in the initial 2.5 release. 
+// [gmurray] Commenting out this module as  upgrade is not supported for  2.5 EA. 
 // include::platform/assembly-operator-upgrade.adoc[leveloffset=+1]
 
 include::platform/assembly-operator-add-execution-nodes.adoc[leveloffset=+1]


### PR DESCRIPTION
[AAP-20941](https://issues.redhat.com/browse/AAP-20941) - Install gateway
[AAP-22178](https://issues.redhat.com/browse/AAP-22718) - Gateway Backup and restore sections

Preparing operator docs ahead of the 2.5 EA release

Docs:
-  **Red Hat Ansible Automation Platform operator backup and recovery guide**
-  **Installing on OpenShift Container Platform** 
(formally known as the Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform) 

Locations:
Doc location: Downstream > titles > aap-operator-installation
Doc location Downstream > titles > aap-operator-backup

Updates:
- Updating existing chapters to allign ahead of the new Gateway content.
- Uncommenting the module include statements for gateway install
- Uncommenting module include statements for backup and restore