### PR TITLE
AAP-26279: create snippet describing automation hub tech preview

### DIFF
--- a/downstream/snippets/snip-hub-tech-preview.adoc
+++ b/downstream/snippets/snip-hub-tech-preview.adoc
@@ -1,1 +1,3 @@
-You can access {HubNameMain} through the full experience or in link:https://access.redhat.com/support/offerings/techpreview[tech preview form]. The tech preview of {HubName} showcases the latest features and user interface currently available for use. 
+In the {PlatformNameShort} 2.5 EA release, {HubName} is available as both the *full experience* and as link:https://access.redhat.com/support/offerings/techpreview[*technology preview*]. Instructions in the documentation follow the full experience.
+
+include::snippets/technology-preview.adoc[leveloffset=+1]

--- a/downstream/snippets/snip-hub-tech-preview.adoc
+++ b/downstream/snippets/snip-hub-tech-preview.adoc
@@ -1,0 +1,1 @@
+You can access {HubNameMain} through the full experience or in link:https://access.redhat.com/support/offerings/techpreview[tech preview form]. The tech preview of {HubName} showcases the latest features and user interface currently available for use. 


### PR DESCRIPTION
This PR fulfills the request made in [AAP-26279](https://issues.redhat.com/browse/AAP-26279) for a snippet describing the automation hub tech preview in the 2.5 EA release.

UPDATE: closing this PR without merging as this snippet is no longer needed--see the JIRA linked above for more info. 