### PR TITLE
Fix typo in User guide sub-heading

### DIFF
--- a/downstream/modules/platform/proc-controller-adding-new-inventory.adoc
+++ b/downstream/modules/platform/proc-controller-adding-new-inventory.adoc
@@ -10,7 +10,7 @@ Adding a new inventory involves the following components:
 * xref:proc-controller-add-source[Adding a source]
 * xref:ref-controller-view-completed-jobs[View completed jobs]
 
-Use the following procedure to create a inventory:
+Use the following procedure to create an inventory:
 
 .Procedure
 . From the navigation panel, select {MenuInfrastructureInventories}.

--- a/downstream/modules/platform/proc-scm-git-subversion.adoc
+++ b/downstream/modules/platform/proc-scm-git-subversion.adoc
@@ -9,7 +9,7 @@ image:projects-create-scm-project.png[Select scm]
 
 . Enter the appropriate details into the following fields:
 
-* *SCM URL* - See an example in the tooltip .
+* *SCM URL* - See an example in the tooltip.
 * Optional: *SCM Branch/Tag/Commit*: Enter the SCM branch, tags, commit hashes, arbitrary refs, or revision number (if applicable) from the source control (Git or Subversion) to checkout. 
 Some commit hashes and references might not be available unless you also provide a custom refspec in the next field. 
 If left blank, the default is `HEAD` which is the last checked out Branch, Tag, or Commit for this project.

--- a/downstream/titles/controller/controller-user-guide/docinfo.xml
+++ b/downstream/titles/controller/controller-user-guide/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>2.4</productnumber>
 <subtitle>User Guide for Automation Controller</subtitle>
 <abstract>
-    <para>This guide shows how to use automation controller to define, operate, scalle and delegate automation.</para>
+    <para>This guide shows how to use automation controller to define, operate, scale and delegate automation.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>


### PR DESCRIPTION
Fix minor typos found in the user guide

https://issues.redhat.com/browse/AAP-26955

Affects `titles/controller-user-guide`