### PR TITLE
AAP-26400 added open source license to creating and using ees (#1566)

### DIFF
--- a/downstream/assemblies/builder/assembly-open-source-license.adoc
+++ b/downstream/assemblies/builder/assembly-open-source-license.adoc
@@ -1,0 +1,5 @@
+[id="assembly-open-source-license"]
+
+= Open source license
+
+include::../aap-common/apache-2.0-license.adoc[leveloffset=+1]

--- a/downstream/titles/builder/docinfo.xml
+++ b/downstream/titles/builder/docinfo.xml
@@ -4,6 +4,7 @@
   <subtitle>Create and use execution environments with Ansible Builder</subtitle>
 <abstract>
 <para>This guide shows how to create consistent and reproducible automation execution environments for your Red Hat Ansible Automation Platform.</para>
+<para>This document includes content from the upstream docs.ansible.com documentation, which is covered by the Apache 2.0 license.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/builder/master.adoc
+++ b/downstream/titles/builder/master.adoc
@@ -21,6 +21,6 @@ include::builder/assembly-publishing-exec-env.adoc[leveloffset=+1]
 include::hub/assembly-populate-container-registry.adoc[leveloffset=+1]
 include::hub/assembly-setup-container-repository.adoc[leveloffset=+1]
 include::hub/assembly-pull-image.adoc[leveloffset=+1]
-
+include::builder/assembly-open-source-license.adoc[levloffset=+1]
 [appendix]
 include::builder/builder/con-ee-precedence.adoc[leveloffset=+1]


### PR DESCRIPTION
2.5 backport for [PR 1566](https://github.com/ansible/aap-docs/pull/1566)

Add open-source license to Creating and using execution environments

https://issues.redhat.com/browse/AAP-26400