### PR TITLE
Move admin username and password to gateway docs, consolidate variables

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -5,18 +5,10 @@
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description*
-| *`admin_password`* | The password for an administration user to access the UI when the installation is complete.
-
-Passwords must be enclosed in quotes when they are provided in plain text in the inventory file.
-
 | *`automation_controller_main_url`* | The full routeable URL used by {EDAName} to connect to a controller host. This URL is required if there is no {ControllerName} configured in inventory.
 
 Format example: `automation_controller_main_url='https://<hostname>'`
 
-| *`automationcontroller_password`* | Password for your {ControllerName} instance.
-
-Passwords must be enclosed in quotes when they are provided in plain text in the inventory file.
-| *`automationcontroller_username`* | Username for your {ControllerName} instance.
 | *`nginx_http_port`* | The nginx HTTP server listens for inbound connections.
 
 Default = 80

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -5,15 +5,6 @@
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description*
-| *`automationedacontroller_admin_password`* | The admin password used by the {EdaController} instance.
-
-Passwords must be enclosed in quotes when they are provided in plain text in the inventory file.
-| *`automationedacontroller_admin_username`* | Username used by django to identify and create the admin superuser in {EDAcontroller}.
-
-Default = `admin`
-| *`automationedacontroller_admin_email`* | Email address used by django for the admin user for {EDAcontroller}.
-
-Default = `admin@example.com`
 | *`automationedacontroller_allowed_hostnames`* | List of additional addresses to enable for user access to {EDAcontroller}.
 
 Default = empty list

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -5,10 +5,21 @@
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description*
-| *`automationgateway_admin_password`* | The admin password used by the platform gateway instance.
+| *`admin_username`* | The username for a platform-wide administration user to access the platform UI upon install completion.
+
+This account will have administrative access to all components as well, such as automation controller.
+
+Default = `admin`
+| *`admin_password`* | The password for the administration user account.
+
+This can be used to login to the platform UI, and also be used for direct access to any components, such as automation controller.
+
+Set to a blank string to leave the administrative account with an unusable password, which can still for allow social auth.
 
 Passwords must be enclosed in quotes when they are provided in plain text in the inventory file.
+| *`admin_email`* | The email associated with the administration user account.
 
+Default = `admin@example.com`
 | *`automationgateway_pg_host`* | The hostname of the Postgres database used by platform gateway, which can be an externally managed database.
 
 | *`automationgateway_pg_port`* | The port number of the Postgres database used by platform gateway.


### PR DESCRIPTION
These are docs changes corresponding to https://github.com/ansible/automation-platform-collection/pull/1201

I believe the `automationcontroller_password` variable was incorrect and never worked.

Other variables, like `automationedacontroller_admin_username` I am intentionally removing as a part of the linked work. The EDA variables, only, would require a specific changelog entry that we stopped supporting them.

Gateway variables like `automationgateway_admin_password` were never in released product, so those are being deleted by me, but require no changelog.