### PR TITLE
2.5titles - Update the 2.5 titles to follow style guidelines & subtitle cleanup

### DIFF
--- a/downstream/titles/aap-containerized-install/docinfo.xml
+++ b/downstream/titles/aap-containerized-install/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Containerized Installation</title>
+<title>Containerized installation</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Containerized Ansible Automation Platform Installation Guide</subtitle>
+<subtitle>Install the containerized version of Ansible Automation Platform</subtitle>
 <abstract>
 <para>This guide helps you to understand the installation requirements and processes behind our new containerized version of Ansible Automation Platform.</para>
 </abstract>

--- a/downstream/titles/aap-containerized-install/master.adoc
+++ b/downstream/titles/aap-containerized-install/master.adoc
@@ -6,7 +6,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Containerized Installation
+= Containerized installation
 
 include::{Boilerplate}[]
 

--- a/downstream/titles/aap-hardening/docinfo.xml
+++ b/downstream/titles/aap-hardening/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Hardening and Compliance</title>
+<title>Hardening and compliance</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Install, configure, and maintain Ansible Automation Platform running on Red Hat Enterprise Linux in a secure manner.</subtitle>
+<subtitle>Install, configure, and maintain Ansible Automation Platform running on Red Hat Enterprise Linux in a secure manner</subtitle>
 <abstract>
     <para>This guide provides recommended practices for various processes needed to install, configure, and maintain {PlatformNameShort} on Red Hat Enterprise Linux in a secure manner.</para>
 </abstract>

--- a/downstream/titles/aap-hardening/master.adoc
+++ b/downstream/titles/aap-hardening/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Hardening and Compliance
+= Hardening and compliance
 
 This guide provides recommended practices for various processes needed to install, configure, and maintain {PlatformNameShort} on Red Hat Enterprise Linux in a secure manner.
 

--- a/downstream/titles/aap-installation-guide/docinfo.xml
+++ b/downstream/titles/aap-installation-guide/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Installing on Virtual Machines</title>
+<title>Installing on virtual machines</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Install Ansible Automation Platform</subtitle>
+<subtitle>Install Ansible Automation Platform on virtual machines</subtitle>
 <abstract>
     <para>This guide shows you how to install Red Hat Ansible Automation Platform based on supported installation scenarios.</para>
 </abstract>

--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -7,7 +7,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Installing on Virtual Machines
+= Installing on virtual machines
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/aap-operator-backup/docinfo.xml
+++ b/downstream/titles/aap-operator-backup/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Backup and Recovery for Operator Environments</title>
+<title>Backup and recovery for operator environments</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>

--- a/downstream/titles/aap-operator-backup/master.adoc
+++ b/downstream/titles/aap-operator-backup/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Backup and Recovery for Operator Environments
+= Backup and recovery for operator environments
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/analytics/job-explorer/docinfo.xml
+++ b/downstream/titles/analytics/job-explorer/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Using Automation Analytics</title>
+<title>Using automation analytics</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Review jobs and templates in greater detail by applying filters and sorting by attributes</subtitle>

--- a/downstream/titles/analytics/job-explorer/master.adoc
+++ b/downstream/titles/analytics/job-explorer/master.adoc
@@ -7,7 +7,7 @@ include::attributes/attributes.adoc[]
 :analytics_automation_savings:
 
 [[analytics_automation_savings]]
-= Using Automation Analytics
+= Using automation analytics
 
 include::{Boilerplate}[]
 

--- a/downstream/titles/automation-mesh/docinfo.xml
+++ b/downstream/titles/automation-mesh/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Automation Mesh for VM environments</title>
+<title>Automation mesh for VM environments</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Automate at scale in a cloud-native way</subtitle>

--- a/downstream/titles/automation-mesh/master.adoc
+++ b/downstream/titles/automation-mesh/master.adoc
@@ -9,7 +9,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Automation Mesh for VM environments
+= Automation mesh for VM environments
 
 Thank you for your interest in {PlatformName}.
 {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.

--- a/downstream/titles/builder/docinfo.xml
+++ b/downstream/titles/builder/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Creating and using execution environments</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-  <subtitle>Create and use execution environments with Ansible Builder</subtitle>
+  <subtitle>Create and use execution environment containers</subtitle>
 <abstract>
 <para>This guide shows how to create consistent and reproducible automation execution environments for your Red Hat Ansible Automation Platform.</para>
 <para>This document includes content from the upstream docs.ansible.com documentation, which is covered by the Apache 2.0 license.</para>

--- a/downstream/titles/builder/master.adoc
+++ b/downstream/titles/builder/master.adoc
@@ -9,7 +9,7 @@ include::attributes/attributes.adoc[]
 // Book Title
 = Creating and using execution environments
 
-Use {Builder} to create consistent and reproducible {ExecEnvName} for your {PlatformName} needs.
+Use {ExecEnvshort} builder to create consistent and reproducible containers for your {PlatformName} needs.
 
 include::{Boilerplate}[]
 

--- a/downstream/titles/central-auth/docinfo.xml
+++ b/downstream/titles/central-auth/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Access Management and Authentication</title>
+<title>Access management and authentication</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Enable central authentication functions for your Ansible Automation Platform
+<subtitle>Enable authentication functions and role based access controls for Ansible Automation Platform
 </subtitle>
 <abstract>
 <para>This guide provides platform administrators with the information and procedures required to enable and configure central authentication on Ansible Automation Platform.</para>

--- a/downstream/titles/central-auth/master.adoc
+++ b/downstream/titles/central-auth/master.adoc
@@ -7,7 +7,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Access Management and Authentication
+= Access management and authentication
 
 {AAPCentralAuth} is a third-party identity provider (idP) solution, allowing for a simplified single sign-on solution that can be used across the {PlatformNameShort}. Platform administrators can utilize {CentralAuth} to test connectivity and authentication, as well as onboard new users and manage user permissions by configuring and assigning them to groups. Along with OpenID Connect-based and LDAP support, {CentralAuth} also provides a supported REST API which can be used to bootstrap customer usage.
 

--- a/downstream/titles/controller/controller-admin-guide/docinfo.xml
+++ b/downstream/titles/controller/controller-admin-guide/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Configuring Automation Execution</title>
+<title>Configuring automation execution</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Administrator guide for automation controller</subtitle>
+<subtitle>Learn how to manage, monitor, and use automation controller</subtitle>
 <abstract>
     <para>This guide shows how to manage automation controller with custom scripts, management jobs, and more.</para>
 </abstract>

--- a/downstream/titles/controller/controller-admin-guide/master.adoc
+++ b/downstream/titles/controller/controller-admin-guide/master.adoc
@@ -9,9 +9,9 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Configuring Automation Execution
+= Configuring automation execution
 
-The {ControllerName} Administration Guide describes the administration of {ControllerName} through custom scripts, management jobs, and more.
+This guide describes the administration of {ControllerName} through custom scripts, management jobs, and more.
 Written for DevOps engineers and administrators, the {ControllerName} Administration Guide assumes a basic understanding of the systems requiring management with {ControllerName}s easy-to-use graphical interface.
 
 include::{Boilerplate}[]

--- a/downstream/titles/controller/controller-api-overview/docinfo.xml
+++ b/downstream/titles/controller/controller-api-overview/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Automation Execution API Overview</title>
+<title>Automation execution API overview</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Developer overview for the {ControllerName} API</subtitle>

--- a/downstream/titles/controller/controller-api-overview/master.adoc
+++ b/downstream/titles/controller/controller-api-overview/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Automation Execution API Overview
+= Automation execution API overview
 
 Thank you for your interest in {PlatformName}.
 {PlatformNameShort} helps teams manage complex multitiered deployments by adding control, knowledge, and delegation to Ansible-powered environments.

--- a/downstream/titles/controller/controller-user-guide/docinfo.xml
+++ b/downstream/titles/controller/controller-user-guide/docinfo.xml
@@ -1,9 +1,9 @@
-<title>Using Automation Execution</title>
+<title>Using automation execution</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>User guide for automation controller</subtitle>
+<subtitle>Use automation execution deploy, define, operate, scale and delegate automation</subtitle>
 <abstract>
-    <para>This guide shows you how to use automation controller to define, operate, scale and delegate automation.</para>
+    <para>This guide shows you how to use automation controller to define, operate, scale and delegate automation across your enterprise.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/controller/controller-user-guide/master.adoc
+++ b/downstream/titles/controller/controller-user-guide/master.adoc
@@ -9,7 +9,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Using Automation Execution
+= Using automation execution
 
 Thank you for your interest in {PlatformName} {ControllerName}.
 {ControllerNameStart} helps teams manage complex multitiered deployments by adding control, knowledge, and delegation to Ansible-powered environments.

--- a/downstream/titles/dev-guide/docinfo.xml
+++ b/downstream/titles/dev-guide/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Red Hat Ansible Automation Platform creator guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Learn to create automation content with Ansible</subtitle>
+<subtitle>Create automation content with Ansible</subtitle>
 <abstract>
 <para>This guide helps developers learn how to use Ansible to  create content for automation.</para>
 </abstract>

--- a/downstream/titles/develop-automation-content/docinfo.xml
+++ b/downstream/titles/develop-automation-content/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Developing automation content</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Install Ansible Automation Platform</subtitle>
+<subtitle>Develop Ansible automation content to run automation jobs</subtitle>
 <abstract>
     <para>This guide describes how to develop Ansible automation content and how to use it to run automation jobs from Red Hat Ansible Automation Platforms.</para>
 </abstract>

--- a/downstream/titles/eda/eda-getting-started-guide/docinfo.xml
+++ b/downstream/titles/eda/eda-getting-started-guide/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Getting started with Event-Driven Ansible guide</title>
+<title>Getting started with Event-Driven Ansible</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Learn about the benefits and how to get started using Event-Driven Ansible.</subtitle>
+<subtitle>Learn about the benefits and how to get started using Event-Driven Ansible</subtitle>
 <abstract>Event-Driven Ansible is a new way to enhance and expand automation by improving IT speed and agility while enabling consistency and resilience. This feature is designed for simplicity and flexibility.
 </abstract>
 <authorgroup>

--- a/downstream/titles/eda/eda-getting-started-guide/master.adoc
+++ b/downstream/titles/eda/eda-getting-started-guide/master.adoc
@@ -9,7 +9,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Getting started with Event-Driven Ansible guide
+= Getting started with Event-Driven Ansible
 
 Thank you for your interest in {EDAname}. {EDAname} is a new way to enhance and expand automation. It helps teams automate decision-making and improve IT speed and agility.
 

--- a/downstream/titles/eda/eda-user-guide/docinfo.xml
+++ b/downstream/titles/eda/eda-user-guide/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Using Automation Decisions </title>
+<title>Using automation decisions </title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Learn to configure and use {EDAcontroller} to enhance and expand automation</subtitle>
+<subtitle>Configure and use {EDAcontroller} to enhance and expand automation</subtitle>
 <abstract>
     <para> Learn how to configure your {EDAcontroller} to set up credentials, new projects, decision environments, tokens to authenticate to Ansible Automation Platform Controller, and rulebook activation.</para>
 </abstract>

--- a/downstream/titles/eda/eda-user-guide/master.adoc
+++ b/downstream/titles/eda/eda-user-guide/master.adoc
@@ -6,9 +6,9 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Using Automation Decisions
+= Using automation decisions
 
-{EDAcontroller} is a new way to enhance and expand automation by improving IT speed and agility while enabling consistency and resilience. 
+{EDAcontroller} is a new way to enhance and expand automation by improving IT speed and agility while enabling consistency and resilience.
 Developed by Red Hat, this feature is designed for simplicity and flexibility. 
 
 include::{Boilerplate}[]

--- a/downstream/titles/getting-started/docinfo.xml
+++ b/downstream/titles/getting-started/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Getting Started with Ansible Automation Platform</title>
+<title>Getting started with Ansible Automation Platform</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Getting Started with Ansible Automation Platform</subtitle>
+<subtitle>Get started with Ansible Automation Platform</subtitle>
 <abstract>
     <para>This guide shows how to get started with Ansible Automation Platform</para>
 </abstract>

--- a/downstream/titles/getting-started/master.adoc
+++ b/downstream/titles/getting-started/master.adoc
@@ -10,8 +10,8 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Getting Started with Ansible Automation Platform
+= Getting started with Ansible Automation Platform
 
-Getting Started with Ansible Automation Platform
+Getting started with Ansible Automation Platform
 
 include::{Boilerplate}[]

--- a/downstream/titles/navigator-guide/docinfo.xml
+++ b/downstream/titles/navigator-guide/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Using Content Creator</title>
+<title>Using content creator</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Develop content that is compatible with Ansible Automation Platform

--- a/downstream/titles/navigator-guide/master.adoc
+++ b/downstream/titles/navigator-guide/master.adoc
@@ -7,7 +7,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Using Content Creator
+= Using content creator
 
 include::{Boilerplate}[]
 

--- a/downstream/titles/operator-mesh/docinfo.xml
+++ b/downstream/titles/operator-mesh/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Automation Mesh for Managed Cloud or Operator Environments</title>
+<title>Automation mesh for managed cloud or operator environments</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Automate at scale in a cloud-native way</subtitle>

--- a/downstream/titles/operator-mesh/master.adoc
+++ b/downstream/titles/operator-mesh/master.adoc
@@ -9,7 +9,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Automation Mesh for Managed Cloud or Operator Environments
+= Automation mesh for managed cloud or operator environments
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/playbooks/playbooks-getting-started/docinfo.xml
+++ b/downstream/titles/playbooks/playbooks-getting-started/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Getting started with Playbooks</title>
+<title>Getting started with playbooks</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Getting started with ansible playbooks</subtitle>
+<subtitle>Get started with Ansible Playbooks</subtitle>
 <abstract>
     <para>This guide shows how to create and use playbooks to address your automation requirements.</para>
     <para>This document includes content from the upstream docs.ansible.com documentation, which is covered by the GNU GENERAL PUBLIC LICENSE v3.0.</para>

--- a/downstream/titles/playbooks/playbooks-getting-started/master.adoc
+++ b/downstream/titles/playbooks/playbooks-getting-started/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Getting started with Playbooks
+= Getting started with playbooks
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
@@ -20,7 +20,3 @@ include::playbooks/assembly-intro-to-playbooks.adoc[leveloffset=+1]
 include::playbooks/assembly-networking-playbook.adoc[leveloffset=+1]
 include::playbooks/assembly-playbook-practical-example.adoc[leveloffset=+1]
 include::playbooks/assembly-open-source-license.adoc[leveloffset=+1]
-
-
-
-

--- a/downstream/titles/playbooks/playbooks-reference/docinfo.xml
+++ b/downstream/titles/playbooks/playbooks-reference/docinfo.xml
@@ -1,7 +1,7 @@
-<title>Reference Guide to Ansible Playbooks</title>
+<title>Reference guide to Ansible Playbooks</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Reference Guide to Ansible Playbooks</subtitle>
+<subtitle>Learn about the different approaches for creating playbooks</subtitle>
 <abstract>
     <para>This guide provides a reference for the differing approaches to the creating of Ansible playbooks. </para>
 </abstract>

--- a/downstream/titles/playbooks/playbooks-reference/master.adoc
+++ b/downstream/titles/playbooks/playbooks-reference/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Reference Guide for Ansible Playbooks
+= Reference guide for Ansible Playbooks
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/release-notes/docinfo.xml
+++ b/downstream/titles/release-notes/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Release Notes</title>
+<title>Release notes</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>New features, enhancements, and bug fix information</subtitle>

--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -2,7 +2,7 @@
 // For each release, make a copy of assembly-rn-template.adoc, rename and save as instructed in the template and add an include statement to this file.
 include::attributes/attributes.adoc[]
 
-= Release Notes
+= Release notes
 
 
 include::{Boilerplate}[]

--- a/downstream/titles/security-guide/docinfo.xml
+++ b/downstream/titles/security-guide/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Implementing Security Automation</title>
+<title>Implementing security automation</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Identify and manage security events using Ansible</subtitle>

--- a/downstream/titles/security-guide/master.adoc
+++ b/downstream/titles/security-guide/master.adoc
@@ -7,7 +7,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Implementing Security Automation
+= Implementing security automation
 
 include::{Boilerplate}[]
 

--- a/downstream/titles/upgrade/docinfo.xml
+++ b/downstream/titles/upgrade/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Red Hat Ansible Automation Platform upgrade and migration guide</title>
+<title>Upgrade and migration</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Upgrade and migrate legacy deployments of Ansible Automation Platform</subtitle>

--- a/downstream/titles/upgrade/master.adoc
+++ b/downstream/titles/upgrade/master.adoc
@@ -6,7 +6,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Red Hat Ansible Automation Platform upgrade and migration guide
+= Upgrade and migration
 
 include::{Boilerplate}[]
 


### PR DESCRIPTION
This PR updates the 2.5 book titles to follow the style guidelines for titles and headings:

Write all titles and headings, including the titles of product documentation guides and Knowledgebase articles, in sentence-style capitalization. Do not use headline-style capitalization.

See here for details: https://docs.google.com/spreadsheets/d/13T9boSY7ZlXpZM_ZlfpjZbDu-irG2mRDsqVewOYvjBA/edit?usp=sharing

This PR also cleans up some of the document subtitles.