### PR TITLE
2.4 Add 2.4-7.1 bundle installer release to release notes

### DIFF
--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -44,6 +44,8 @@ include::topics/rpm-24-2.adoc[leveloffset=+3]
 
 include::topics/installer-version-table.adoc[leveloffset=+3]
 
+include::topics/installer-24-71.adoc[leveloffset=+3]
+
 include::topics/installer-24-7.adoc[leveloffset=+3]
 
 include::topics/installer-24-62.adoc[leveloffset=+3]

--- a/downstream/titles/release-notes/topics/installer-24-71.adoc
+++ b/downstream/titles/release-notes/topics/installer-24-71.adoc
@@ -1,0 +1,15 @@
+// This is the release notes for 2.4-7.1 bundle installer release
+
+[id="installer-24-71"]
+
+= RHBA-2024:4555 - bundle installer release 2.4-7.1 - July 15, 2024
+
+link:https://access.redhat.com/errata/RHBA-2024:4555[RHBA-2024:4555]
+
+== Related RPM releases
+
+* link:https://access.redhat.com/errata/RHSA-2024:4522[RHSA-2024:4522 - Security Advisory - July 12, 2024]
+
+== Related container releases
+
+* link:https://access.redhat.com/errata/RHBA-2024:4523[RHBA-2024:4523 - Bug Fix Advisory - July 12, 2024]

--- a/downstream/titles/release-notes/topics/installer-version-table.adoc
+++ b/downstream/titles/release-notes/topics/installer-version-table.adoc
@@ -6,6 +6,14 @@
 |===
 | Installation bundle | Component versions
 
+| xref:installer-24-71[2.4-7.1] + 
+July 15, 2024  | 
+* `ansible-automation-platform-setup` 2.4-7.1
+* `ansible-core` 2.15.12
+* {ControllerNameStart} 4.5.8
+* {HubNameStart} 4.9.2
+* {EDAName} 1.0.7
+
 | xref:installer-24-7[2.4-7] + 
 June 12, 2024  | 
 * `ansible-automation-platform-setup` 2.4-7


### PR DESCRIPTION
2.4 Release Notes - AAP 2.4-7.1 Bundle Installer release

https://issues.redhat.com/browse/AAP-26751