### PR TITLE
[Backport] AAP-19920 Convert/create modules for gateway roles (#1572)

### DIFF
--- a/downstream/modules/platform/con-gw-roles.adoc
+++ b/downstream/modules/platform/con-gw-roles.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="con-gw-roles_{context}"]
+
+= Roles
+
+Roles are units of organization in the {PlatformName}. When you assign a role to a team or user, you are granting access to use, read, or write credentials. Because of the file structure associated with a role, roles become redistributable units that enable you to share behavior among resources, or with other users. All access that is granted to use, read, or write credentials is handled through roles, and roles are defined for a resource.

--- a/downstream/modules/platform/proc-gw-create-roles.adoc
+++ b/downstream/modules/platform/proc-gw-create-roles.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-gw-create-roles_{context}"]
+
+= Creating a role
+
+ifdef::auto-exec[]
+{ControllerNameStart} provides a set of predefined roles with permissions sufficient for standard automation execution tasks. It is also possible to configure custom roles, and assign one or more permission filters to them. Permission filters define the actions allowed for a specific resource type.
+endif::auto-exec[]
+
+ifdef::auto-dec[]
+{EDAName} provides a set of predefined roles with permissions sufficient for standard automation decision tasks. It is also possible to configure custom roles, and assign one or more permission filters to them. Permission filters define the actions allowed for a specific resource type.
+endif::auto-dec[]
+
+.Procedure
+
+. From the navigation panel, select {MenuAMRoles}.
+ifdef::auto-exec[]
+. Select the *Automation Execution* tab.
+endif::auto-exec[]
+ifdef::auto-dec[]
+. Select the *Automation Decisions* tab.
+endif::auto-dec[]
+. Click btn:[Create role].
+. Provide a *Name* and optionally include a *Description* for the role.
+. Select a *Content type*.
+. Select the *Permissions* you want assigned to this role.
+. Click btn:[Create role] to create your new role.

--- a/downstream/modules/platform/proc-gw-delete-roles.adoc
+++ b/downstream/modules/platform/proc-gw-delete-roles.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-gw-delete-roles_{context}"]
+
+= Deleting a role
+
+Built in roles can not be deleted, however, you can delete custom roles from the *Roles* list view.
+
+.Procedure
+
+. From the navigation panel, select {MenuAMRoles}.
+ifdef::auto-exec[]
+. Select the *Automation Execution* tab.
+endif::auto-exec[]
+ifdef::auto-dec[]
+. Select the *Automation Decisions* tab.
+endif::auto-dec[]
+. Click the *More Actions* icon *{MoreActionsIcon}* next to the role you want and select *Delete role*.
+. To delete roles in bulk, select the roles you want to delete from the *Roles* list view, click the *More Actions* icon *{MoreActionsIcon}*, and select *Delete selected roles*.

--- a/downstream/modules/platform/proc-gw-edit-roles.adoc
+++ b/downstream/modules/platform/proc-gw-edit-roles.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-gw-edit-roles_{context}"]
+
+= Editing a role
+
+Built in roles can not be changed, however, you can modify custom roles from the *Roles* list view.
+
+.Procedure
+
+. From the navigation panel, select {MenuAMRoles}.
+ifdef::auto-exec[]
+. Select the *Automation Execution* tab.
+endif::auto-exec[]
+ifdef::auto-dec[]
+. Select the *Automation Decisions* tab.
+endif::auto-dec[]
+. Click the *Edit role* icon image:leftpencil.png[Edit,15,15] next to the role you want and modify the role settings as needed.
+. Click btn:[Save role] to save your changes.

--- a/downstream/modules/platform/proc-gw-roles.adoc
+++ b/downstream/modules/platform/proc-gw-roles.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-gw-roles_{context}"]
+
+ifdef::auto-exec[]
+= Automation execution roles
+
+You can display the set of roles assigned for automation execution resources by using *Access Management*. From here, you can also sort or search the roles list, and create, edit, or delete automation execution roles.
+endif::auto-exec[]
+
+ifdef::auto-dec[]
+= Automation decision roles
+
+You can display the set of roles assigned for automation decision resources by using *Access Management*. From here, you can also sort or search the roles list, and create, edit, or delete automation decision roles.
+endif::auto-dec[]
+
+.Procedure
+
+. From the navigation panel, select {MenuAMRoles}.
+ifdef::auto-exec[]
+. Select the *Automation Execution* tab.
+endif::auto-exec[]
+ifdef::auto-dec[]
+. Select the *Automation Decisions* tab.
+endif::auto-dec[]
+. From the table header, you can sort the list of roles by using the arrows for *Role*, *Description*, *Created* and *Editable* or by making sort selections in the *Sort* list.
+. You can filter the list of roles by selecting *Name* or *Editable* from the filter list and clicking the arrow.


### PR DESCRIPTION
This PR backports the changes from the #1572 to the 2.5 branch and includes the following changes:

* AAP-19920 Creating new modules for Roles
* AAP-19920 - corrections based on peer review
* AAP-19920 Added missing title for Roles concept module