### PR TITLE
List RHEL 9.0 as supported in planning guide

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -14,7 +14,7 @@ Your system must meet the following minimum system requirements to install and r
 
 h| Subscription | Valid {PlatformName} |
 
-h| OS | {RHEL} 8.6 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
+h| OS | {RHEL} 8.8 or later 64-bit (x86, ppc64le, s390x, aarch64), or {RHEL} 9.0 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
 h| Ansible-core | Ansible-core version {CoreInstVers} or later | {PlatformNameShort} includes execution environments that contain ansible-core {CoreUseVers}.
 


### PR DESCRIPTION
Explicitly list RHEL 9.0 as supported in the base system requirements in the planning guide

Explicitly list RHEL 9 as supported

https://issues.redhat.com/browse/AAP-26227