### PR TITLE
Added note to API guide for filtering exact matches (#1606)

### DIFF
--- a/downstream/modules/platform/ref-controller-api-field-lookups.adoc
+++ b/downstream/modules/platform/ref-controller-api-field-lookups.adoc
@@ -11,7 +11,7 @@ You can use field lookups for more advanced queries, by appending the lookup to 
 
 The following field lookups are supported:
 
-* exact: Exact match (default lookup if not specified).
+* exact: Exact match (default lookup if not specified, see the following note for more information).
 * iexact: Case-insensitive version of exact.
 * contains: Field contains value.
 * icontains: Case-insensitive version of contains.
@@ -37,3 +37,21 @@ You can specify lists (for the `in` lookup) as a comma-separated list of values.
 Filtering based on the requesting user's level of access by query string parameter:
 
 * `role_level`: Level of role to filter on, such as `admin_role`
+
+[NOTE]
+====
+Earlier releases of {PlatformNameShort} returned queries with *_exact* results by default. 
+As a workaround, set the `limit` to `?limit_exact` for the default filter. 
+For example, `/api/v2/jobs/?limit_exact=example.domain.com` results in:
+
+----
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+...
+----
+====
+
+


### PR DESCRIPTION
Addresses API behavior change from previous release regarding default exact matches.

https://issues.redhat.com/browse/AAP-27347

Affects `titles/controller-api-overview`