### PR TITLE
2.4 Update tech preview notice per supplementary style guide (#1639)

### DIFF
--- a/downstream/snippets/technology-preview.adoc
+++ b/downstream/snippets/technology-preview.adoc
@@ -1,3 +1,5 @@
-Technology Preview features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. 
+Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs) and might not be functionally complete.
+Red{nbsp}Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
-For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].


### PR DESCRIPTION
Update the tech preview notice to follow the guidelines in the supplementary style guide.

Note that the snippet is generic and is not enclosed in an admonition.

This is so that we can reuse the snippet, for example:

```
[IMPORTANT]
====
<New Feature> is a Technology Preview feature only.
include::snippets/technology-preview.adoc[]
====
```