### PR TITLE
Updating the EDA section of the deploy guide (#1659)

### DIFF
--- a/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
+++ b/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
@@ -14,9 +14,22 @@
 
 . Locate and select your installation of {PlatformNameShort}.
 
-. Under *Provided APIs*, locate the {EDAName} modal and click *Create instance*. 
+. Under the *Details* tab, locate the *EDA* modal and click *Create instance*. 
+
+. Click btn:[Form view], and in the *Name* field, enter the name you want for your new {EDAcontroller} deployment.
 +
-This takes you to the Form View to customize your installation. 
+[IMPORTANT]
+====
+If you have installed other {PlatformNameShort} components in your current {OCPShort} namespace, ensure that you provide a unique name for your {EDAcontroller} when you create your {EDAName} custom resource. Otherwise, naming conflicts can occur and impact {EDAcontroller} deployment.
+====
+. Specify your controller URL in the *Automation Server URL* field. 
++
+If you deployed {ControllerName} in Openshift as well, you can find the URL in the navigation panel under menu:Networking[Routes].
++
+[NOTE]
+====
+This is the only required customization, but you can customize other options using the UI form or directly in the YAML configuration tab, if desired.
+====
 +
 [IMPORTANT]
 ====
@@ -35,34 +48,16 @@ extra_settings:
     value: '12'
 ----
 +
-. Click btn:[Reload] and btn:[Save]. Return to the *Form* view.
-
-. In the *Name* field, enter the name you want for your new {EDAcontroller} deployment. 
-+
-[IMPORTANT]
-====
-If you have other {PlatformNameShort} components installed in your current {OCPShort} namespace, ensure that you provide a unique name for your {EDAcontroller} when you create your {EDAName} custom resource. Otherwise, naming conflicts can occur and impact {EDAcontroller} deployment.
-====
-+
-. Specify your controller URL. 
-+
-If you deployed {ControllerName} in Openshift as well, you can find the URL in the navigation panel under menu:Networking[Routes].
-+
-[NOTE]
-====
-This is the only required customization, but you can customize other options using the UI form or directly in the YAML configuration tab, if desired.
-====
-
 . Click btn:[Create].
 This deploys {EDAcontroller} in the namespace you specified. 
 +
-After a couple minutes when the installation is marked as *Successful*, you can find the URL for the {EDAName} UI on the *Routes* page in the Openshift UI. 
+After a couple minutes when the installation is marked as *Successful*, you can find the URL for the {EDAName} UI on the *Routes* page in the OpenShift UI. 
 
 . From the navigation panel, select menu:Networking[Routes] to find the new Route URL that has been created for you. 
 +
 Routes are listed according to the name of your custom resource.
 
-. Click the new URL to navigate to {EDAName} in the browser.
+. Click the new URL under the *Location* column to navigate to {EDAName} in the browser.
 
 . From the navigation panel, select menu:Workloads[Secrets] and locate the Admin Password k8s secret that was created for you, unless you specified a custom one.
 +


### PR DESCRIPTION
As part of the docX initiative to improve operator docs I have reviewed and refreshed the EDA section which had outdated UI elements.[AAP-28105](https://issues.redhat.com/browse/AAP-28105)

Updated the UI to be more accurate
Reordered the steps to focus on form view instructions first, then YAML view.