### PR TITLE
AAP-26281 New snippet to explain the hybrid (EDA 2.5 + ac 2.4) and 2.5 releases. 

### DIFF
--- a/downstream/snippets/snip-eda-24-plus-aap-25.adoc
+++ b/downstream/snippets/snip-eda-24-plus-aap-25.adoc
@@ -1,0 +1,4 @@
+You can configure a new installation of Event-Driven Ansible controller 1.1 with automation controller 4.4 or 4.5, which is considered a general availability release fully supported by Red Hat. Upgrading to Event-Driven Ansible controller 1.1 from an earlier release is unsupported at this time.
+
+You can also configure Event-Driven Ansible controller 1.1 with automation controller 4.6, which is also a general availability release fully supported by Red Hat. Upgrading to Event-Driven Ansible controller 1.1 from an earlier release is unsupported at this time.
+//This is subject to change.

--- a/downstream/snippets/snip-eda-24-plus-aap-25.adoc
+++ b/downstream/snippets/snip-eda-24-plus-aap-25.adoc
@@ -1,4 +1,0 @@
-You can configure a new installation of Event-Driven Ansible controller 1.1 with automation controller 4.4 or 4.5, which is considered a general availability release fully supported by Red Hat. Upgrading to Event-Driven Ansible controller 1.1 from an earlier release is unsupported at this time.
-
-You can also configure Event-Driven Ansible controller 1.1 with automation controller 4.6, which is also a general availability release fully supported by Red Hat. Upgrading to Event-Driven Ansible controller 1.1 from an earlier release is unsupported at this time.
-//This is subject to change.

--- a/downstream/snippets/snip-eda-25-plus-aap24.adoc
+++ b/downstream/snippets/snip-eda-25-plus-aap24.adoc
@@ -1,0 +1,4 @@
+You can configure a new installation of {EDAcontroller} 1.1 with {ControllerName} 4.4 or 4.5, which is considered a general avaliability release fully supported by Red Hat.
+You can also configure {EDAcontroller} 1.1 with {ControllerName} 4.6, which is also a general availability release fully supported by Red Hat.
+Upgrading to {EDAcontroller} 1.1 from an earlier release is unsupported at this time.
+


### PR DESCRIPTION
This new snippet describes the hybrid release as well as the 2.5 GA release. It will be included in the following: 

- 2.4 Release Notes
- 2.5 Release Notes
- EDA controller user guide 2.5 
- 2.4 installation guide (VM only)
