### PR TITLE
AAP-23515 OpenSSL deficiency

### DIFF
--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -15,6 +15,13 @@ To improve the performance of the PostgreSQL server, configure the following _Gr
 
 * `shared_buffers`: determines how much memory is dedicated to the server for caching data. The default value for this parameter is 128 MB. When you modify this value, you must set it between 15% and 25% of the machine's total RAM. 
 
+WARNING
+====
+If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the BIO_get_app_data call instead of open_get_data. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database.
+
+If you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
+====
+
 NOTE: You must restart the database server after changing the value for shared_buffers.
 
 * `work_mem`: provides the amount of memory to be used by internal sort operations and hash tables before disk-swapping. Sort operations are used for order by, distinct, and merge join operations. Hash tables are used in hash joins and hash-based aggregation. The default value for this parameter is 4 MB. Setting the correct value of the `work_mem` parameter improves the speed of a search by reducing disk-swapping.

--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -22,7 +22,17 @@ If you are compiling Postgres against OpenSSL 3.2, your system regresses to remo
 If you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
 ====
 
-NOTE: You must restart the database server after changing the value for shared_buffers.
+WARNING
+====
+If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the BIO_get_app_data call instead of open_get_data. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database.
+
+If you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
+====
+
+NOTE
+====
+You must restart the database server after changing the value for shared_buffers.
+====
 
 * `work_mem`: provides the amount of memory to be used by internal sort operations and hash tables before disk-swapping. Sort operations are used for order by, distinct, and merge join operations. Hash tables are used in hash joins and hash-based aggregation. The default value for this parameter is 4 MB. Setting the correct value of the `work_mem` parameter improves the speed of a search by reducing disk-swapping.
 ** Use the following formula to calculate the optimal value of the `work_mem` parameter for the database server: 


### PR DESCRIPTION
[AAP-23515](https://issues.redhat.com/browse/AAP-23515): Added a warning about patch 3.2 for OpenSSL that makes Ansible automation crash upon load. It requires the administrator to change the API call used for every user in the system.

If that double warning is showing up for you, please delete it. Merge & squash if possible. I can't consistently get those two repeating chunks to show.