### PR TITLE
2.5 Update ordering and hierarchy of HA automation hub sections in VM-install guide (#1664)

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -48,14 +48,9 @@ include::platform/con-eda-2-5-with-controller-2-4.adoc[leveloffset=+3]
 // include::platform/ref-standalone-controller-hub-ext-database-inventory.adoc[leveloffset=+3]
 //[rjgrange] Removed for AAP-22613 Removing all references to SSO and LDAP installation
 //include::platform/ref-connect-hub-to-rhsso.adoc[leveloffset=+4]
-
 include::platform/ref-gateway-controller-ext-db.adoc[leveloffset=+3]
 include::platform/ref-gateway-controller-hub-ext-db.adoc[leveloffset=+3]
-include::platform/con-ha-hub-installation.adoc[leveloffset=+4]
-include::platform/proc-install-ha-hub-selinux.adoc[leveloffset=+4]
-include::platform/proc-configure-pulpcore-service.adoc[leveloffset=+4]
-include::platform/proc-apply-selinux-context.adoc[leveloffset=+4]
-include::hub/hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+3]
+
 //[rjgrange] Removed for AAP-22613 Removing all references to SSO and LDAP installation
 //include::platform/ref-ldap-config-on-pah.adoc[leveloffset=+3]
 //include::platform/ref-ldap-referrals.adoc[leveloffset=+3]
@@ -64,6 +59,13 @@ include::hub/hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+3]
 //include::platform/ref-standalone-hub-ext-database-customer-provided.adoc[leveloffset=+3]
 // dcdacosta - removed this assembly because the modules are included above. include::assembly-installing-high-availability-hub.adoc[leveloffset=+3]
 include::platform/ref-gateway-controller-hub-eda-ext-db.adoc[leveloffset=+3]
+
+include::platform/con-ha-hub-installation.adoc[leveloffset=+3]
+include::platform/proc-install-ha-hub-selinux.adoc[leveloffset=+3]
+include::platform/proc-configure-pulpcore-service.adoc[leveloffset=+4]
+include::platform/proc-apply-selinux-context.adoc[leveloffset=+4]
+include::hub/hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+3]
+
 include::platform/proc-running-setup-script.adoc[leveloffset=+1]
 include::platform/proc-verify-aap-installation.adoc[leveloffset=+1]
 


### PR DESCRIPTION
VM-install guide - HA automation hub should be moved up a level in the document hierarchy

https://issues.redhat.com/browse/AAP-28097