### PR TITLE
Update URL of trial licence

### DIFF
--- a/downstream/modules/platform/ref-controller-trial-evaluation.adoc
+++ b/downstream/modules/platform/ref-controller-trial-evaluation.adoc
@@ -4,6 +4,6 @@
 You require a license to run {ControllerName}. 
 You can start by using a free trial license.
 
-* Trial licenses for {PlatformNameShort} are available at: http://ansible.com/license
+* Trial licenses for {PlatformNameShort} are available at: https://www.redhat.com/en/products/trials?products=ansible
 
 * Support is not included in a trial license or during an evaluation of the {ControllerName} software.


### PR DESCRIPTION
update URL of trial license from ansible.com to redhat.com

https://issues.redhat.com/browse/AAP-26587