### PR TITLE
AAP-28448 Update performance tuning chapter in EDA controller user guide for 2.5

### DIFF
--- a/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
+++ b/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 By default, {EDAcontroller} allows 12 rulebook activations to run simultaneously.
-If more than 12 rulebook activations are created, the expected behavior is that subsequent rulebook activations wait in pending until there is an available rulebook activation worker.
+If more than 12 rulebook activations are created, the expected behavior is that subsequent rulebook activations wait in pending status until there is an available rulebook activation worker.
 In this case, the rulebook activation status is displayed as *Pending* even if there is enough free memory and CPU on your {EDAcontroller} instance.
 To change this behavior, you must change the default maximum number of running rulebook activations.
 

--- a/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
+++ b/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 By default, {EDAcontroller} allows 12 rulebook activations to run simultaneously.
-If more than 12 rulebook activations are created, the expected behavior is that subsequent rulebook activations wait in pending status until there is an available rulebook activation worker.
+If more than 12 rulebook activations are created, the expected behavior is that subsequent rulebook activations wait until there is an available rulebook activation worker.
 In this case, the rulebook activation status is displayed as *Pending* even if there is enough free memory and CPU on your {EDAcontroller} instance.
 To change this behavior, you must change the default maximum number of running rulebook activations.
 

--- a/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
+++ b/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
@@ -10,7 +10,7 @@ To change this behavior, you must change the default maximum number of running r
 
 [NOTE]
 ====
-The value for `EDA_MAX_RUNNING_ACTIVATIONS` does not change when you modify the instance size, so it needs to be adjusted manually.
+The value for `MAX_RUNNING_ACTIVATIONS` does not change when you modify the instance size, so it needs to be adjusted manually.
 ====
 
 include::proc-modifying-activations-during-install.adoc[leveloffset=+1]

--- a/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
+++ b/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
@@ -10,8 +10,8 @@ To change this behavior, you must change the default maximum number of running r
 
 [NOTE]
 ====
- The value for `EDA_MAX_RUNNING_ACTIVATIONS` does not change whe you modify the instance size, so it needs to be adjusted manually.
- ====
+The value for `EDA_MAX_RUNNING_ACTIVATIONS` does not change when you modify the instance size, so it needs to be adjusted manually.
+====
 
 include::proc-modifying-activations-during-install.adoc[leveloffset=+1]
 include::proc-modifying-activations-after-install.adoc[leveloffset=+1]

--- a/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
+++ b/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
@@ -4,11 +4,14 @@
 
 [role="_abstract"]
 By default, {EDAcontroller} allows 12 rulebook activations to run simultaneously.
-If any more than 12 rulebook activations are created, the expected behavior is that subsequent rulebook activations wait in pending until there is an available rulebook activation worker.
-In this case, the rulebook activation status will display as “pending” even if there is enough free memory and CPU on your {EDAcontroller} instance.
+If more than 12 rulebook activations are created, the expected behavior is that subsequent rulebook activations wait in pending until there is an available rulebook activation worker.
+In this case, the rulebook activation status is displayed as *Pending* even if there is enough free memory and CPU on your {EDAcontroller} instance.
 To change this behavior, you must change the default maximum number of running rulebook activations.
 
-**Note:** The value for `EDA_MAX_RUNNING_ACTIVATIONS` doesn’t change with the change in instance size, so it needs to be adjusted manually.
+[NOTE]
+====
+ The value for `EDA_MAX_RUNNING_ACTIVATIONS` does not change whe you modify the instance size, so it needs to be adjusted manually.
+ ====
 
 include::proc-modifying-activations-during-install.adoc[leveloffset=+1]
 include::proc-modifying-activations-after-install.adoc[leveloffset=+1]

--- a/downstream/modules/eda/proc-modifying-activations-after-install.adoc
+++ b/downstream/modules/eda/proc-modifying-activations-after-install.adoc
@@ -7,8 +7,8 @@ By default, {EDAcontroller} allows 12 activations to run simultaneously.
 You can modify this default value after installation by using the following procedure:
 
 .Procedure
-. Navigate to the environment file at `/etc/ansible-automation-platform/eda`.
+. Navigate to the environment file at `/etc/ansible-automation-platform/eda/settings.yaml`.
 . Choose the number of maximum running activations that you need.
-For example, `EDA_MAX_RUNNING_ACTIVATIONS = 16`
-. Use the following command to restart EDA services: `systemctl restart automation-eda-controller.target`
+For example, `MAX_RUNNING_ACTIVATIONS = 16`
+. Use the following command to restart EDA services: `automation-eda-controller-service restart`
 

--- a/downstream/modules/eda/proc-modifying-activations-after-install.adoc
+++ b/downstream/modules/eda/proc-modifying-activations-after-install.adoc
@@ -10,5 +10,5 @@ You can modify this default value after installation by using the following proc
 . Navigate to the environment file at `/etc/ansible-automation-platform/eda/settings.yaml`.
 . Choose the number of maximum running activations that you need.
 For example, `MAX_RUNNING_ACTIVATIONS = 16`
-. Use the following command to restart EDA services: `automation-eda-controller-service restart`
+. Use the following command to restart {EDAName} services: `automation-eda-controller-service restart`
 

--- a/downstream/modules/eda/proc-modifying-memory-after-install.adoc
+++ b/downstream/modules/eda/proc-modifying-memory-after-install.adoc
@@ -7,7 +7,7 @@ By default, each rulebook activation container has a 200MB memory limit.
 You can modify this default value after installation by using the following procedure:
 
 .Procedure
-. Navigate to the environment file at `/etc/ansible-automation-platform/eda`.
+. Navigate to the environment file at `/etc/ansible-automation-platform/eda/settings.yaml`.
 . Modify the default container memory limit.
-For example, `EDA_PODMAN_MEM_LIMIT = '300m'`.
-. Restart the {EDAcontroller} services using `systemctl restart automation-eda-controller.target`.
+For example, `PODMAN_MEM_LIMIT = '300m'`.
+. Restart the {EDAcontroller} services using `automation-eda-controller-service restart`.

--- a/downstream/modules/eda/ref-performance-troubleshooting.adoc
+++ b/downstream/modules/eda/ref-performance-troubleshooting.adoc
@@ -15,6 +15,6 @@ If the event you are expecting is coming from a source other than what is in the
 
 * My activation keeps restarting in an infinite loop.
 ** By default, the reset policy for rulebook activations is set to “on failure”. Change the restart policy using the following procedure:
-. Navigate to the Rulebook Activation screen.
+. Navigate to {MenuADRulebookActivations}.
 . Click the *Restart Policy* list to display the options. 
-. Select the appropriate value: “On Failure”, “Always”, “Never”.
+. Select the appropriate value: *On Failure*, *Always*, *Never*.

--- a/downstream/modules/eda/ref-performance-troubleshooting.adoc
+++ b/downstream/modules/eda/ref-performance-troubleshooting.adoc
@@ -14,7 +14,7 @@ If the event you are expecting is coming from a source other than what is in the
 ** Ensure that you have set the correct conditions for matching the event and taking actions in the rulebook activation.
 
 * My activation keeps restarting in an infinite loop.
-** By default, the reset policy for rulebook activations is set to “on failure”. Change the estart policy using the following procedure:
+** By default, the reset policy for rulebook activations is set to “on failure”. Change the restart policy using the following procedure:
 . Navigate to the Rulebook Activation screen.
-. Click the Restart Policy drop down menu. 
-. Choose the appropriate value: “On Failure”, “Always”, “Never”.
+. Click the *Restart Policy* list to display the options. 
+. Select the appropriate value: “On Failure”, “Always”, “Never”.


### PR DESCRIPTION
Applied updates specifically for 2.5 GA, per information from SME @jamesmarshall24 , and other syntactical/UI/style edits (found during peer review for backporting the chapter to 2.5 branch and general discovery while working on content).