### PR TITLE
AAP-19236 fix include statements to include platform/

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-organizations.adoc
+++ b/downstream/assemblies/platform/assembly-controller-organizations.adoc
@@ -18,23 +18,23 @@ Only Enterprise or Premium licenses can add new organizations.
 
 Enterprise and Premium license users who want to add a new organization should refer to the xref:proc-controller-create-organization[Creating an organization].
 
-include::proc-controller-review-organizations.adoc[leveloffset=+1]
+include::platform/proc-controller-review-organizations.adoc[leveloffset=+1]
 
-include::proc-controller-create-organization.adoc[leveloffset=+1]
+include::platform/proc-controller-create-organization.adoc[leveloffset=+1]
 
-include::con-controller-access-organizations.adoc[leveloffset=+1]
+include::platform/con-controller-access-organizations.adoc[leveloffset=+1]
 
-include::proc-controller-add-organization-user.adoc[leveloffset=+2]
+include::platform/proc-controller-add-organization-user.adoc[leveloffset=+2]
 
-include::proc-gw-add-admin-organization.adoc[leveloffset=+2]
+include::platform/proc-gw-add-admin-organization.adoc[leveloffset=+2]
 
-include::proc-gw-add-team-organization.adoc[leveloffset=+2]
+include::platform/proc-gw-add-team-organization.adoc[leveloffset=+2]
 
-include::proc-gw-delete-organization.adoc[leveloffset=+2]
+include::platform/proc-gw-delete-organization.adoc[leveloffset=+2]
 
-include::proc-gw-oganization-notifications.adoc[leveloffset=+1]
+include::platform/proc-gw-oganization-notifications.adoc[leveloffset=+1]
 
-include::proc-gw-organizations-exec-env.adoc[leveloffset=+1]
+include::platform/proc-gw-organizations-exec-env.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-controller-teams.adoc
+++ b/downstream/assemblies/platform/assembly-controller-teams.adoc
@@ -11,21 +11,21 @@ ifdef::context[:parent-context: {context}]
 A team is a subdivision of an organization with associated users and resources. Teams provide a means to implement role-based access control schemes and delegate responsibilities across organizations. For instance, you can grant permissions to a team rather than each user on the team.
 You can create as many teams as needed for your organization. Teams can only be assigned to one organization while an organization can be made up of multiple teams. Each team can be assigned roles, the same way roles are assigned for users. With teams you can assign credential ownership at scale, preventing the need to click through multiple interfaces to assign the same credentials to each individual user.
 
-include::proc-controller-creating-a-team.adoc[leveloffset=+1]
+include::platform/proc-controller-creating-a-team.adoc[leveloffset=+1]
 
-include::proc-gw-team-list-view.adoc[leveloffset=+1]
+include::platform/proc-gw-team-list-view.adoc[leveloffset=+1]
 
-include::proc-gw-team-add-user.adoc[leveloffset=+1]
+include::platform/proc-gw-team-add-user.adoc[leveloffset=+1]
 
-include::proc-gw-team-remove-user.adoc[leveloffset=+1]
+include::platform/proc-gw-team-remove-user.adoc[leveloffset=+1]
 
-include::proc-gw-add-admin-team.adoc[leveloffset=+1]
+include::platform/proc-gw-add-admin-team.adoc[leveloffset=+1]
 
-include::proc-controller-user-permissions.adoc[leveloffset=+1]
+include::platform/proc-controller-user-permissions.adoc[leveloffset=+1]
 
-include::proc-gw-remove-roles-team.adoc[leveloffset=+1]
+include::platform/proc-gw-remove-roles-team.adoc[leveloffset=+1]
 
-include::proc-gw-delete-team.adoc[leveloffset=+1]
+include::platform/proc-gw-delete-team.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-controller-users.adoc
+++ b/downstream/assemblies/platform/assembly-controller-users.adoc
@@ -17,15 +17,15 @@ You can add other users to an organization, including a normal user or system ad
 You can sort or search the User list by *Username*, *First name*, *Last name*, or *Email*. Click the arrows in the header to toggle your sorting preference.
 You can view *User type* and *Email* beside the user name on the Users page.
 
-include::proc-gw-users-list-view.adoc[leveloffset=+1]
+include::platform/proc-gw-users-list-view.adoc[leveloffset=+1]
 
-include::proc-controller-creating-a-user.adoc[leveloffset=+1]
+include::platform/proc-controller-creating-a-user.adoc[leveloffset=+1]
 
-include::proc-controller-deleting-a-user.adoc[leveloffset=+1]
+include::platform/proc-controller-deleting-a-user.adoc[leveloffset=+1]
 
-include::ref-controller-user-roles.adoc[leveloffset=+1]
+include::platform/ref-controller-user-roles.adoc[leveloffset=+1]
 
-include::proc-gw-remove-roles-user.adoc[leveloffset=+1]
+include::platform/proc-gw-remove-roles-user.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-gw-resources.adoc
+++ b/downstream/assemblies/platform/assembly-gw-resources.adoc
@@ -10,9 +10,9 @@ ifdef::context[:parent-context: {context}]
 
 You can manage user access to {PlatformNameShort} resources and what users can do with those resources. Users are granted access through the roles to which they are assigned or through roles inherited through the role hierarchy, for example, through the roles they inherit through team membership. {PlatformNameShort} resources differ depending on the functionality you are configuring. For example, resources can be job templates and projects for automation execution or decision environments and rulebook activations for automation decisions.
 
-include:: proc-gw-team-access-resources.adoc[leveloffset=+1]
+include::platform/proc-gw-team-access-resources.adoc[leveloffset=+1]
 
-include:: proc-gw-user-access-resources.adoc[leveloffset=+1]
+include::platform/proc-gw-user-access-resources.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
This PR corrects the access management assemblies to include platform/ in the include statements. 