### PR TITLE
Backport-2.5-1682 Ensure UI parity for just a couple of sections for EDA controller 

### DIFF
--- a/downstream/modules/eda/con-eda-rulebook-activation-list-view.adoc
+++ b/downstream/modules/eda/con-eda-rulebook-activation-list-view.adoc
@@ -2,12 +2,13 @@
 
 = Rulebook activation list view
 
-On the *Rulebook Activations* page, you can view the rulebook activations that you have created along with the *Activation status*, *Number of rules associated* with the rulebook, the *Fire count*, and *Restart count*.
+On the *Rulebook Activations* page, you can view the rulebook activations that you have created along with the *Status*, *Number of rules* with the rulebook, the *Fire count*, and *Restart count*.
 
 If the *Activation Status* is *Running*, it means that the rulebook activation is running in the background and executing the required actions according to the rules declared in the rulebook.
 
 You can view more details by selecting the activation from the *Rulebook Activations* list view.
 
+//Replace this screen shot with current view
 image::eda-rulebook-activations-list-view.png[Rulebook activation][width=25px]
 
 For all activations that have run, you can view the *Details* and *History* tabs to get more information about what happened.

--- a/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
@@ -13,8 +13,9 @@ For more information, see the xref:eda-set-up-credential[Setting up credentials]
 
 .Procedure
 // ddacosta I'm not sure whether there will be an EDA specific dashboard in the gateway. Step 1 might need to change to something like "Log in to AAP".
-. Navigate to the {EDAcontroller} Dashboard.
-. From the navigation panel, select {MenuADDecisionEnvironments}.
+. Log in to the {PlatformNameShort} Dashboard.
+. Navigate to {MenuADDecisionEnvironments}.
+. Click btn:[Create decision environment].
 . Insert the following:
 +
 Name:: Insert the name.
@@ -23,7 +24,7 @@ Image:: This is the full image location, including the container registry, image
 Credential:: This field is optional. This is the token needed to utilize the decision environment image.
 . Select btn:[Create decision environment].
 
-Your decision environment is now created and can be managed on the *Decision Environments* screen.
+Your decision environment is now created and can be managed on the *Decision Environments* page.
 
 After saving the new decision environment, the decision environment's details page is displayed.
 From there or the *Decision Environments* list view, you can edit or delete it.

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -4,15 +4,16 @@
 
 .Prerequisites
 // [ddacosta] I'm not sure whether there will be an EDA specific dashboard in the gateway. Step 1 might need to change to something like "Log in to AAP".
-* You are logged in to the {EDAcontroller} Dashboard as a Content Consumer.
+* You are logged in to the {PlatformNameShort} Dashboard as a Content Consumer.
 * You have set up a project.
 * You have set up a decision environment.
 * You have set up an {ControllerName} token.
 
 .Procedure
 // [ddacosta] I'm not sure whether there will be an EDA specific dashboard in the gateway. Step 1 might need to change to something like "Log in to AAP".
-. Navigate to the {EDAcontroller} Dashboard.
-. From the navigation panel, select {MenuADRulebookActivations}.
+. Log in to the {PlatformNameShort} Dashboard.
+. Navigate to the {MenuADRulebookActivations}.
+. Click btn:[Create rulebook activation]. 
 . Insert the following:
 +
 Name:: Insert the name.

--- a/downstream/modules/eda/proc-eda-view-activation-output.adoc
+++ b/downstream/modules/eda/proc-eda-view-activation-output.adoc
@@ -9,6 +9,7 @@ You can view the output of the activations in the *History* tab.
 An activation instance represents a single execution of the activation.
 . Then select the activation instance in question, this will show you the *Output* produced by that specific execution.
 
+//Replace this screenshot with current view
 image::eda-rulebook-activation-history.png[Rulebook activation history]
 
 To view events that came in and triggered an action, you can use the xref:eda-rule-audit[Rule Audit] section in the {EDAcontroller} Dashboard.

--- a/downstream/modules/eda/proc-eda-view-rule-audit-actions.adoc
+++ b/downstream/modules/eda/proc-eda-view-rule-audit-actions.adoc
@@ -5,7 +5,7 @@
 .Procedure
 
 . From the navigation panel select *{MenuADRuleAudit}*.
-. Select the desired rule, this brings you to the *Actions* tab.
+. Select the desired rule, then select the *Actions* tab.
 
 From here you can view executed actions that were taken.
 Some actions are linked out to {ControllerName} where you can view the output.


### PR DESCRIPTION
This PR covers just a few sections of the EDA controller user guide since multiple sections are being covered under separate jiras that required changes beyond the scope of UI parity.

Covered in this PR:

downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc (Settting up a new decision environment)
downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc (Setting up a rulebook activation)
downstream/modules/eda/con-eda-rulebook-activation-list-view.adoc (Rulebook activation list view)
downstream/modules/eda/proc-eda-view-activation-output.adoc (Viewing activation output)
downstream/modules/eda/proc-eda-view-rule-audit-actions.adoc (Viewing rule audit actions)