### PR TITLE
2.5 AAP-27260 Add attributes for docs titles (#1589)

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -275,3 +275,92 @@
 // Not yet implemented but look to be in the future scope 2.5-next plan
 //:MenuSetLogin: {MenuAEAdminSettings}[Log In Settings]
 //:MenuSetUI: {MenuAEAdminSettings}[User Interface Settings]
+
+// Title attributes
+//
+// titles/troubleshooting-aap
+:TitleTroubleshootingAAP: Troubleshooting Ansible Automation Platform
+//
+// titles/aap-plugin-rhdh-install
+:TitlePluginRHDHInstall: Installing Ansible plug-ins for Red Hat Developer Hub
+//
+// titles/aap-plugin-rhdh-using
+:TitlePluginRHDHUsing: Using Ansible plug-ins for Red Hat Developer Hub
+//
+// titles/aap-operations-guide
+:TitleAAPOperationsGuide: Operating Ansible Automation Platform
+//
+// titles/eda/eda-user-guide
+:TitleEDAUserGuide: Using automation decisions 
+//
+// titles/upgrade
+:TitleUpgrade: Upgrade and migration
+//
+// titles/aap-operator-installation
+:TitleOperatorInstallation: Installing on Openshift Container Platform
+//
+// titles/aap-installation-guide
+:TitleInstallationGuide: Installing on virtual machines
+//
+// titles/aap-planning-guide
+:TitlePlanningGuide: Planning your installation
+//
+// titles/operator-mesh
+:TitleOperatorMesh: Automation mesh for managed cloud or operator environments
+//
+// titles/automation-mesh
+:TitleAutomationMesh: Automation mesh for VM environments
+//
+// titles/ocp_performance_guide
+:TitleOCPPerformanceGuide: Performance considerations for operator environments
+//
+// titles/security-guide
+:TitleSecurityGuide: Implementing security automation
+//
+// titles/playbooks/playbooks-getting-started
+:TitlePlaybooksGettingStarted: Getting started with playbooks
+//
+// titles/playbooks/playbooks-reference
+:TitlePlaybooksReference: Reference guide to Ansible Playbooks
+//
+// titles/release-notes
+:TitleReleaseNotes: Release notes
+//
+// titles/controller/controller-user-guide
+:TitleControllerUserGuide: Using automation execution
+//
+// titles/controller/controller-admin-guide
+:TitleControllerAdminGuide: Configuring automation execution
+//
+// titles/controller/controller-api-overview
+:TitleControllerAPIOverview: Automation execution API overview
+//
+// titles/aap-operator-backup
+:TitleOperatorBackup: Backup and recovery for operator environments
+//
+// titles/central-auth
+:TitleCentralAuth: Access management and authentication
+//
+// titles/getting-started
+:TitleGettingStarted: Getting started with Ansible Automation Platform
+//
+// titles/aap-containerized-install
+:TitleContainerizedInstall: Containerized installation
+//
+// titles/navigator-guide
+:TitleNavigatorGuide: Using content creator
+//
+// titles/aap-hardening
+:TitleHardening: Hardening and compliance
+//
+// titles/builder
+:TitleBuilder: Creating and using execution environments
+//
+// titles/hub/managing-content
+:TitleHubManagingContent: Managing content in automation hub
+//
+// titles/analytics/job-explorer
+:TitleAnalyticsJobExplorer: Using automation analytics
+//
+// titles/develop-automation-content
+:TitleDevelopAutomationContent: Developing automation content


### PR DESCRIPTION
Create attributes for docs titles so that external links to other docs in the AAP docset don't break when titles are updated.
Backports #1589 