### PR TITLE
2.5 Update inventory file variables for controller and gateway (#1697)

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -5,18 +5,20 @@
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description*
-| *`admin_password`* | The password for an administration user to access the UI when the installation is complete.
+| *`admin_password`* | The admin password used to connect to the {ControllerName} instance.
 
 Passwords must be enclosed in quotes when they are provided in plain text in the inventory file.
 
-| *`automation_controller_main_url`* | The full routeable URL used by {EDAName} to connect to a controller host. This URL is required if there is no {ControllerName} configured in inventory.
+| *`automation_controller_main_url`* | The full URL used by {EDAName} to connect to a controller host. This URL is required if there is no {ControllerName} configured in the inventory file.
 
 Format example: `automation_controller_main_url='https://<hostname>'`
 
-| *`automationcontroller_password`* | Password for your {ControllerName} instance.
+| *`admin_username`* | 
+The username used to identify and create the admin superuser in {ControllerName}.
 
-Passwords must be enclosed in quotes when they are provided in plain text in the inventory file.
-| *`automationcontroller_username`* | Username for your {ControllerName} instance.
+| *`admin_email`* | 
+The email address used for the admin user for {ControllerName}.
+
 | *`nginx_http_port`* | The nginx HTTP server listens for inbound connections.
 
 Default = 80

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -5,9 +5,13 @@
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description*
-| *`automationgateway_admin_password`* | The admin password used by the platform gateway instance.
+| *`automationgateway_admin_username`* | The username used to identify and create the admin superuser in platform gateway.
+
+| *`automationgateway_admin_password`* | The admin password used to connect to the platform gateway instance.
 
 Passwords must be enclosed in quotes when they are provided in plain text in the inventory file.
+
+| *`automationgateway_admin_email`* | The email address used for the admin user for platform gateway.
 
 | *`automationgateway_pg_host`* | The hostname of the Postgres database used by platform gateway, which can be an externally managed database.
 


### PR DESCRIPTION
Updates the following inventory file variables in the VM installer guide:

Add:
- automationgateway_admin_email
- automationgateway_admin_username
- admin_username
- admin_email

Remove:
- automationcontroller_password
- automationcontroller_username

Update:
- automationgateway_admin_password
- admin_password

Affects: VM-install guide - titles/aap-installation-guide

AAP 2.5 Update the inventory file variables in the VM Install guide

https://issues.redhat.com/browse/AAP-27328