### PR TITLE
[Backport] AAP-18761-A - add assembly for the gateway dashboard (#1700)

### DIFF
--- a/downstream/assemblies/platform/assembly-gw-dashboard.adoc
+++ b/downstream/assemblies/platform/assembly-gw-dashboard.adoc
@@ -1,0 +1,18 @@
+ifdef::context[:parent-context: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id="gw-dashboard_{context}"]
+= {PlatformNameShort} dashboard
+
+:context: gw-dashboard
+
+[role="_abstract"]
+The {PlatformNameShort} dashboard provides automation management and monitoring capabilities, allowing you to administer and configure automation functions, as well as view recent job activity details and performance statistics related to it. 
+
+include::platform/con-gw-dash-features.adoc[leveloffset=+1]
+
+include::platform/con-gw-dash-components.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]


### PR DESCRIPTION
This PR backports the changes from #1700 to the 2.5 branch and includes the following:

* AAP-18761-A - add assembly for the gateway dashboard

* AAP-18761-A - include peer review changes