### PR TITLE
Updated default execution environment setting

### DIFF
--- a/downstream/modules/builder/con-ee-precedence.adoc
+++ b/downstream/modules/builder/con-ee-precedence.adoc
@@ -8,7 +8,7 @@ Project updates will always use the control plane {ExecEnvName} by default, howe
 . The `default_environment` defined on the project that the job uses.
 . The `default_environment` defined on the organization of the job.
 . The `default_environment` defined on the organization of the inventory the job uses.
-. The current `DEFAULT_EXECUTION_ENVIRONMENT` setting (configurable at `api/v2/settings/jobs/`)
+. The current `DEFAULT_EXECUTION_ENVIRONMENT` setting (configurable at `api/v2/settings/system/`)
 . Any image from the `GLOBAL_JOB_EXECUTION_ENVIRONMENTS` setting.
 . Any other global {ExecEnvShort}.
 


### PR DESCRIPTION
[Docs] DEFAULT_EXECUTION_ENVIRONMENT setting is not present at api/v2/settings/jobs/ as mentioned in AAP document

https://issues.redhat.com/browse/AAP-28741