### PR TITLE
Add admonition to use of installer setup script (#1718)

### DIFF
--- a/downstream/modules/platform/proc-running-setup-script.adoc
+++ b/downstream/modules/platform/proc-running-setup-script.adoc
@@ -5,6 +5,11 @@
 [role="_abstract"]
 After you update the inventory file with required parameters, run the installer setup script.
 
+[IMPORTANT]
+====
+You must have installed ansible-core {CoreUseVers} before using the installer setup script.
+====
+
 .Procedure
 
 * Run the `setup.sh` script


### PR DESCRIPTION
Update text in docs to tell users ansible-core 2.16 must be installed before running setup.sh

https://issues.redhat.com/browse/AAP-29119