### PR TITLE
AAP-28685: Fix typo in secret example

### DIFF
--- a/downstream/modules/platform/proc-create-secret-key-secret.adoc
+++ b/downstream/modules/platform/proc-create-secret-key-secret.adoc
@@ -15,12 +15,16 @@ To migrate your data to {OperatorPlatform} on {OCPShort}, you must create a secr
 apiVersion: v1
 kind: Secret
 metadata:
-  name: <resourcename>-secret-key
+  name: <resourcename>-admin-password
   namespace: <target-namespace>
 stringData:
-  secret_key: <old-secret-key>
+  password: mysuperlongpassword
 type: Opaque
 -----
++
+[NOTE]
+ If admin_password_secret is not provided, the operator will look for a secret named <resourcename>-admin-password for the admin password. If it is not present, the operator will generate a password and create a Secret from it named <resourcename>-admin-password.
+
 . Apply the secret key yaml to the cluster:
 +
 -----


### PR DESCRIPTION
Link to Jira issue: [AAP-28685](https://issues.redhat.com/browse/AAP-28685)

- Revised typo in secret example to use `password` instead of `secret_key`

- Added note for additional context.
