### PR TITLE
Removing EDA 2.5 with controller 2.4 install steps

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -37,7 +37,8 @@ There are several supported installation scenarios for {PlatformName}. To instal
 include::platform/proc-editing-inventory-file.adoc[leveloffset=+1]
 include::platform/con-install-scenario-examples.adoc[leveloffset=+1]
 include::platform/con-install-scenario-recommendations.adoc[leveloffset=+2]
-include::platform/con-eda-2-5-with-controller-2-4.adoc[leveloffset=+3]
+//[emcwhinn] Removing for AAP-29246 as content is being moved to one guide in 2.4 customer portal 
+//include::platform/con-eda-2-5-with-controller-2-4.adoc[leveloffset=+3]
 //[ifowler] Removed for AAP-18700 Install Guide Scenario Consolidation  
 //include::platform/ref-platform-non-inst-database-inventory.adoc[leveloffset=+3]
 //include::platform/ref-single-controller-ext-customer-managed-db.adoc[leveloffset=+3]


### PR DESCRIPTION
Remove EDA 2.5 w/controller 2.4 install steps from 2.5 doc

https://issues.redhat.com/browse/AAP-29246

Affects 'titles/aap-installation-guide'