### PR TITLE
Backport-2.5-1722 (AAP-21827) Add new field for the k8s_service_name

### DIFF
--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -33,6 +33,7 @@ Restart policy:: This is a policy to decide when to restart a rulebook.
 ... Always: Restarts when a rulebook finishes
 ... Never: Never restarts a rulebook when it finishes
 ... On failure: Only restarts when it fails
+Service Name:: This defines a service name for Kubernetes to configure inbound connections if the activation exposes a port. This field is optional.
 Rulebook activation enabled?:: This automatically enables the rulebook activation to run.
 Variables:: The variables for the rulebook are in a JSON/YAML format.
 The content would be equivalent to the file passed through the `--vars` flag of ansible-rulebook command.


### PR DESCRIPTION
Just one update made for the Create Rulebook Activations fields: Service Name. Other more extensive changes will be tracked in a separate PR.