### PR TITLE
AAP-29276 Add minimum Python 3.10 requirement to navigator doc

### DIFF
--- a/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
+++ b/downstream/modules/navigator/proc-installing-navigator-rhel-rpm.adoc
@@ -11,6 +11,7 @@ You can install {Navigator} on Red Hat Enterprise Linux (RHEL) from an RPM.
 
 .Prerequisites
 
+* You have installed Python 3.10 or later.
 * You have installed RHEL 8.6 or later.
 * You registered your system with Red Hat Subscription Manager.
 


### PR DESCRIPTION
AAP-29276 Add minimum Python 3.10 requirement to navigator doc
Affects `/titles/navigator`