### PR TITLE
Document the requirement that upgrade from 2.4 containerized TP is not supported

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -19,6 +19,11 @@ endif::[]
 
 This guide helps you to understand the installation requirements and processes behind the containerized version of {PlatformNameShort}. 
 
+[NOTE]
+====
+include::snippets/container-upgrades.adoc[]
+====
+
 .Prerequisites
 
 * A RHEL 9.2 based host. Minimal operating system (OS) base install is recommended.

--- a/downstream/snippets/container-upgrades.adoc
+++ b/downstream/snippets/container-upgrades.adoc
@@ -1,0 +1,1 @@
+Upgrades from 2.4 Containerized {PlatformNameShort} Tech Preview to 2.5 Containerized {PlatformNameShort} are unsupported at this time.


### PR DESCRIPTION
Document the requirement that upgrade from 2.4 containerized TP is not supported

Created a snippet for this text /snippets/container-upgrades.adoc

https://issues.redhat.com/browse/AAP-28343