### PR TITLE
AAP-29499: Added on-prem troubleshooting cross-reference and removed on-prem monitoring content

### DIFF
--- a/lightspeed/assemblies/assembly_configuring-lightspeed-onpremise.adoc
+++ b/lightspeed/assemblies/assembly_configuring-lightspeed-onpremise.adoc
@@ -30,7 +30,6 @@ include::modules/proc_create-lightspeed-instance.adoc[leveloffset=+1]
 include::modules/proc_update-redirect-uri.adoc[leveloffset=+1]
 include::modules/proc_configure-vscode-extension-onpremise-deployment.adoc[leveloffset=+1]
 include::modules/proc_update-connection-secrets.adoc[leveloffset=+1]
-include::modules/proc_monitor-onpremise-deployment.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/lightspeed/modules/proc_configure-vscode-extension-onpremise-deployment.adoc
+++ b/lightspeed/modules/proc_configure-vscode-extension-onpremise-deployment.adoc
@@ -22,5 +22,9 @@ To access the on-premise deployment of {LightspeedShortName}, all Ansible users 
 +
 After configuring Ansible VS Code extension to connect to {LightspeedShortName} on-premise deployment, you must xref:login-vscode-extension_configuring-with-code-assistant[log in to Ansible Lightspeed through the Ansible VS Code extension].
 
+[role="_additional-resources"]
+.Additional resources
+* xref:troubleshooting-lightspeed-onpremise-config_troubleshooting-lightspeed[Troubleshooting {LightspeedShortName} on-premise deployment errors]
+
 
 

--- a/lightspeed/modules/proc_create-connection-secrets.adoc
+++ b/lightspeed/modules/proc_create-connection-secrets.adoc
@@ -139,7 +139,7 @@ secretGenerator:
       disableNameSuffixHash: true
 ....
 
-After you create the bundle secret, you must select the secret when you  xref:create-lightspeed-instance_configuring-lightspeed-onpremise[create and deploy an {LightspeedshortName} instance].
+After you create the bundle secret, you must select the secret when you xref:create-lightspeed-instance_configuring-lightspeed-onpremise[create and deploy an {LightspeedshortName} instance].
 
 [role="_additional-resources"]
 .Additional resources

--- a/lightspeed/modules/proc_create-connection-secrets.adoc
+++ b/lightspeed/modules/proc_create-connection-secrets.adoc
@@ -140,3 +140,7 @@ secretGenerator:
 ....
 
 After you create the bundle secret, you must select the secret when you  xref:create-lightspeed-instance_configuring-lightspeed-onpremise[create and deploy an {LightspeedshortName} instance].
+
+[role="_additional-resources"]
+.Additional resources
+* xref:troubleshooting-lightspeed-onpremise-config_troubleshooting-lightspeed[Troubleshooting {LightspeedShortName} on-premise deployment errors]

--- a/lightspeed/modules/proc_create-lightspeed-instance.adoc
+++ b/lightspeed/modules/proc_create-lightspeed-instance.adoc
@@ -25,3 +25,7 @@ Use this procedure to create and deploy a {LightspeedShortName} instance to your
 . Click *Create*. 
 +
 The {LightspeedShortName} instance takes a few minutes to deploy to your namespace. After the installation status is displayed as *Successful*, the Ansible Lightspeed portal URL is available under menu:Networking[Routes] in {OCP}.
+
+[role="_additional-resources"]
+.Additional resources
+* xref:troubleshooting-lightspeed-onpremise-config_troubleshooting-lightspeed[Troubleshooting {LightspeedShortName} on-premise deployment errors]

--- a/lightspeed/modules/proc_create-oauth-app.adoc
+++ b/lightspeed/modules/proc_create-oauth-app.adoc
@@ -37,3 +37,7 @@ The following image is an example of the generated client ID and client secret:
 +
 [.thumb]
 image::popup-window-client-ID-secret.png[{Example of a generated client ID and client secret]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:troubleshooting-lightspeed-onpremise-config_troubleshooting-lightspeed[Troubleshooting {LightspeedShortName} on-premise deployment errors]

--- a/lightspeed/modules/proc_troubleshooting-lightspeed-onpremise-config.adoc
+++ b/lightspeed/modules/proc_troubleshooting-lightspeed-onpremise-config.adoc
@@ -1,7 +1,7 @@
 :_content-type: PROCEDURE
 
 [id="troubleshooting-lightspeed-onpremise-config_{context}"]
-= Troubleshooting on-premise deployment configuration errors
+= Troubleshooting {LightspeedShortName} on-premise deployment errors
 
 == Cannot log in to the Ansible Lightspeed portal
 After you configure an {LightspeedShortName} on-premise deployment and try to log in to the Ansible Lightspeed portal, the log-in attempt fails. The following scenarios are possible:

--- a/lightspeed/modules/proc_update-connection-secrets.adoc
+++ b/lightspeed/modules/proc_update-connection-secrets.adoc
@@ -28,4 +28,8 @@ image:update-connection-secrets.png[Setting to update the connection secrets])
 +
 The new AnsibleLightspeed Pods are created. After the new pods are running successfully, the old AnsibleLightspeed Pods are terminated.
 
+[role="_additional-resources"]
+.Additional resources
+* xref:troubleshooting-lightspeed-onpremise-config_troubleshooting-lightspeed[Troubleshooting {LightspeedShortName} on-premise deployment errors]
+
 

--- a/lightspeed/modules/proc_update-redirect-uri.adoc
+++ b/lightspeed/modules/proc_update-redirect-uri.adoc
@@ -69,3 +69,7 @@ If you are running multiple instances of {LightspeedShortName} application with 
 ====
 
 . Apply the revised YAML. This task restarts the automation controller pods.
+
+[role="_additional-resources"]
+.Additional resources
+* xref:troubleshooting-lightspeed-onpremise-config_troubleshooting-lightspeed[Troubleshooting {LightspeedShortName} on-premise deployment errors]


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-29499.

Changes made:

- Reverted changes made in PR https://github.com/ansible/aap-docs/pull/1707. Some additional steps need to be added to the procedure, and because the PR is merged, this ticket reverses that change and starts afresh.
- Added hyperlinks to the 'troubleshooting on-prem deployment issues' topic from 'Setting up Lightspeed on-premise deployment' 