### PR TITLE
AAP-25298-update: Updated trial urls and removed duplicate topic

### DIFF
--- a/lightspeed/modules/con_lightspeed-key-features.adoc
+++ b/lightspeed/modules/con_lightspeed-key-features.adoc
@@ -13,12 +13,18 @@
 +
 Organization administrators can now create and use fine-tuned, custom models that are trained on your organization's existing Ansible content. With this capability, you can tune the models to your organization's automation patterns and improve the code recommendation experience. 
 +
-You can configure multiple custom models for your organization. For example, you can create a custom model for your corporate IT automation team and a different one for your engineering team's infrastructure. You can also configure a custom model to make it available for all Ansible users or select Ansible users in your organization.
+You can configure multiple custom models for your organization. For example, you can create a custom model for your corporate IT automation team and a different one for your engineering team's infrastructure. You can also configure a custom model to make it available for all Ansible users or select Ansible users in your organization. 
 
 * *{LightspeedShortName} cloud service and on-premise deployments*
 +
 {LightspeedShortName} is available both as a cloud service and as an on-premise deployment. 
 {LightspeedShortName} on-premise deployments provide the {PlatformName} customers more control over their data and supports compliance with enterprise security policies. For example, organizations in sensitive industries with data privacy or air-gapped requirements can use on-premise deployments of both {LightspeedShortName} and {ibmwatsonxcodeassistant} for {LightspeedShortName} on Cloud Pak for Data. {LightspeedShortName} on-premise deployments are supported on {PlatformName} version 2.4.
+
+* *{LightspeedShortName} trial*
++
+Existing Ansible users can now start a free 90-day {LightspeedShortName} cloud service trial. You can create single-task and multitask recommendations, generate playbooks, and view playbook explanations with a trial account. 
++
+To start your {LightspeedShortName} trial, you need a trial or paid subscription to the {PlatformName}; however, you do not need a trial or paid subscription to {ibmwatsonxcodeassistant}. For more information, see xref:start-lightspeed-trial_lightspeed-user-guide[Starting a trial of {LightspeedShortName}].
 
 * *Playbook and task generation*
 

--- a/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-intro.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-intro.adoc
@@ -4,7 +4,18 @@
 = Overview
 {LightspeedFullName} is a generative AI service that helps automation teams create, adopt, and maintain Ansible content more efficiently. It uses natural language prompts to generate code recommendations for automation tasks based on Ansible best practices. {LightspeedShortName} is also the cloud service that enables the integration of generative AI into Ansible Automation Platform.
 
-To use {LightspeedFullName}, your organization must have:
+To use the {LightspeedShortName} cloud service, you must meet *one* of the following requirements:
 
-* A trial or paid subscription to the {PlatformNameShort} 
-* A trial or paid subscription to {ibmwatsonxcodeassistant}
+** Your organization has a trial or paid subscription to both the {PlatformName} and {ibmwatsonxcodeassistant}.
+** Your organization has a trial or paid subscription to the {PlatformName}, and you have a {LightspeedShortName} trial account.
++
+[NOTE]
+====
+A {LightspeedShortName} trial account does not require an {ibmwatsonxcodeassistant} subscription.
+====
+
+To use an on-premise deployment of {LightspeedShortName}, your organization must have the following subscriptions:
+
+** A trial or paid subscription to the {PlatformName} 
+
+** An installation of {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data

--- a/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-august2024.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-august2024.adoc
@@ -9,4 +9,4 @@ This release includes the following new feature:
 +
 Existing Ansible users can now start a free 90-day {LightspeedShortName} cloud service trial. You can create single-task and multitask recommendations, generate playbooks, and view playbook explanations with a trial account. 
 +
-To start your {LightspeedShortName} trial, you need a trial or paid subscription to the {PlatformName}; however, you do not need a trial or paid subscription to {ibmwatsonxcodeassistant}. 
+To start your {LightspeedShortName} trial, you need a trial or paid subscription to the {PlatformName}; however, you do not need a trial or paid subscription to {ibmwatsonxcodeassistant}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html-single/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/index#start-lightspeed-trial_lightspeed-user-guide[Starting a trial of {LightspeedShortName}].

--- a/lightspeed/titles/lightspeed-user-guide/master.adoc
+++ b/lightspeed/titles/lightspeed-user-guide/master.adoc
@@ -13,7 +13,6 @@ include::attributes/attributes.adoc[]
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::assemblies/assembly-lightspeed-intro.adoc[leveloffset=+1]
-include::assemblies/assembly_logging-in-lightspeed-admin-portal.adoc[leveloffset=+1]
 include::assemblies/assembly_starting-lightspeed-trial.adoc[leveloffset=+1]
 include::assemblies/assembly_setting-up-lightspeed.adoc[leveloffset=+1]
 include::assemblies/assembly_logging-in-out-portal.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR is an addendum to JIRA https://issues.redhat.com/browse/AAP-25298.

Changes made:

- Added 'Lightspeed trials' info. in key features section.
- Added cross ref. to 'Lightspeed trials' topic in the release notes.
- Removed a duplicate section 'logging in to Lightspeed admin portal'