### PR TITLE
Document the Metric Collection Utility (#1735)

### DIFF
--- a/downstream/assemblies/platform/assembly_metrics-utility.adoc
+++ b/downstream/assemblies/platform/assembly_metrics-utility.adoc
@@ -1,0 +1,80 @@
+:_newdoc-version: 2.18.3
+:_template-generated: 2024-07-12
+
+ifdef::context[:parent-context-of-metrics-utility: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id="metrics-utility_{context}"]
+
+:context: metrics-utility
+
+= About Ansible automation platform metrics-utility
+
+The Ansible Automation Platform metrics utility tool (metrics-utility) is a command-line utility that is installed on a system containing an instance of automation controller. 
+
+When installed and configured, metrics-utility gathers billing-related metrics from your system and creates a consumption-based billing report. Metrics-utility is especially suited for users who have multiple managed hosts and want to use consumption-based billing. Once a report is generated, it is deposited in a target location that you specify in the configuration file. 
+
+Metrics-utility collects two types of data from your system: configuration data and reporting data. 
+
+The configuration data includes the following information:
+
+* version information for automation controller and for the operating system 
+* subscription information
+* the base URL
+
+The reporting data includes the following information:
+
+* job name and ID
+* host name
+* inventory name 
+* organization name 
+* project name 
+* success or failure information
+* the date and time the report was generated.  
+
+To ensure that metrics-utility continues to work as configured, be sure to clear your report directories of outdated reports regularly. 
+
+
+
+
+
+//Include modules here.
+
+//==== Configuring the metrics-utility
+//include::platform/proc_configuring-the-metrics-utility.adoc[leveloffset=+1]
+
+//==== Fetching a monthly report
+//include::platform/ref_fetching-a-monthly-report.adoc[leveloffset=+1]
+
+//==== Modifying the run schedule
+//include::platform/proc_modifying-the-run-schedule.adoc[leveloffset=+1]
+
+
+
+
+//This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. 
+
+
+//* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+//* You can also link to other modules or assemblies the user must follow before starting this assembly.
+//* Delete the section title and bullets if the assembly has no prerequisites.
+//* X is installed. For information about installing X, see <link>.
+//* You can log in to X with administrator privileges.
+
+
+
+
+
+
+
+//[role="_additional-resources"]
+//== Additional resources
+
+//* This section is optional.
+//* Provide a bulleted list of links to other closely-related material. These links can include `link:` and `xref:` macros.
+//* Use an unnumbered bullet (*) if the list includes only one step.
+
+//ifdef::parent-context-of-metrics-utility[:context: {parent-context-of-metrics-utility}]
+//ifndef::parent-context-of-metrics-utility[:!context:]
+

--- a/downstream/modules/platform/proc_configuring-the-metrics-utility.adoc
+++ b/downstream/modules/platform/proc_configuring-the-metrics-utility.adoc
@@ -1,0 +1,199 @@
+:_newdoc-version: 2.18.3
+:_template-generated: 2024-07-15
+:_mod-docs-content-type: PROCEDURE
+
+[id="configuring-the-metrics-utility_{context}"]
+= configuring-the-metrics-utility
+
+
+== On RHEL 
+
+=== Prerequisites:
+
+* An active Ansible Automation Platform subscription
+
+
+Metrics-utility is included with Ansible Automation Platform, so no separate installation is needed. The following commands gather the relevant data and generate a CCSP report containing your usage metrics. You can configure these commands as cronjobs to ensure they run at the beginning of every month. See link:https://www.redhat.com/sysadmin/linux-cron-command[How to schedule jobs using the Linux ‘Cron’ utility] for more on configuring using the cron syntax. 
+
+
+
+=== *Procedure:*
+
+. In the cron file, set the following variables to ensure metrics-utility gathers the relevant data. To open the cron file for editing, run: 
++
+[source, ]
+----
+crontab -e
+----
++
+. Specify the following variables to indicate where the report will be deposited in your file system:
++
+[source, ]
+----
+export METRICS_UTILITY_SHIP_TARGET=directory
+export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
+----
++
+. Set these variables to generate a report: 
++
+[source, ]
+----
+export METRICS_UTILITY_REPORT_TYPE=CCSP
+export METRICS_UTILITY_PRICE_PER_NODE=11.55 # in USD
+export METRICS_UTILITY_REPORT_SKU=MCT3752MO
+export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
+export METRICS_UTILITY_REPORT_H1_HEADING="CCSP Reporting <Company>: ANSIBLE Consumption"
+export METRICS_UTILITY_REPORT_COMPANY_NAME="Company Name"
+export METRICS_UTILITY_REPORT_EMAIL="email@email.com"
+export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
+export METRICS_UTILITY_REPORT_COMPANY_BUSINESS_LEADER="BUSINESS LEADER"
+export METRICS_UTILITY_REPORT_COMPANY_PROCUREMENT_LEADER="PROCUREMENT LEADER"
+----
++
+. Add the following parameter to gather and store the data in the provided SHIP_PATH directory in the ./report_data subdirectory: 
++
+[source, ]
+----
+metrics-utility gather_automation_controller_billing_data --ship --until=10m
+----
++
+. To configure the run schedule, add the following parameters to the end of the file and specify how often you want metrics-utility to gather information and build a report using link:https://www.redhat.com/sysadmin/linux-cron-command[cron syntax]. In the example below, the gather command is configured to run every hour at 00 minutes. The build_report command is configured to run every second day of each month at 4:00 am. 
++
+[source, ]
+----
+0 */1 * * * metrics-utility gather_automation_controller_billing_data --ship --until=10m
+0 4 2 * *  metrics-utili
+ty build_report
+----
++
+. Save and close the file.
+. To verify that your changes are saved, run:
++
+[source, ]
+----
+crontab -l
+----
++
+. You can also check the logs to ensure that data is being collected. Run: 
++
+[source, ]
+----
+cat /var/log/cron 
+----
++
+The following is an example of the output. Note that time and date may vary depending on how your configure the run schedule:
++
+[source, ]
+----
+May  8 09:45:03 ip-10-0-6-23 CROND[51623]: (root) CMDOUT (No billing data for month: 2024-04)
+May  8 09:45:03 ip-10-0-6-23 CROND[51623]: (root) CMDEND (metrics-utility build_report)
+May  8 09:45:19 ip-10-0-6-23 crontab[51619]: (root) END EDIT (root)
+May  8 09:45:34 ip-10-0-6-23 crontab[51659]: (root) BEGIN EDIT (root)
+May  8 09:46:01 ip-10-0-6-23 CROND[51688]: (root) CMD (metrics-utility gather_automation_controller_billing_data --ship --until=10m)
+May  8 09:46:03 ip-10-0-6-23 CROND[51669]: (root) CMDOUT (/tmp/9e3f86ee-c92e-4b05-8217-72c496e6ffd9-2024-05-08-093402+0000-2024-05-08-093602+0000-0.tar.gz)
+May  8 09:46:03 ip-10-0-6-23 CROND[51669]: (root) CMDEND (metrics-utility gather_automation_controller_billing_data --ship --until=10m)
+May  8 09:46:26 ip-10-0-6-23 crontab[51659]: (root) END EDIT (root)
+----
++
+. Run the following command to build a report for the previous month:
++
+[source, ]
+----
+metrics-utility build_report
+----
++
+The generated report will have the default name CCSP-<YEAR>-<MONTH>.xlsx and will be deposited in the ship path that you specified in step 2.
+
+== On Openshift Container Platform from the AAP operator
+
+Metrics-utility is included in the Openshift Container Platform image beginning with version 4.12. If your system does not have metrics-utility installed, update your OpenShift image to the latest version. 
+
+Follow the steps below to configure the run schedule for metrics-utility on Openshift Container Platform using the AAP operator.
+
+.Prerequisites:
+* A running OpenShift cluster
+* An operator-based installation of Ansible Automation Platform on OpenShift. 
+
+NOTE: Metrics-utility will run as indicated by the parameters you set in the configuration file. The utility cannot be run manually on Openshift Container Platform.
+
+=== Create a ConfigMap in the Openshift UI YAML view
+
+. From the navigation panel on the left side, select *ConfigMaps*, and then click the *Create ConfigMap* button.
+. On the next screen, select the *YAML view* tab.
+. In the YAML field, enter the following parameters with the appropriate variables set: 
++
+[source, ]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: automationcontroller-metrics-utility-configmap
+data:
+  METRICS_UTILITY_SHIP_TARGET: directory
+  METRICS_UTILITY_SHIP_PATH: /metrics-utility
+  METRICS_UTILITY_REPORT_TYPE: CCSP
+  METRICS_UTILITY_PRICE_PER_NODE: '11' # in USD
+  METRICS_UTILITY_REPORT_SKU: MCT3752MO
+  METRICS_UTILITY_REPORT_SKU_DESCRIPTION: "EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
+  METRICS_UTILITY_REPORT_H1_HEADING: "CCSP Reporting <Company>: ANSIBLE Consumption"
+  METRICS_UTILITY_REPORT_COMPANY_NAME: "Company Name"
+  METRICS_UTILITY_REPORT_EMAIL: "email@email.com"
+  METRICS_UTILITY_REPORT_RHN_LOGIN: "test_login"
+  METRICS_UTILITY_REPORT_COMPANY_BUSINESS_LEADER: "BUSINESS LEADER"
+  METRICS_UTILITY_REPORT_COMPANY_PROCUREMENT_LEADER: "PROCUREMENT LEADER"
+----
++
+. Click the *Create* button.
+. To verify that the ConfigMap was created and the metric utility is installed, select *ConfigMap* from the navigation panel and look for your ConfigMap in the list.
+
+
+=== Deploy automation controller
+
+Deploy automation controller and specify variables for how often the metric collection utility gathers usage information and generates a report. 
+
+. From the navigation panel, select *Installed Operators*.
+. Click on Ansible Automation Platform
+. In the Operator details, select the *Automaton Controller* tab.
+. Click the button labeled *Create AutomationController*.
+. Select the *YAML view* option. The YAML now shows the default parameters for automation controller. 
+The relevant parameters for metrics-utility are the following: 
++
+----
+[cols="50%,50%",options="header"]
+|====
+| *Parameter* | *Variable*
+| *`metrics_utility_enabled`* | True.
+| *`metrics_utility_cronjob_gather_schedule`* | @hourly or @daily.
+| *`metrics_utility_cronjob_report_schedule`* | @daily or @monthly.
+|====
+----
++
+. Find the `metrics_utility_enabled` parameter and change the variable to true.
+. Find the `metrics_utility_cronjob_gather_schedule` parameter and enter a variable for how often the utility should gather usage information (for example, @hourly or @daily). 
+. Find the `metrics_utility_cronjob_report_schedule` parameter and enter a variable for how often the utility generates a report (for example, @daily or @monthly).
+. Click the *Create* button.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+== NewDoc
+
+[role="_additional-resources"]
+.Additional resources
+
+* This section is optional.
+* Provide a bulleted list of links to other closely-related material. These links can include `link:` and `xref:` macros.
+* Use an unnumbered bullet (*) if the list includes only one step.
+

--- a/downstream/modules/platform/proc_modifying-the-run-schedule.adoc
+++ b/downstream/modules/platform/proc_modifying-the-run-schedule.adoc
@@ -1,0 +1,53 @@
+:_newdoc-version: 2.18.3
+:_template-generated: 2024-07-15
+:_mod-docs-content-type: PROCEDURE
+
+[id="modifying-the-run-schedule_{context}"]
+= modifying-the-run-schedule
+
+
+You can configure metrics-utility to run at specified times and intervals. Run frequency is expressed in cronjobs; see link:https://www.redhat.com/sysadmin/linux-cron-command[How to schedule jobs using the Linux ‘Cron’ utility] for more information. 
+
+== On RHEL
+=== *Procedure*
+ 
+. From the command line, run: 
++
+[source, ]
+----
+crontab -e 
+----
++
+. After the code editor has opened, update the gather and build parameters using cron syntax as shown below: 
++
+[source, ]
+----
+*/2 * * * *     metrics-utility gather_automation_controller_billing_data --ship --until=10m
+*/5 * * * *     metrics-utili
+ty build_report
+----
++
+. Save and close the file.
+
+== On Openshift Container Platform from the AAP operator 
+=== *Procedure*
+
+. From the navigation panel, select *Workloads > Deployments*.
+. On the next screen, click *automation-controller-operator-controller-manager*.
+. Beneath the heading *Deployment Details*, click the down arrow button to change the number of pods to zero. This will pause the deployment so you can update the running schedule. 
+. From the navigation panel, click *Installed Operators*. From the list of installed operators, select Ansible Automation Platform. 
+. On the next screen, select the Automation Controller tab. 
+. From the list that appears, click your controller instance. 
+. On the next screen, select the YAML tab. 
+. In the YAML file, find the following parameters and enter a variable representing how often metrics-utility should gather data and how often it should produce a report: 
++
+[source, ]
+----
+metrics_utility_cronjob_gather_schedule:
+metrics_utility_cronjob_report_schedule: 
+----
++
+. Click *Save*.
+. From the navigation menu, select *Deployments* and click automation-controller-operator-controller-manager.
+. Increase the number of pods to 1.
+. To verify that you have changed the utility-metrics running schedule successfully, return to the YAML file and ensure that the parameters described above reflect the correct variables. OR From the navigation menu, select *Workloads > Cronjobs* and ensure that your cronjobs show the updated schedule. 

--- a/downstream/modules/platform/ref_fetching-a-monthly-report.adoc
+++ b/downstream/modules/platform/ref_fetching-a-monthly-report.adoc
@@ -1,0 +1,162 @@
+:_newdoc-version: 2.18.3
+:_template-generated: 2024-07-15
+
+:_mod-docs-content-type: REFERENCE
+
+[id="fetching-a-monthly-report_{context}"]
+= fetching-a-monthly-report
+
+
+== On RHEL
+To fetch a monthly report on RHEL, run: 
+
+[source, ]
+----
+scp -r username@controller_host:$METRICS_UTILITY_SHIP_PATH/data/<YYYY>/<MM>/ /local/directory/
+----
+
+The generated report will have the default name CCSP-<YEAR>-<MONTH>.xlsx and will be deposited in the ship path that you specified.
+
+== On Openshift Container Platform from the AAP operator
+
+Use the following playbook to fetch a monthly consumption report for AAP on Openshift Container Platform:
+
+[source, ]
+----
+- name: Copy directory from Kubernetes PVC to local machine
+  hosts: localhost
+
+  vars:
+    report_dir_path: "/mnt/metrics/reports/{{ year }}/{{ month }}/"
+
+  tasks:
+    - name: Create a temporary pod to access PVC data
+      kubernetes.core.k8s:
+        definition:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: temp-pod
+            namespace: "{{ namespace_name }}"
+          spec:
+            containers:
+            - name: busybox
+              image: busybox
+              command: ["/bin/sh"]
+              args: ["-c", "sleep 3600"]  # Keeps the container alive for 1 hour
+              volumeMounts:
+              - name: "{{ pvc }}"
+                mountPath: "/mnt/metrics"
+            volumes:
+            - name: "{{ pvc }}"
+              persistentVolumeClaim:
+                claimName: automationcontroller-metrics-utility
+            restartPolicy: Never
+      register: pod_creation
+
+    - name: Wait for both initContainer and main container to be ready
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ namespace_name }}"
+        name: temp-pod
+      register: pod_status
+      until: >
+        pod_status.resources[0].status.containerStatuses[0].ready
+      retries: 30
+      delay: 10
+
+    - name: Create a tarball of the directory of the report in the container
+      kubernetes.core.k8s_exec:
+        namespace: "{{ namespace_name }}"
+        pod: temp-pod
+        container: busybox
+        command: tar czf /tmp/metrics.tar.gz -C "{{ report_dir_path }}" .
+      register: tarball_creation
+
+    - name: Copy the report tarball from the container to the local machine
+      kubernetes.core.k8s_cp:
+        namespace: "{{ namespace_name }}"
+        pod: temp-pod
+        container: busybox
+        state: from_pod
+        remote_path: /tmp/metrics.tar.gz
+        local_path: "{{ local_dir }}/metrics.tar.gz"
+      when: tarball_creation is succeeded
+
+    - name: Ensure the local directory exists
+      ansible.builtin.file:
+        path: "{{ local_dir }}"
+        state: directory
+
+    - name: Extract the report tarball on the local machine
+      ansible.builtin.unarchive:
+        src: "{{ local_dir }}/metrics.tar.gz"
+        dest: "{{ local_dir }}"
+        remote_src: yes
+        extra_opts: "--strip-components=1"
+      when: tarball_creation is succeeded
+
+    - name: Delete the temporary pod
+      kubernetes.core.k8s:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ namespace_name }}"
+        name: temp-pod
+        state: absent
+----
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+.Labeled list
+Term 1:: Definition
+Term 2:: Definition
+
+.Table
+[options="header"]
+|====
+|Column 1|Column 2|Column 3
+|Row 1, column 1|Row 1, column 2|Row 1, column 3
+|Row 2, column 1|Row 2, column 2|Row 2, column 3
+|====
+
+
+


### PR DESCRIPTION
This is the backport for [PR 1735](https://github.com/ansible/aap-docs/pull/1735/files). It backports the work in that PR to the 2.5 branch. 


See [AAP-19692](https://issues.redhat.com/browse/AAP-19692) for more detail.