### PR TITLE
AAP-24690 Tweaked note about write-scope status for controller token

### DIFF
--- a/downstream/modules/eda/proc-eda-set-up-token.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-token.adoc
@@ -1,6 +1,6 @@
 [id="eda-set-up-token-to-authenticate"]
 
-= Setting up a token to authenticate to {PlatformNameShort} Controller
+= Setting up a token to authenticate to {ControllerName}
 
 .Prerequisites
 
@@ -24,7 +24,7 @@ For more information about creating the token, see the link:https://docs.ansible
 +
 [NOTE]
 ====
-The token must be in write-scope.
+Your token must be in write-scope and if you are the assigned user, you must have permission to execute job and workflow templates.
 ====
 . Select btn:[Create controller token].
 


### PR DESCRIPTION
For the EDA controller user guide, chapter 5.1, tweaked the note after step 5 to include permissions to execute job and workflow templates. (Note: this update will occur in the 2.4 guide, but will be applied to 2.5 separately since the process will change slightly.)