### PR TITLE
[Backport] AAP-29223 - Create structure for Access management and authentication (#1769)

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-organizations.adoc
+++ b/downstream/assemblies/platform/assembly-controller-organizations.adoc
@@ -32,7 +32,7 @@ include::platform/proc-gw-add-team-organization.adoc[leveloffset=+2]
 
 include::platform/proc-gw-delete-organization.adoc[leveloffset=+2]
 
-include::platform/proc-gw-oganization-notifications.adoc[leveloffset=+1]
+include::platform/ref-controller-organization-notifications.adoc[leveloffset=+1] 
 
 include::platform/proc-gw-organizations-exec-env.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-gw-config-authentication-type.adoc
+++ b/downstream/assemblies/platform/assembly-gw-config-authentication-type.adoc
@@ -1,0 +1,59 @@
+ifdef::context[:parent-context: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id="gw-config-authentication-type_{context}"]
+
+= Configuring authentication in the {PlatformNameShort}
+
+:context: gw-auth-type
+
+Ansible Automation Platform provides multiple authenticator plugins that you can configure to simplify the login experience for your organization. These are the authenticator plugins that are provided:
+* xref:gw-local-authentication[Local] 
+* xref:controller-set-up-LDAP[LDAP] 
+* xref:controller-set-up-SAML[SAML] 
+* xref:controller-set-up-tacacs[TACACS+] 
+* xref:controller-set-up-radius[Radius]
+* xref:controller-set-up-azure[Azure]
+* xref:proc-controller-google-oauth2-settings[Google OAuth]
+* xref:controller-set-up-generic-oidc[Generic OIDC]
+* xref:gw-config-keycloak-settings[Keycloak]
+* xref:proc-controller-github-settings[GitHub]
+* xref:proc-controller-github-organization-setttings[GitHub organization]
+* xref:proc-controller-github-team-settings[GitHub team]
+* xref:proc-controller-github-enterprise-settings[GitHub enterprise]
+* xref:proc-controller-github-enterprise-org-settings[GitHub enterprise organization]
+* xref:proc-controller-github-enterprise-team-settings[GitHub enterprise team]
+
+include::platform/proc-gw-local-authentication.adoc[leveloffest=+1]
+
+include::platform/proc-controller-set-up-LDAP.adoc[leveloffset=+1]
+
+include::platform/proc-controller-set-up-SAML.adoc[leveloffset=+1]
+
+include::platform/proc-controller-set-up-tacacs+.adoc[leveloffset=+1]
+
+include::platform/proc-controller-set-up-azure.adoc[leveloffset=+1]
+
+include::platform/proc-controller-google-oauth2-settings.adoc[leveloffset=+1]
+
+include::platform/proc-controller-set-up-generic-oidc.adoc[leveloffest=+1]
+
+include::platform/proc-gw-config-keycloak-settings.adoc[leveloffset=+1]
+
+include::platform/proc-controller-github-settings.adoc[leveloffset=+1]
+
+include::platform/proc-controller-github-organization-settings.adoc[leveloffset=+1]
+
+include::platform/proc-controller-github-team-settings.adoc[leveloffset=+1]
+
+include::platform/proc-controller-github-enterprise-settings.adoc[leveloffset=+1]
+
+include::platform/proc-controller-github-enterprise-org-settings.adoc[leveloffset=+1]
+
+include::platform/proc-controller-github-enterprise-team-settings.adoc[leveloffset=+1]
+
+include::platform/proc-controller-set-up-radius.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-gw-configure-authentication.adoc
+++ b/downstream/assemblies/platform/assembly-gw-configure-authentication.adoc
@@ -1,0 +1,37 @@
+ifdef::context[:parent-context: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id="gw-configure-authentication_{context}"]
+
+= Configuring authentication in the {PlatformNameShort}
+
+:context: gw-auth-wizard
+
+Using the authentication settings in {PlatformNameShort}, you can set up a simplified login through several authentication methods, such as LDAP and SAML
+Depending on the authentication method you select, you will be required to enter different information to complete the configuration. Be sure to include all the information required for your configuration needs.
+
+== Prerequisites
+
+* A running installation of {PlatformNameShort} {PlatformVers}
+* A running instance of your authentication source
+* Administrator rights to the {PlatformNameShort}
+* Any connection information needed to connect {PlatformNameShort} {PlatformVers} to your source (see individual authentication types for details).
+
+include::platform/con-gw-pluggable-authentication.adoc[leveloffest=+1]
+
+include::platform/con-gw-create-authentication.adoc[leveloffset=+1]
+
+include::platform/proc-gw-select-auth-type.adoc[leveloffset=+2]
+
+include::platform/proc-gw-configure-auth-details.adoc[leveloffset=+2]
+
+include::platform/proc-gw-define-rules-triggers.adoc[leveloffset=+2]
+
+include::platform/proc-gw-adjust-mapping-order.adoc[leveloffset=+2]
+
+include::assembly-gw-config-authentication-type.adoc[leveloffset=+1]
+
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-gw-managing-access.adoc
+++ b/downstream/assemblies/platform/assembly-gw-managing-access.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: ASSEMBLY
+
+[id="gw-managing-access_{context}"]
+
+= Managing access with role based access control
+
+:context: gw-manage-rbac
+
+Role-based access control (RBAC) restricts user access based on their role within an organization. The roles in RBAC refer to the levels of access that users have to the network.
+
+You can control what users can do with the components of {PlatformNameShort} at a broad or granular level depending on your RBAC policy. You can designate whether the user is a system administrator or normal user and align roles and access permissions with their positions within the organization.
+
+Roles can be defined with multiple permissions that can then be assigned to resources, teams and users. The permissions that make up a role dictate what the assigned role allows. Permissions are allocated with only the access needed for a user to perform the tasks appropriate for their role.
+
+include::assembly-controller-organizations.adoc[leveloffset=+1]
+include::assembly-controller-teams.adoc[leveloffset=+1]
+include::assembly-controller-users.adoc[leveloffset=+1]
+include::assembly-gw-resources.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-gw-managing-authentication.adoc
+++ b/downstream/assemblies/platform/assembly-gw-managing-authentication.adoc
@@ -1,0 +1,24 @@
+ifdef::context[:parent-context: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id="gw-managing-authentication_{context}"]
+
+= Managing authentication in {PlatformNameShort}
+
+:context: gw-manage-auth
+
+After you have configured your authentication settings, you can view a list of authenticators, search, sort and view the details for each authenticator configured on the system.
+
+include::platform/proc-gw-authentication-list-view.adoc[leveloffset=+1]
+
+include::platform/proc-gw-searching-authenticator.adoc[leveloffset=+1]
+
+include::platform/proc-gw-display-auth-details.adoc[leveloffset=+1]
+
+include::platform/proc-gw-edit-authenticator.adoc[leveloffset=+1]
+
+include::platform/proc-gw-delete-authenticator.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-gw-mapping.adoc
+++ b/downstream/assemblies/platform/assembly-gw-mapping.adoc
@@ -1,0 +1,31 @@
+ifdef::context[:parent-context: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id="gw-mapping_{context}"]
+
+= Mapping
+
+:context: gw-mapping
+
+To control which users are allowed into the {PlatformNameShort} server, and placed into {PlatformNameShort} organizations or teams based on their attributes (like username and email address) or what groups they belong to, you can configure authenticator maps. 
+Authenticator maps allow you to add conditions that must be met before a user is given or denied access to a resource type. Authenticator maps are associated with an authenticator and are given an order. The maps are processed in order when the user logs in. These can be thought of like firewall rules or mail filters.
+
+include::platform/con-gw-authenticator-map-types.adoc[leveloffset=+1]
+
+include::platform/con-gw-authenticator-map-triggers.adoc[leveloffset=+1]
+
+include::platform/con-gw-authenticator-map-examples.adoc[leveloffset=+1]
+
+include::platform/proc-gw-allow-mapping.adoc[leveloffset=+1]
+
+include::platform/ref-controller-organization-mapping.adoc[leveloffset=+1]
+
+include::platform/ref-controller-team-mapping.adoc[leveloffset=+1]
+
+include::platform/proc-gw-role-mapping.adoc[leveloffset=+1]
+
+include::platform/proc-gw-superuser-mapping.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-gw-roles.adoc
+++ b/downstream/assemblies/platform/assembly-gw-roles.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+
+[id="assembly-gw-roles_{context}"]
+
+= Roles
+
+:context: gw-roles
+
+Roles are units of organization in the {PlatformName}. When you assign a role to a team or user, you are granting access to use, read, or write credentials. Because of the file structure associated with a role, roles become redistributable units that enable you to share behavior among resources, or with other users. All access that is granted to use, read, or write credentials is handled through roles, and roles are defined for a resource.
+
+include::platform/proc-gw-roles.adoc[leveloffset=+1]
+include::platform/proc-gw-create-roles.adoc[leveloffset=+1]
+include::platform/proc-gw-edit-roles.adoc[leveloffset=+1]
+include::platform/proc-gw-delete-roles.adoc[leveloffset=+1]
+

--- a/downstream/assemblies/platform/assembly-gw-settings.adoc
+++ b/downstream/assemblies/platform/assembly-gw-settings.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: ASSEMBLY
+
+[id="assembly-gw-settings_{context}"]
+
+= Configuring {PlatformNameShort}
+
+:context: gw-settings
+
+You can configure Ansible Automation platform from the *Settings* menu using the following selections:
+
+* *Subscriptions*
+* *Platform gateway*
+* *User Preferences*
+* *Troubleshooting*
+
+[NOTE]
+====
+The other selections available from the *Settings* menu are specific to automation execution. For more information, refer to the link:https://{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/controller-config[TitleControllerAdminGuide] guide.
+====
+
+include::/platform/proc-controller-configure-subscriptions.adoc[leveloffset=+1]
+include::/platform/proc-settings-platform-gateway.adoc[leveloffset=+1]
+include::/platform/proc-settings-user-preferences.adoc[leveloffset=+1]
+include::/platform/proc-settings-troubleshooting.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-gw-token-based-authentication.adoc
+++ b/downstream/assemblies/platform/assembly-gw-token-based-authentication.adoc
@@ -1,0 +1,15 @@
+ifdef::context[:parent-context: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+[id="gw-token-based-authentication_{context}"]
+
+= Configuring token-based authentication
+
+:context: gw-token-auth
+
+[TBD] The content for this is in progress in separate link:https://docs.google.com/document/d/1GLk5zcD-8hZxU61Ik8wASDofkX7iQo5IJvkCOv5gRMw/edit?usp=sharing[Applications] and link:https://docs.google.com/document/d/1w9KjK8CybZ3w0u0DGNf0rNDC72vomwbdt5rZkUZCaBk/edit#bookmark=id.1rtgxk9mwxi0[Token-based authentication] drafts. Once converted/updated in AsciiDoc and in the repo, update this section to include those modules. 
+
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/ref-controller-organization-notifications.adoc
+++ b/downstream/modules/platform/ref-controller-organization-notifications.adoc
@@ -7,12 +7,11 @@
 When {ControllerName} is enabled on the platform, you can review any notifier integrations you have set up and manage their settings within the organization resource. 
 
 .Procedure
-. From the navigation panel, select Access Management › Organizations.
+. From the navigation panel, select {MenuAMOrganizations}.
 . From the Organizations list view, select the organization to which you want to manage notifications.
 //ddacosta - this might change to Notifiers tab.
 . Select the *Notification* tab. 
 . Use the toggles to enable or disable the notifications to use with your particular organization. For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution/controller-enable-disable-notifications[Enable and disable notifications].
 . If no notifiers have been set up, select {MenuAEAdminJobNotifications} from the navigation panel.
-
 
 For information on configuring notification types, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution/controller-notifications#controller-notification-types[Notification types].

--- a/downstream/titles/central-auth/docinfo.xml
+++ b/downstream/titles/central-auth/docinfo.xml
@@ -1,10 +1,10 @@
 <title>Access management and authentication</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Enable authentication functions and role based access controls for Ansible Automation Platform
+<subtitle>Configure role based access control, authenticators and authenticator maps in Ansible Automation Platform
 </subtitle>
 <abstract>
-<para>This guide provides platform administrators with the information and procedures required to enable and configure central authentication on Ansible Automation Platform.</para>
+<para>This guide provides requirements, options, and recommendations for controlling access to Red Hat Ansible Automation Platform resources.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/central-auth/master.adoc
+++ b/downstream/titles/central-auth/master.adoc
@@ -9,13 +9,11 @@ include::attributes/attributes.adoc[]
 // Book Title
 = Access management and authentication
 
-{AAPCentralAuth} is a third-party identity provider (idP) solution, allowing for a simplified single sign-on solution that can be used across the {PlatformNameShort}. Platform administrators can utilize {CentralAuth} to test connectivity and authentication, as well as onboard new users and manage user permissions by configuring and assigning them to groups. Along with OpenID Connect-based and LDAP support, {CentralAuth} also provides a supported REST API which can be used to bootstrap customer usage.
-
 include::{Boilerplate}[]
 
-include::central-auth/assembly-central-auth-hub.adoc[leveloffset=+1]
-include::central-auth/assembly-central-auth-add-user-storage.adoc[leveloffset=+1]
-include::central-auth/assembly-assign-hub-admin-permissions.adoc[leveloffset=+1]
-include::central-auth/assembly-central-auth-identity-broker.adoc[leveloffset=+1]
-include::central-auth/assembly-central-auth-group-perms.adoc[leveloffset=+1]
-include::central-auth/assembly-configuring-central-auth-generic-oidc-settings.adoc[leveloffset=+1]
+include::platform/platform/con-gw-overview-access-auth.adoc[leveloffset=+1]
+include::platform/assembly-gw-configure-authentication.adoc[leveloffset=+1]
+include::platform/assembly-gw-token-based-authentication.adoc[leveloffset=+1]
+include::platform/assembly-gw-managing-access.adoc[leveloffset=+1]
+include::platform/assembly-gw-roles.adoc[leveloffset=+1]
+include::platform/assembly-gw-settings.adoc[leveloffset=+1]

--- a/downstream/titles/central-auth/platform
+++ b/downstream/titles/central-auth/platform
@@ -1,0 +1,1 @@
+../../assemblies/platform


### PR DESCRIPTION
This PR backports the changes from #1769 to the 2.5 branch and includes the following:

* AAP-29223 - Create structure for Access management and authentication guide

* AAP29223 - add symlink to assemblies/platform

* AAP-29223 - formatting fixes

* AAP-29223 Fixed duplicate ids in assemlies and other corrections