### PR TITLE
Added warning to "About inventory installer file" AAP-15722

### DIFF
--- a/downstream/archive/archived-modules/platform/con-inventory-introduction.adoc
+++ b/downstream/archive/archived-modules/platform/con-inventory-introduction.adoc
@@ -61,7 +61,7 @@ registry_password='<registry password>'
 
 The first part of the inventory file specifies the hosts or groups that Ansible can work with. 
 
-[WARNING]
+[NOTE]
 ====
 You must have valid subscriptions attached before installing the Ansible Automation Platform. If you have a new Red Hat Account, you do not have to perform any additional tasks. By default, Simple Content Access, which hosts access to all your subscriptions and content, is enabled. You can enable Simple Content Access by visiting Red Hat Console. 
 

--- a/downstream/archive/archived-modules/platform/con-inventory-introduction.adoc
+++ b/downstream/archive/archived-modules/platform/con-inventory-introduction.adoc
@@ -63,7 +63,7 @@ The first part of the inventory file specifies the hosts or groups that Ansible 
 
 [NOTE]
 ====
-You must have valid subscriptions attached before installing the Ansible Automation Platform. If you have a new Red Hat Account, you do not have to perform any additional tasks. By default, Simple Content Access, which hosts access to all your subscriptions and content, is enabled. You can enable Simple Content Access by visiting Red Hat Console. 
+You must have valid subscriptions attached before installing the {PlatformNameShort}. If you have a new Red Hat Account, you do not have to perform any additional tasks. By default, Simple Content Access, which hosts access to all your subscriptions and content, is enabled. You can enable Simple Content Access by visiting Red Hat Console. 
 
 The only scenario where you still need to attach a subscription manually is to an air-gapped system that uses Red Hat Satellite for subscription validation. This exception is no longer supported after Red Hat Satellite 16.6.
 ====

--- a/downstream/archive/archived-modules/platform/con-inventory-introduction.adoc
+++ b/downstream/archive/archived-modules/platform/con-inventory-introduction.adoc
@@ -65,5 +65,5 @@ The first part of the inventory file specifies the hosts or groups that Ansible 
 ====
 You must have valid subscriptions attached before installing the {PlatformNameShort}. If you have a new Red Hat Account, you do not have to perform any additional tasks. By default, Simple Content Access, which hosts access to all your subscriptions and content, is enabled. You can enable Simple Content Access by visiting Red Hat Console. 
 
-The only scenario where you still need to attach a subscription manually is to an air-gapped system that uses Red Hat Satellite for subscription validation. This exception is no longer supported after Red Hat Satellite 16.6.
+The only scenario where you still need to attach a subscription manually is to an air-gapped system that uses Red Hat Satellite for subscription validation. This exception is no longer supported after Red Hat Satellite 6.6.
 ====

--- a/downstream/archive/archived-modules/platform/con-inventory-introduction.adoc
+++ b/downstream/archive/archived-modules/platform/con-inventory-introduction.adoc
@@ -61,6 +61,9 @@ registry_password='<registry password>'
 
 The first part of the inventory file specifies the hosts or groups that Ansible can work with. 
 
-[NOTE]
+[WARNING]
 ====
-The inventory file variables `registry_username` and `registry_password` are only required if a non-bundle installer is used.
+You must have valid subscriptions attached before installing the Ansible Automation Platform. If you have a new Red Hat Account, you do not have to perform any additional tasks. By default, Simple Content Access, which hosts access to all your subscriptions and content, is enabled. You can enable Simple Content Access by visiting Red Hat Console. 
+
+The only scenario where you still need to attach a subscription manually is to an air-gapped system that uses Red Hat Satellite for subscription validation. This exception is no longer supported after Red Hat Satellite 16.6.
+====

--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -25,6 +25,13 @@ If you are compiling Postgres against OpenSSL 3.2, your system regresses to remo
 You must restart the database server after changing the value for `shared_buffers`.
 ====
 
+Warning
+====
+If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the BIO_get_app_data call instead of open_get_data. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database.
+
+If you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
+====
+
 * `work_mem`: provides the amount of memory to be used by internal sort operations and hash tables before disk-swapping. Sort operations are used for order by, distinct, and merge join operations. Hash tables are used in hash joins and hash-based aggregation. The default value for this parameter is 4 MB. Setting the correct value of the `work_mem` parameter improves the speed of a search by reducing disk-swapping.
 ** Use the following formula to calculate the optimal value of the `work_mem` parameter for the database server: 
 

--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -15,7 +15,7 @@ To improve the performance of the PostgreSQL server, configure the following _Gr
 
 * `shared_buffers`: determines how much memory is dedicated to the server for caching data. The default value for this parameter is 128 MB. When you modify this value, you must set it between 15% and 25% of the machine's total RAM. 
 
-[WARNING]
+[NOTE]
 ====
 If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the BIO_get_app_data call instead of open_get_data. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database. f you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
 ====
@@ -23,13 +23,6 @@ If you are compiling Postgres against OpenSSL 3.2, your system regresses to remo
 [NOTE]
 ====
 You must restart the database server after changing the value for `shared_buffers`.
-====
-
-Warning
-====
-If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the BIO_get_app_data call instead of open_get_data. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database.
-
-If you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
 ====
 
 * `work_mem`: provides the amount of memory to be used by internal sort operations and hash tables before disk-swapping. Sort operations are used for order by, distinct, and merge join operations. Hash tables are used in hash joins and hash-based aggregation. The default value for this parameter is 4 MB. Setting the correct value of the `work_mem` parameter improves the speed of a search by reducing disk-swapping.


### PR DESCRIPTION
Added warning that the air-gapped exception to the deprecation of manifests, which currently applies to all other use cases, is disappearing with Satellite 6.16 as per AAP-15722.