### PR TITLE
Backport-2.5-1385 (AAP-24694) Added note about rulebook activations shutting down and canceling jobs on controller

### DIFF
--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -48,7 +48,12 @@ The content would be equivalent to the file passed through the `--vars` flag of 
 
 . Click btn:[Create rulebook activation].
 
-Your rulebook activation is now created and can be managed in the *Rulebook Activations* screen.
+Your rulebook activation is now created and can be managed on the *Rulebook Activations* page.
 
 After saving the new rulebook activation, the rulebook activation's details page is displayed.
-From there or the *Rulebook Activations* list view you can edit or delete it.
+From there or the *Rulebook Activations* list view, you can edit or delete it.
+
+[NOTE]
+====
+Occasionally, when a source plugin shuts down, it causes a rulebook to exit gracefully after a certain amount of time. When a rulebook activation shuts down, any tasks that are waiting to be performed will be canceled, and an info level message will be sent to the activation log. For more information, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/rulebooks.html#[Rulebooks].
+====


### PR DESCRIPTION
Added a note at the end of [section 6.1 Setting up a rulebook activation](https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/event-driven_ansible_controller_user_guide/index#eda-set-up-rulebook-activation) in the EDA controller user guide to inform users that when an activation shuts down, any tasks that are waiting to be performed will be canceled and an info level message will be sent to the activation log. Tracked in jira [AAP-24694](https://issues.redhat.com/browse/AAP-24694).
