### PR TITLE
2.4 AAP-29953 Fix YAML indentation in devtools example playbook (#1787)

### DIFF
--- a/downstream/modules/devtools/proc-devtools-writing-first-playbook.adoc
+++ b/downstream/modules/devtools/proc-devtools-writing-first-playbook.adoc
@@ -19,10 +19,10 @@ The playbook consists of a single play that executes a `ping` to your local mach
 +
 ----
 - name: My first play
- hosts: localhost
- tasks:
-  - name: Ping my hosts
-    ansible.builtin.ping:
+  hosts: localhost
+  tasks:
+    - name: Ping my hosts
+      ansible.builtin.ping:
 
 ----
 +


### PR DESCRIPTION
AAP-29953 Fix YAML indentation in devtools example playbook
Backports #1787 to 2.4