### PR TITLE
Backport of AAP-15722: about inventory install file

### DIFF
--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -22,7 +22,7 @@ You must restart the database server after changing the value for `shared_buffer
 
 [NOTE]
 ====
-If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the BIO_get_app_data call instead of open_get_data. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database.
+If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the `BIO_get_app_data` call instead of `open_get_data`. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database.
 
 If you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
 ====

--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -25,6 +25,13 @@ If you are compiling Postgres against OpenSSL 3.2, your system regresses to remo
 You must restart the database server after changing the value for `shared_buffers`.
 ====
 
+Warning
+====
+If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the BIO_get_app_data call instead of open_get_data. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database.
+
+If you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
+====
+
 * `work_mem`: provides the amount of memory to be used by internal sort operations and hash tables before disk-swapping. Sort operations are used for order by, distinct, and merge join operations. Hash tables are used in hash joins and hash-based aggregation. The default value for this parameter is 4 MB. Setting the correct value of the `work_mem` parameter improves the speed of a search by reducing disk-swapping.
 ** Use the following formula to calculate the optimal value of the `work_mem` parameter for the database server: 
 

--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -17,7 +17,7 @@ To improve the performance of the PostgreSQL server, configure the following _Gr
 
 [WARNING]
 ====
-If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the BIO_get_app_data call instead of open_get_data. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database. f you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
+If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the `BIO_get_app_data` call instead of `open_get_data`. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database. f you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
 ====
 
 [NOTE]

--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -15,11 +15,6 @@ To improve the performance of the PostgreSQL server, configure the following _Gr
 
 * `shared_buffers`: determines how much memory is dedicated to the server for caching data. The default value for this parameter is 128 MB. When you modify this value, you must set it between 15% and 25% of the machine's total RAM. 
 
-[WARNING]
-====
-If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the `BIO_get_app_data` call instead of `open_get_data`. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database. f you update your systems without the OpenSSL patch, you are not impacted, and you do not need to take action.
-====
-
 [NOTE]
 ====
 You must restart the database server after changing the value for `shared_buffers`.

--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -25,7 +25,7 @@ If you are compiling Postgres against OpenSSL 3.2, your system regresses to remo
 You must restart the database server after changing the value for `shared_buffers`.
 ====
 
-Warning
+[NOTE]
 ====
 If you are compiling Postgres against OpenSSL 3.2, your system regresses to remove the parameter for User during startup. You can rectify this by using the BIO_get_app_data call instead of open_get_data. Only an administrator can make these changes, but it impacts all users connected to the PostgreSQL database.
 


### PR DESCRIPTION
Backport of PR #1780

Added warning that the air-gapped exception to the deprecation of manifests, which currently applies to all other use cases, is disappearing with Satellite 6.16 as per AAP-15722.