### PR TITLE
[Backport] - AAP-29213 - Convert authentication type content (#1760)

### DIFF
--- a/downstream/modules/platform/proc-controller-add-organization-user.adoc
+++ b/downstream/modules/platform/proc-controller-add-organization-user.adoc
@@ -1,23 +1,27 @@
 [id="proc-controller-add-organization-user"]
 
-Adding a user to an organization
+= Adding a user to an organization
 
 You can provide a user with access to an organization by adding them to the organization and managing the roles associated with the user. To add a user to an organization, the user must already exist. For more information, see xref:proc-controller-creating-a-user[Creating a user]. 
 To add roles for a user, the role must already exist. See xref:proc-gw-roles_auto-eec[Automation execution roles] and xref:proc-gw-roles_auto-dec[Automation decision] roles for more information about creating new roles. 
+
 .Procedure
 . From the navigation panel, select {MenuAMOrganizations}.
-. From the Organizations list view, select the organization to which you want to add a user. 
+. From the *Organizations* list view, select the organization to which you want to add a user. 
 . Click the *Users* tab to add users.
 . Click btn:[Add users] and select one or more users from the list by clicking the checkbox next to the name to add them as members.
 . Click btn:[Next].
 . Select the roles you want the selected user to have. Scroll down for a complete list of roles.
 +
-include::snippets/snip-gw-roles-note-multiple-components.adoc
+include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Click btn:[Next] to review the roles settings.
 . Click btn:[Finish] to apply the roles to the selected users, and to add them as members. The *Add users* dialog displays the updated roles assigned for each user.
 +
-[NOTE] A user with associated roles retains them if they are reassigned to another organization.
+[NOTE]
+====
+A user with associated roles retains them if they are reassigned to another organization.
+====
 +
 . To remove a particular user from the organization, select *Remove user* from the {MoreActionsIcon} list next to the user or team. This launches a confirmation dialog, asking you to confirm the removal.
 

--- a/downstream/modules/platform/proc-controller-creating-a-team.adoc
+++ b/downstream/modules/platform/proc-controller-creating-a-team.adoc
@@ -13,7 +13,7 @@ To add a user or administrator to a team, the user must have already been create
 . From the navigation panel, select {MenuAMTeams}.
 . Click btn:[Create team].
 . Enter a *Name* and optionally give a *Description* for the team. 
-. Select an organization from the *Organization* list to which you want to associate this team.
+. Select an *Organization* to be associated with this team.
 +
 [NOTE]
 ====

--- a/downstream/modules/platform/proc-controller-creating-a-user.adoc
+++ b/downstream/modules/platform/proc-controller-creating-a-user.adoc
@@ -5,25 +5,30 @@
 = Creating a user
 
 You can assign two types of users: 
+
 Normal user:: Normal users have read and write access limited to the resources (such as inventory, projects, and job templates) for which that user has been granted the appropriate roles and privileges.
-System administrator:: A System administrator (also known as a Superuser) has full system administration privileges — with full read and write privileges over the entire installation. A System administrator is typically responsible for managing all aspects of and delegating responsibilities for day-to-day work to various users.
-Select the Organization to be assigned for this user. For information about creating a new organization or team, refer to xref:proc-controller-create-organization[Creating an organization].
+{PlatformNameShort} Administrator:: An administrator (also known as a Superuser) has full system administration privileges — with full read and write privileges over the entire installation. An administrator is typically responsible for managing all aspects of and delegating responsibilities for day-to-day work to various users.
+{PlatformNameShort} Auditor:: Auditors have read-only capability for all objects within the environment.
+
 .Procedure
 . From the navigation panel, select {MenuAMUsers}. 
 . Click btn:[Create user].
-. Enter the details about your new user in the fields on the Create user page. Fields marked with an asterisk (*) are required.
-+
+. Enter the details about your new user in the fields on the *Create* user page. Fields marked with an asterisk (*) are required.
+. Normal users are the default when no User type is specified. To define a user as an administrator or auditor, select a *User type*.
 [NOTE]
 ====
 If you are modifying your own password, log out and log back in again for it to take effect.
 ====
++
+. Select the *Organization* to be assigned for this user. For information about creating a new organization, refer to xref:proc-controller-create-organization[Creating an organization].
 . Click btn:[Create user].
-+
-When the user is successfully created, the User dialog opens. From here, you can review and modify the user’s Teams, Roles, Tokens and other membership details.
-+
+
+When the user is successfully created, the *User* dialog opens. From here, you can review and modify the user’s Teams, Roles, Tokens and other membership details.
+
 [NOTE]
 ====
 If the user is not newly-created, the details screen displays the last login activity of that user.
 ====
+
 If you log in as yourself, and view the details of your user profile, you can manage tokens from your user profile by selecting the *Tokens* tab.
 For more information, see xref:proc-controller-apps-create-tokens[Adding a token].

--- a/downstream/modules/platform/proc-controller-deleting-a-user.adoc
+++ b/downstream/modules/platform/proc-controller-deleting-a-user.adoc
@@ -5,12 +5,14 @@
 = Deleting a user
 
 Before you can delete a user, you must have normal user or system administrator permissions. When you delete a user account, the name and email of the user are permanently removed from {PlatformNameShort}.
+
 .Procedure
 . From the navigation panel, select {MenuAMUsers}.
-. Select the check box for the user that you want to remove.
+. Select the checkbox for the user that you want to remove.
 . Click the {MoreActionsIcon} icon next to the user you want removed and select *Delete user*.
 +
 [NOTE]
 ====
 You can delete multiple users by selecting the checkbox next to each user you want to remove, and clicking *Delete selected users* from the {MoreActionsIcon} list. 
+====
 

--- a/downstream/modules/platform/proc-controller-github-enterprise-org-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-enterprise-org-settings.adoc
@@ -4,36 +4,34 @@
 
 To set up social authentication for a GitHub Enterprise Organization, you must obtain a GitHub Enterprise Organization URL, an Organization API URL, an Organization OAuth2 key and secret for a web application.
 
-To obtain the URLs, refer to the GitHub documentation on link:https://docs.github.com/en/enterprise-server@3.1/rest/reference/enterprise-admin[GitHub Enterprise administration].
+To obtain the URLs, refer to the link:https://docs.github.com/en/enterprise-server@3.1/rest/reference/enterprise-admin[GitHub Enterprise administration documentation].
 
-To obtain the key and secret, you must first register your enterprise organization-owned application at `https://github.com/organizations/<yourorg>/settings/applications`
+The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI. To register the application, you must supply it with your webpage URL, which is the *Callback URL* shown in the Authenticator details for your authenticator configuration. See xref:gw-display-auth-details[Displaying authenticator details] for instructions on accessing this information.
 
-To register the application, you must supply it with your Authorization callback URL, which is the *Callback URL* shown in the *Details* page.
-
-Because it is hosted on site and not `github.com`, you must specify which authentication adapter it communicates with.
-
-Each key and secret must belong to a unique application and cannot be shared or reused between different authentication backends.
-The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI.
+Each key and secret must belong to a unique application and cannot be shared or reused between different authentication backends. The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI.
 
 .Procedure
-. From the navigation panel, select {MenuAEAdminSettings}.
-. On the *Settings* page, select *GitHub settings* from the list of *Authentication* options.
-. Click the *GitHub Enterprise Organization* tab.
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *GitHub enterprise organization* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this authentication configuration.
+. When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
-The *GitHub Enterprise Organization OAuth2 Callback URL* field is already pre-populated and non-editable.
-When the application is registered, GitHub displays the Client ID and Client Secret.
+.. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 
+.. Copy and paste the GitHub Client Secret into the GitHub OAuth2 Secret field. 
++
+. In the *Base URL* field, enter the hostname of the GitHub Enterprise instance, for example, `https://github.example.com`.
+. In the *Github OAuth2 Enterprise API URL* field, enter the API URL of the GitHub Enterprise instance, for example, `https://github.example.com/api/v3`.
+. Enter the name of your GitHub Enterprise organization, as used in your organization’s URL, for example, `https://github.com/<yourorg>/` in the *GitHub OAuth2 Enterprise Org Name* field.
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
 
-. Click btn:[Edit] to configure GitHub Enterprise Organization settings.
-. In the *GitHub Enterprise Organization URL* field, enter the hostname of the GitHub Enterprise Organization instance, for example, https://github.orgexample.com.
-. In the *GitHub Enterprise Organization API URL* field, enter the API URL of the GitHub Enterprise Organization instance, for example, https://github.orgexample.com/api/v3.
-. Copy and paste GitHub's Client ID into the *GitHub Enterprise Organization OAuth2 Key* field.
-. Copy and paste GitHub's Client Secret into the *GitHub Enterprise Organization OAuth2 Secret* field.
-. Enter the name of your GitHub Enterprise organization, as used in your organization's URL, for example, https://github.com/<yourorg>/ in the *GitHub Enterprise Organization Name* field.
-. For more information on completing the mapping fields, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team mapping].
-. Click btn:[Save].
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]
 
-.Verification
-To verify that the authentication was configured correctly, logout of {ControllerName}.
-The login screen displays the GitHub Enterprise Organization logo to enable logging in with those credentials.
-
-image:configure-controller-auth-github-ent-org-logo.png[image]
+include::snippets/snip-gw-authentication-verification.adoc[]

--- a/downstream/modules/platform/proc-controller-github-enterprise-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-enterprise-settings.adoc
@@ -1,37 +1,36 @@
 [id="proc-controller-github-enterprise-settings"]
 
-= GitHub Enterprise settings
+= Configuring GitHub enterprise authentication
 
-To set up social authentication for a GitHub Enterprise, you must obtain a GitHub Enterprise URL, an API URL, OAuth2 key and secret for a web application.
+To set up social authentication for a GitHub enterprise, you must obtain a GitHub Enterprise URL, an API URL, OAuth2 key and secret for a web application.
 
-To obtain the URLs, refer to the link:https://docs.github.com/en/enterprise-server@3.1/rest/reference/enterprise-admin[GitHub Enterprise administration] documentation.
+To obtain the URLs, refer to the link:https://docs.github.com/en/enterprise-server@3.1/rest/reference/enterprise-admin[GitHub Enterprise administration documentation].
 
-To obtain the key and secret, you must first register your enterprise-owned application at \https://github.com/organizations/<yourorg>/settings/applications.
+The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI. To register the application, you must supply it with your webpage URL, which is the *Callback URL* shown in the Authenticator details for your authenticator configuration. See xref:gw-display-auth-details[Displaying authenticator details] for instructions on accessing this information.
 
-To register the application, you must supply it with your Authorization callback URL, which is the *Callback URL* shown in the *Details* page.
-Because it is hosted on site and not `github.com`, you must specify which authentication adapter it communicates with.
-
-Each key and secret must belong to a unique application and cannot be shared or reused between different authentication backends.
-The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI.
+Each key and secret must belong to a unique application and cannot be shared or reused between different authentication backends. The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI.
 
 .Procedure
-. From the navigation panel, select {MenuAEAdminSettings}.
-. On the *Settings* page, select *GitHub settings* from the list of *Authentication* options.
-. Click the *GitHub Enterprise* tab.
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *GitHub enterprise* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this authentication configuration.
+. When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
-The *GitHub Enterprise OAuth2 Callback URL* field is already pre-populated and non-editable.
-When the application is registered, GitHub displays the Client ID and Client Secret.
+.. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 
+.. Copy and paste the GitHub Client Secret into the GitHub OAuth2 Secret field. 
++
+. In the *Base URL* field, enter the hostname of the GitHub Enterprise instance, for example, `https://github.example.com`.
+. In the *Github OAuth2 Enterprise API URL* field, enter the API URL of the GitHub Enterprise instance, for example, `https://github.example.com/api/v3`.
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
 
-. Click btn:[Edit] to configure GitHub Enterprise settings.
-. In the *GitHub Enterprise URL* field, enter the hostname of the GitHub Enterprise instance, for example, https://github.example.com.
-. In the *GitHub Enterprise API URL* field, enter the API URL of the GitHub Enterprise instance, for example, https://github.example.com/api/v3.
-. Copy and paste GitHub's Client ID into the *GitHub Enterprise OAuth2 Key* field.
-. Copy and paste GitHub's Client Secret into the *GitHub Enterprise OAuth2 Secret* field.
-. For more information on completing the mapping fields, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team mapping].
-. Click btn:[Save].
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]
 
-.Verification
-To verify that the authentication was configured correctly, logout of {ControllerName}.
-The login screen displays the GitHub Enterprise logo to enable logging in with those credentials.
-
-image:configure-controller-auth-github-ent-logo.png[image]
+include::snippets/snip-gw-authentication-verification.adoc[]

--- a/downstream/modules/platform/proc-controller-github-enterprise-team-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-enterprise-team-settings.adoc
@@ -1,41 +1,41 @@
 [id="proc-controller-github-enterprise-team-settings"]
 
-= GitHub Enterprise Team settings
+= Configuring GitHub enterprise team authentication
 
-To set up social authentication for a GitHub Enterprise team, you must obtain a GitHub Enterprise Organization URL, an Organization API URL, an Organization OAuth2 key and secret for a web application.
+To set up social authentication for a GitHub enterprise team, you must obtain a GitHub Enterprise Organization URL, an Organization API URL, an Organization OAuth2 key and secret for a web application.
 
-To obtain the URLs, refer to the GitHub documentation on link:https://docs.github.com/en/enterprise-server@3.1/rest/reference/enterprise-admin[GitHub Enterprise administration].
+To obtain the URLs, refer to the link:https://docs.github.com/en/enterprise-server@3.1/rest/reference/enterprise-admin[GitHub Enterprise administration documentation].
 
-To obtain the key and secret, you must first register your enterprise team-owned application at `https://github.com/organizations/<yourorg>/settings/applications`.
+To obtain the key and secret, you must first register your enterprise organization-owned application at `https://github.com/organizations/<yourorg>/settings/applications`.
 
-To register the application, you must supply it with your Authorization callback URL, which is the *Callback URL* shown in the *Details* page.
-Because it is hosted on site and not github.com, you must specify which authentication adapter it communicates with.
+The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI. To register the application, you must supply it with your webpage URL, which is the *Callback URL* shown in the Authenticator details for your authenticator configuration. See xref:gw-display-auth-details[Displaying authenticator details] for instructions on accessing this information.
 
 Each key and secret must belong to a unique application and cannot be shared or reused between different authentication  backends.
 The OAuth2key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI.
 
 .Procedure
-. Find the numeric team ID using the link:https://fabian-kostadinov.github.io/2015/01/16/how-to-find-a-github-team-id/[GitHub API].
-The Team ID will be used to supply a required field in the UI.
-. From the navigation panel, select {MenuAEAdminSettings}.
-. On the *Settings* page, select *GitHub settings* from the list of *Authentication* options.
-. Click the *GitHub Enterprise Team* tab.
+
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *GitHub enterprise team* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this authentication configuration.
+. When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
-The *GitHub Enterprise Team OAuth2 Callback URL* field is already pre-populated and non-editable.
-When the application is registered, GitHub displays the Client ID and Client Secret.
+.. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 
+.. Copy and paste the GitHub Client Secret into the GitHub OAuth2 Secret field. 
++
+. In the *Base URL* field, enter the hostname of the GitHub Enterprise instance, for example, `https://github.orgexample.com`.
+. In the *Github OAuth2 Enterprise API URL* field, enter the API URL of the GitHub Enterprise instance, for example, `https://github.example.com/api/v3`.
+. Enter the OAuth2 key (Client ID) from your GitHub developer application in the *GitHub OAuth2* team ID field.
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
 
-. Click btn:[Edit] to configure GitHub Enterprise Team settings.
-. In the *GitHub Enterprise Team URL* field, enter the hostname of the GitHub Enterprise team instance, for example, https://github.teamexample.com.
-. In the *GitHub Enterprise Team API URL* field, enter the API URL of the GitHub Enterprise team instance, for example,
-https://github.teamexample.com/api/v3.
-. Copy and paste GitHub's Client ID into the *GitHub Enterprise Team OAuth2 Key* field.
-. Copy and paste GitHub's Client Secret into the *GitHub Enterprise Team OAuth2 Secret* field.
-. Copy and paste GitHub's team ID in the *GitHub Enterprise Team ID* field.
-. For more information on completing the mapping fields, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team mapping].
-. Click btn:[Save].
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]
 
-.Verification
-To verify that the authentication was configured correctly, logout of {ControllerName}.
-The login screen displays the GitHub Enterprise Teams logo to enable logging in with those credentials.
-
-image:configure-controller-auth-github-ent-teams-logo.png[image]
+include::snippets/snip-gw-authentication-verification.adoc[]

--- a/downstream/modules/platform/proc-controller-github-organization-setttings.adoc
+++ b/downstream/modules/platform/proc-controller-github-organization-setttings.adoc
@@ -1,37 +1,37 @@
 [id="proc-controller-github-organization-setttings"]
 
-= GitHub Organization settings
+= Configuring GitHub organization authentication
 
-When defining account authentication with either an organization or a team within an organization, you should use the specific organization and team settings.
-Account authentication can be limited by an organization and by a team within an organization.
-
+When defining account authentication with either an organization or a team within an organization, you should use the specific organization and team settings. Account authentication can be limited by an organization and by a team within an organization.
 You can also choose to permit all by specifying non-organization or non-team based settings.
+You can limit users who can log in to the platform by limiting only those in an organization or on a team within an organization.
 
-You can limit users who can login to the controller by limiting only those in an organization or on a team within an organization.
+To set up social authentication for a GitHub organization, you must obtain an OAuth2 key and secret for a web application using the link:https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app[registering the new application with GitHub].
 
-To set up social authentication for a GitHub Organization, you must obtain an OAuth2 key and secret for a web application. To do this, you must first register your organization-owned application at \https://github.com/organizations/<yourorg>/settings/applications.
-
-To register the application, you must supply it with your Authorization callback URL, which is the *Callback URL* shown in the *Details* page.
-Each key and secret must belong to a unique application and cannot be shared or reused between different authentication backends.
-The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI.
+The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI. To register the application, you must supply it with your webpage URL, which is the Callback URL shown in the Authenticator details for your authenticator configuration. See xref:gw-display-auth-details[Displaying authenticator details] for instructions on accessing this information.
 
 .Procedure
-. From the navigation panel, select {MenuAEAdminSettings}.
-. On the *Settings* page, select *GitHub settings* from the list of *Authentication* options.
-. Select the *GitHub Organization* tab.
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *GitHub organization* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this authentication configuration.
+. When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
-The *GitHub Organization OAuth2 Callback URL* field is already pre-populated and non-editable.
+.. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 
+.. Copy and paste the GitHub Client Secret into the GitHub OAuth2 Secret field. 
 +
-When the application is registered, GitHub displays the Client ID and Client Secret.
+. Enter the name of your GitHub organization, as used in your organization’s URL, for example, `https://github.com/<yourorg>/` in the *GitHub OAuth Organization Name* field.
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+. Enter the authorization scope for users in the *GitHub OAuth2 Scope* field. The default is `read:org`.
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
 
-. Click btn:[Edit] and copy and paste GitHub's Client ID into the *GitHub Organization OAuth2 Key* field.
-. Copy and paste GitHub's Client Secret into the *GitHub Organization OAuth2 Secret* field.
-. Enter the name of your GitHub organization, as used in your organization's URL, for example, \https://github.com/<yourorg>/ in the *GitHub Organization Name* field.
-. For more information on completing the mapping fields, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team mapping].
-. Click btn:[Save].
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]
 
-.Verification
-To verify that the authentication was configured correctly, logout of {ControllerName}.
-The login screen displays the GitHub Organization logo to enable logging in with those credentials.
-
-image:configure-controller-auth-github-orgs-logo.png[image]
+include::snippets/snip-gw-authentication-verification.adoc[]

--- a/downstream/modules/platform/proc-controller-github-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-settings.adoc
@@ -1,28 +1,30 @@
 [id="proc-controller-github-settings"]
 
-= GitHub settings
+= Configuring GitHub authentication
 
-To set up social authentication for GitHub, you must obtain an OAuth2 key and secret for a web application.
-To do this, you must first register the new application with GitHub at https://github.com/settings/developers.
+You can connect GitHub identities to {PlatformNameShort} using OAuth. To set up GitHub authentication, you need to obtain an OAuth2 key and secret by registering your organization-owned application from GitHub using the link:https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app[registering the new application with GitHub].
 
-To register the application, you must supply it with your homepage URL, which is the *Callback URL* shown in the *Details* tab of the *GitHub default settings* page.
-The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI.
+The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI. To register the application, you must supply it with your webpage URL, which is the Callback URL shown in the Authenticator details for your authenticator configuration. See xref:gw-display-auth-details[Displaying authenticator details] for instructions on accessing this information. 
 
 .Procedure
-. From the navigation panel, select {MenuAEAdminSettings}.
-. On the *Settings* page, select *GitHub settings* from the list of *Authentication* options.
-. Select the *GitHub Default* tab if not already selected.
+
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *GitHub* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this authentication configuration.
+. When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
-The *GitHub OAuth2 Callback URL* field is already pre-populated and non-editable.
-When the application is registered, GitHub displays the Client ID and Client Secret.
+.. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 
+.. Copy and paste the GitHub Client Secret into the GitHub OAuth2 Secret field. 
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
 
-. Click btn:[Edit] and copy and paste the GitHub Client ID into the *GitHub OAuth2 Key* field.
-. Copy and paste the GitHub Client Secret into the *GitHub OAuth2 Secret* field.
-. For more information on completing the mapping fields, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team mapping].
-. Click btn:[Save].
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]
 
-.Verification
-To verify that the authentication was configured correctly, logout of {ControllerName}.
-The login screen now displays the GitHub logo to enable logging in with those credentials.
-
-image:configure-controller-auth-github-logo.png[image]
+include::snippets/snip-gw-authentication-verification.adoc[]

--- a/downstream/modules/platform/proc-controller-github-team-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-team-settings.adoc
@@ -1,32 +1,35 @@
 [id="proc-controller-github-team-settings"]
 
-= GitHub Team settings
+= Configuring GitHub team authentication
 
-To set up social authentication for a GitHub Team, you must obtain an OAuth2 key and secret for a web application.
-To do this, you must first register your team-owned application at `https://github.com/organizations/<yourorg>/settings/applications`.
-To register the application, you must supply it with your Authorization callback URL, which is the *Callback URL* shown in the *Details* page.
-Each key and secret must belong to a unique application and cannot be shared or reused between different authentication
-backends.
-The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI.
+To set up social authentication for a GitHub team, you must obtain an OAuth2 key and secret for a web application using the instructions provided in link:https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app[registering the new application with GitHub].
+
+The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI. To register the application, you must supply it with your webpage URL, which is the *Callback URL* shown in the Authenticator details for your authenticator configuration. See xref:gw-display-auth-details[Displaying authenticator details] for instructions on accessing this information.
+
+Each key and secret must belong to a unique application and cannot be shared or reused between different authentication backends. The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the required fields in the UI.
 
 .Procedure
-. Find the numeric team ID using the link:https://fabian-kostadinov.github.io/2015/01/16/how-to-find-a-github-team-id/[GitHub API].
-The Team ID is used to supply a required field in the UI.
-. From the navigation panel, select {MenuAEAdminSettings}.
-. On the *Settings* page, select *GitHub settings* from the list of *Authentication* options.
-. Click the *GitHub Team* tab.
+
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *GitHub team* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this authentication configuration.
+. When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
-The *GitHub Team OAuth2 Callback URL* field is already pre-populated and non-editable.
-When the application is registered, GitHub displays the Client ID and Client Secret.
+.. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 
+.. Copy and paste the GitHub Client Secret into the GitHub OAuth2 Secret field. 
++
+. Copy and paste GitHub’s team ID in the *GitHub OAuth2 Team ID* field.
+. Enter the authorization scope for users in the GitHub OAuth2 Scope field. The default is `read:org`. 
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
 
-. Click btn:[Edit] and copy and paste GitHub's Client ID into the *GitHub Team OAuth2 Key* field.
-. Copy and paste GitHub's Client Secret into the *GitHub Team OAuth2 Secret* field.
-. Copy and paste GitHub's team ID in the *GitHub Team ID* field.
-. For more information on completing the mapping fields, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team mapping].
-. Click btn:[Save]
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]
 
-.Verification
-To verify that the authentication was configured correctly, logout of {ControllerName}.
-The login screen displays the GitHub Team logo to enable logging in with those credentials.
-
-image:configure-controller-auth-github-teams-logo.png[image]
+include::snippets/snip-gw-authentication-verification.adoc[]

--- a/downstream/modules/platform/proc-controller-google-oauth2-settings.adoc
+++ b/downstream/modules/platform/proc-controller-google-oauth2-settings.adoc
@@ -1,36 +1,43 @@
 [id="proc-controller-google-oauth2-settings"]
 
-= Google OAuth2 settings
+= Configuring Google OAuth2 authentication
 
-To set up social authentication for Google, you must obtain an OAuth2 key and secret for a web application.
-To do this, you must first create a project and set it up with Google.
+To set up social authentication for Google, you must obtain an OAuth2 key and secret for a web application. To do this, you must first create a project and set it up with Google.
 
 For instructions, see link:https://support.google.com/googleapi/answer/6158849[Setting up OAuth 2.0] in the Google API Console Help documentation.
 
-If you have already completed the setup process, you can access those credentials by going to the Credentials section of the
-link:https://console.developers.google.com/[Google API Manager Console].
-The OAuth2 key (Client ID) and secret (Client secret) are used to supply the required fields in the UI.
+If you have already completed the setup process, you can access those credentials by going to the Credentials section of the link:https://console.cloud.google.com/projectselector2/apis/dashboard?pli=1&supportedpurview=project[Google API Manager Console]. The OAuth2 key (Client ID) and secret (Client secret) are used to supply the required fields in the UI.
 
 .Procedure
-. From the navigation panel, select {MenuAEAdminSettings}.
-. On the *Settings* page, select *Google OAuth 2 settings* from the list of *Authentication* options.
+
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *Google OAuth* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this authentication setting.
+. The *Google OAuth2 Key* and *Google OAuth2 Secret* fields are pre-populated. 
 +
-The *Google OAuth2 Callback URL* field is already pre-populated and non-editable.
-
-. The following fields are also pre-populated.
-If not, use the credentials Google supplied during the web application setup process, and look for the values with the same format as the ones shown in the example below:
-
-* Click *Edit* and copy and paste Google's Client ID into the *Google OAuth2 Key* field.
-* Copy and paste Google's Client secret into the *Google OAuth2 Secret* field.
+If not, use the credentials Google supplied during the web application setup process. Save these settings for use in the following steps.
 +
-image:configure-controller-auth-google.png[image]
+. Copy and paste Google’s Client ID into the *Google OAuth2 Key* field.
+. Copy and paste Google’s Client secret into the *Google OAuth2 Secret* field. 
+. Optional: Enter information for the following fields using the tooltips provided for instructions and required format:
++
+* *Access Token URL*
+* *Access Token Method*
+* *Authorization URL*
+* *Revoke Token Method*
+* *Revoke Token URL*
+* *OIDC JWT Algorithm(s)*
+* *OIDC JWT*
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+Click btn:[Next].
 
-. To complete the remaining optional fields, refer to the tooltips in each of the fields for instructions and required format.
-. For more information on completing the mapping fields, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team mapping].
-. Click btn:[Save].
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]
 
-.Verification
-To verify that the authentication was configured correctly, logout of {ControllerName}.
-The login screen displays the Google logo to indicate it as an alternate method of logging into {ControllerName}.
-
-image:configure-controller-auth-google-logo.png[image]
+include::snippets/snip-gw-authentication-verification.adoc[]

--- a/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
@@ -1,176 +1,53 @@
+:_mod-docs-content-type: PROCEDURE
+
 [id="controller-set-up-LDAP"]
 
-= Setting up LDAP authentication
+= Configuring LDAP authentication
 
-When configured, a user who logs in with an LDAP username and password automatically has an {ControllerName} account created for them.
-They can be automatically placed into organizations as either regular users or organization administrators.
+As a platform administrator, you can configure LDAP as the source for account authentication information for {PlatformNameShort} users. 
 
-Users created in the user interface (Local) take precedence over those logging into {ControllerName} for their first time with an alternative authentication solution.
-You must delete the local user if you want to re-use with another authentication method, such as LDAP.
+When LDAP is configured, an account is created for any user who logs in with an LDAP username and password and they can be automatically placed into organizations as either regular users or organization administrators. 
 
-Users created through an LDAP login cannot change their username, given name, surname, or set a local password for themselves.
-You can also configure this to restrict editing of other field names.
-
-[NOTE]
-====
-If the LDAP server you want to connect to has a certificate that is self-signed or signed by a corporate internal certificate authority (CA),
-you must add the CA certificate to the system's trusted CAs.
-Otherwise, connection to the LDAP server results in an error that the certificate issuer is not recognized.
-For more information, see xref:controller-import-CA-cert-LDAP[Importing a certificate authority in {ControllerName} for LDAPS integration].
-If prompted, use your Red Hat customer credentials to login.
-====
+Users created through an LDAP login should not change their username, first name, last name, or set a local password for themselves. Any changes made to this information is overwritten the next time the user logs in to the platform. 
 
 .Procedure
 
-. Create a user in LDAP that has access to read the entire LDAP structure.
-. Use the `ldapsearch` command to test if you can make successful queries to the LDAP server.
-You can install this tool from {ControllerName}'s system command line, and by using other Linux and OSX systems.
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *LDAP* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this LDAP configuration. The configuration name is required, must be unique across all authenticators, and must not be longer than 512 characters.
+. In the *LDAP Server URI* field, enter or modify the list of LDAP servers to which you want to connect. This field supports multiple addresses.
+. In the *LDAP Bind DN text* field, enter the Distinguished Name (DN) to specify the user that the Ansible Automation Platform uses to connect to the LDAP server. For example:
 +
-.Example
+----
+CN=josie,CN=users,DC=website,DC=com
+----
 +
-[literal, options="nowrap" subs="+attributes"]
-----
-ldapsearch -x  -H ldap://win -D "CN=josie,CN=Users,DC=website,DC=com" -b "dc=website,dc=com" -w Josie4Cloud
-----
-In this example, `CN=josie,CN=users,DC=website,DC=com` is the distinguished name of the connecting user.
+. In the *LDAP Bind Password* text field, enter the password to use for the binding user.
+. Select a group type from the *LDAP Group Type* list.
 +
 [NOTE]
 ====
-The `ldapsearch` utility is not automatically pre-installed with {ControllerName}.
-However, you can install it from the `openldap-clients` package.
+The LDAP group types that are supported by the Ansible Automation Platform use the underlying link:https://django-auth-ldap.readthedocs.io/en/latest/reference.html#django_auth_ldap.config.LDAPGroupType[django-auth-ldap library]. 
 ====
 +
-. From the navigation panel, select {MenuAEAdminSettings} in the {ControllerName} UI.
-. Select *LDAP settings* in the list of *Authentication* options.
+. To use *LDAP User DN Template* as an alternative to user search, enter the name of the template. This approach is more efficient for user lookups than searching if it is usable in your organizational environment. If this setting has a value it will be used instead of the *LDAP User Search* setting.
+. *LDAP Start TLS* is disabled by default. To enable TLS when the LDAP connection is not using SSL, set the switch to *On*.
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc
 +
-You do not need multiple LDAP configurations per LDAP server, but you can configure many LDAP servers from this page, otherwise, leave the server at *Default*.
+. Enter any *LDAP Connection Options* to set for the LDAP connection. 
+. In the *LDAP Group Type Parameters* field, enter the parameters required for the LDAP Group Type you previously selected to identify LDAP groups and the members that belong to those groups.
 +
-The equivalent API endpoints show `AUTH_LDAP_*` repeated: `AUTH_LDAP_1_*`, `AUTH_LDAP_2_*`, `AUTH_LDAP_5_*` to denote server designations.
-. To enter or change the LDAP server address, click btn:[Edit] and enter in the *LDAP Server URI* field by using the same format as the one pre-populated in the text field.
+To determine the parameters that a specific *LDAP Group Type* requires, refer to the link:https://django-auth-ldap.readthedocs.io/en/latest/reference.html#django_auth_ldap.config.LDAPGroupType[django_auth_ldap documentation] on the classes `init` parameters.
 +
-[NOTE]
-====
-You can specify multiple LDAP servers by separating each with spaces or commas. Click the image:question_circle.png[Tooltip,12,12] icon to comply with the correct syntax and rules.
-====
+. In the *LDAP Group Search* field, specify which groups should be searched and how to search them. 
+. In the *LDAP User Attribute Map* field, enter user attributes to map LDAP fields to your Ansible Automation Platform users for example, email or first_name. 
+. In the *LDAP User Search* field, enter where to search for users during authentication. 
 +
-. Enter the password to use for the binding user in the *LDAP Bind Password* text field.
-For more information about LDAP variables, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#ref-hub-variables[Ansible automation hub variables].
-. Click to select a group type from the *LDAP Group Type* list.
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
 +
-The LDAP group types that are supported by {ControllerName} use the underlying link:https://django-auth-ldap.readthedocs.io/en/latest/groups.html#types-of-groups[django-auth-ldap library].
-To specify the parameters for the selected group type, see Step 15.
-. The *LDAP Start TLS* is disabled by default.
-To enable TLS when the LDAP connection is not using SSL/TLS, set the toggle to *On*.
-. Enter the distinguished name in the *LDAP Bind DN* text field to specify the user that {ControllerName} uses to connect (Bind) to the LDAP server.
-*  If that name is stored in key `sAMAccountName`, the *LDAP User DN Template* is populated from `(sAMAccountName=%(user)s)`.
-Active Directory stores the username to `sAMAccountName`.
-For OpenLDAP, the key is `uid` and the line becomes `(uid=%(user)s)`.
-. Enter the distinguished group name to enable users within that group to access {ControllerName} in the *LDAP Require Group* field, using the same format as the one shown in the text field, `CN=controller Users,OU=Users,DC=website,DC=com`.
-. Enter the distinguished group name to prevent users within that group from accessing {ControllerName} in the *LDAP Deny Group* field, using the same format as the one shown in the text field.
-. Enter where to search for users while authenticating in the *LDAP User Search* field by using the same format as the one shown in the text field.
-In this example, use:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-[
-"OU=Users,DC=website,DC=com",
-"SCOPE_SUBTREE",
-"(cn=%(user)s)"
-]
-----
-+
-The first line specifies where to search for users in the LDAP tree.
-In the earlier example, the users are searched recursively starting from `DC=website,DC=com`.
-+
-The second line specifies the scope where the users should be searched:
-+
-* *SCOPE_BASE*: Use this value to indicate searching only the entry at the base DN, resulting in only that entry being returned.
-* *SCOPE_ONELEVEL*: Use this value to indicate searching all entries one level under the base DN, but not including the base DN and not including any entries under that one level under the base DN.
-* *SCOPE_SUBTREE*: Use this value to indicate searching of all entries at all levels under and including the specified base DN.
-+
-The third line specifies the key name where the user name is stored.
-+
-For many search queries, use the following correct syntax:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-[
-  [
-  "OU=Users,DC=northamerica,DC=acme,DC=com",
-  "SCOPE_SUBTREE",
-  "(sAMAccountName=%(user)s)"
-  ],
-  [
-  "OU=Users,DC=apac,DC=corp,DC=com",
-  "SCOPE_SUBTREE",
-  "(sAMAccountName=%(user)s)"
-  ],
-  [
-  "OU=Users,DC=emea,DC=corp,DC=com",
-  "SCOPE_SUBTREE",
-  "(sAMAccountName=%(user)s)"
-  ]
-]
-----
-+
-. In the *LDAP Group Search* text field, specify which groups to search and how to search them. In this example, use:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-[
-"dc=example,dc=com",
-"SCOPE_SUBTREE",
-"(objectClass=group)"
- ]
-----
-+
-* The first line specifies the BASE DN where the groups should be searched.
-* The second line specifies the scope and is the same as that for the user directive.
-* The third line specifies what the `objectClass` of a group object is in the LDAP that you are using.
-+
-. Enter the user attributes in the *LDAP User Attribute Map* the text field.
-In this example, use:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-{
-"first_name": "givenName",
-"last_name": "sn",
-"email": "mail"
-}
-----
-+
-The earlier example retrieves users by surname from the key `sn`.
-You can use the same LDAP query for the user to decide what keys they are stored under.
-+
-Depending on the selected *LDAP Group Type*, different parameters are available in the *LDAP Group Type Parameters* field to account for this.
-`LDAP_GROUP_TYPE_PARAMS` is a dictionary that is converted by {ControllerName} to `kwargs` and passed to the *LDAP Group Type* class selected.
-There are two common parameters used by any of the *LDAP Group Type*; `name_attr` and `member_attr`.
-Where `name_attr defaults` to cn and `member_attr` defaults to member:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-{"name_attr": "cn", "member_attr": "member"}
-----
-+
-To find what parameters a specific *LDAP Group Type* expects, see the link:https://django-auth-ldap.readthedocs.io/en/latest/reference.html#django_auth_ldap.config.LDAPGroupType[django_auth_ldap] documentation around the classes `init` parameters.
-+
-. Enter the user profile flags in the *LDAP User Flags by Group* text field.
-The following example uses the syntax to set LDAP users as "Superusers" and "Auditors":
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-{
-"is_superuser": "cn=superusers,ou=groups,dc=website,dc=com",
-"is_system_auditor": "cn=auditors,ou=groups,dc=website,dc=com"
-}
-----
-+
-. For more information about completing the mapping fields, *LDAP Organization Map* and *LDAP Team Map*, see the xref:controller-LDAP-organization-team-mapping[LDAP Organization and team mapping] section.
-. Click btn:[Save].
+. Click btn:[Next].
 
-[NOTE]
-====
-{ControllerNameStart} does not actively synchronize users, but they are created during their initial login.
-To improve performance associated with LDAP authentication, see xref:controller-prevent-LDAP-attributes[Preventing LDAP attributes from updating on each login].
-====
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]

--- a/downstream/modules/platform/proc-controller-set-up-SAML.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-SAML.adoc
@@ -1,79 +1,28 @@
 [id="controller-set-up-SAML"]
 
-= SAML authentication
+= Configuring SAML authentication
 
-SAML enables the exchange of authentication and authorization data between an Identity Provider (IdP - a system of servers that provide the Single Sign On service) and a service provider, in this case, {ControllerName}.
+SAML allows the exchange of authentication and authorization data between an Identity Provider (IdP) and a Service Provider (SP). {PlatformNameShort} is a SAML SP that can be configured to talk with one or more SAML IdPs in order to authenticate users. Based on groups and attributes optionally provided by the IdP users can be placed into teams and organizations in {PlatformNameShort} based on authenticator maps tied to this authenticator.
 
-You can configure {ControllerName} to communicate with SAML to authenticate (create/login/logout) {ControllerName} users.
-You can embed User, Team, and Organization membership in the SAML response to {ControllerName}.
-
-image::ag-configure-auth-saml-topology.png[SAML topology]
-
-The following instructions describe {ControllerName} as the service provider.
-To authenticate users through RHSSO (keycloak), see link:https://www.ansible.com/blog/red-hat-single-sign-on-integration-with-ansible-tower[Red Hat Single Sign On Integration with the Automation Controller].
 
 .Procedure
 
-. From the navigation panel, select {MenuAEAdminSettings}.
-. Select *SAML settings* from the list of *Authentication* options.
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *SAML* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this SAML configuration. 
+. Enter the application-defined unique identifier used as the audience of the SAML service provider configuration in the *SAML Service Provider Entity ID* field. This is usually the URL for the service.
+. Include the certificate content in the *SAML Service Provider Public Certificate* field.
+. Include the private key content in the *SAML Service Provider Private Key*.
+. Enter the URL to redirect the user to for login initiation in the *IdP Login URL* field.
+. Enter the public cert used for secrets coming from the *IdP in the IdP Public Cert* field.
+. Enter the entity ID returned in the assertion in the *Entity ID*. 
+.Enter user details in the *Groups*, *User Email*, *Username*, *User Last Name*, *User First Name* and *User Permanent ID* fields.  
+. The *SAML Assertion Consumer Service (ACS) URL* field registers the service as a service provider (SP) with each identity provider (IdP) you have configured. 
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc
 +
-[NOTE]
-====
-The *SAML Assertion Consume Service (ACS) URL* and *SAML Service Provider Metadata URL* fields are pre-populated and are non-editable. Contact the IdP administrator and provide the information contained in these fields.
-====
-. Click btn:[Edit] and set the *SAML Service Provider Entity ID* to be the same as the *Base URL* of the {ControllerName} host field, found in the *Miscellaneous System settings* screen.
-You can view it through the API in the `/api/v2/settings/system`, under the `CONTROLLER_BASE_URL` variable.
-You can set the *Entity ID* to any one of the individual {ControllerName} cluster nodes, but it is good practice to set it to the URL of the service provider.
-Ensure that the *Base URL* matches the FQDN of the load balancer, if used.
+. In the *SAML Service Provider Organization Info* field, provide the URL, display name, and the name of your app.
 +
-[NOTE]
-====
-The *Base URL* is different for each node in a cluster.
-A load balancer often sits in front of {ControllerName} cluster nodes to provide a single entry point, the {ControllerName} Cluster FQDN.
-The SAML service provider must be able establish an outbound connection and route to the {ControllerName} Cluster Node or the {ControllerName} Cluster FQDN that you set in the *SAML Service Provider Entity ID*.
-====
-+
-In the following example, the service provider is the {ControllerName} cluster, and therefore, the ID is set to the {ControllerName} Cluster FQDN:
-+
-image::configure-auth-saml-service-provider.png[SAML service provider]
-+
-. Create a server certificate for the Ansible cluster.
-Typically when an Ansible cluster is configured, the {ControllerName} nodes are configured to handle HTTP traffic only and the load balancer is an SSL Termination Point.
-In this case, an SSL certificate is required for the load balancer, and not for the individual {ControllerName} Cluster Nodes.
-You can enable or disable SSL per individual {ControllerName} node, but you must disable it when using an SSL terminated load balancer.
-Use a non-expiring self signed certificate to avoid periodically updating certificates.
-This way, authentication does not fail in case someone forgets to update the certificate.
-+
-[NOTE]
-====
-The *SAML Service Provider Public Certificate* field must contain the entire certificate, including the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
-====
-+
-If you are using a CA bundle with your certificate, include the entire bundle in this field.
-+
-.Example
-+
-[literal, options="nowrap" subs="+attributes"]
-----
------BEGIN CERTIFICATE-----
-... cert text ...
------END CERTIFICATE-----
-----
-+
-. Create an optional private key for the controller to use as a service provider and enter it in the *SAML Service Provider Private Key* field.
-+
-.Example
-+
-[literal, options="nowrap" subs="+attributes"]
-----
------BEGIN PRIVATE KEY-----
-... key text ...
------END PRIVATE KEY-----
-----
-+
-. Provide the IdP with details about the {ControllerName} cluster during the SSO process in the *SAML Service Provider Organization Info* field:
-+
-[literal, options="nowrap" subs="+attributes"]
 ----
 {
   "en-US": {
@@ -84,15 +33,8 @@ If you are using a CA bundle with your certificate, include the entire bundle in
 }
 ----
 +
-[IMPORTANT]
-====
-You must complete these fields to configure SAML correctly within {ControllerName}.
-====
+. In the *SAML Service Provider Technical Contact* field, provide the name and email address of the technical contact for your service provider. 
 +
-. Provide the IdP with the technical contact information in the *SAML Service Provider Technical Contact* field.
-Do not remove the contents of this field:
-+
-[literal, options="nowrap" subs="+attributes"]
 ----
 {
 "givenName": "Some User",
@@ -100,285 +42,33 @@ Do not remove the contents of this field:
 }
 ----
 +
-. Provide the IdP with the support contact information in the *SAML Service Provider Support Contact* field.
-Do not remove the contents of this field:
+. In the *SAML Service Provider Support Contact* field, provide the name and email address of the support contact for your service provider. 
 +
-[literal, options="nowrap" subs="+attributes"]
-----
+----	
 {
 "givenName": "Some User",
 "emailAddress": "suser@example.com"
 }
 ----
 +
-. In the *SAML Enabled Identity Providers* field, provide information on how to connect to each IdP listed.
-The following example shows what {ControllerName} expects SAML attributes to be:
+. Optional: Provide extra configuration data in the *SAML Service Provider extra configuration data* field. This field is the equivalent to the `SOCIAL_AUTH_SAML_SP_EXTRA` in the API. For more information, see link:https://github.com/SAML-Toolkits/python-saml#settings[OneLogin’s SAML Python Toolkit] to learn about the valid service provider extra (SP_EXTRA) parameters.
+. Optional: Provide security settings in the *SAML Security Config* field. This field is the equivalent to the `SOCIAL_AUTH_SAML_SECURITY_CONFIG` field in the API. 
 +
-[literal, options="nowrap" subs="+attributes"]
 ----
-Username(urn:oid:0.9.2342.19200300.100.1.1)
-Email(urn:oid:0.9.2342.19200300.100.1.3)
-FirstName(urn:oid:2.5.4.42)
-LastName(urn:oid:2.5.4.4)
-----
-+
-If these attributes are not known, map existing SAML attributes to `Username`, `Email`, `FirstName`, and `LastName`.
-+
-Configure the required keys for each IdP:
-+
-* `attr_user_permanent_id` - The unique identifier for the user.
-It can be configured to match any of the attributes sent from the IdP.
-It is normally set to `name_id` if the `SAML:nameid` attribute is sent to the {ControllerName} node.
-It can be the username attribute or a custom unique identifier.
-* `entity_id` - The Entity ID provided by the IdP administrator.
-The administrator creates a SAML profile for {ControllerName} and it generates a unique URL.
-* `url`- The Single Sign On (SSO) URL that {ControllerName} redirects the user to, when SSO is activated.
-* `x509_cert` - The certificate provided by the IdP administrator that is generated from the SAML profile created on the IdP.
-Remove the `---BEGIN CERTIFICATE---` and `---END CERTIFICATE---` headers, then enter the certificate as one non-breaking string.
-+
-Multiple SAML IdPs are supported.
-Some IdPs might provide user data using attribute names that differ from the default OIDs.
-The SAML NameID is a special attribute used by some IdPs to tell the service provider (the {ControllerName} cluster) what the unique user identifier is.
-If it is used, set the `attr_user_permanent_id` to `name_id` as shown in the following example.
-Other attribute names can be overridden for each IdP:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-"myidp": {
-  "entity_id": "https://idp.example.com",
-  "url": "https://myidp.example.com/sso",
-  "x509cert": ""
-},
-"onelogin": {
-  "entity_id": "https://app.onelogin.com/saml/metadata/123456",
-  "url": "https://example.onelogin.com/trust/saml2/http-post/sso/123456",
-"x509cert": "",
-  "attr_user_permanent_id": "name_id",
-  "attr_first_name": "User.FirstName",
-  "attr_last_name": "User.LastName",
-  "attr_username": "User.email",
-  "attr_email": "User.email"
-  }
-}
-----
-+
-[WARNING]
-====
-Do not create a SAML user that shares the same email with another user (including a non-SAML user).
-Doing so results in the accounts being merged.
-Note that this same behavior exists for system administrators.
-Therefore, a SAML login with the same email address as the system administrator can login with system administrator privileges.
-To avoid this, you can remove (or add) administrator privileges based on SAML mappings.
-====
-+
-. Optional: Provide the *SAML Organization Map*.
-For more information, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team mapping].
-. You can configure {ControllerName} to look for particular attributes that contain Team and Organization membership to associate with users when they log in to {ControllerName}.
-The attribute names are defined in the *SAML Organization Attribute Mapping* and the *SAML Team Attribute Mapping* fields.
-+
-.Example SAML Organization Attribute Mapping
-+
-The following is an example SAML attribute that embeds user organization membership in the attribute `member-of`:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-<saml2:AttributeStatement>
-    <saml2:Attribute FriendlyName="member-of" Name="member-of"
-NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
-        <saml2:AttributeValue>Engineering</saml2:AttributeValue>
-        <saml2:AttributeValue>IT</saml2:AttributeValue>
-        <saml2:AttributeValue>HR</saml2:AttributeValue>
-        <saml2:AttributeValue>Sales</saml2:AttributeValue>
-    </saml2:Attribute>
-    <saml2:Attribute FriendlyName="admin-of" Name="admin-of"
-NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">
-        <saml2:AttributeValue>Engineering</saml2:AttributeValue>
-    </saml2:Attribute>
-</saml2:AttributeStatement>
-----
-+
-The following is the corresponding {ControllerName} configuration:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-{
-  "saml_attr": "member-of",
-  "saml_admin_attr": "admin-of",
-  "remove": true,
-  "remove_admins": false
-}
-----
-+
-* `saml_attr`: The SAML attribute name where the organization array can be found and `remove` is set to `true` to remove a user from all organizations before adding the user to the list of organizations.
-To keep the user in the organizations they are in while adding the user to the organizations in the SAML attribute, set `remove` to `false`.
-* `saml_admin_attr`: Similar to the `saml_attr` attribute, but instead of conveying organization membership, this attribute conveys administrator organization permissions.
-+
-.Example SAML Team Attribute Mapping
-+
-The following example is another SAML attribute that contains a team membership in a list:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-<saml:AttributeStatement>
-     <saml:Attribute
-        xmlns:x500="urn:oasis:names:tc:SAML:2.0:profiles:attribute:X500"
-        x500:Encoding="LDAP"
-        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
-        Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.1"
-        FriendlyName="eduPersonAffiliation">
-        <saml:AttributeValue
-            xsi:type="xs:string">member</saml:AttributeValue>
-        <saml:AttributeValue
-            xsi:type="xs:string">staff</saml:AttributeValue>
-        </saml:Attribute>
-</saml:AttributeStatement>
-{
-    "saml_attr": "eduPersonAffiliation",
-    "remove": true,
-    "team_org_map": [
-    {
-        "team": "member",
-        "organization": "Default1"
-    },
-    {
-        "team": "staff",
-        "organization": "Default2"
-    }
-  ]
-}
-----
-+
-* `saml_attr`: The SAML attribute name where the team array can be found.
-* `remove`: Set `remove` to `true` to remove the user from all teams before adding the user to the list of teams.
-To keep the user in the teams they are in while adding the user to the teams in the SAML attribute, set `remove` to `false`.
-* `team_org_map`: An array of dictionaries of the form `{ "team": "<AWX Team Name>", "organization": "<AWX Org Name>" }` that defines mapping from controller Team -> {ControllerName} organization.
-You need this because the same named team can exist in multiple organizations in {ControllerName}.
-The organization to which a team listed in a SAML attribute belongs to is ambiguous without this mapping.
-+
-You can create an alias to override both teams and organizations in the *SAML Team Attribute Mapping* field.
-This option is useful in cases when the SAML backend sends out complex group names, as show in the following example:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-{
- "remove": false,
- "team_org_map": [
-  {
-   "team": "internal:unix:domain:admins",
-   "organization": "Default",
-   "team_alias": "Administrators"
-  },
-  {
-   "team": "Domain Users",
-   "organization_alias": "OrgAlias",
-   "organization": "Default"
-  }
- ],
- "saml_attr": "member-of"
-}
-----
-+
-Once the user authenticates, {ControllerName} creates organization and team aliases.
-+
-. Optional: Provide team membership mapping in the *SAML Team Map* field.
-For more information, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team Mapping].
-. Optional: Provide security settings in the *SAML Security Config* field.
-This field is the equivalent to the `SOCIAL_AUTH_SAML_SECURITY_CONFIG` field in the API.
-For more information, see link:https://github.com/SAML-Toolkits/python-saml#settings[OneLogin's SAML Python Toolkit].
-+
-{ControllerNameStart} uses the `python-social-auth` library when users log in through SAML.
-This library relies on the `python-saml` library to make the settings available for the next two optional fields, *SAML Service Provider extra configuration data* and *SAML IDP to extra_data attribute mapping*.
-+
-* The *SAML Service Provider extra configuration data* field is equivalent to the `SOCIAL_AUTH_SAML_SP_EXTRA` in the API.
-For more information, see link:https://github.com/SAML-Toolkits/python-saml#settings[OneLogin's SAML Python Toolkit] to learn about the valid service provider extra (`SP_EXTRA`) parameters.
-* The *SAML IDP to extra_data attribute mapping* field is equivalent to the `SOCIAL_AUTH_SAML_EXTRA_DATA` in the API.
-For more information, see Python's SAML link:https://python-social-auth.readthedocs.io/en/latest/backends/saml.html#advanced-settings[Advanced Settings] documentation.
-* The *SAML User Flags Attribute Mapping* field enables you to map SAML roles and attributes to special user flags.
-The following attributes are valid in this field:
-** `is_superuser_role`: Specifies one or more SAML roles which grants a user the superuser flag.
-** `is_superuser_attr`: Specifies a SAML attribute which grants a user the superuser flag.
-** `is_superuser_value`: Specifies one or more values required for `is_superuser_attr` that is required for the user to be a superuser.
-** `remove_superusers`: Boolean indicating if the superuser flag should be removed for users or not.
-This defaults to `true`.
-** `is_system_auditor_role`: Specifies one or more SAML roles which will grant a user the system auditor flag.
-** `is_system_auditor_attr`: Specifies a SAML attribute which will grant a user the system auditor flag.
-** `is_system_auditor_value`: Specifies one or more values required for `is_system_auditor_attr` that is required for the user to be a system auditor.
-** `remove_system_auditors`: Boolean indicating if the `system_auditor` flag should be removed for users or not.
-This defaults to `true`.
-+
-The `role` and `value` fields are lists and are 'OR' logic.
-If you specify two roles: [ "Role 1", "Role 2" ] and the SAML user has either role, the logic considers them to have the required role for the flag.
-This is the same with the `value` field, if you specify: [ "Value 1", "Value 2"] and the SAML user has either value for their attribute the logic considers their attribute value to have matched.
-+
-If you specify `role` and `attr` for either `superuser` or `system_auditor`, the settings for `attr` take precedence over a role.
-System administrators and System auditor roles are evaluated at login for a SAML user.
-If you grant a SAML user one of these roles through the UI and not through the SAML settings, the roles are removed on the user's next login unless the `remove` flag is set to `false`.
-The `remove` flag, if `false`, never enables the SAML adapter to remove the corresponding flag from a user.
-The following table describes how the logic works:
-+
-[cols="33%,33%,33%,33%,33%,33%",options="header"]
-|===
-| *Has one or more roles* | *Has `attr`* | *Has one or more `attr Values`* | *Remove flag* | *Previous Flag* | *Is flagged*
-| No | No | N/A | True | False | No
-| No | No | N/A | False | False | No
-| No | No | N/A | True | True | No
-| No | No | N/A | False | True | Yes
-| Yes | No | N/A | True | False | Yes
-| Yes | No | N/A | False | False | Yes
-| Yes | No | N/A | True | True | Yes
-| Yes | No | N/A | False | False | Yes
-| No | Yes | Yes | True | True | Yes
-| No | Yes | Yes | True | False | Yes
-| No | Yes | Yes | False | False | Yes
-| No | Yes | Yes | True | True | Yes
-| No | Yes | Yes | False | True | Yes
-| No | Yes | No | True | False | No
-| No | Yes | No | False | False | No
-| No | Yes | No | True | True | No
-| No | Yes | No | False | True | Yes
-| No | Yes | Unset | True | False | Yes
-| No | Yes | Unset | False | False | Yes
-| No | Yes | Unset | True | True | Yes
-| No | Yes | Unset | False | True | Yes
-| Yes | Yes | Yes | True | False | Yes
-| Yes | Yes | Yes | False | False | Yes
-| Yes | Yes | Yes | True | True | Yes
-| Yes | Yes | Yes | False | True | Yes
-| Yes | Yes | No | True | False | No
-| Yes | Yes | No | False | False | No
-| Yes | Yes | No | True | True | No
-| Yes | Yes | No | False | True | Yes
-| Yes | Yes | Unset | True | False | Yes
-| Yes | Yes | Unset | False | False | Yes
-| Yes | Yes | Unset | True | True | Yes
-| Yes | Yes | Unset | False | True | Yes
-|===
-+
-Each time a SAML user authenticates to {ControllerName}, these checks are performed and the user flags are altered as needed.
-If `System Administrator` or `System Auditor` is set for a SAML user within the UI, the SAML adapter overrides the UI setting based on the preceding rules.
-If you prefer that the user flags for SAML users do not get removed when a SAML user logs in, you can set the `remove_` flag to `false`.
-With the `remove` flag set to `false`, a user flag set to `true` through either the UI, API or SAML adapter is not removed.
-However, if a user does not have the flag, and the preceding rules determine the flag should be added, it is added, even if the flag is `false`.
-+
-.Example
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-{
-    "is_superuser_attr": "blueGroups",
-    "is_superuser_role": ["is_superuser"],
-    "is_superuser_value": ["cn=My-Sys-Admins,ou=memberlist,ou=mygroups,o=myco.com"],
-    "is_system_auditor_attr": "blueGroups",
-    "is_system_auditor_role": ["is_system_auditor"],
-    "is_system_auditor_value": ["cn=My-Auditors,ou=memberlist,ou=mygroups,o=myco.com"]
-}
-----
-. Click btn:[Save].
+// Indicates whether the <samlp:AuthnRequest> messages sent by this SP // will be signed. [Metadata of the SP will offer this info] "authnRequestsSigned": false,
 
-.Verification
-To verify that the authentication is configured correctly, load the auto-generated URL found in the *SAML Service Provider Metadata URL* into a browser.
-If you do not get XML output, you have not configured it correctly.
+// Indicates a requirement for the <samlp:Response>, <samlp:LogoutRequest> // and <samlp:LogoutResponse> elements received by this SP to be signed. "wantMessagesSigned": false,
 
-Alternatively, logout of {ControllerName} and the login screen displays the SAML logo to indicate it as a alternate method of logging into {ControllerName}:
+// Indicates a requirement for the <saml:Assertion> elements received by // this SP to be signed. [Metadata of the SP will offer this info] "wantAssertionsSigned": false,
+----
+For more information and additional options, see link:https://github.com/SAML-Toolkits/python-saml#settings[OneLogin’s SAML Python Toolkit].
++
+. Optional: In the *SAML IDP to extra_data attribute mapping* field, enter values to map  IDP attributes to extra_data attributes. For more information, see link:https://python-social-auth.readthedocs.io/en/latest/backends/saml.html#advanced-settings[advanced SAML settings].
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc.[]
++
+. Click btn:[Next].
 
-image::ag-configure-auth-saml-logo.png[SAML logo]
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]

--- a/downstream/modules/platform/proc-controller-set-up-azure.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-azure.adoc
@@ -1,35 +1,35 @@
 [id="controller-set-up-azure"]
 
-= {Azure} active directory authentication
+= Configuring {Azure} active directory authentication
 
-To set up enterprise authentication for {Azure} Active Directory (AD), you need to obtain an OAuth2 key and secret by registering your organization-owned application from Azure at:
-https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app.
+To set up enterprise authentication for {Azure} Active Directory (AD), you need to obtain an OAuth2 key and secret by registering your organization-owned application from Azure using the link:https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[Quickstart: Register an application with the Microsoft identity platform]. 
 
-Each key and secret must belong to a unique application and cannot be shared or reused between different authentication backends.
-To register the application, you must supply it with your webpage URL, which is the Callback URL shown in the *Authentication* tab of the *Settings* screen.
+Each key and secret must belong to a unique application and cannot be shared or reused between different authentication backends. To register the application, you must supply it with your webpage URL, which is the Callback URL shown in the Authenticator details for your authenticator configuration. See dxref:gw-display-auth-details[Displaying authenticator details] for instructions on accessing this information.  
 
 .Procedure
 
-. From the navigation panel, select {MenuAEAdminSettings}.
-. Select *Azure AD settings* from the list of *Authentication* options.
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *Azuread* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this authentication configuration.
+. Click btn:[Edit], copy and paste Microsoft’s *Application (Client) ID* to the *OIDC Key* field.
++ 
+Following instructions for link:https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app[registering your application with the Microsoft identity platform], supply the key (shown at one time only) to the client for authentication. 
 +
-[NOTE]
-====
-The *Azure AD OAuth2 Callback URL* field is already pre-populated and non-editable.
-Once the application is registered, {Azure} displays the Application ID and Object ID.
-====
-. Click btn:[Edit], copy and paste {Azure}'s Application ID to the *Azure AD OAuth2 Key* field.
+. Copy and paste the secret key created for your Microsoft Azure AD application to the OIDC Secret field.
 +
-Following {Azure} AD's documentation for connecting your application to {Azure} Active Directory, supply the key (shown at one time only) to the client for authentication.
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
 +
-. Copy and paste the secret key created for your {Azure} AD application to the *Azure AD OAuth2 Secret* field of the *Settings - Authentication* screen.
-. For more information on completing the {Azure} AD OAuth2 Organization Map and {Azure} AD OAuth2 Team Map fields, see xref:ref-controller-organization-mapping[Organization mapping] and xref:ref-controller-team-mapping[Team Mapping].
-. Click btn:[Save].
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+Click btn:[Next].
 
-.Verification
-To verify that the authentication is configured correctly, log out of {ControllerName} and the login screen displays the {Azure} logo to enable logging in with those credentials:
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]
 
-image::ag-configure-auth-azure-logo.png[Azure AD logo]
+include::snippets/snip-gw-authentication-verification.adoc[]
 
+[role="_additional-resources"]
 .Additional resources
 For application registering basics in {Azure} AD, see the link:https://learn.microsoft.com/en-us/entra/identity-platform/v2-overview[What is the Microsoft identity platform?] overview.

--- a/downstream/modules/platform/proc-controller-set-up-generic-oidc.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-generic-oidc.adoc
@@ -1,34 +1,49 @@
 [id="controller-set-up-generic-oidc"]
 
-= Generic OIDC authentication
+= Configuring generic OIDC authentication
 
-OpenID Connect (OIDC) uses the OAuth 2.0 framework.
-It enables third-party applications to verify the identity and obtain basic end-user information.
-The main difference between OIDC and SAML is that SAML has a service provider (SP)-to-IdP trust relationship, whereas OIDC establishes the trust with the channel (HTTPS) that is used to obtain the security token.
-To obtain the credentials needed to set up OIDC with {ControllerName}, see the documentation from the IdP of your choice that has OIDC support.
+OpenID Connect (OIDC) uses the OAuth 2.0 framework. It enables third-party applications to verify the identity and obtain basic end-user information. The main difference between OIDC and SAML is that SAML has a service provider (SP)-to-IdP trust relationship, whereas OIDC establishes the trust with the channel (HTTPS) that is used to obtain the security token. To obtain the credentials needed to set up OIDC with {PlatformNameShort}, see the documentation from the IdP of your choice that has OIDC support.
 
 .Procedure
 
-. From the navigation panel, select {MenuAEAdminSettings}.
-. Select *Generic OIDC settings* from the list of *Authentication* options.
-. Click btn:[Edit] and enter the following information:
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *Generic OIDC* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this authentication configuration.
+. Enter the following information:
++
+* *OIDC Provider URL*: The URL for your OIDC provider.
 * *OIDC Key*: The client ID from your third-party IdP.
 * *OIDC Secret*: The client secret from your IdP.
-* *OIDC Provider URL*: The URL for your OIDC provider.
-* *Verify OIDC Provider Certificate*: Use the toggle to enable or disable the OIDC provider SSL certificate verification.
-. Click btn:[Save].
 +
+. Optional: Select the HTTP method to be used when requesting an access token from the *Access Token Method* list. The default method is *POST*.
+. Optionally enter information for the following fields using the tooltips provided for instructions and required format:
++
+* *Access Token Method* - The default method is *POST*.
+* *Access Token URL*
+* *Access Token Method*
+* *Authorization URL*
+* *ID Key*
+* *ID Token Issuer*
+* *JWKS URI*
+* *OIDC Public Key*
+* *Revoke Token Method* - The default method is *GET*.
+* *Revoke Token URL*
+* *Response Type*
+* *Token Endpoint Auth Method*
+* *Userinfo URL*
+* *Username Key*
++
+. Use the *Verify OIDC Provider Certificate* to enable or disable the OIDC provider SSL certificate verification.
+. Use the *Redirect* State to enable or disable the state parameter in the redirect URI. It is recommended that this is enabled to prevent Cross Site Request Forgery (CSRF) attacks.
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
+
 [NOTE]
 ====
-Team and organization mappings for OIDC are currently not supported.
-The OIDC adapter does authentication only and not authorization.
-It is only capable of authenticating whether this user is who they say they are.
-It does not authorize what this user is enabled to do.
-Configuring generic OIDC creates the UserID appended with an ID or key to differentiate the same user ID originating from two different sources and therefore, considered different users.
-So you get an ID of just the user name and the second is the username-<random number>.
+Team and organization mappings for OIDC are currently not supported. The OIDC adapter does authentication only and not authorization. It is only capable of authenticating whether this user is who they say they are. It does not authorize what this user is enabled to do. Configuring generic OIDC creates the UserID appended with an ID or key to differentiate the same user ID originating from two different sources and therefore, considered different users. So you get an ID of just the user name and the second is the username-<random number>.
 ====
-
-.Verification
-To verify that the authentication is configured correctly, logout of {ControllerName} and the login screen displays the OIDC logo to indicate it as a alternative method of logging into {ControllerName}:
-
-image:ag-configure-auth-oidc-logo.png[OIDClogo]

--- a/downstream/modules/platform/proc-controller-set-up-radius.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-radius.adoc
@@ -1,14 +1,24 @@
 [id="controller-set-up-radius"]
 
-= RADIUS authentication
+= Configuring RADIUS authentication
 
-You can configure {ControllerName} to centrally use RADIUS as a source for authentication information.
+You can configure {PlatformNameShort} to centrally use RADIUS as a source for authentication information.
 
 .Procedure
 
-. From the navigation panel, select {MenuAEAdminSettings}.
-. Select *RADIUS settings* from the list of *Authentication* options.
-. Click btn:[Edit] and enter the host or IP of the RADIUS server in the *RADIUS Server* field.
-If you leave this field blank, RADIUS authentication is disabled.
-. Enter the port and secret information in the next two fields.
-. Click btn:[Save].
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *Radius* from the *Authentication type* list and click btn:[Next].
+. Click btn:[Create authentication].
+. Enter the host or IP of the RADIUS server in the *RADIUS Server* field. If you leave this field blank, RADIUS authentication is disabled.
+. Enter the *Shared secret for authenticating to RADIUS server*.
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
+
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]

--- a/downstream/modules/platform/proc-controller-set-up-tacacs+.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-tacacs+.adoc
@@ -1,9 +1,8 @@
 [id="controller-set-up-tacacs"]
 
-= TACACS Plus authentication
+= Configuring TACACS+ authentication
 
-Terminal Access Controller Access-Control System Plus (TACACS+) is a protocol that handles remote authentication and related services for networked access control through a centralized server.
-TACACS+ provides authentication, authorization and accounting (AAA) services, in which you can configure {ControllerName} to use as a source for authentication.
+Terminal Access Controller Access-Control System Plus (TACACS+) is a protocol that handles remote authentication and related services for networked access control through a centralized server. TACACS+ provides authentication, authorization and accounting (AAA) services, in which you can configure Ansible Automation Platform to use as a source for authentication.
 
 [NOTE]
 ====
@@ -11,15 +10,24 @@ This feature is deprecated and will be removed in a future release.
 ====
 
 .Procedure
-. From the navigation panel, select {MenuAEAdminSettings}.
-. Select *TACACs+ settings* from the list of *Authentication* options.
-. Click btn:[Edit] and enter the following information:
-* *TACACS+ Server*: Provide the hostname or IP address of the TACACS+ server with which to authenticate.
-If you leave this field blank, TACACS+ authentication is disabled.
-* *TACACS+ Port*: TACACS+ uses port 49 by default, which is already pre-populated.
-* *TACACS+ Secret*: The secret key for TACACS+ authentication server.
-* *TACACS+ Auth Session Timeout*: The session timeout value in seconds.
-The default is 5 seconds.
-* *TACACS+ Authentication Protocol*: The protocol used by the TACACS+ client.
-The options are *ascii* or *pap*.
-. Click btn:[Save].
+
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *TACACS+* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this TACACS+ configuration.
+. Enter the following information:
++
+* Hostname of TACACS+ Server: Provide the hostname or IP address of the TACACS+ server with which to authenticate. If you leave this field blank, TACACS+ authentication is disabled.
+* TACACS+ Authentication Protocol: The protocol used by the TACACS+ client. The options are ascii or pap.
+* Shared secret for authenticating to TACACS+ server: The secret key for TACACS+ authentication server.
+. The *TACACS+ client address sending enabled* is disabled by default. To enable client address sending, select the checkbox.
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+Click btn:[Next].
+
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]

--- a/downstream/modules/platform/proc-controller-user-permissions.adoc
+++ b/downstream/modules/platform/proc-controller-user-permissions.adoc
@@ -12,7 +12,7 @@ You can set permissions through an inventory, project, job template and other re
 . Select the team *Name* to which you want to add roles.
 . Select the *Roles* tab and click btn:[Add roles].
 +
-include::snippets/snip-gw-roles-note-multiple-components.adoc
+include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Select a *Resource type* and click btn:[Next]. 
 . Select the resources to receive the new roles and click btn:[Next].

--- a/downstream/modules/platform/proc-gw-config-keycloak-settings.adoc
+++ b/downstream/modules/platform/proc-gw-config-keycloak-settings.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="gw-keycloak-authentication"]
+
+= Configuring keycloak authentication
+
+You can configure {PlatformNameShort} to integrate Keycloak to manage user authentication.
+
+.Procedure
+
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *Keycloak* from the *Authentication type* list and click btn:[Next].
+. Enter a *Name* for this keycloak configuration. The configuration name is required, must be unique across all authenticators, and must not be longer than 512 characters. 
+. Enter the location where the user's token can be retrieved in the *Keycloak Access Token URL* field.
+. Optional: Enter the redirect location the user is taken to during the login flow in the *Keycloak Provider URL* field. 
+. Enter the Client ID from your Keycloak installation in the *Keycloak OIDC Key* field.
+. Enter the RS256 public key provided by your Keycloak realm in the *Keycloak Public Key* field. 
+. Enter the OIDC secret (Client Secret) from your Keycloak installation in the *Keycloak OIDC Secret* field.
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
+
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]

--- a/downstream/modules/platform/proc-gw-local-authentication.adoc
+++ b/downstream/modules/platform/proc-gw-local-authentication.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="gw-local-authentication"]
+
+= Configuring local authentication
+
+As a platform administrator, you can configure local system authentication. With local authentication, users and their passwords are checked against local system accounts.
+
+[NOTE]
+====
+A local authenticator is automatically created by the {PlatformNameShort} installation process, and is configured with the specified admin credentials in the inventory file before installation. After successful installation, you can log in to the {PlatformNameShort} using those credentials. 
+====
+
+.Procedure
+
+. From the navigation panel, select {MenuAMAuthentication}.
+. Click btn:[Create authentication].
+. Select *Local* from the *Authentication type* list and click btn:[Next]. 
+. Enter a *Name* for this Local configuration. The configuration name is required, must be unique across all authenticators, and must not be longer than 512 characters. 
++
+include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
++
+include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
++
+. Click btn:[Next].
+
+[role="_additional-resources"]
+.Next steps
+include::snippets/snip-gw-authentication-next-steps.adoc[]

--- a/downstream/modules/platform/proc-gw-remove-roles-team.adoc
+++ b/downstream/modules/platform/proc-gw-remove-roles-team.adoc
@@ -12,7 +12,7 @@ You can remove roles from a team by selecting the - icon next to the resource. T
 . Select the team *Name* from which you want to remove roles.
 . Select the *Roles* tab.
 +
-include::snippets/snip-gw-roles-note-multiple-components.adoc
+include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Select the checkbox next to each resource you want to remove and click *Remove selected roles* from the *{MoreActionsIcon}* list on the menu bar.
 . Select the checkbox to confirm removal of the selected roles and click *Remove role*.

--- a/downstream/modules/platform/proc-gw-remove-roles-user.adoc
+++ b/downstream/modules/platform/proc-gw-remove-roles-user.adoc
@@ -11,7 +11,7 @@ You can remove roles from a user by selecting the *-* icon next to the resource.
 . Select the user Name from which you want to remove roles.
 . Select the *Roles* tab.
 +
-include::snippets/snip-gw-roles-note-multiple-components.adoc
+include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Select the checkbox next to each resource you want to remove and click *Remove selected roles* from the {MoreActionsIcon} list on the menu bar.
 . Select the checkbox to confirm removal of the selected roles and click btn:[Remove role].

--- a/downstream/modules/platform/ref-controller-user-roles.adoc
+++ b/downstream/modules/platform/ref-controller-user-roles.adoc
@@ -5,13 +5,14 @@
 = Adding roles for a user
 
 You can grant access for users to use, read, or write credentials by assigning roles to them.
+
 .Procedure
 . From the navigation panel, select {MenuAMUsers}.
 . From the Users list view, click on the user to which you want to add roles.
 . Select the *Roles* tab to display the set of roles assigned to this user. These provide the ability to read, modify, and administer resources.
 . To add new roles, click btn:[Add roles].
 +
-include::snippets/snip-gw-roles-note-multiple-components.adoc
+include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Select a Resource type and click btn:[Next]. 
 . Select the resources that will receive new roles and click btn:[Next].


### PR DESCRIPTION
This PR backports the changes from #1760 to the 2.5 branch and includes the following: 

* AAP-29213 - Convert authentication type content

* AAP-29213 - fixing formatting issues

* AAP-29213 - fixed duplicate id and removed duplicate file

* AAP-29213 - fix snippets formatting in local auth

* AAP-29213 - Fixed formatting issues to get a clean build

* AAP-29213 - removing an unused file

* AAP-29213 - formatting fixes and UI updates

* AAP-29213 - Fixed missing space in a step and replaced erroneous keycloak content

* AAP-29213 - incorporating peer review feedback