### PR TITLE
Add procedure to set registry variables

### DIFF
--- a/downstream/assemblies/platform/assembly-inventory-introduction.adoc
+++ b/downstream/assemblies/platform/assembly-inventory-introduction.adoc
@@ -61,7 +61,7 @@ registry_password='<registry password>'
 
 The first part of the inventory file specifies the hosts or groups that Ansible can work with.
 
-For more information on `registry_username` and `registry_password`, see xref:proc-set-registry-username-password[Setting registry_username and registry_password].
+For more information on `registry_username` and `registry_password`, see {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/planning_your_installation/about_the_installer_inventory_file#about_the_installer_inventory_file[Setting registry_username and registry_password].
 
 include::platform/ref-guidelines-hosts-groups.adoc[leveloffset=+1]
 include::platform/ref-deprovisioning.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-inventory-introduction.adoc
+++ b/downstream/assemblies/platform/assembly-inventory-introduction.adoc
@@ -61,6 +61,8 @@ registry_password='<registry password>'
 
 The first part of the inventory file specifies the hosts or groups that Ansible can work with.
 
+For more information on `registry_username` and `registry_password`, see xref:proc-set-registry-username-password[Setting registry_username and registry_password].
+
 include::platform/ref-guidelines-hosts-groups.adoc[leveloffset=+1]
 include::platform/ref-deprovisioning.adoc[leveloffset=+1]
 include::platform/con-inventory-variables-intro.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -37,6 +37,8 @@ There are several supported installation scenarios for {PlatformName}. To instal
 include::platform/proc-editing-inventory-file.adoc[leveloffset=+1]
 include::platform/con-install-scenario-examples.adoc[leveloffset=+1]
 include::platform/con-install-scenario-recommendations.adoc[leveloffset=+2]
+//Added for AAP-29120
+include::platform/proc-set-registry-username-password.adoc[leveloffset=+2]
 //[emcwhinn] Removing for AAP-29246 as content is being moved to one guide in 2.4 customer portal 
 //include::platform/con-eda-2-5-with-controller-2-4.adoc[leveloffset=+3]
 //[ifowler] Removed for AAP-18700 Install Guide Scenario Consolidation  

--- a/downstream/modules/platform/proc-set-registry-username-password.adoc
+++ b/downstream/modules/platform/proc-set-registry-username-password.adoc
@@ -1,0 +1,23 @@
+[id="proc-set-registry-username-password"]
+
+= Setting registry_username and registry_password
+
+If you intend to use the `registry_username` and `registry_password`` variables in an inventory file you are recommended to use the following method to create a Registry Service Account to set a token with an expiration in the plaintext `inventory/vars.yml` file instead of using a plaintext username and password, for reasons of security.
+
+Registry service accounts provide named tokens that can be used in environments where credentials are shared, such as deployment systems.
+
+.Procedure
+. Navigate to https://access.redhat.com/terms-based-registry/accounts
+. On the *Registry Service Accounts* page click btn:[New Service Account].
+. Enter a name for the account using only the accepted characters
+. Optionally enter a description for the account.
+. Click btn:[Create account].
+. Find the created account in the list. 
+The list of accounts is long so you might have to click btn:[Next] multiple times before finding the account you created. 
+Alternatively, if you know the name of your token, you can go directly to the page by entering the URL https://access.redhat.com/terms-based-registry/token/<name-of-your-token>
+. Click the name of the account that you created. 
+. A token page opens, displaying a generated Username (different to the account name) and a token. 
+If no Username and token are displayed, click btn:[Regenerate token]. You can also click this to generate a new Username and token.
+. Copy the service account name and use it to set `registry_username`.
+. Copy the token and use it to set `registry_password`.
+

--- a/downstream/modules/platform/proc-set-registry-username-password.adoc
+++ b/downstream/modules/platform/proc-set-registry-username-password.adoc
@@ -2,7 +2,7 @@
 
 = Setting registry_username and registry_password
 
-If you intend to use the `registry_username` and `registry_password`` variables in an inventory file you are recommended to use the following method to create a Registry Service Account to set a token with an expiration in the plaintext `inventory/vars.yml` file instead of using a plaintext username and password, for reasons of security.
+If you intend to use the `registry_username` and `registry_password` variables in an inventory file you are recommended to use the following method to create a Registry Service Account to set a token with an expiration in the plaintext `inventory/vars.yml` file instead of using a plaintext username and password, for reasons of security.
 
 Registry service accounts provide named tokens that can be used in environments where credentials are shared, such as deployment systems.
 
@@ -14,7 +14,7 @@ Registry service accounts provide named tokens that can be used in environments 
 . Click btn:[Create account].
 . Find the created account in the list. 
 The list of accounts is long so you might have to click btn:[Next] multiple times before finding the account you created. 
-Alternatively, if you know the name of your token, you can go directly to the page by entering the URL https://access.redhat.com/terms-based-registry/token/<name-of-your-token>
+Alternatively, if you know the name of your token, you can go directly to the page by entering the URL \https://access.redhat.com/terms-based-registry/token/<name-of-your-token>
 . Click the name of the account that you created. 
 . A token page opens, displaying a generated Username (different to the account name) and a token. 
 If no Username and token are displayed, click btn:[Regenerate token]. You can also click this to generate a new Username and token.

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -23,6 +23,8 @@ Used for both `[automationcontroller]` and `[automationhub]` groups.
 Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
 
 When `registry_url` is `registry.redhat.io`, username and password are required if not using a bundle installer.
+
+For more information, see xref:proc-set-registry-username-password[Setting registry_username and registry_password].
 | *`registry_url`* | Used for both `[automationcontroller]` and `[automationhub]` groups.
 
 Default = `registry.redhat.io`.
@@ -33,6 +35,8 @@ User credential for access to `registry_url`.
 Used for both `[automationcontroller]` and `[automationhub]` groups, but only if the value of `registry_url` is `registry.redhat.io`.
 
 Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
+
+For more information, see xref:proc-set-registry-username-password[Setting registry_username and registry_password].
 | *`routable_hostname`* | `routable hostname` is used if the machine running the installer can only route to the target host through a specific URL, for example, if you use shortnames in your inventory, but the node running the installer can only resolve that host using FQDN.
 
 If `routable_hostname` is not set, it should default to `ansible_host`. If you do not set `ansible_host`, `inventory_hostname` is used as a last resort.


### PR DESCRIPTION
Add to docs to create a token at access.redhat.com/terms-based-registry/accounts is necessary for entering a registry_username and registry_password

https://issues.redhat.com/browse/AAP-29120