### PR TITLE
Adding post install steps for VM install

### DIFF
--- a/downstream/assemblies/platform/assembly-VM-eda-controller-install.adoc
+++ b/downstream/assemblies/platform/assembly-VM-eda-controller-install.adoc
@@ -7,3 +7,4 @@ If you have an existing {PlatformNameShort} 2.4 Virtual Machine (VM)-based insta
 If you do not have an existing {PlatformNameShort} 2.4 VM-based installation of {ControllerName}, see the link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index[Red Hat Ansible Automation Platform installation guide], ensuring that you use an {PlatformNameShort} 2.4 installer.
 
 include::platform/proc-VM-install-eda-controller.adoc[leveloffset=+1]
+include::platform/con-VM-install-eda-post-steps.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-eda-controller-post-install.adoc
+++ b/downstream/assemblies/platform/assembly-eda-controller-post-install.adoc
@@ -4,4 +4,4 @@
 
 After completing your installation you need to connect Automation Decisions ({EDAcontroller}) to Automation Execution ({ControllerName}) to run rulebook activations successfully. 
 
-To do this for all installation types, follow the steps provided in [ADD LINK TO 2.5 DOC][Setting up a Red Hat Ansible Automation Platform credential].
+To do this for a VM-based install, follow the steps provided in [ADD LINK TO 2.5 DOC][Setting up a Red Hat Ansible Automation Platform credential].

--- a/downstream/modules/platform/con-VM-install-eda-post-steps.adoc
+++ b/downstream/modules/platform/con-VM-install-eda-post-steps.adoc
@@ -2,12 +2,12 @@
 
 = Post installation steps for VM-based install
 
-You need to complete post-install steps for setting up {PlatformNameShort} 2.5 with {EDAcontroller} 1.1 and {PlatformNameShort} 2.4 with {HubName} 4.9. 
+You must complete post-install steps for setting up {PlatformNameShort} 2.5 with {EDAcontroller} 1.1 and {PlatformNameShort} 2.4 with {HubName} 4.9. 
 The installation program does not handle the creation of decision environments and credentials in this scenario. 
 See the following steps to complete the installation:
 
 . Upload the 2.5 [ADD LINK FOR namespace for 2.5 image will be "ansible-automation-platform-25] de-supported decision environment to {HubName}. 
-For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/2.5/html-single/managing_content_in_automation_hub/index#push-containers[ Pushing a container image to private automation hub].
+For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/2.5/html-single/managing_content_in_automation_hub/index#push-containers[Pushing a container image to private automation hub].
 +
 [NOTE]
 ====

--- a/downstream/modules/platform/con-VM-install-eda-post-steps.adoc
+++ b/downstream/modules/platform/con-VM-install-eda-post-steps.adoc
@@ -1,0 +1,18 @@
+[id="con-VM-install-eda-post-steps"]
+
+= Post installation steps for VM-based install
+
+You need to complete post-install steps for setting up {PlatformNameShort} 2.5 with {EDAcontroller} 1.1 and {PlatformNameShort} 2.4 with {HubName} 4.9. 
+The installation program does not handle the creation of decision environments and credentials in this scenario. 
+See the following steps to complete the installation:
+
+. Upload the 2.5 [ADD LINK FOR namespace for 2.5 image will be "ansible-automation-platform-25] de-supported decision environment to {HubName}. 
+For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/2.5/html-single/managing_content_in_automation_hub/index#push-containers[ Pushing a container image to private automation hub].
++
+[NOTE]
+====
+If you are doing a bundle install, the image is included in the setup bundle .tar file.
+====
++
+. Create an {HubName} container registry credential in {EDAName}. 
+For more information, see [ADD 2.5 LINK]Setting up credentials for Event-Driven Ansible controller.

--- a/downstream/titles/eda-controller/eda-controller-install/docinfo.xml
+++ b/downstream/titles/eda-controller/eda-controller-install/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Using Event-Drive Ansible 2.5 with Ansible Automation Platform 2.4</title>
+<title>Using Event-Driven Ansible 2.5 with Ansible Automation Platform 2.4</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.4</productnumber>
 <subtitle>Install Ansible Automation Platform</subtitle>

--- a/downstream/titles/eda-controller/eda-controller-install/docinfo.xml
+++ b/downstream/titles/eda-controller/eda-controller-install/docinfo.xml
@@ -1,10 +1,9 @@
-<title>Install and configure Event-Driven Ansible 1.1 with automation controller 4.4 or 4.5</title>
+<title>Using Event-Drive Ansible 2.5 with Ansible Automation Platform 2.4</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.4</productnumber>
 <subtitle>Install Ansible Automation Platform</subtitle>
 <abstract>
-    <para>This guide shows you how to install and configure Event-Driven Ansible 1.1 to work with automation controller 4.4 or 4.5 for container-based, operator-based, and Virtual Machine (VM)-based installations. 
-    Follow the steps for your chosen installation method as well as the post installation configuration section.</para>
+    <para>Install and configure Event-Driven ANsible 2.5 with an existing automation controller 2.4 installation.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/eda-controller/eda-controller-install/master.adoc
+++ b/downstream/titles/eda-controller/eda-controller-install/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Using Event-Drive Ansible 2.5 with Ansible Automation Platform 2.4 
+= Using Event-Driven Ansible 2.5 with Ansible Automation Platform 2.4 
 
 You can configure a new installation of {EDAcontroller} 1.1 with {ControllerName} 4.4 or 4.5, which is considered a general availability release fully supported by Red Hat. 
 {ControllerNameStart} 4.4 and 4.5 were released as part of {PlatformNameShort} 2.4.

--- a/downstream/titles/eda-controller/eda-controller-install/master.adoc
+++ b/downstream/titles/eda-controller/eda-controller-install/master.adoc
@@ -8,16 +8,18 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Install and configure Event-Driven Ansible 1.1 with automation controller 4.4 or 4.5
+= Using Event-Drive Ansible 2.5 with Ansible Automation Platform 2.4 
 
 You can configure a new installation of {EDAcontroller} 1.1 with {ControllerName} 4.4 or 4.5, which is considered a general availability release fully supported by Red Hat. 
 {ControllerNameStart} 4.4 and 4.5 were released as part of {PlatformNameShort} 2.4.
 
 Upgrading to {EDAcontroller} 1.1 from an earlier release is unsupported at this time.
 
+This guide shows you how to install and configure Event-Driven Ansible 1.1 to work with automation controller 4.4 or 4.5 for a Virtual Machine (VM)-based installation. 
+
 include::{Boilerplate}[]
 
-include::platform/assembly-container-based-install.adoc[leveloffset=+1]
-include::platform/assembly-operator-eda-controller-install.adoc[leveloffset=+1]
+//include::platform/assembly-container-based-install.adoc[leveloffset=+1]
+//include::platform/assembly-operator-eda-controller-install.adoc[leveloffset=+1]
 include::platform/assembly-VM-eda-controller-install.adoc[leveloffset=+1]
 include::platform/assembly-eda-controller-post-install.adoc[leveloffset=+1]


### PR DESCRIPTION
Adding steps for VM install with hub and removing operator and container based steps

VM - New content to install and configure EDA 2.5 with controller 2.4

https://issues.redhat.com/browse/AAP-23518

Affects `titles/eda-controller/eda-controller-install`