### PR TITLE
fixing note adminotions (#1809)

### DIFF
--- a/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
@@ -16,7 +16,10 @@ The platform gateway for {PlatformNameShort} enables you to manage the following
 Before you can deploy the platform gateway you must have {OperatorPlatform} installed in a namespace. 
 If you have not installed {OperatorPlatform} see <<Installing the Red Hat Ansible Automation Platform operator on Red Hat OpenShift Container Platform>>.
 
-NOTE: Platform gateway is only available under {OperatorPlatform} version 2.5. Every component deployed under {OperatorPlatform} 2.5 will also default to version 2.5.
+[NOTE] 
+====
+Platform gateway is only available under {OperatorPlatform} version 2.5. Every component deployed under {OperatorPlatform} 2.5 will also default to version 2.5.
+====
 
 If you have the {OperatorPlatform} and some or all of the {PlatformNameShort} components installed see <<Deploying the platform gateway with existing {PlatformNameShort} components>> for how to proceed. 
 

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -32,5 +32,8 @@ If existing components have already been deployed, you must specify these compon
 * Same with {ControllerName} and {EDAName}
 |===
 
-// Commenting out as upgrade is not included in EA [gmurray]
-// NOTE: The stand-alone EDA user interface will not work upon upgrade. After you configure {PlatformNameShort}, other stand-alone user interfaces will not work.
+//Commenting out as upgrade is not included in EA [gmurray]
+//[NOTE]
+//====
+//The stand-alone EDA user interface will not work upon upgrade. After you configure {PlatformNameShort}, other stand-alone user interfaces will not work.
+//====

--- a/downstream/modules/platform/proc-configure-ldap-hub-ocp.adoc
+++ b/downstream/modules/platform/proc-configure-ldap-hub-ocp.adoc
@@ -34,10 +34,7 @@ spec:
 ----
 
 [NOTE]
-
 ====
-
 Do not leave any fields empty. For fields with no variable, enter ```` to indicate a default value.
-
 ====
 

--- a/downstream/modules/platform/proc-operator-deploy-central-config.adoc
+++ b/downstream/modules/platform/proc-operator-deploy-central-config.adoc
@@ -50,7 +50,10 @@ The following procedure simulates a scenario where you have {ControllerName} as 
 . Click btn:[Create].
 . To access your new instance, see <<Accessing the platform gateway>>.
 
-NOTE: If you have an existing controller with a managed Postgres pod, after creating the *{PlatformNameShort}* resource your {ControllerName} instance will continue to use that original Postgres pod. If you were to do a fresh install you would have a single Postgres managed pod for all instances. 
+[NOTE]
+====
+If you have an existing controller with a managed Postgres pod, after creating the *{PlatformNameShort}* resource your {ControllerName} instance will continue to use that original Postgres pod. If you were to do a fresh install you would have a single Postgres managed pod for all instances.
+====
 
 
 


### PR DESCRIPTION
[AAP-30293](https://issues.redhat.com/browse/AAP-30293)

Updating incorrect use of Note admonition in the Installing on OpenShift Container Platform document. Converting these instances to the correct format.

i.e From "NOTE:" to [NOTE] with '===='