### PR TITLE
AAP-30336 remove subscription info from operations guide

### DIFF
--- a/downstream/archive/archived-assemblies/platform/assembly-aap-manifest-files.adoc
+++ b/downstream/archive/archived-assemblies/platform/assembly-aap-manifest-files.adoc
@@ -1,5 +1,5 @@
 
-
+// emurtoug archived this file to avoid duplication of subscription content within Access mangement and authentication
 ifdef::context[:parent-context: {context}]
 
 

--- a/downstream/titles/aap-operations-guide/master.adoc
+++ b/downstream/titles/aap-operations-guide/master.adoc
@@ -14,7 +14,7 @@ After installing Red Hat Ansible Automation Platform, your system might need ext
 
 include::{Boilerplate}[]
 include::platform/assembly-aap-activate.adoc[leveloffset=+1]
-include::platform/assembly-aap-manifest-files.adoc[leveloffset=+1]
+// emurtoug removed this assembly to avoid duplication within Access management and authentication include::platform/assembly-aap-manifest-files.adoc[leveloffset=+1]
 //ifowler assembly transferred from installation guide as part of AAP-18700
 include::platform/assembly-platform-whats-next.adoc[leveloffset=+1]
 include::platform/assembly-configuring-proxy-support.adoc[leveloffset=+1]


### PR DESCRIPTION
[AAP-30336](https://issues.redhat.com/browse/AAP-30336) 

Commented out [Ch 2 Obtaining a file manifest](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#assembly-aap-obtain-manifest-files) within the Operations guide to avoid duplication with Access management and authentication 

Archived assembly-aap-manifest-files.adoc