### PR TITLE
am-formatting-2 - Fixing issues with document structure/chapter breakdown

### DIFF
--- a/downstream/assemblies/platform/assembly-gw-config-authentication-type.adoc
+++ b/downstream/assemblies/platform/assembly-gw-config-authentication-type.adoc
@@ -4,9 +4,10 @@ ifdef::context[:parent-context: {context}]
 
 [id="gw-config-authentication-type"]
 
-= Configuring authentication in the {PlatformNameShort}
+= Configuring an authentication type
 
-Ansible Automation Platform provides multiple authenticator plugins that you can configure to simplify the login experience for your organization. These are the authenticator plugins that are provided:
+{PlatformNameShort} provides multiple authenticator plugins that you can configure to simplify the login experience for your organization. These are the authenticator plugins that are provided:
+
 * xref:gw-local-authentication[Local] 
 * xref:controller-set-up-LDAP[LDAP] 
 * xref:controller-set-up-SAML[SAML] 
@@ -23,7 +24,7 @@ Ansible Automation Platform provides multiple authenticator plugins that you can
 * xref:proc-controller-github-enterprise-org-settings[GitHub enterprise organization]
 * xref:proc-controller-github-enterprise-team-settings[GitHub enterprise team]
 
-include::platform/proc-gw-local-authentication.adoc[leveloffest=+1]
+include::platform/proc-gw-local-authentication.adoc[leveloffset=+1]
 
 include::platform/proc-controller-set-up-LDAP.adoc[leveloffset=+1]
 
@@ -35,7 +36,7 @@ include::platform/proc-controller-set-up-azure.adoc[leveloffset=+1]
 
 include::platform/proc-controller-google-oauth2-settings.adoc[leveloffset=+1]
 
-include::platform/proc-controller-set-up-generic-oidc.adoc[leveloffest=+1]
+include::platform/proc-controller-set-up-generic-oidc.adoc[leveloffset=+1]
 
 include::platform/proc-gw-config-keycloak-settings.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-gw-configure-authentication.adoc
+++ b/downstream/assemblies/platform/assembly-gw-configure-authentication.adoc
@@ -16,24 +16,19 @@ Depending on the authentication method you select, you will be required to enter
 * Administrator rights to the {PlatformNameShort}
 * Any connection information needed to connect {PlatformNameShort} {PlatformVers} to your source (see individual authentication types for details).
 
-include::platform/con-gw-pluggable-authentication.adoc[leveloffest=+1]
+include::platform/con-gw-pluggable-authentication.adoc[leveloffset=+1]
 
-include::platform/con-gw-create-authentication.adoc[leveloffset=+1]
+include::platform/con-gw-create-authentication.adoc[leveloffset=+2]
 
-include::platform/proc-gw-select-auth-type.adoc[leveloffset=+2]
+include::platform/proc-gw-select-auth-type.adoc[leveloffset=+3]
 
-include::platform/proc-gw-configure-auth-details.adoc[leveloffset=+2]
+include::platform/proc-gw-configure-auth-details.adoc[leveloffset=+3]
 
-include::platform/proc-gw-define-rules-triggers.adoc[leveloffset=+2]
+include::platform/proc-gw-define-rules-triggers.adoc[leveloffset=+3]
 
-include::platform/proc-gw-adjust-mapping-order.adoc[leveloffset=+2]
+include::platform/proc-gw-adjust-mapping-order.adoc[leveloffset=+3]
 
-include::platform/proc-gw-review-auth-settings.adoc[leveloffset=+2]
-
-include::assembly-gw-config-authentication-type.adoc[leveloffset=+1]
-
-include::assembly-gw-managing-authentication.adoc[leveloffset=+1]
-
+include::platform/proc-gw-review-auth-settings.adoc[leveloffset=+3]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/proc-controller-google-oauth2-settings.adoc
+++ b/downstream/modules/platform/proc-controller-google-oauth2-settings.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: PROCEDURE
+
 [id="proc-controller-google-oauth2-settings"]
 
 = Configuring Google OAuth2 authentication

--- a/downstream/modules/platform/proc-controller-set-up-generic-oidc.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-generic-oidc.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: PROCEDURE
+
 [id="controller-set-up-generic-oidc"]
 
 = Configuring generic OIDC authentication

--- a/downstream/titles/central-auth/master.adoc
+++ b/downstream/titles/central-auth/master.adoc
@@ -13,7 +13,11 @@ include::{Boilerplate}[]
 
 include::platform/platform/con-gw-overview-access-auth.adoc[leveloffset=+1]
 include::platform/assembly-gw-configure-authentication.adoc[leveloffset=+1]
+include::platform/assembly-gw-config-authentication-type.adoc[leveloffset=+2]
+include::platform/assembly-gw-mapping.adoc[leveloffset=+2]
+include::platform/assembly-gw-managing-authentication.adoc[leveloffset=+2]
 include::platform/assembly-gw-token-based-authentication.adoc[leveloffset=+1]
 include::platform/assembly-gw-managing-access.adoc[leveloffset=+1]
 include::platform/assembly-gw-roles.adoc[leveloffset=+1]
 include::platform/assembly-gw-settings.adoc[leveloffset=+1]
+ 


### PR DESCRIPTION
This PR fixes typos in leveloffsets and other formatting to correct the chapter layout of the document. 