### PR TITLE
AAP-28434 Added notes about the impact of Redis failure on EDA controller resources

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-projects.adoc
+++ b/downstream/assemblies/eda/assembly-eda-projects.adoc
@@ -6,6 +6,12 @@ Projects are a logical collection of rulebooks.
 They must be a git repository and only http protocol is supported. 
 The rulebooks of a project must be located in the path defined for {EDAName} content in Ansible collections: `/extensions/eda/rulebooks` at the root of the project.
 
+[NOTE]
+====
+* Do not link a project to an empty repository. Linking a project to an empty repository causes synchronization errors.
+* When Redis is unavailable due to a failure, you will not be able to create or sync projects.
+====
+
 include::eda/proc-eda-set-up-new-project.adoc[leveloffset=+1]
 include::eda/con-eda-projects-list-view.adoc[leveloffset=+1]
 include::eda/proc-eda-editing-a-project.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-projects.adoc
+++ b/downstream/assemblies/eda/assembly-eda-projects.adoc
@@ -6,10 +6,10 @@ Projects are a logical collection of rulebooks.
 They must be a git repository and only http protocol is supported. 
 The rulebooks of a project must be located in the path defined for {EDAName} content in Ansible collections: `/extensions/eda/rulebooks` at the root of the project.
 
-[NOTE]
+[IMPORTANT]
 ====
-* Do not link a project to an empty repository. Linking a project to an empty repository causes synchronization errors.
-* When Redis is unavailable due to a failure, you will not be able to create or sync projects.
+//(J. Self) Commenting this out until we can confirm it's no longer needed. Brought to our attention by developer Joe Shimkus. * Do not link a project to an empty repository. Linking a project to an empty repository causes synchronization errors.
+To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable, you will not be able to create or sync projects.
 ====
 
 include::eda/proc-eda-set-up-new-project.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
+++ b/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
@@ -6,6 +6,17 @@
 
 A rulebook activation is a process running in the background defined by a decision environment executing a specific rulebook.
 
+[IMPORTANT]
+====
+To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable due to failure, the following functions will not be available:
+
+* Creating an activation, if `is_enabled` is True
+* Deleting an activation
+* Enabling an activation, if not already enabled
+* Disabling an activation, if not already disabled
+* Restarting an activation
+====
+
 include::eda/proc-eda-set-up-rulebook-activation.adoc[leveloffset=+1]
 include::eda/con-eda-rulebook-activation-list-view.adoc[leveloffset=+1]
 include::eda/proc-eda-view-activation-output.adoc[leveloffset=+2]

--- a/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
+++ b/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
@@ -8,7 +8,7 @@ A rulebook activation is a process running in the background defined by a decisi
 
 [IMPORTANT]
 ====
-To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable due to failure, the following functions will not be available:
+To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable, the following functions will not be available:
 
 * Creating an activation, if `is_enabled` is True
 * Deleting an activation

--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -18,5 +18,5 @@ The following procedures form the user configuration:
 
 ====
 * API documentation for {EDAcontroller} is available at \https://<eda-server-host>/api/eda/v1/docs
-* To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable due to a failure, you will not be able to create projects or enable rulebook activations.
+* To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable, you will not be able to create projects or enable rulebook activations.
 ====

--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -17,7 +17,6 @@ The following procedures form the user configuration:
 [NOTE]
 
 ====
-
-API documentation for {EDAcontroller} is available at \https://<eda-server-host>/api/eda/v1/docs
-
+* API documentation for {EDAcontroller} is available at \https://<eda-server-host>/api/eda/v1/docs
+* To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable due to a failure, you will not be able to create projects or enable rulebook activations.
 ====


### PR DESCRIPTION
Added notes in 3 places about the impact of HA Redis failure on EDA controller resources:

- downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
- downstream/assemblies/eda/assembly-eda-projects.adoc
- downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc

