### PR TITLE
Fix the title for Managing content document

### DIFF
--- a/downstream/titles/hub/managing-content/docinfo.xml
+++ b/downstream/titles/hub/managing-content/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Managing content in automation hub</title>
+<title>Managing automation content in Ansible Automation Platform</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Create and manage collections, content and repositories in automation hub</subtitle>

--- a/downstream/titles/hub/managing-content/master.adoc
+++ b/downstream/titles/hub/managing-content/master.adoc
@@ -4,7 +4,7 @@
 :experimental:
 include::attributes/attributes.adoc[]
 
-= Managing content in automation hub
+= Managing automation content in Ansible Automation Platform
 
 
 include::{Boilerplate}[]


### PR DESCRIPTION
This PR fixes the title for the Managing content document to reflect what was decided in the Miro board https://miro.com/app/board/uXjVNGGa88w=/