### PR TITLE
AAP-28228 added OCP assembly (#1837)

### DIFF
--- a/downstream/assemblies/topologies/assembly-ocp-topologies.adoc
+++ b/downstream/assemblies/topologies/assembly-ocp-topologies.adoc
@@ -1,0 +1,9 @@
+[id="ocp-topologies"]
+
+= Operator supported topologies
+
+The {OperatorPlatform} uses Red Hat OpenShift operators to deploy {PlatformNameShort} within Red Hat OpenShift. Customers manage the product and infrastructure lifecycle.
+
+//OCP growth topology
+
+//OCP enterprise topology

--- a/downstream/titles/topologies/master.adoc
+++ b/downstream/titles/topologies/master.adoc
@@ -18,5 +18,6 @@ include::topologies/assembly-rpm-topologies.adoc[leveloffset=+1]
 include::topologies/assembly-container-topologies.adoc[leveloffset=+1]
 
 //Operator supported topologies
+include::topologies/assembly-ocp-topologies.adoc[leveloffset=+1]
 
 //Automation mesh nodes 


### PR DESCRIPTION
2.5 backport of [PR 1837](https://github.com/ansible/aap-docs/pull/1837)

[AAP-28228](https://issues.redhat.com/browse/AAP-28228)

Files added:

assembly-ocp-topologies.adoc
Files modified:

topologies/master.adoc