### PR TITLE
Fix Managing content document title to remove AAP

### DIFF
--- a/downstream/titles/hub/managing-content/docinfo.xml
+++ b/downstream/titles/hub/managing-content/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Managing automation content in Ansible Automation Platform</title>
+<title>Managing automation content</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Create and manage collections, content and repositories in automation hub</subtitle>

--- a/downstream/titles/hub/managing-content/master.adoc
+++ b/downstream/titles/hub/managing-content/master.adoc
@@ -4,7 +4,7 @@
 :experimental:
 include::attributes/attributes.adoc[]
 
-= Managing automation content in Ansible Automation Platform
+= Managing automation content
 
 
 include::{Boilerplate}[]


### PR DESCRIPTION
This PR fixes the Managing automation content in Ansible Automation Platform to Managing automation content per Slack conversation here: https://redhat-internal.slack.com/archives/C04NT5T2V28/p1725639042037859