### PR TITLE
[Backport] Fix Managing content document title to remove AAP (#1844)

### DIFF
--- a/downstream/titles/hub/managing-content/docinfo.xml
+++ b/downstream/titles/hub/managing-content/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Managing content in automation hub</title>
+<title>Managing automation content</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
 <subtitle>Create and manage collections, content and repositories in automation hub</subtitle>

--- a/downstream/titles/hub/managing-content/master.adoc
+++ b/downstream/titles/hub/managing-content/master.adoc
@@ -4,7 +4,7 @@
 :experimental:
 include::attributes/attributes.adoc[]
 
-= Managing content in automation hub
+= Managing automation content
 
 
 include::{Boilerplate}[]


### PR DESCRIPTION
This PR backports the changes from #1844 to the 2.5 branch.