### PR TITLE
AAP-29177 updated FDQN guidelines (#1861)

### DIFF
--- a/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
+++ b/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
@@ -13,7 +13,7 @@
 * Do not install {HubNameMain} and {ControllerName} on the same node.
 * Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure that users can synchronize and install content from {HubNameMain} and {ControllerName} from a different node. 
 +
-The FQDN must not contain either the `-` or the `_` symbols, as it will not be processed correctly.
+The FQDN must not contain the `_` symbol, as it will not be processed correctly in Skopeo. You may use the `-` symbol, as long as it is not at the start or the end of the host name.
 +
 Do not use `localhost`.
 


### PR DESCRIPTION
2.4 backport of PR 1861

[AAP-29177](https://issues.redhat.com/browse/AAP-29177)

Updated language around symbol restrictions for creating hostnames