### PR TITLE
fix repo name in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -108,12 +108,12 @@ The first time you contribute:
 . Clone the forked repository locally.
 
 -----
-$ git clone git@github.com:<username>/red-hat-ansible-automation-platform-documentation.git
+$ git clone git@github.com:<username>/aap-docs.git
 -----
 
    If this command fails, be sure that you have link:https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account[set up an SSH key for GitHub].
 
-. Navigate to the `red-hat-ansible-automation-platform-documentation` directory.
+. Navigate to the `aap-docs` directory.
 
 . Set the upstream remote repository.
 


### PR DESCRIPTION
fix repo name to `aap-docs`