### PR TITLE
Remove attributes from job-explorer title

### DIFF
--- a/downstream/titles/analytics/job-explorer/master.adoc
+++ b/downstream/titles/analytics/job-explorer/master.adoc
@@ -5,7 +5,7 @@
 :analytics_automation_savings:
 
 [[analytics_automation_savings]]
-= Evaluating your {ControllerName} job runs using the {explorer}
+= Evaluating your Automation controller job runs using the Job Explorer
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Remove attributes from `master.adoc` for _Evaluating your Automation controller job runs using the Job Explorer_ to prevent Pantheon build failures. 
Only needed for 2.3: 2.4 and 2.5 are OK.
Affects `titles/analytics/job-explorer`