### PR TITLE
Update title attributes for navigator

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -349,7 +349,7 @@
 :TitleContainerizedInstall: Containerized installation
 //
 // titles/navigator-guide
-:TitleNavigatorGuide: Using content creator
+:TitleNavigatorGuide: Using content navigator
 //
 // titles/aap-hardening
 :TitleHardening: Hardening and compliance


### PR DESCRIPTION
Backport to 2.5
Update the title attribute for the Navigator guide.
The title files were updated in #1887
