### PR TITLE
2.5 Update title attributes for navigator (#1891)

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -348,7 +348,7 @@
 :TitleContainerizedInstall: Containerized installation
 //
 // titles/navigator-guide
-:TitleNavigatorGuide: Using content creator
+:TitleNavigatorGuide: Using content navigator
 //
 // titles/aap-hardening
 :TitleHardening: Hardening and compliance


### PR DESCRIPTION
Update the title attribute for the Navigator guide.
The title files were updated in 2.5 in https://github.com/ansible/aap-docs/pull/1888