### PR TITLE
2.3 Remove attributes from title names

### DIFF
--- a/downstream/titles/aap-installation-guide/master.adoc
+++ b/downstream/titles/aap-installation-guide/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} Installation Guide
+= Red Hat Ansible Automation Platform Installation Guide
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/aap-operations-guide/master.adoc
+++ b/downstream/titles/aap-operations-guide/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} Operations Guide
+= Red Hat Ansible Automation Platform Operations Guide
 
 After installing {PlatformName}, your system might need extra configuration to ensure your deployment runs smoothly. This guide provides procedures for configuration tasks that you can perform after installing {PlatformName}.
 

--- a/downstream/titles/aap-operator-backup/master.adoc
+++ b/downstream/titles/aap-operator-backup/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} Operator Backup and Recovery Guide
+= Red Hat Ansible Automation Platform Operator Backup and Recovery Guide
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -9,7 +9,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Deploying the {PlatformName} operator on {OCPShort}
+= Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/aap-planning-guide/master.adoc
+++ b/downstream/titles/aap-planning-guide/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} Planning Guide
+= Red Hat Ansible Automation Platform Planning Guide
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/automation-mesh/docinfo.xml
+++ b/downstream/titles/automation-mesh/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Red Hat Ansible Automation Platform Automation Mesh Guide</title>
+<title>Red Hat Ansible Automation Platform automation mesh guide</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.3</productnumber>
 <subtitle>This guide provides information used to deploy automation mesh as part of your Ansible Automation Platform environment</subtitle>

--- a/downstream/titles/automation-mesh/master.adoc
+++ b/downstream/titles/automation-mesh/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} {MeshName} guide
+= Red Hat Ansible Automation Platform automation mesh guide
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 

--- a/downstream/titles/central-auth/master.adoc
+++ b/downstream/titles/central-auth/master.adoc
@@ -7,7 +7,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Installing and Configuring Central Authentication for the {PlatformNameShort}
+= Installing and Configuring Central Authentication for the Ansible Automation Platform
 
 {AAPCentralAuth} is a third-party identity provider (idP) solution, allowing for a simplified single sign-on solution that can be used across the {PlatformNameShort}. Platform administrators can utilize {CentralAuth} to test connectivity and authentication, as well as onboard new users and manage user permissions by configuring and assigning them to groups. Along with OpenID Connect-based and LDAP support, {CentralAuth} also provides a supported REST API which can be used to bootstrap customer usage.
 

--- a/downstream/titles/dev-guide/master.adoc
+++ b/downstream/titles/dev-guide/master.adoc
@@ -7,7 +7,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} Creator Guide
+= Red Hat Ansible Automation Platform Creator Guide
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -1,6 +1,6 @@
 
 :imagesdir: images
-= Managing Red Hat Certified and {Galaxy} collections in {HubName}
+= Managing Red Hat Certified and Ansible Galaxy collections in automation hub
 :numbered:
 :experimental:
 

--- a/downstream/titles/hub/getting-started/master.adoc
+++ b/downstream/titles/hub/getting-started/master.adoc
@@ -8,7 +8,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Getting started with {HubName}
+= Getting started with automation hub
 
 Red Hat Ansible {HubName} provides a place for Red Hat subscribers to quickly find and use content that is supported by Red Hat and our technology partners to deliver additional reassurance for the most demanding environments.
 

--- a/downstream/titles/hub/high-availability/master.adoc
+++ b/downstream/titles/hub/high-availability/master.adoc
@@ -2,7 +2,7 @@
 :numbered:
 include::attributes/attributes.adoc[]
 
-= Deploying a high availability {HubName}
+= Deploying a high availability automation hub
 
 This guide provides an overview of the requirements and procedures for a high availability deployment of your {HubName}.
 

--- a/downstream/titles/hub/install/master.adoc
+++ b/downstream/titles/hub/install/master.adoc
@@ -4,7 +4,7 @@
 :experimental:
 include::attributes/attributes.adoc[]
 
-= Installing and upgrading {PrivateHubName}
+= Installing and upgrading private automation hub
 
 You can install Private Automation Hub or upgrade to a new version on a {RHEL} (RHEL) 8.4 or later, or RHEL 9 or later virtual or physical machine with a valid {PlatformName} subscription.
 

--- a/downstream/titles/hub/manage-containers/master.adoc
+++ b/downstream/titles/hub/manage-containers/master.adoc
@@ -6,7 +6,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Managing containers in {PrivateHubName}
+= Managing containers in private automation hub
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 

--- a/downstream/titles/ocp_performance_guide/master.adoc
+++ b/downstream/titles/ocp_performance_guide/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 :context: ocp-performance
 
 // Book Title
-= {PlatformName} Performance Considerations for Operator Based Installations
+= Red Hat Ansible Automation Platform Performance Considerations for Operator Based Installations
 
 Deploying applications to a container orchestration platform such as {OCP} provides a number of advantages from an operational perspective. 
 For example, an update to the base image of an application can be made through a simple in-place upgrade with little to no disruption.

--- a/downstream/titles/upgrade/master.adoc
+++ b/downstream/titles/upgrade/master.adoc
@@ -7,7 +7,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= {PlatformName} Upgrade and Migration Guide
+= Red Hat Ansible Automation Platform Upgrade and Migration Guide
 
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 

--- a/downstream/titles/worker-install/master.adoc
+++ b/downstream/titles/worker-install/master.adoc
@@ -8,7 +8,7 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Installing the {CatalogName} worker
+= Installing the automation services catalog worker
 
 You can extend {PlatformName} to connect to {CatalogName} on cloud.redhat.com by using the {PlatformNameShort} setup or setup bundle installer.
 


### PR DESCRIPTION
2.3 Remove attributes from title names because they're causing build failures in Pantheon.