### PR TITLE
AAP-29296-B updated About the installer inventory file (#1917)

### DIFF
--- a/downstream/assemblies/platform/assembly-inventory-introduction.adoc
+++ b/downstream/assemblies/platform/assembly-inventory-introduction.adoc
@@ -17,9 +17,11 @@ The following table shows possible locations:
 [cols="30%,70%",options="header"]
 |====
 | Installer | Location
-| *Bundle tar* | `/ansible-automation-platform-setup-bundle-<latest-version>`
-| *Non-bundle tar* | `/ansible-automation-platform-setup-<latest-version>`
 | *RPM* | `/opt/ansible-automation-platform/installer`
+| *RPM bundle tar* | `/ansible-automation-platform-setup-bundle-<latest-version>`
+| *RPM non-bundle tar* | `/ansible-automation-platform-setup-<latest-version>`
+| *Container bundle tar* | `/ansible-automation-platform-containerized-setup-bundle-<latest-version>`
+| *Container non-bundle tar* | `/ansible-automation-platform-containerized-setup-<latest-version>`
 |====
 
 You can verify the hosts in your inventory using the command:
@@ -34,15 +36,20 @@ ansible all -i <path-to-inventory-file. --list-hosts
 [options="nowrap" subs="+quotes,attributes"]
 ----
 [automationcontroller]
-host1.example.com
-host2.example.com
-Host4.example.com
+controller.example.com
+
 
 [automationhub]
-host3.example.com
+automationhub.example.com
+
+[automationedacontroller]
+automationedacontroller.example.com
+
+[automationgateway]
+gateway.example.com
 
 [database]
-Host5.example.com
+data.example.com
 
 [all:vars]
 admin_password='<password>'


### PR DESCRIPTION
2.5 backport of [PR 1917](https://github.com/ansible/aap-docs/pull/1917)

AAP-29296-B: child of [AAP-29296](https://issues.redhat.com/browse/AAP-29296)

Updated Chapter 8. About the installer inventory file of the Planning guide. See [[WIP] v2.5 Red Hat Ansible Automation Platform planning guide](https://docs.google.com/document/d/1tCXiQxr0WspctajD7Hxwji9zsaOaPMl-WhRsB1sF-qs/edit).

Modified files:

assembly-inventory-introduction.adoc