### PR TITLE
2.4 Use attributes to reference Navigator Title and URL (#1894)

### DIFF
--- a/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
+++ b/downstream/assemblies/platform/assembly-migrate-legacy-venv-to-ee.adoc
@@ -1,16 +1,9 @@
-
-
 ifdef::context[:parent-context: {context}]
-
-
 
 [id="upgrading-to-ees"]
 = Migrating to {ExecEnvName}
 
-
 :context: upgrading-to-ees
-
-
 
 // [role="_abstract"]
 
@@ -34,7 +27,7 @@ include::dev-guide/assembly-virt-env-to-ee.adoc[leveloffset=+1]
 // Remove comments once 2.2 version of the docs are published.
 //== Additional resources
 
-//* See the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_navigator_creator_guide/index[Red Hat Ansible Automation Platform Creator Guide] for more information on migrating to {ExecEnvName}.
+//* See the _link:{LinkNavigatorGuide}_ guide for more information on migrating to {ExecEnvName}.
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-playbooks.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-playbooks.adoc
@@ -3,4 +3,7 @@
 
 = Playbooks
 
-You can use {Navigator} to interactively troubleshoot your playbook. For more information about troubleshooting a playbook with {Navigator}, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_content_navigator_creator_guide/assembly-troubleshooting-navigator_ansible-navigator[Troubleshooting Ansible content with {Navigator}] in the Automation Content Navigator Creator Guide.
+You can use {Navigator} to interactively troubleshoot your playbook.
+For more information about troubleshooting a playbook with {Navigator}, see
+link:{URLNavigatorGuide}/assembly-troubleshooting-navigator_ansible-navigator[Troubleshooting Ansible content with {Navigator}]
+in the _{TitleNavigatorGuide}_ Guide.

--- a/downstream/modules/devtools/proc-devtools-extension-run-ansible-navigator.adoc
+++ b/downstream/modules/devtools/proc-devtools-extension-run-ansible-navigator.adoc
@@ -24,5 +24,6 @@ image:devtools-extension-navigator-tasks.png[Tasks in ansible-navigator output]
 Type the number next to a task to review the task results.
 
 For more information on running playbooks with {Navigator}, see
-link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_content_navigator_creator_guide/assembly-execute-playbooks-navigator_ansible-navigator#proc-execute-playbook-tui_execute-playbooks-navigator[Executing a playbook from automation content navigator].
+link:{URLNavigatorGuide}/assembly-execute-playbooks-navigator_ansible-navigator#proc-execute-playbook-tui_execute-playbooks-navigator[Executing a playbook from automation content navigator]
+in the _{TitleNavigatorGuide}_ Guide.
 

--- a/downstream/modules/devtools/proc-devtools-testing-playbook.adoc
+++ b/downstream/modules/devtools/proc-devtools-testing-playbook.adoc
@@ -26,6 +26,6 @@ The output is displayed in the terminal.
 You can inspect the results and step into each play and task that was executed.
 
 For more information about running playbooks, refer to 
-link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_content_navigator_creator_guide/assembly-execute-playbooks-navigator_ansible-navigator[Running Ansible playbooks with automation content navigator]
-in the _Automation content navigator creator guide_.
+link:{URLNavigatorGuide}/assembly-execute-playbooks-navigator_ansible-navigator[Running Ansible playbooks with automation content navigator]
+in the _{TitleNavigatorGuide}_ guide.
 


### PR DESCRIPTION
Update docs to use attributes for referencing the Navigator title and URL.

Affects 
* `titles/troubleshooting-aap/`
* `titles/upgrade/`
* `titles/develop-automation-content/`