### PR TITLE
AAP-26512 - Update example for SAML Security Config per SME feedback

### DIFF
--- a/downstream/modules/platform/proc-controller-set-up-SAML.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-SAML.adoc
@@ -55,11 +55,14 @@ include::snippets/snip-gw-authentication-additional-auth-fields.adoc
 . Optional: Provide security settings in the *SAML Security Config* field. This field is the equivalent to the `SOCIAL_AUTH_SAML_SECURITY_CONFIG` field in the API. 
 +
 ----
-// Indicates whether the <samlp:AuthnRequest> messages sent by this SP // will be signed. [Metadata of the SP will offer this info] "authnRequestsSigned": false,
+// Indicates whether the <samlp:AuthnRequest> messages sent by this SP // will be signed. [Metadata of the SP will offer this info] 
+"authnRequestsSigned": false,
 
-// Indicates a requirement for the <samlp:Response>, <samlp:LogoutRequest> // and <samlp:LogoutResponse> elements received by this SP to be signed. "wantMessagesSigned": false,
+// Indicates a requirement for the <samlp:Response>, <samlp:LogoutRequest> // and <samlp:LogoutResponse> elements received by this SP to be signed. 
+"wantMessagesSigned": false,
 
-// Indicates a requirement for the <saml:Assertion> elements received by // this SP to be signed. [Metadata of the SP will offer this info] "wantAssertionsSigned": false,
+// Indicates a requirement for the <saml:Assertion> elements received by // this SP to be signed. [Metadata of the SP will offer this info] 
+"wantAssertionsSigned": false,
 ----
 For more information and additional options, see link:https://github.com/SAML-Toolkits/python-saml#settings[OneLogin’s SAML Python Toolkit].
 +


### PR DESCRIPTION
This PR fixes the example under the step for SAML Security Config to have the parameters on a line by themselves for easier usability. 