### PR TITLE
AAP-30807 Commented out, and updated text for the 2.5 release.

### DIFF
--- a/downstream/assemblies/platform/assembly-disconnected-installation.adoc
+++ b/downstream/assemblies/platform/assembly-disconnected-installation.adoc
@@ -13,7 +13,7 @@ If you are not connected to the internet or do not have access to online reposit
 
 Before installing {PlatformNameShort} on a disconnected network, you must meet the following prerequisites:
 
-. A created subscription manifest. See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#doc-wrapper[Obtaining a manifest file] for more information.
+. A subscription manifest that you can upload to the platform. See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#doc-wrapper[Obtaining a manifest file] for more information.
 
 . The {PlatformNameShort} setup bundle at link:{PlatformDownloadUrl}[Customer Portal] is downloaded.
 
@@ -28,27 +28,36 @@ include::platform/proc-creating-a-new-web-server-to-host-repositories.adoc[level
 
 include::platform/proc-accessing-rpm-repositories-for-locally-mounted-dvd.adoc[leveloffset=+1]
 
-include::platform/proc-adding-a-subscription-manifest-to-aap-without-an-internet-connection.adoc[leveloffset=+1]
+//include::platform/proc-adding-a-subscription-manifest-to-aap-without-an-internet-connection.adoc[leveloffset=+1]
+//removed for 2.5 changes AAP-30807 made by rjgrange
 
 include::platform/proc-installing-the-aap-setup-bundle.adoc[leveloffset=+1]
 
 include::platform/proc-completing-post-installation-tasks.adoc[leveloffset=+1]
 
-include::platform/proc-importing-collections-into-private-automation-hub.adoc[leveloffset=+1]
+//include::platform/proc-importing-collections-into-private-automation-hub.adoc[leveloffset=+1]
+//removed for 2.5 changes AAP-30807 made by rjgrange
 
-include::platform/proc-creating-collection-namespace.adoc[leveloffset=+1]
+//include::platform/proc-creating-collection-namespace.adoc[leveloffset=+1]
+//removed for 2.5 changes AAP-30807 made by rjgrange
 
-include::platform/proc-approving-the-imported-collection.adoc[leveloffset=+1]
+//include::platform/proc-approving-the-imported-collection.adoc[leveloffset=+1]
+//removed for 2.5 changes AAP-30807 made by rjgrange
 
-include::platform/con-building-an-execution-environment-in-a-disconnected-environment.adoc[leveloffset=+1]
+//include::platform/con-building-an-execution-environment-in-a-disconnected-environment.adoc[leveloffset=+1]
+//removed for 2.5 changes AAP-30807 made by rjgrange
 
-include::platform/proc-installing-the-ansible-builder-rpm.adoc[leveloffset=+2]
+//include::platform/proc-installing-the-ansible-builder-rpm.adoc[leveloffset=+2]
+//removed for 2.5 changes AAP-30807 made by rjgrange
 
-include::platform/proc-creating-the-custom-execution-environment-definition.adoc[leveloffset=+2]
+//include::platform/proc-creating-the-custom-execution-environment-definition.adoc[leveloffset=+2]
+//removed for 2.5 changes AAP-30807 made by rjgrange
 
-include::platform/proc-building-the-custom-execution-environment.adoc[leveloffset=+2]
+//include::platform/proc-building-the-custom-execution-environment.adoc[leveloffset=+2]
+//removed for 2.5 changes AAP-30807 made by rjgrange
 
-include::platform/proc-uploading-the-custom-execution-environment-to-the-private-hub.adoc[leveloffset=+2]
+//include::platform/proc-uploading-the-custom-execution-environment-to-the-private-hub.adoc[leveloffset=+2]
+//removed for 2.5 changes AAP-30807 made by rjgrange
 
 // Removing references to upgrades for 2.5-ea - AAP-17771
 // include::platform/proc-upgrading-between-minor-aap-releases.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-aap-installation-on-disconnected-rhel.adoc
+++ b/downstream/modules/platform/con-aap-installation-on-disconnected-rhel.adoc
@@ -4,11 +4,15 @@
 = {PlatformNameShort} installation on disconnected RHEL
 
 [role="_abstract"]
-You can install {PlatformNameShort} {ControllerName} and {PrivateHubName} without an internet connection by using the installer-managed database located on the {ControllerName}. Use the setup bundle for a disconnected installation as it includes additional components that make installing {PlatformNameShort} easier in a disconnected environment. These include the {PlatformNameShort} Red Hat package managers (RPMs) and the default {ExecEnvShort} (EE) images.
+You can install {PlatformNameShort} without an internet connection by using the installer-managed database located on the {ControllerName}. The setup bundle is recommended for disconnected installation because it includes additional components that make installing {PlatformNameShort} easier in a disconnected environment. These include the {PlatformNameShort} Red Hat package managers (RPMs) and the default {ExecEnvShort} (EE) images.
+
+.Additional Resources
+
+For a comprehensive list of pre-defined variables used in Ansible installation inventory files, see xref:ref-ansible-inventory-variables[Ansible variables].
 
 == System requirements for disconnected installation
 
-Ensure that your system has all the hardware requirements before performing a disconnected installation of {PlatformNameShort}. For more information about hardware requirements, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_installation_guide/index#platform-system-requirements[Chapter 2. System requirements].
+Ensure that your system has all the hardware requirements before performing a disconnected installation of {PlatformNameShort}. You can find these in xref:platform-system-requirements[system requirements].
 
 == RPM Source
 
@@ -20,8 +24,8 @@ RPM dependencies for {PlatformNameShort} that come from the BaseOS and AppStream
 [NOTE]
 
 ====
-The RHEL Binary DVD method requires the DVD for supported versions of RHEL, including version 8.6 or higher. See link:https://access.redhat.com/support/policy/updates/errata[Red Hat Enterprise Linux Life Cycle] for information about which versions of RHEL are currently supported.
+The RHEL Binary DVD method requires the DVD for supported versions of RHEL. See link:https://access.redhat.com/support/policy/updates/errata[Red Hat Enterprise Linux Life Cycle] for information on which versions of RHEL are currently supported.
 ====
 
-.Additional Resources
+.Additional resources
 * link:{BaseURL}/red_hat_satellite/{SatelliteVers}/html/installing_satellite_server_in_a_disconnected_network_environment/index[Satellite]

--- a/downstream/modules/platform/proc-completing-post-installation-tasks.adoc
+++ b/downstream/modules/platform/proc-completing-post-installation-tasks.adoc
@@ -3,75 +3,17 @@
 = Completing post installation tasks
 
 [role="_abstract"]
+
 After you have completed the installation of {PlatformNameShort}, ensure that {HubName} and {ControllerName} deploy properly.
 
+Before your first login, you must add your subscription information to the platform. To obtain your subscription information in uploadable form, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#assembly-aap-obtain-manifest-files[Obtaining a manifest file] in the Access management and authentication guide.
 
-== Adding a controller subscription
+Once you have obtained your subscription manifest, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/getting_started/with/Ansible_automation_platform[{TitleGettingStarted}] for instructions on how to upload your subscription information.
 
+Now that you have successfully installed Ansible Automation Platform, to begin using its features, see the following guides for your next steps:
 
+link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/getting_started/with/Ansible_automation_platform[{TitleGettingStarted}]
 
-.Procedure
+link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/managing_content_in_automation_hub/index[Managing content in automation hub]
 
-. Navigate to the FQDN of the {ControllerNameStart}. Log in with the username admin and the password you specified as `admin_password` in your inventory file.
-
-. Click btn:[Browse] and select the __manifest.zip__ you created earlier.
-
-. Click btn:[Next].
-
-. Uncheck btn:[User analytics] and btn:[Automation analytics]. These rely on an internet connection and must be turned off.
-
-. Click btn:[Next].
-
-. Read the End User License Agreement and click btn:[Submit] if you agree.
-
-== Updating the CA trust store
-
-As part of your post-installation tasks, you must update the software's certificates.
-By default, {PlatformNameShort} {HubName} and {ControllerName} are installed using self-signed certificates. Because of this, the controller does not trust the hub’s certificate and will not download the {ExecEnvShort} from the hub. 
-
-To ensure that automation controller downloads the execution environment from automation hub, you must import the hub’s Certificate Authority (CA) certificate as a trusted certificate on the controller. You can do this in one of two ways, depending on whether SSH is available as root user between {ControllerName} and {PrivateHubName}. 
-
-=== Using secure copy (SCP) as a root user
-
-If SSH is available as the root user between the controller and {PrivateHubName}, use SCP to copy the root certificate on the {PrivateHubName} to the controller.
-
-
-.Procedure
-
- . Run `update-ca-trust` on the controller to update the CA trust store:
-
-----
-$ sudo -i
-# scp <hub_fqdn>:/etc/pulp/certs/root.crt
-/etc/pki/ca-trust/source/anchors/automationhub-root.crt
-# update-ca-trust
-----
-
-=== Copying and pasting as a non root user
-
-If SSH is unavailable as root between the {PrivateHubName} and the controller, copy the contents of the file __/etc/pulp/certs/root.crt__ on the {PrivateHubName} and paste it into a new file on the controller called __/etc/pki/ca-trust/source/anchors/automationhub-root.crt__. 
-
-.Procedure
-
-. Run `update-ca-trust` to update the CA trust store with the new certificate. On the {PrivateHubName}, run:
-
-----
-$ sudo -i
-# cat /etc/pulp/certs/root.crt
-(copy the contents of the file, including the lines with 'BEGIN CERTIFICATE' and
-'END CERTIFICATE')
-----
-
-. On the {ControllerName}:
-
-----
-$ sudo -i
-# vi /etc/pki/ca-trust/source/anchors/automationhub-root.crt
-(paste the contents of the root.crt file from the private automation hub into the new file and write to disk)
-# update-ca-trust
-----
-
-
-.Additional Resources
-
-* For further information on unknown certificate authority, see link:https://access.redhat.com/solutions/6707451[Project sync fails with unknown certificate authority error in {PlatformNameShort} 2.1].
+link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/creating_and_consuming_execution_environments/index[Creating and consuming execution environments]

--- a/downstream/modules/platform/proc-completing-post-installation-tasks.adoc
+++ b/downstream/modules/platform/proc-completing-post-installation-tasks.adoc
@@ -8,12 +8,12 @@ After you have completed the installation of {PlatformNameShort}, ensure that {H
 
 Before your first login, you must add your subscription information to the platform. To obtain your subscription information in uploadable form, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#assembly-aap-obtain-manifest-files[Obtaining a manifest file] in the Access management and authentication guide.
 
-Once you have obtained your subscription manifest, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/getting_started/with/Ansible_automation_platform[{TitleGettingStarted}] for instructions on how to upload your subscription information.
+Once you have obtained your subscription manifest, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/getting_started/with/Ansible_automation_platform[{TitleGettingStarted}] for instructions on how to upload your subscription information.
 
 Now that you have successfully installed Ansible Automation Platform, to begin using its features, see the following guides for your next steps:
 
-link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/getting_started/with/Ansible_automation_platform[{TitleGettingStarted}]
+link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/getting_started/with/Ansible_automation_platform[{TitleGettingStarted}]
 
-link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/managing_content_in_automation_hub/index[Managing content in automation hub]
+link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/managing_content_in_automation_hub/index[Managing content in automation hub]
 
-link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/creating_and_consuming_execution_environments/index[Creating and consuming execution environments]
+link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/creating_and_consuming_execution_environments/index[Creating and consuming execution environments]

--- a/downstream/modules/platform/proc-completing-post-installation-tasks.adoc
+++ b/downstream/modules/platform/proc-completing-post-installation-tasks.adoc
@@ -6,7 +6,7 @@
 
 After you have completed the installation of {PlatformNameShort}, ensure that {HubName} and {ControllerName} deploy properly.
 
-Before your first login, you must add your subscription information to the platform. To obtain your subscription information in uploadable form, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#assembly-aap-obtain-manifest-files[Obtaining a manifest file] in the Access management and authentication guide.
+Before your first login, you must add your subscription information to the platform. To obtain your subscription information in uploadable form, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/red_hat_ansible_automation_platform_operations_guide/assembly-aap-obtain-manifest-files#assembly-aap-obtain-manifest-files[Obtaining a manifest file] in the Access management and authentication guide.
 
 Once you have obtained your subscription manifest, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/getting_started/with/Ansible_automation_platform[{TitleGettingStarted}] for instructions on how to upload your subscription information.
 

--- a/downstream/modules/platform/proc-creating-a-new-web-server-to-host-repositories.adoc
+++ b/downstream/modules/platform/proc-creating-a-new-web-server-to-host-repositories.adoc
@@ -57,7 +57,7 @@ $ sudo firewall-cmd --zone=public --add-service=http –add-service=https --perm
 $ sudo firewall-cmd --reload
 ----
 
-. On {ControllerName} and {HubName}, add a repo file at __/etc/yum.repos.d/local.repo__, and add the optional repos if needed:
+. On automation services, add a repo file at __/etc/yum.repos.d/local.repo__, and add the optional repos if needed:
 +
 ----
 [Local-BaseOS]

--- a/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
+++ b/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
@@ -11,7 +11,7 @@ Choose the setup bundle to download {PlatformNameShort} for disconnected install
 
 .Procedure
 
-. Download the {PlatformNameShort} setup bundle package by navigating to the link:https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software{PlatformDownloadUrl}[{PlatformName} download] page and clicking btn:[Download Now] for the {PlatformNameShort} {PlatformVers} Setup Bundle.
+. Download the {PlatformNameShort} setup bundle package by navigating to the link:{PlatformDownloadUrl}[{PlatformName} download] page and clicking btn:[Download Now] for the {PlatformNameShort} {PlatformVers} Setup Bundle.
 
 . On control node, untar the bundle:
 +

--- a/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
+++ b/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
@@ -5,76 +5,25 @@
 = Downloading and installing the {PlatformNameShort} setup bundle
 
 [role="_abstract"]
+
 Choose the setup bundle to download {PlatformNameShort} for disconnected installations. This bundle includes the RPM content for {PlatformNameShort} and the default {ExecEnvShort} images that will be uploaded to your {PrivateHubName} during the installation process.
 
 
 .Procedure
 
-. Download the {PlatformNameShort} setup bundle package by navigating to the link:{PlatformDownloadUrl}[{PlatformName} download] page and clicking btn:[Download Now] for the {PlatformNameShort} {PlatformVers} Setup Bundle.
+. Download the {PlatformNameShort} setup bundle package by navigating to the link:https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software{PlatformDownloadUrl}[{PlatformName} download] page and clicking btn:[Download Now] for the {PlatformNameShort} {PlatformVers} Setup Bundle.
 
-. From {ControllerName}, untar the bundle:
+. On control node, untar the bundle:
 +
 ----
 $ tar xvf \
-   ansible-automation-platform-setup-bundle-2.4-1.tar.gz
-$ cd ansible-automation-platform-setup-bundle-2.4-1
+   ansible-automation-platform-setup-bundle-2.5-1.tar.gz
+$ cd ansible-automation-platform-setup-bundle-2.5-1
 ----
 +
-. Edit the inventory file to include the required options:
-
-.. automationcontroller group
-.. automationhub group
-.. admin_password
-.. pg_password
-.. automationhub_admin_password
-.. automationhub_pg_host, automationhub_pg_port
-.. automationhub_pg_password
-+
-*Example Inventory file*
-+
-----
-[automationcontroller]
-automationcontroller.example.org ansible_connection=local
-
-[automationcontroller:vars]
-peers=execution_nodes
-
-[automationhub]
-automationhub.example.org
-
-[all:vars]
-admin_password='password123'
-
-pg_database='awx'
-pg_username='awx'
-pg_password='dbpassword123'
-
-receptor_listener_port=27199
-
-automationhub_admin_password='hubpassword123'
-
-automationhub_pg_host='automationcontroller.example.org'
-automationhub_pg_port=5432
-
-automationhub_pg_database='automationhub'
-automationhub_pg_username='automationhub'
-automationhub_pg_password='dbpassword123'
-automationhub_pg_sslmode='prefer'
-----
-+
-. Run the {PlatformNameShort} setup bundle executable as the root user:
-+
-----
-$ sudo -i
-# cd /path/to/ansible-automation-platform-setup-bundle-2.4-1
-# ./setup.sh
-----
-+
-. When installation is complete, navigate to the Fully Qualified Domain Name (FQDN) for the {ControllerName} node that was specified in the installation inventory file.
-
-. Log in using the administrator credentials specified in the installation inventory file.
+. Edit the inventory file to include variables based on your host names and desired password values.
 
 [NOTE]
 ====
-The inventory file must be kept intact after installation because it is used for backup, restore, and upgrade functions. Keep a backup copy in a secure location, given that the inventory file contains passwords.
+See section link:https://docs.google.com/document/d/1fIrlSrj8bSSWBVptXWmm0ZFixhZ4mM5pW2CQx_3Oh7A/edit#heading=h.tevmra11zce4[3.2 Inventory file examples base on installation scenarios] for a list of examples that best fits your scenario.
 ====

--- a/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
+++ b/downstream/modules/platform/proc-installing-the-aap-setup-bundle.adoc
@@ -25,5 +25,5 @@ $ cd ansible-automation-platform-setup-bundle-2.5-1
 
 [NOTE]
 ====
-See section link:https://docs.google.com/document/d/1fIrlSrj8bSSWBVptXWmm0ZFixhZ4mM5pW2CQx_3Oh7A/edit#heading=h.tevmra11zce4[3.2 Inventory file examples base on installation scenarios] for a list of examples that best fits your scenario.
+See section xref:con-install-scenario-examples[3.2 Inventory file examples base on installation scenarios] for a list of examples that best fits your scenario.
 ====

--- a/downstream/modules/platform/proc-synchronizing-rpm-repositories-by-using-reposync.adoc
+++ b/downstream/modules/platform/proc-synchronizing-rpm-repositories-by-using-reposync.adoc
@@ -25,19 +25,13 @@ To perform a reposync you need a RHEL host that has access to the internet. Afte
     -p /path/to/download
 ----
 
-.. Use reposync with `--download-metadata` and without `--newest-only`. See link://https://access.redhat.com/solutions/5186621[RHEL 8] Reposync.
+... Use reposync with `--download-metadata` and without `--newest-only`. See link://https://access.redhat.com/solutions/5186621[RHEL 8] Reposync.
 
 * If you are not using `--newest-only,` the repos downloaded will be ~90GB.
 
 * If you are using `--newest-only,` the repos downloaded will be ~14GB.
 
-. If you plan to use {RHSSO}, sync these repositories:
-
-.. jb-eap-7.3-for-rhel-8-x86_64-rpms
-.. rh-sso-7.4-for-rhel-8-x86_64-rpms
-
 +
 After the reposync is completed, your repositories are ready to use with a web server.
-
 
 . Move the repositories to your disconnected network.


### PR DESCRIPTION
Commented out several sections due to obsolescence. Made edits to update version numbers, context, system requirements, etc.

These changes were made due to the new installation methods which simplify both installation in a connected, and disconnected network.

Partially resolves: AAP-30807