### PR TITLE
[Backport] Removing TBDs from Controller docs (#1867)

### DIFF
--- a/downstream/assemblies/platform/assembly-ag-controller-usability-analytics.adoc
+++ b/downstream/assemblies/platform/assembly-ag-controller-usability-analytics.adoc
@@ -11,8 +11,9 @@ Only users installing a trial of or a fresh installation of are opted-in for thi
 //You can opt out or control the way {ControllerName} collects data by setting your participation level in the *User Interface settings* in the {MenuAEAdminSettings} menu.
 
 //Should Settings menu be a link?
+For information on setting up {Analytics}, see xref:proc-controller-configure-analytics[Configuring {Analytics}].
 
-include::platform/proc-controller-control-data-collection.adoc[leveloffset=+1]
+//include::platform/proc-controller-control-data-collection.adoc[leveloffset=+1]
 include::platform/ref-controller-automation-analytics.adoc[leveloffset=+1]
 include::platform/ref-controller-use-by-organization.adoc[leveloffset=+2]
 include::platform/ref-controller-jobs-run-by-organization.adoc[leveloffset=+2]

--- a/downstream/assemblies/platform/assembly-controller-secret-management.adoc
+++ b/downstream/assemblies/platform/assembly-controller-secret-management.adoc
@@ -23,7 +23,7 @@ These external secret values are fetched before running a playbook that needs th
 
 .Additional resources
 
-For more information about specifying secret management system credentials in the user interface, see TBD[Managing user credentials].
+For more information about specifying secret management system credentials in the user interface, see xref:controller-credentials[Managing user credentials].
 
 include::platform/proc-controller-configure-secret-lookups.adoc[leveloffset=+1]
 include::platform/ref-controller-metadata-credential-input.adoc[leveloffset=+2]

--- a/downstream/modules/platform/con-controller-overview-details.adoc
+++ b/downstream/modules/platform/con-controller-overview-details.adoc
@@ -24,7 +24,7 @@ If you want to give any user or team permissions to use a job template, you can 
 An auditor is useful for a service account that scrapes automation information from the REST API.
 
 .Additional resources
-* For more information about user roles, see TBD[Role-Based Access Controls].
+* For more information about user roles, see link:{URLCentralAuth}/index#gw-managing-access[Managing access with role based access control].
 
 = Cloud and autoscaling flexibility
 {ControllerNameStart} includes a powerful optional provisioning callback feature that enables nodes to request configuration on-demand.

--- a/downstream/modules/platform/con-controller-role-based-access-controls.adoc
+++ b/downstream/modules/platform/con-controller-role-based-access-controls.adoc
@@ -12,6 +12,6 @@ You must have `execute` access to a job template to add it to a workflow job tem
 You can also perform other tasks, such as making a duplicate copy or re-launching a workflow, depending on which permissions are granted to a user. 
 You must have permissions to all the resources used in a workflow, such as job templates, before relaunching or making a copy.
 
-For more information, see TBD[Role-based access controls].
+For more information, see link:link:{URLCentralAuth}/index#gw-managing-access[Managing access with role based access control].
 
 For more information on performing the tasks described in this section, see xref:controller-workflow-job-templates[Workflow job templates].

--- a/downstream/modules/platform/proc-controller-configure-analytics.adoc
+++ b/downstream/modules/platform/proc-controller-configure-analytics.adoc
@@ -2,7 +2,7 @@
 
 = Configuring {Analytics}
 
-Configure {Analytics} on the *Subscription* page and the *System Settings* page of the *Settings* menu.
+When you imported your license for the first time, you were automatically opted in for the collection of data that powers {Analytics}, a cloud service that is part of the {PlatformNameShort} subscription.
 
 .Procedure
 . From the navigation panel, select {MenuSetSubscription}.
@@ -13,16 +13,18 @@ image::automation_analytics.png[Automation analytics page]
 
 . From the navigation panel, select {MenuSetSystem}.
 . Click btn:[Edit].
-. On the *System Settings* page, select *Gather data for {Analytics}*.
+. Toggle the *Gather data for {Analytics}* switch and enter your Red Hat customer credentials.
 . You can also configure the following options:
-
++
 * *Red Hat Customer Name*: This username is used to send data to {Analytics}.
 * *Red Hat Customer Password*: This password is used to send data to {Analytics}.
 * *Red Hat or Satellite Username*: This username is used to send data to {Analytics}.
 * *Red Hat or Satellite password*: This password is used to send data to {Analytics}.
 * *Last gather date for Automation Analytics*: Set the date and time
 * *Automation Analytics Gather Interval*: Interval (in seconds) between data gathering.
-//No tooltip and no information for this.
-* *Last gathered entries from the data collection service of {Analytics}*: TBD
++
+. Click btn:[Save].
+//This field has been removed.
+//* *Last gathered entries from the data collection service of {Analytics}*: TBD
 
 

--- a/downstream/modules/platform/proc-controller-importing-subscriptions.adoc
+++ b/downstream/modules/platform/proc-controller-importing-subscriptions.adoc
@@ -3,6 +3,18 @@
 = Importing a subscription
 
 After you have obtained an authorized {PlatformNameShort} subscription, you must import it into the {ControllerName} system before you can use {ControllerName}.
+
+[NOTE]
+====
+You are opted in for {Analytics} by default when you activate the {ControllerName} on first time log in. This helps Red Hat improve the product by delivering you a much better user experience. You can opt out, by doing the following: 
+. From the navigation panel, select menu:Settings[] and select the *Miscellaneous System settings* option.
+. Click btn:[Edit].
+. Toggle the *Gather data for Automation Analytics* switch to the off position.
+. Click btn:[Save].
+For opt-in of {Analytics} to be effective, your instance of {ControllerName} must be running on {RHEL}. 
+For more information, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_administration_guide/index#ref-controller-automation-analytics[{Analytics}] section.
+====
+
 .Prerequisites
 
 * You have obtained a subscriptions manifest. 
@@ -34,25 +46,26 @@ After you enter your credentials, click btn:[Get Subscriptions].
 Then, it prompts you to select the subscription that you want to run and applies that metadata to {ControllerName}. 
 You can log in over time and retrieve new subscriptions if you have renewed.
 +
-. Click btn:[Next] to proceed to the *Tracking and Insights* page. 
-+
-Tracking and insights collect data to help Red Hat improve the product and deliver a better user experience. 
+. Click btn:[Next] to proceed to the End User Agreement.
+//[ddacosta - removed analytics selection for AAP-30863 and AAP-29909] to proceed to the *Tracking and Insights* page. 
+//+
+//Tracking and insights collect data to help Red Hat improve the product and deliver a better user experience. 
 //For more information about data collection, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_administration_guide/index#controller-usability-analytics-data-collection[Usability Analytics and Data Collection] of the _{ControllerAG}_.
-+ 
-This option is checked by default, but you can opt out of any of the following:
+//+ 
+//This option is checked by default, but you can opt out of any of the following:
 
 //* *User analytics*. Collects data from the controller UI.
-* *Insights Analytics*. Provides a high level analysis of your automation with {ControllerName}. 
-It helps you to identify trends and anomalous use of the controller. 
-For opt-in of {Analytics} to be effective, your instance of {ControllerName} must be running on {RHEL}. 
-For more information, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_administration_guide/index#ref-controller-automation-analytics[{Analytics}] section. TBD
-+
-[NOTE]
-====
-You can change your analytics data collection preferences at any time.
-====
-+
-. After you have specified your tracking and Insights preferences, click btn:[Next] to proceed to the End User Agreement.
+//* *Insights Analytics*. Provides a high level analysis of your automation with {ControllerName}. 
+//It helps you to identify trends and anomalous use of the controller. 
+//For opt-in of {Analytics} to be effective, your instance of {ControllerName} must be running on {RHEL}. 
+//For more information, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/configuring_automation_execution/index#ref-controller-automation-analytics[{Analytics}] section of _{ControllerAG}_.
+//+
+//[NOTE]
+//====
+//You can change your analytics data collection preferences at any time.
+//====
+//+
+//. After you have specified your tracking and Insights preferences, click btn:[Next] 
 . Review and check the *I agree to the End User License Agreement* checkbox and click btn:[Submit].
 +
 After your subscription is accepted, {ControllerName} displays the subscription details and opens the Dashboard. 

--- a/downstream/modules/platform/proc-controller-view-host.adoc
+++ b/downstream/modules/platform/proc-controller-view-host.adoc
@@ -13,8 +13,8 @@ The *Hosts* page displays the following information about the host or hosts affe
 
 * The *Name* of the Host. 
 * The *Inventory* associated with that host. Selecting this inventory displays details of the inventory.
-* When the Host was *Created* and who by. Selecting the creator displays TBD
-* When the Host was *Last Modified*. Selecting the creator displays TBD
+* When the Host was *Created* and who by. Selecting the creator displays details of the creator.
+* When the Host was *Last Modified*. Selecting the creator displays details of the creator.
 * *Variables* associated with the Host. You can display the variables in YAML or JSON format.
 
 . Click btn:[Edit host] to edit details of the host.

--- a/downstream/modules/platform/ref-controller-analytics-reports.adoc
+++ b/downstream/modules/platform/ref-controller-analytics-reports.adoc
@@ -1,25 +1,34 @@
 [id="ref-controller-analytics-reports"]
 
 = Analytics Reports
+//[ddacosta - removed to reflect current environment but this might be updated in the product later and this statement could be added back.]
+//Reports from collection are accessible through the {ControllerName} UI if you have superuser-level permissions.
+//By including the analytics view on-prem where it is most convenient, you can access data that can affect your day-to-day work.
+//This data is aggregated from the automation provided on link:https://console.redhat.com[{Console}].
 
-Reports from collection are accessible through the {ControllerName} UI if you have superuser-level permissions.
-By including the analytics view on-prem where it is most convenient, you can access data that can affect your day-to-day work.
-This data is aggregated from the automation provided on link:https://console.redhat.com[{Console}].
+Reports for data collected are available through link:https://console.redhat.com[{Console}].
 
-Currently available is a view-only version of the Automation Calculator utility that shows a report that represents (possible) savings to the subscriber.
+Other {Analytics} data currently available and accessible through the platform UI include the following:
+
+*Automation Calculator* is a view-only version of the Automation Calculator utility that shows a report that represents (possible) savings to the subscriber.
 
 image:aa-automation-calculator.png[Automation calculator]
 
-[NOTE]
-====
-This option is available for technical preview and is subject to change in a future release.
-To preview the analytic reports view, set the *Enable Preview of New User Interface* toggle to *On* from the *Miscellaneous System Settings* option of the {MenuAEAdminSettings} menu.
+*Host Metrics* is an analytics report collected for host data such as, when they were first automated, when they were most recently automated, how many times they were automated, and how many times each host has been deleted.
 
-After saving, logout and log back in to access the options under the *Analytics* section on the navigation panel.
+*Subscription Usage* reports the historical usage of your subscription. Subscription capacity and licenses consumed per month are displayed, with the ability to filter by the last year, two years, or three years.
 
-image:aa-options-navbar.png[Navigation panel]
-====
+//I don't think this is included
+//[NOTE]
+//====
+//This option is available for technical preview and is subject to change in a future release.
+//To preview the analytic reports view, set the *Enable Preview of New User Interface* toggle to *On* from the *Miscellaneous System Settings* option of the {MenuAEAdminSettings} menu.
 
-Host Metrics is another analytics report collected for host data.
-The ability to access this option from this part of the UI is currently in tech preview and is subject to change in a future release.
-For more information, see the _Host Metrics view_ in xref:controller-config[{ControllerNameStart} configuration].
+//After saving, logout and log back in to access the options under the *Analytics* section on the navigation panel.
+
+//image:aa-options-navbar.png[Navigation panel]
+//====
+
+//Host Metrics is another analytics report collected for host data.
+//The ability to access this option from this part of the UI is currently in tech preview and is subject to change in a future release.
+//For more information, see the _Host Metrics view_ in xref:controller-config[{ControllerNameStart} configuration].

--- a/downstream/modules/platform/ref-controller-automation-analytics.adoc
+++ b/downstream/modules/platform/ref-controller-automation-analytics.adoc
@@ -2,7 +2,7 @@
 
 = {Analytics}
 
-When you imported your license for the first time, you were given options related to the collection of data that powers {Analytics}, a cloud service that is part of the {PlatformNameShort} subscription.
+When you imported your license for the first time, you were automatically opted in for the collection of data that powers {Analytics}, a cloud service that is part of the {PlatformNameShort} subscription.
 
 [IMPORTANT]
 ====
@@ -12,15 +12,7 @@ For opt-in of {Analytics} to have any effect, your instance of {ControllerName} 
 As with Red Hat Insights, {Analytics} is built to collect the minimum amount of data needed.
 No credential secrets, personal data, automation variables, or task output is gathered.
 
-For more information, see xref:ref-controller-data-collection-details[Details of data collection].
-
-To enable this feature, turn on data collection for {Analytics} and enter your Red Hat customer credentials in the *Miscellaneous System settings* of the System configuration list of options in the {MenuAEAdminSettings} menu.
-
-image:configure-controller-system-misc-analytics.png[Miscellaneous System Settings]
-
-You can view the location to which the collection of insights data is uploaded in the *{Analytics} upload URL* field on the *Details* page.
-
-image:misc-system-details-analytics-url.png[Insights location]
+When you imported your license for the first time, you were automatically opted in to {Analytics}. To configure or disable this feature, see xref:proc-controller-configure-analytics[Configuring {Analytics}].
 
 By default, the data is collected every four hours.
 When you enable this feature, data is collected up to a month in arrears (or until the previous collection).
@@ -34,7 +26,7 @@ This setting can also be enabled through the API by specifying `INSIGHTS_TRACKIN
 
 The {Analytics} generated from this data collection can be found on the link:https://cloud.redhat.com[Red Hat Cloud Services] portal.
 
-image:aa-dashboard.png[Analytics dashboard]
+//image:aa-dashboard.png[Analytics dashboard]
 
 *Clusters* data is the default view.
 This graph represents the number of job runs across all {ControllerName} clusters over a period of time.
@@ -53,3 +45,8 @@ On the clouds navigation panel, select menu:Organization Statistics[] to view in
 * xref:ref-controller-use-by-organization[Use by organization]
 * xref:ref-controller-jobs-run-by-organization[Job runs by organization]
 * xref:ref-controller-organization-status[Organization status]
+
+[NOTE]
+====
+The organization statistics page will be deprecated in a future release.
+====

--- a/downstream/modules/platform/ref-controller-content-sourcing.adoc
+++ b/downstream/modules/platform/ref-controller-content-sourcing.adoc
@@ -28,6 +28,6 @@ The organization's *Add* and *Edit* windows have an optional *Credential* lookup
 image:organizations-galaxy-credentials.png[Create organization]
 
 It is important to specify the order of these credentials as order sets precedence for the sync and lookup of the content. 
-For more information, see TBD[Creating an organization]. 
+For more information, see link:{URLCentralAuth}/index#proc-controller-create-organization[Creating an organization]. 
 
 For more information about how to set up a project by using collections, see xref:proc-projects-using-collections-with-hub[Using Collections with {HubName}].

--- a/downstream/titles/controller/controller-admin-guide/master.adoc
+++ b/downstream/titles/controller/controller-admin-guide/master.adoc
@@ -52,8 +52,6 @@ include::platform/assembly-controller-awx-manage-utility.adoc[leveloffset=+1]
 //include::platform/assembly-ag-controller-session-limits.adoc[leveloffset=+1]
 include::platform/assembly-ag-controller-backup-and-restore.adoc[leveloffset=+1]
 //section 28 is a replica of section 18.4.2, so removing it
-//Uses Settings menu. Which may be separate documentation.
-//Usability analytics is no longer supported.
-//include::platform/assembly-ag-controller-usability-analytics.adoc[leveloffset=+1]
+include::platform/assembly-ag-controller-usability-analytics.adoc[leveloffset=+1]
 include::platform/assembly-ag-controller-troubleshooting.adoc[leveloffset=+1]
 include::platform/assembly-ag-controller-tips-and-tricks.adoc[leveloffset=+1]

--- a/downstream/titles/controller/controller-user-guide/master.adoc
+++ b/downstream/titles/controller/controller-user-guide/master.adoc
@@ -21,9 +21,11 @@ For more information about these and other Ansible concepts, see the link:https:
 include::{Boilerplate}[]
 
 include::platform/assembly-UG-overview.adoc[leveloffset=+1]
-include::platform/assembly-controller-licensing.adoc[leveloffset=+1]
+//Moved to Access management doc
+//include::platform/assembly-controller-licensing.adoc[leveloffset=+1]
 include::platform/assembly-controller-login.adoc[leveloffset=+1]
-include::platform/assembly-controller-managing-subscriptions.adoc[leveloffset=+1]
+//Moved to Access management doc
+//include::platform/assembly-controller-managing-subscriptions.adoc[leveloffset=+1]
 //Rewritten for 2.5
 include::platform/assembly-controller-user-interface.adoc[leveloffset=+1]
 include::platform/assembly-controller-search.adoc[leveloffset=+1]
@@ -56,7 +58,7 @@ include::platform/assembly-controller-instances.adoc[leveloffset=+1]
 include::platform/assembly-controller-execution-environments.adoc[leveloffset=+1]
 include::platform/assembly-controller-ee-setup-reference.adoc[leveloffset=+1]
 //Moved to Donna's Access management document
-//include::platform/assembly-controller-organizations.adoc[leveloffset=+1
+//include::platform/assembly-controller-organizations.adoc[leveloffset=+1]
 //include::platform/assembly-controller-users.adoc[leveloffset=+1]
 //include::platform/assembly-controller-teams.adoc[leveloffset=+1]
 //Possibly in Donna's credentials document


### PR DESCRIPTION
This PR backports the changes from #1867 to the 2.5 branch and includes the following:

* Removing TBDs from Controller docs

Remove TBDs from Controller documentation

https://issues.redhat.com/browse/AAP-30985

* Removing TBDs from Controller docs

Added link

Remove TBDs from Controller documentation

https://issues.redhat.com/browse/AAP-30985

* Removing TBDs from Controller docs

Added Analytics back to Configuring AE

Remove TBDs from Controller documentation

https://issues.redhat.com/browse/AAP-30985

* Adding changes to Ian's PR-1867 in his absence

---------