### PR TITLE
AAP-30716 Add YAML separator in devtools example

### DIFF
--- a/downstream/modules/devtools/proc-devtools-writing-first-playbook.adoc
+++ b/downstream/modules/devtools/proc-devtools-writing-first-playbook.adoc
@@ -18,6 +18,7 @@ The instructions below describe how {ToolsName} help you to create and run your 
 The playbook consists of a single play that executes a `ping` to your local machine. 
 +
 ----
+---
 - name: My first play
   hosts: localhost
   tasks:
@@ -31,3 +32,4 @@ There are no errors in this playbook:
 +
 image::ansible-lint-no-errors.png[Ansible-lint showing no errors in a playbook]
 . Save your playbook file.
+


### PR DESCRIPTION
AAP-30716 Add YAML separator in devtools example
Affects `titles/develop-automation-content/`