### PR TITLE
AAP-30415 Describe Ansible language file association in VSCode extension

### DIFF
--- a/downstream/assemblies/devtools/assembly-devtools-install.adoc
+++ b/downstream/assemblies/devtools/assembly-devtools-install.adoc
@@ -18,6 +18,7 @@ include::devtools/proc-devtools-setup-registry-redhat-io.adoc[leveloffset=+2]
 include::devtools/proc-devtools-install-vsc.adoc[leveloffset=+1]
 include::devtools/proc-devtools-install-vscode-extension.adoc[leveloffset=+1]
 include::devtools/proc-devtools-extension-settings.adoc[leveloffset=+1]
+include::devtools/proc-devtools-extension-set-language.adoc[leveloffset=+1]
 include::devtools/proc-devtools-install-container.adoc[leveloffset=+1]
 include::devtools/proc-devtools-install-rpm.adoc[leveloffset=+1]
 

--- a/downstream/modules/devtools/proc-devtools-extension-set-language.adoc
+++ b/downstream/modules/devtools/proc-devtools-extension-set-language.adoc
@@ -1,0 +1,43 @@
+[id="devtools-extension-set-language_{context}"]
+
+= Associating the Ansible language to YAML files
+
+[role="_abstract"]
+
+The Ansible {VSCode} extension works only when the language associated with a file is set to Ansible.
+The extension provides features that help create Ansible playbooks, such as auto-completion, hover, and diagnostics.
+
+The Ansible {VSCode} extension automatically associates the Ansible language with some files.
+The procedures below describe how to set the language for files that are not recognized as Ansible files.
+
+.Manually associating the Ansible language to YAML files
+
+The following procedure describes how to manually assign the Ansible language to a YAML file that is open in {VSCode}.
+
+. Open or create a YAML file in {VSCode}.
+. Hover the cursor over the language identified in the status bar at the bottom of the {VSCode} window to open the *Select Language Mode* list.
+. Select *Ansible* in the list.
++
+The language shown in the status bar at the bottom of the {VSCode} window for the file is changed to Ansible.
+
+.Adding persistent file association for the Ansible language to `settings.json`
+
+Alternatively, you can add file association for the Ansible language in your `settings.json` file.
+
+. Open the `settings.json` file:
+.. Click menu:View[Command Palette] to open the command palette.
+.. Enter `Workspace settings` in the search box and select *Open Workspace Settings (JSON)*.
+. Add the following code to `settings.json`.
++
+----
+{
+  ...
+
+  "files.associations": {
+    "*plays.yml": "ansible",
+    "*init.yml": "yaml",
+  }
+}
+----
+
+

--- a/downstream/modules/devtools/proc-devtools-install-vscode-extension.adoc
+++ b/downstream/modules/devtools/proc-devtools-install-vscode-extension.adoc
@@ -18,11 +18,16 @@ To install the Ansible {VSCode} extension:
 . In the search field in the *Extensions* view, type `Ansible Red Hat`. 
 . Select the Ansible extension and click btn:[Install].
 
-.Verification
-
-When the Ansible extension is enabled, create or open a `.yml` file in VS Code. It can be an empty file.
-The  language identified for the .yml file is Ansible.
-It is displayed in the Status bar.
-
 When the language for a file is recognized as Ansible, the Ansible extension provides features such as auto-completion, hover, diagnostics, and goto.
+The language identified for a file is displayed in the Status bar at the bottom of the {VSCode} window.
+
+The following files are assigned the Ansible language:
+
+* YAML files in a `/playbooks` directory 
+* Files with the following double extension: `.ansible.yml` or `.ansible.yaml`
+* Certain YAML names recognized by Ansible, for example `site.yml` or `site.yaml`
+* YAML files whose filename contains "playbook": `*playbook*.yml` or `*playbook*.yaml`
+
+If the extension does not identify the language for your playbook files as Ansible, follow the procedure in 
+xref:devtools-extension-set-language_installing-devtools[Associating the Ansible language to YAML files].
 


### PR DESCRIPTION
AAP-30415
The Ansible VS Code extension requires the Ansible language to be associated with files.
Affects `/titles/develop-automation-content`