### PR TITLE
AAP-29296-D added platform gateway content to the planning guide

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-platform-components.adoc
+++ b/downstream/assemblies/platform/assembly-aap-platform-components.adoc
@@ -10,6 +10,8 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 {PlatformNameShort} is a modular platform composed of separate components that can be connected together to meet your deployment needs. {PlatformNameShort} deployments start with {ControllerName} which is the enterprise framework for controlling, securing, and managing Ansible automation with a user interface (UI) and RESTful application programming interface (API). Then, you can add to your deployment any combination of the following automation platform components:
 
+include::platform/con-about-platform-gateway.adoc[leveloffset=+1]
+
 include::platform/con-about-automation-hub.adoc[leveloffset=+1]
 
 include::platform/con-about-pa-hub.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-inventory-introduction.adoc
+++ b/downstream/assemblies/platform/assembly-inventory-introduction.adoc
@@ -70,6 +70,7 @@ The first part of the inventory file specifies the hosts or groups that Ansible 
 
 For more information on `registry_username` and `registry_password`, see {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/planning_your_installation/about_the_installer_inventory_file#about_the_installer_inventory_file[Setting registry_username and registry_password].
 
+include::snippets/snip-gateway-component-description.adoc[leveloffset=+1]
 include::platform/ref-guidelines-hosts-groups.adoc[leveloffset=+1]
 include::platform/ref-deprovisioning.adoc[leveloffset=+1]
 include::platform/con-inventory-variables-intro.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-about-platform-gateway.adoc
+++ b/downstream/modules/platform/con-about-platform-gateway.adoc
@@ -1,0 +1,15 @@
+[id="con-about-platform-gateway_{context}"]
+
+= Platform gateway
+
+[role="_abstract"]
+// content taken from snippets/snip-gateway-component-description.adoc and con-gw-activity-stream.adoc 
+Platform gateway is the service that handles authentication and authorization for the {PlatformNameShort}. It provides a single entry into the {PlatformNameShort} and serves the platform user interface so you can authenticate and access all of the {PlatformNameShort} services from a single location. For more information about the services available in the {PlatformNameShort}, refer to link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/getting_started_with_ansible_automation_platform/index#assembly-gs-key-functionality[Key functionality and concepts] in _{TitleGettingStarted}_.
+
+The platform gateway includes an activity stream that captures changes to gateway resources, such as the creation or modification of organizations, users, and service clusters, among others. For each change, the activity stream collects information about the time of the change, the user that initiated the change, the action performed, and the actual changes made to the object, when possible. The information gathered varies depending on the type of change.
+
+You can access the details captured by the activity stream from the API:
+
+-----
+/api/gateway/v1/activitystream/
+-----

--- a/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
+++ b/downstream/modules/platform/ref-guidelines-hosts-groups.adoc
@@ -31,10 +31,13 @@ If you use one value in `[database]` and both {ControllerName} and {HubNameMain}
 
 .{ControllerNameStart}
 * {ControllerNameStart} does not configure replication or failover for the database that it uses.
-* {ControllerName} works with any replication that you have.
+* {ControllerNameStart} works with any replication that you have.
 
 .{EDAcontroller}
 * {EDAcontroller} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
+
+.Platform gateway
+* The platform gateway is the service that handles authentication and authorization for {PlatformNameShort}. It provides a single entry into the platform and serves the platform’s user interface.
 
 .Clustered installations
 * When upgrading an existing cluster, you can also reconfigure your cluster to omit existing instances or instance groups. 


### PR DESCRIPTION
AAP-29296-B: child of [AAP-29296](https://issues.redhat.com/browse/AAP-29296)

Updated Planning guide with Platform gateway content. See [[WIP] v2.5 Red Hat Ansible Automation Platform planning guide](https://docs.google.com/document/d/1tCXiQxr0WspctajD7Hxwji9zsaOaPMl-WhRsB1sF-qs/edit).

Modified files:
- assembly-aap-platform-components.adoc
- assembly-inventory-introduction.adoc
- con-about-platform-gateway.adoc
- ref-guidelines-hosts-groups.adoc
