### PR TITLE
[2.5] AAP-30807: Edit 2.4 links (#1936)

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -10,7 +10,9 @@ ifdef::context[:parent-context: {context}]
 :context: platform-install-scenario
 
 [role="_abstract"]
-{PlatformNameShort} is a modular platform. You can deploy {ControllerName} with other components such as {HubName}, {EDAcontroller} and platform gateway. For more information about the components provided with {PlatformNameShort}, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#ref-platform-components[{PlatformName} components] in the {PlatformName} Planning Guide.
+{PlatformNameShort} is a modular platform. The platform gateway deploys automation platform components, such as {ControllerName}, {HubName}, and {EDAcontroller}. 
+
+For more information about the components provided with {PlatformNameShort}, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#ref-platform-components[{PlatformName} components] in link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/planning_your_installation[{TitlePlanningGuide}]. 
 
 There are several supported installation scenarios for {PlatformName}. To install {PlatformName}, you must edit the inventory file parameters to specify your installation scenario. You can use one of the following as a basis for your own inventory file:
 
@@ -18,6 +20,9 @@ There are several supported installation scenarios for {PlatformName}. To instal
 * xref:ref-gateway-controller-ext-db[Single platform gateway and {ControllerName} with an external (installer managed) database]
 * xref:ref-gateway-controller-hub-ext-db[Single platform gateway, {ControllerName}, and {HubName} with an external (installer managed) database]
 * xref:ref-gateway-controller-hub-eda-ext-db[Single platform gateway, {ControllerName}, {HubName}, and {EDAcontroller} node with an external (installer managed) database]
+
+.Additional resources
+For a comprehensive list of pre-defined variables used in Ansible installation inventory files, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-ansible-inventory-variables[A.6. Ansible variables].
 
 // Removed for install scenario consolidation AAP-17771
 // * xref:ref-single-controller-ext-installer-managed-db[Single {ControllerName} with external (installer managed) database]
@@ -71,6 +76,7 @@ include::hub/hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+3]
 
 include::platform/proc-running-setup-script.adoc[leveloffset=+1]
 include::platform/proc-verify-aap-installation.adoc[leveloffset=+1]
+include::platform/con-adding-subscription-manifest.adoc[leveloffset=+1]
 
 // Removing to consolidate AAP installation verification - you verify by logging into the gateway rather than logging into each component's UI - AAP-17771  
 // include::platform/proc-verify-controller-installation.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-adding-subscription-manifest.adoc
+++ b/downstream/modules/platform/con-adding-subscription-manifest.adoc
@@ -1,0 +1,7 @@
+[id="con-adding-subscription-manifest"]
+
+= Adding a subscription manifest to {PlatformNameShort}
+
+[role="_abstract"]
+
+Before you first log in, you must add your subscription information to the platform. To add a subscription to {PlatformNameShort}, see link:{URLAAPOperationsGuide}/index#assembly-aap-obtain-manifest-files[Obtaining a manifest file] in the Link:{LinkCentralAuth}. 

--- a/downstream/modules/platform/con-ha-hub-installation.adoc
+++ b/downstream/modules/platform/con-ha-hub-installation.adoc
@@ -26,9 +26,9 @@ automationhub_pg_port=5432
 * If installing a clustered setup, replace `localhost ansible_connection=local` in the [automationhub] section with the hostname or IP of all instances. For example:
 -----
 [automationhub]
-automationhub1.testing.ansible.com ansible_user=cloud-user ansible_host=192.0.2.18
-automationhub2.testing.ansible.com ansible_user=cloud-user ansible_host=192.0.2.20
-automationhub3.testing.ansible.com ansible_user=cloud-user ansible_host=192.0.2.22
+automationhub1.testing.ansible.com ansible_user=cloud-user
+automationhub2.testing.ansible.com ansible_user=cloud-user
+automationhub3.testing.ansible.com ansible_user=cloud-user
 -----
 
 [role="_additional-resources"]

--- a/downstream/modules/platform/con-install-scenario-recommendations.adoc
+++ b/downstream/modules/platform/con-install-scenario-recommendations.adoc
@@ -7,11 +7,9 @@ Before selecting your installation method for {PlatformNameShort}, review the fo
 
 // Removed for AAP-20847 and until such time as a decision is made regarding database support.
 //* Internal databases `[database]` are not supported. See the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_ansible_automation_platform_installation_guide/index[Containerized {PlatformName} Installation Guide] for further information on using the containerized installer for environments requiring a monolithc deployment. 
-* Do not install more than one component, for example {ControllerName} and {HubName}, on the same node for versions of {PlatformNameShort} in a production or customer environment.
-This can cause connection issues and heavy resource use.
 * Provide a reachable IP address or fully qualified domain name (FQDN) for the `[automationhub]` and `[automationcontroller]` hosts to ensure users can sync and install content from {HubName} from a different node.
 +
-The FQDN must not contain either the `-` or the `_` symbols, as it will not be processed correctly.
+The FQDN must not contain either the `-` or the `_` symbols, as it will not be processed correctly. 
 +
 Do not use `localhost`.
 * `admin` is the default user ID for the initial log in to {PlatformNameShort} and cannot be changed in the inventory file.

--- a/downstream/modules/platform/proc-running-setup-script.adoc
+++ b/downstream/modules/platform/proc-running-setup-script.adoc
@@ -5,11 +5,6 @@
 [role="_abstract"]
 After you update the inventory file with required parameters, run the installer setup script.
 
-[IMPORTANT]
-====
-You must have installed ansible-core {CoreUseVers} before using the installer setup script.
-====
-
 .Procedure
 
 * Run the `setup.sh` script
@@ -18,7 +13,19 @@ You must have installed ansible-core {CoreUseVers} before using the installer se
 $ sudo ./setup.sh
 -----
 
+[NOTE]
+====
+If you are running the setup as a non-root user with `sudo` privileges, you can use the following command:
+----
+$ ANSIBLE_BECOME_METHOD='sudo'
+ANSIBLE_BECOME=True ./setup.sh
+----
+====
+
 Installation of {PlatformName} will begin.
+
+.Additional resources
+See link:https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_privilege_escalation.html[Understanding privilege escalation] for additional `setup.sh` script examples.
 
 ifdef::mesh-VM[]
 If you want to add additional nodes to your {AutomationMesh} after the initial setup, edit the inventory file to add the new node, then rerun the `setup.sh` script.

--- a/downstream/modules/platform/proc-set-registry-username-password.adoc
+++ b/downstream/modules/platform/proc-set-registry-username-password.adoc
@@ -9,14 +9,15 @@ Registry service accounts provide named tokens that can be used in environments 
 .Procedure
 . Navigate to https://access.redhat.com/terms-based-registry/accounts
 . On the *Registry Service Accounts* page click btn:[New Service Account].
-. Enter a name for the account using only the accepted characters
+. Enter a name for the account using only the accepted characters.
 . Optionally enter a description for the account.
 . Click btn:[Create account].
 . Find the created account in the list. 
 The list of accounts is long so you might have to click btn:[Next] multiple times before finding the account you created. 
 Alternatively, if you know the name of your token, you can go directly to the page by entering the URL \https://access.redhat.com/terms-based-registry/token/<name-of-your-token>
 . Click the name of the account that you created. 
-. A token page opens, displaying a generated Username (different to the account name) and a token. 
+. A *token* page opens, displaying a generated Username (different to the account name) and a token. 
++
 If no Username and token are displayed, click btn:[Regenerate token]. You can also click this to generate a new Username and token.
 . Copy the service account name and use it to set `registry_username`.
 . Copy the token and use it to set `registry_password`.

--- a/downstream/modules/platform/proc-verify-aap-installation.adoc
+++ b/downstream/modules/platform/proc-verify-aap-installation.adoc
@@ -3,19 +3,12 @@
 = Verifying installation of {PlatformNameShort}
 
 [role="_abstract"]
-Verify that you installed {PlatformNameShort} successfully by logging in with the admin credentials you inserted in the inventory file.
-
-.Procedure
-. Go to the IP address specified for the platform gateway node in the inventory file.
-. Log in with the user ID `admin` and the password credentials you set in the inventory file.
-. Depending on the components you configured as part of your installation, you will see the following in the platform UI:
-.. For {ControllerName}, you will see *Automation Execution*.
-.. For {EDAName}, you will see *Automation Decisions*.
-.. For {HubName}, you will see *Automation Content*.
+Upon a successful login, your installation of {PlatformName} is complete.
 
 [IMPORTANT]
 ====
-If the installation fails and you are a customer who has purchased a valid license for {PlatformName}, contact Ansible through the link:https://access.redhat.com/[Red Hat Customer portal].
+If the installation fails and you are a customer who has purchased a valid license for {PlatformName}, contact Ansible through the link:https://docs.redhat.com/[Red Hat Customer portal].
 ====
 
-Upon a successful login, your installation of {PlatformName} is complete.
+.Additional resources
+See Link:{LinkGettingStarted} for post installation instructions.

--- a/downstream/modules/platform/ref-gateway-controller-ext-db.adoc
+++ b/downstream/modules/platform/ref-gateway-controller-ext-db.adoc
@@ -5,7 +5,7 @@
 
 
 [role="_abstract"]
-Use this example to populate the inventory file to deploy single instances of platform gateway and {ControllerName} with an external (installer managed) database.
+Use this example to see what is minimally needed within the inventory file to deploy single instances of platform gateway and {ControllerName} with an external (installer managed) database.
 
 -----
 [automationcontroller]
@@ -24,7 +24,7 @@ pg_port=5432
 pg_database='awx'
 pg_username='awx'
 pg_password='<password>'
-pg_sslmode='prefer'  # set to 'verify-full' for client-side enforced SSL
+pg_sslmode='prefer' # set to 'verify-full' for client-side enforced SSL
 
 registry_url='registry.redhat.io'
 registry_username='<registry username>'
@@ -33,7 +33,7 @@ registry_password='<registry password>'
 # Automation Gateway configuration
 automationgateway_admin_password=''
 
-automationgateway_pg_host=''
+automationgateway_pg_host='data.example.com'
 automationgateway_pg_port=5432
 
 automationgateway_pg_database='automationgateway'

--- a/downstream/modules/platform/ref-gateway-controller-hub-eda-ext-db.adoc
+++ b/downstream/modules/platform/ref-gateway-controller-hub-eda-ext-db.adoc
@@ -128,3 +128,5 @@ automationgateway_pg_sslmode='prefer'
 # automationedacontroller_ssl_key=/path/to/automationeda.key
 
 -----
+.Additional resources
+For more information about these inventory variables, refer to the link:{URLInstallationGuide}/index#ref-hub-variables[{HubNameMain} variables]. 


### PR DESCRIPTION
Backport for[ PR#1936](https://github.com/ansible/aap-docs/pull/1936)

Using [RPM installation 2.5 Draft](https://docs.google.com/document/d/1fIrlSrj8bSSWBVptXWmm0ZFixhZ4mM5pW2CQx_3Oh7A/edit#heading=h.iaypu8e8mkj4) as source of truth.

NOTE that I left out content from section Adding a safe variable plugin to Event-Driven Ansible controller. This section is part of [PR#1794](https://github.com/ansible/aap-docs/pull/1794/files) - content created by @jself-sudoku. To merge after this assembly has been successfully merged and backported.

[AAP-30807](https://issues.redhat.com/browse/AAP-30807) Converting platform/assembly-platform-install-scenario.adoc

Link to [2.5 install guide tracker](https://docs.google.com/spreadsheets/d/1APv4UzRGABm8ItMtTY6aiIcxWBtGU_sA/edit?gid=679299608#gid=679299608)