### PR TITLE
[Backport] AAP-30592 - Divide the Platform gateway settings into separate procedures by option (#1956)

### DIFF
--- a/downstream/assemblies/platform/assembly-gw-settings.adoc
+++ b/downstream/assemblies/platform/assembly-gw-settings.adoc
@@ -18,5 +18,11 @@ The other selections available from the *Settings* menu are specific to automati
 
 include::platform/proc-controller-configure-subscriptions.adoc[leveloffset=+1]
 include::platform/proc-settings-platform-gateway.adoc[leveloffset=+1]
+include::platform/proc-settings-gw-security-options.adoc[leveloffset=+2]
+include::platform/proc-settings-gw-session-options.adoc[leveloffset=+2]
+include::platform/proc-settings-gw-password-security.adoc[leveloffset=+2]
+include::platform/proc-settings-gw-custom-login.adoc[leveloffset=+2]
+include::platform/proc-settings-gw-additional-options.adoc[leveloffset=+2]
 include::platform/proc-settings-user-preferences.adoc[leveloffset=+1]
 include::platform/proc-settings-troubleshooting.adoc[leveloffset=+1]
+ 

--- a/downstream/modules/platform/proc-controller-configure-subscriptions.adoc
+++ b/downstream/modules/platform/proc-controller-configure-subscriptions.adoc
@@ -5,18 +5,13 @@
 You can use the *Subscription* menu to view the details of your subscription, such as compliance, host-related statistics, or expiry, or you can apply a new subscription.
 
 .Procedure
-. From the navigation panel, select {MenuSetSubscription}.
-The *Subscription* page is displayed.
-+
-image::settings_subscription_page.png[Initial subscriptions page]
+. From the navigation panel, select {MenuSetSubscription}. The *Subscription* page is displayed.
+//[ddacosta] - Removing images but they can be added back if requested.
+//image::settings_subscription_page.png[Initial subscriptions page]
 . Click btn:[Edit subscription].
 . You can either enter your Red Hat Username and Password, or attach a current Subscription Manifest in the *Welcome* page.
-+
-image::subscriptions_first-page.png[Suscriptions page for password or manifest]
-+ 
-. Click btn:[Next].
-The *{Analytics}* page is displayed.
-+
-image::automation_analytics.png[Automation analytics page]
-. Select the checkbox to use analytics data to enhance future releases of {PlatformNameShort} and to give the Red Hat insights service to subscribers.
+//[ddacosta] - Removing images but they can be added back if requested.
+//image::subscriptions_first-page.png[Suscriptions page for password or manifest]
 . Click btn:[Next] and agree to the terms of the license agreement.
+. Click btn:[Next] to review the subscription settings.
+. Click btn:[Finish] to complete the configuration.

--- a/downstream/modules/platform/proc-settings-gw-additional-options.adoc
+++ b/downstream/modules/platform/proc-settings-gw-additional-options.adoc
@@ -1,0 +1,32 @@
+[id="proc-settings-gw-other-options"]
+
+= Configuring additional platform options
+
+//Content divided into multiple procedures to address issue AAP-30592
+
+From the *Platform gateway settings* page, you can configure additional platform options.
+
+.Procedure
+. From the navigation panel, select {MenuSetGateway}.
+. The *Platform gateway settings* page is displayed. 
+. Click btn:[Edit platform gateway settings].
+. You can configure the following *Other settings*:
++
+* *JWT expiration buffer in seconds*: The number of seconds before a JWT token's expiration to revoke from the cache.
++
+When authentication happens a JWT token is created for the user and that token is cached. 
+When subsequent calls happen to services such as {ControllerName} or {EDAName}, the token is taken from the cache and sent to the service. 
+Both the token and the cache of the token have an expiration time. 
+If the token expires while in the cache the authentication process attempts results in a 401 error (unauthorized). 
+This setting gives {PlatformName} a buffer by removing the JWT token from the cache before the token expires. 
+When a token is revoked from cache a new token with a new expiration is generated and cached for the user. 
+As a result, expired tokens from the cache are never used. 
+This setting defaults to 2 seconds. 
+If you have a large latency between platform gateway and your services and observe 401 responses you must increase this setting to lower the number of 401 responses.
+* *Status endpoint backend timeout seconds*: Timeout (in seconds) for the status endpoint to wait when trying to connect to a backend.
+* *Allow auth2 for external users*: For security reasons, users from external authentication providers, such as LDAP, SAML, SSO, Radius, and others, are not allowed to create OAuth2 tokens. 
+To change this behavior, enable this setting. 
+Existing tokens are not deleted when this setting is turned off.
++
+. Click btn:[Save platform gateway settings] to save the changes or proceed to configure the other platform options available.
+

--- a/downstream/modules/platform/proc-settings-gw-custom-login.adoc
+++ b/downstream/modules/platform/proc-settings-gw-custom-login.adoc
@@ -1,0 +1,18 @@
+[id="proc-settings-gw-custom-login"]
+
+= Configuring a custom platform log in
+
+//Content divided into multiple procedures to address issue AAP-30592
+
+From the *Platform gateway settings* page, you can configure the custom log in options.
+
+.Procedure
+. From the navigation panel, select {MenuSetGateway}.
+. The *Platform gateway settings* page is displayed. 
+. To configure the options, click btn:[Edit platform gateway settings].
+. You can configure the following *Custom Login* options:
++
+* *Custom login info*: Provide specific information (such as a legal notice or a disclaimer) to a text box in the login modal. For example, you can include a company banner with a statement such as, “This is only to be used for `<COMPANY_NAME>`, etc.”
+* *Custom logo* : Provide an image file for setting up a custom logo (must be a data URL with a base64-encoded GIF, PNG, or JPEG image).
++
+. Click btn:[Save platform gateway settings] to save the changes or proceed to configure the other platform options available.

--- a/downstream/modules/platform/proc-settings-gw-password-security.adoc
+++ b/downstream/modules/platform/proc-settings-gw-password-security.adoc
@@ -1,0 +1,21 @@
+[id="proc-settings-gw-password-security"]
+
+= Configuring a platform password security policy
+
+//Content divided into multiple procedures to address issue AAP-30592
+
+From the *Platform gateway settings* page, you can configure a password security policy.
+
+.Procedure
+. From the navigation panel, select {MenuSetGateway}.
+. The *Platform gateway settings* page is displayed. 
+. To configure the options, click btn:[Edit platform gateway settings].
+. You can configure the following *Password Security* options:
++
+* *Password min upper*: How many uppercase characters need to be in a local password.
+* *Password min length*: The minimum length of a local password.
+* *Password min digits*: How many numerical characters need to be in a local password.
+* *Password min special*: How many special characters need to be in a local password.
++
+. Click btn:[Save platform gateway settings] to save the changes or proceed to configure the other platform options available.
+

--- a/downstream/modules/platform/proc-settings-gw-security-options.adoc
+++ b/downstream/modules/platform/proc-settings-gw-security-options.adoc
@@ -1,0 +1,50 @@
+[id="proc-settings-gw-security-options"]
+
+= Configuring platform security
+
+//Content divided into multiple procedures to address issue AAP-30592
+
+From the *Platform gateway settings* page, you can configure platform security settings.
+
+.Procedure
+. From the navigation panel, select {MenuSetGateway}.
+. The *Platform gateway settings* page is displayed. 
+. To configure the options, click btn:[Edit].
+. You can configure the following *Security* settings:
++
+* *Allow admin to set insecure*: Whether a superuser account can save an insecure password when editing any local user account.
+* *Platform gateway basic auth enabled*: Enable basic authentication to the platform gateway API.
++
+Turning this off prevents all basic authentication (local users), so customers need to make sure they have their alternative authentication mechanisms correctly configured before doing so. 
++
+Turning it off with only local authentication configured also prevents all access to the UI.
++
+*Social auth username in full email*: Enabling this setting alerts social authentication to use the full email as username instead of the full name.
++
+*Platform gateway token name*: The header name to push from the proxy to the backend service. 
++
+[WARNING]
+==== 
+If this name is changed, backends must be updated to compensate.
+====
++
+* *Platform gateway access token expiration*: How long the access tokens are valid for.
+* *JWT private key*: The private key used to encrypt the JWT tokens sent to back end services. 
++
+This should be a private RSA key and one should be generated automatically on installation.
++
+[NOTE]
+==== 
+Use caution when rotating the key as it will cause current sessions to fail until their JWT keys are reset.
+====
++
+* (Read only) *JWT public key*: The private key used to encrypt the JWT tokens sent to back end services. 
++
+This should be a private RSA key and one should be generated automatically on installation. 
++
+[NOTE]
+==== 
+See other services' documentation on how they consume this key.
+====
++
+. Click btn:[Save changes] to save the changes or proceed to configure the other platform options available.

--- a/downstream/modules/platform/proc-settings-gw-session-options.adoc
+++ b/downstream/modules/platform/proc-settings-gw-session-options.adoc
@@ -1,0 +1,15 @@
+[id="proc-settings-gw-session-options"]
+
+= Configuring platform sessions
+
+//Content divided into multiple procedures to address issue AAP-30592
+
+From the *Platform gateway settings* page, you can configure platform session settings.
+
+.Procedure
+. From the navigation panel, select {MenuSetGateway}.
+. The *Platform gateway settings* page is displayed. 
+. To configure the options, click btn:[Edit platform gateway settings].
+. Enter the time in seconds before a session expires in the *Session cookie age* field.
+. Click btn:[Save platform gateway settings] to save the changes or proceed to configure the other platform options available.
+

--- a/downstream/modules/platform/proc-settings-platform-gateway.adoc
+++ b/downstream/modules/platform/proc-settings-platform-gateway.adoc
@@ -3,94 +3,24 @@
 = Platform gateway
 
 //To be added to Donna's AAP/UI document for 2.5 
+//Content divided into multiple procedures to address issue AAP-30592
 
 The Platform gateway is the service that handles authentication and authorization for {PlatformNameShort}. 
 It provides a single ingress into the Platform and serves the Platform's user interface.
 
-Use the following procedure to configure the options.
+From the {MenuSetGateway} menu, you can configure *Platform gateway*, 
+*Security*, *Session*, *Platform Security*, *Custom Login*, and *Other* settings. 
 
 .Procedure
 . From the navigation panel, select {MenuSetGateway}.
-. The Platform gateway settings page is displayed. 
-+
-image::platform_gateway_settings_page.png[Initial platform gateway settings page]
-+
-. To configure the options, click btn:[Edit].
-+
-image::platform_gateway_full.png[Platform gateway configurable options]
-+
+. The *Platform gateway settings* page is displayed. 
+//[Removing screen captures but they can be added back if requested.]
+//image::platform_gateway_settings_page.png[Initial platform gateway settings page]
+. To configure the options, click btn:[Edit platform gateway settings].
+//image::platform_gateway_full.png[Platform gateway configurable options]
 . You can configure the following platform gateway options:
-
++
 * *Platform gateway proxy url*: URL to the platform gateway proxy layer.
 * *Platform gateway proxy url ignore cert*: Ignore the certificate to the platform gateway proxy layer.
-* *Allow admin to set insecure*: Whether a superuser account can save an insecure password when editing any local user account.
-* *Platform gateway basic auth enabled*: Enable basic authentication to the platform gateway API.
 +
-Turning this off prevents all basic authentication (local users), so customers need to make sure they have their alternative authentication mechanisms correctly configured before doing so. 
-+
-Turning it off with only local authentication configured also prevents all access to the UI.
-+
-*Social auth username in full email*: Enabling this setting alerts social authentication to use the full email as username instead of the full name.
-+
-*Platform gateway token name*: The header name to push from the proxy to the backend service. 
-+
-[WARNING]
-==== 
-If this name is changed, backends must be updated to compensate.
-====
-+
-* *Platform gateway access token expiration*: How long the access tokens are valid for.
-* *JWT private key*: The private key used to encrypt the JWT tokens sent to back end services. 
-+
-This should be a private RSA key and one should be generated automatically on installation.
-+
-[NOTE]
-==== 
-Use caution when rotating the key as it will cause current sessions to fail until their JWT keys are reset.
-====
-+
-* (Read only) *JWT public key*: The private key used to encrypt the JWT tokens sent to back end services. 
-+
-This should be a private RSA key and one should be generated automatically on installation. 
-+
-[NOTE]
-==== 
-See other services' documentation on how they consume this key.
-====
-+
-You can configure the following Session options:
-
-* *Session cookie age*: Time in seconds before a session expires.
-
-You can configure the following Password security options:
-
-* *Password min upper*: How many uppercase characters need to be in a local password.
-* *Password min length*: The minimum length of a local password.
-* *Password min digits*: How many numerical characters need to be in a local password.
-* *Password min special*: How many special characters need to be in a local password.
-
-You can configure the following Custom login options:
-
-* *Custom login info*: Provide specific information (such as a legal notice or a disclaimer) to a text box in the login modal.
-* *Custom logo* : Provide an image file for setting up a custom logo (must be a data URL with a base64-encoded GIF, PNG, or JPEG image).
- 
-You can configure the following additional settings:
-
-* *JWT expiration buffer in seconds*: The number of seconds before a JWT token's expiration to revoke from the cache.
-+
-When authentication happens a JWT token is created for the user and that token is cached. 
-When subsequent calls happen to services such as automation controller or EDA, the token is taken from the cache and sent to the service. 
-Both the token and the cache of the token have an expiration time. 
-If the token expires while in the cache the authentication process attempts results in a 401 error (unauthorized). 
-This setting gives {PlatformName} a buffer by removing the JWT token from the cache before the token expires. 
-When a token is revoked from cache a new token with a new expiration is generated and cached for the user. 
-As a result, expired tokens from the cache are never used. 
-This setting defaults to 2 seconds. 
-If you have a large latency between platform gateway and your services and observe 401 responses you m  increase this setting to lower the number of 401 responses.
-* *Status endpoint backend timeout seconds*: Timeout (in seconds) for the status endpoint to wait when trying to connect to a backend.
-* *Allow auth2 for external users*: For security reasons, users from external authentication providers, such as LDAP, SAML, SSO, Radius, and others, are not allowed to create OAuth2 tokens. 
-To change this behavior, enable this setting. 
-Existing tokens are not deleted when this setting is turned off.
-
-[start=5]
-. Click btn:[Save] to save your changes.
+. Click btn:[Save platform gateway settings] to save the changes or proceed to configure the other platform options available.

--- a/downstream/modules/platform/proc-settings-troubleshooting.adoc
+++ b/downstream/modules/platform/proc-settings-troubleshooting.adoc
@@ -9,10 +9,10 @@ You can use the *Troubleshooting* page to enable or disable certain flags that a
 . From the navigation panel, select {MenuSetTroubleshooting}.
 . The *Troubleshooting* page is displayed. 
 . Click btn:[Edit].
-+
-image::troubleshooting_options.png[Troubleshooting options]
+//[ddacosta] Removing screen captures but they can be added back if requested.
+//image::troubleshooting_options.png[Troubleshooting options]
 . You can select the following options:
- 
++
 * *Enable or Disable tmp dir cleanup*: Select this to enable or disable the cleanup of tmp directories generated during execution of a job after job execution completes.
 * *Debug Web Requests*: Select this to enable or disable web request profiling for debugging slow web requests.
 * *Release Receptor Work*: Select this to turn on or off the deletion of job pods after they complete or fail. This can be helpful in debugging why a job failed. 

--- a/downstream/modules/platform/proc-settings-user-preferences.adoc
+++ b/downstream/modules/platform/proc-settings-user-preferences.adoc
@@ -14,37 +14,37 @@ User preferences are stored locally in your browser. This means that they are un
 .Procedure
 
 . From the navigation panel, select {MenuSetUserPref}.
-//No Edit button, page is displayed as if an edit button has been clicked.
-+
-image::user_preferences_page.png[User preferences options]
-. The *User preferences page* is displayed. Set the configurable options from the fields provided. Click the tooltip icon next to the field that you need additional information about.
+. The *User preferences page* is displayed. 
+. Click btn:[Edit]. 
 . You can configure the following options:
-
++
 * *Refresh interval*: Select the refresh interval for the page.
 +
 This refreshes the data on the page at the selected interval.
 +
 The refresh happens in the background and does not reload the page.
-
++
 * *Color Theme*: Select from:
 ** Dark theme
 ** Light theme
 ** System default
-
++
 * *Table Layout*: Select from:
 ** Comfortable
 ** Compact
-
++
 * *Form Columns*: Select from:
 ** Multiple columns of inputs
 ** Single column of inputs
-
++
 * *Form Labels*: Select from:
 ** Labels above inputs
 ** Labels beside inputs
-
++
 * *Date Format* Select from
 ** Shows dates relative to the current time
 ** Shows dates as date and time
-
++
 * *Preferred Date Format*: Sets the default format for when editing date fields.
++
+. Click btn:[Save user preferences].


### PR DESCRIPTION
This PR backports the changes from #1956 to the 2.5 branch and includes the following: 

* AAP-30592 - Divide the Platform gateway settings into separate procedures by option

* AAP-30592 - implemented peer review fixes