### PR TITLE
AAP-28228-C added xrefs to topology table (#1966)

### DIFF
--- a/downstream/assemblies/topologies/assembly-overview-tested-deployment-models.adoc
+++ b/downstream/assemblies/topologies/assembly-overview-tested-deployment-models.adoc
@@ -15,20 +15,20 @@ The following table outlines the different ways to install or deploy {PlatformNa
 | Mode | Infrastructure | Description | Tested topologies
 | RPM | Virtual machines and bare metal | The RPM installer deploys {PlatformNameShort} on {RHEL} by using RPMs to install the platform on host machines. Customers manage the product and infrastructure lifecycle.
 a| 
-* RPM enterprise topology
-* RPM mixed enterprise topology
+* xref:rpm-b-env-a[RPM enterprise topology]
+* xref:rpm-b-env-b[RPM mixed enterprise topology]
 
 | Containers
 | Virtual machines and bare metal
 | The containerized installer deploys {PlatformNameShort} on {RHEL} by using Podman which runs the platform in containers on host machines. Customers manage the product and infrastructure lifecycle.
 a| 
-* Container growth topology
-* Container enterprise topology
+* xref:cont-a-env-a[Container growth topology]
+* xref:cont-b-env-a[Container enterprise topology]
 
 | Operator
 | Red Hat OpenShift
 | The Operator uses Red Hat OpenShift Operators to deploy {PlatformNameShort} within Red Hat OpenShift. Customers manage the product and infrastructure lifecycle.
 a| 
-* Operator growth topology
-* Operator enterprise topology
+* xref:ocp-a-env-a[Operator growth topology]
+* xref:ocp-b-env-a[Operator enterprise topology]
 |====


### PR DESCRIPTION
2.5 backport of [PR 1966](https://github.com/ansible/aap-docs/pull/1966)

Added xrefs to assembly-overview-tested-deployment-models.adoc