### PR TITLE
opg-fix - Removed activating manifest files 

### DIFF
--- a/downstream/titles/aap-operations-guide/master.adoc
+++ b/downstream/titles/aap-operations-guide/master.adoc
@@ -13,7 +13,7 @@ include::attributes/attributes.adoc[]
 After installing Red Hat Ansible Automation Platform, your system might need extra configuration to ensure your deployment runs smoothly. This guide provides procedures for configuration tasks that you can perform after installing {PlatformName}.
 
 include::{Boilerplate}[]
-include::platform/assembly-aap-activate.adoc[leveloffset=+1]
+// ddacosta - removed to avoid duplication with access management guide include::platform/assembly-aap-activate.adoc[leveloffset=+1]
 // emurtoug removed this assembly to avoid duplication within Access management and authentication include::platform/assembly-aap-manifest-files.adoc[leveloffset=+1]
 //ifowler assembly transferred from installation guide as part of AAP-18700
 include::platform/assembly-platform-whats-next.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR removes the activating manifest files from the Operations guide because the content as moved to the Access management guide. 