### PR TITLE
[Backport] cae-fix - Correcting broken xrefs due to information moving to a new document (#1985)

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-secret-management.adoc
+++ b/downstream/assemblies/platform/assembly-controller-secret-management.adoc
@@ -23,7 +23,7 @@ These external secret values are fetched before running a playbook that needs th
 
 .Additional resources
 
-For more information about specifying secret management system credentials in the user interface, see xref:controller-credentials[Managing user credentials].
+For more information about specifying secret management system credentials in the user interface, see link:{URLControllerUserGuide}/index#controller-credentials[Managing user credentials].
 
 include::platform/proc-controller-configure-secret-lookups.adoc[leveloffset=+1]
 include::platform/ref-controller-metadata-credential-input.adoc[leveloffset=+2]

--- a/downstream/modules/platform/ref-controller-config-json.adoc
+++ b/downstream/modules/platform/ref-controller-config-json.adoc
@@ -47,7 +47,7 @@ Which includes the following fields:
 
 * *ansible_version*: The system Ansible version on the host
 * *authentication_backends*: The user authentication backends that are available. 
-For more information, see xref:assembly-controller-set-up-social-authentication[Setting up social authentication] or  xref:controller-LDAP-authentication[Setting up LDAP authentication].
+For more information, see link:{URLCentralAuth}/index#gw-config-authentication-type[Configuring an authentication type].
 * *external_logger_enabled*: Whether external logging is enabled
 * *external_logger_type*: What logging backend is in use if enabled. 
 For more information, see xref:assembly-controller-logging-aggregation[Logging and aggregation].


### PR DESCRIPTION
This PR backports the changes from #1985 to the 2.5 branch.