### PR TITLE
edavar - Fixed errors in the EDA variables preventing the doc from building

### DIFF
--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -58,17 +58,17 @@ Default = `5432`.
 | *`automationedacontroller_pg_username`* | The username for your {EDAcontroller} Postgres database.
 
 Default = `automationedacontroller`.
-| *`automationedacontroller_rq_workers*` | Number of Redis Queue (RQ) workers used by :EDAcontroller:. RQ workers are Python processes that run in the background.
+| *`automationedacontroller_rq_workers`* | Number of Redis Queue (RQ) workers used by {EDAcontroller}. RQ workers are Python processes that run in the background.
 
 Default = (# of cores or threads) * 2 + 1
 | *`automationedacontroller_ssl_cert`* | _Optional_
 
 `/root/ssl_certs/eda.<example>.com.crt`
 
-Same as `automationhub_ssl_cert` but for :EDAcontroller: UI and API.
+Same as `automationhub_ssl_cert` but for {EDAcontroller} UI and API.
 | *`automationedacontroller_ssl_key`* | _Optional_
 
 `/root/ssl_certs/eda.<example>.com.key`
 
-Same as `automationhub_server_ssl_key` but for :EDAcontroller: UI and API.
+Same as `automationhub_server_ssl_key` but for {EDAcontroller} UI and API.
 |====


### PR DESCRIPTION
This PR fixes a few errors in the EDA variables that were preventing the installation guide from building. 