### PR TITLE
AAP-29296-A updated system requirements (#1915)

### DIFF
--- a/downstream/assemblies/platform/assembly-system-requirements.adoc
+++ b/downstream/assemblies/platform/assembly-system-requirements.adoc
@@ -13,16 +13,20 @@ Use this information when planning your {PlatformName} installations and designi
 * You can de-escalate privileges from root to users such as: AWX, PostgreSQL, {EDAName}, or Pulp.
 * You have configured an NTP client on all nodes. For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide/migrate-isolated-execution-nodes#automation_controller_configuration_requirements[Configuring NTP server using Chrony].
 
-include::platform/ref-system-requirements.adoc[leveloffset=+1]
-include::platform/ref-gateway-system-requirements.adoc[leveloffset=+1]
-include::platform/ref-controller-system-requirements.adoc[leveloffset=+1]
-include::platform/ref-automation-hub-requirements.adoc[leveloffset=+1]
-include::platform/ref-ha-hub-reqs.adoc[leveloffset=+2]
-include::platform/ref-eda-system-requirements.adoc[leveloffset=+1]
-include::platform/ref-postgresql-requirements.adoc[leveloffset=+1]
-include::platform/proc-setup-postgresql-ext-database.adoc[leveloffset=+2]
-include::platform/proc-enable-hstore-extension.adoc[leveloffset=+2]
-include::platform/proc-benchmark-postgresql.adoc[leveloffset=+2]
+// emurtough commented out files to address duplication across 2.5 doc set 9/18/2024
+// include::platform/ref-system-requirements.adoc[leveloffset=+1]
+include::platform/ref-RPM-system-requirements.adoc[leveloffset=+1]
+include::platform/ref-containerized-system-requirements.adoc[leveloffset=+1]
+include::platform/ref-OCP-system-requirements.adoc[leveloffset=+1]
+// include::platform/ref-gateway-system-requirements.adoc[leveloffset=+1]
+// include::platform/ref-controller-system-requirements.adoc[leveloffset=+1]
+// include::platform/ref-automation-hub-requirements.adoc[leveloffset=+1]
+// include::platform/ref-ha-hub-reqs.adoc[leveloffset=+2]
+// include::platform/ref-eda-system-requirements.adoc[leveloffset=+1]
+// include::platform/ref-postgresql-requirements.adoc[leveloffset=+1]
+// include::platform/proc-setup-postgresql-ext-database.adoc[leveloffset=+2]
+// include::platform/proc-enable-hstore-extension.adoc[leveloffset=+2]
+// include::platform/proc-benchmark-postgresql.adoc[leveloffset=+2]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/ref-OCP-system-requirements.adoc
+++ b/downstream/modules/platform/ref-OCP-system-requirements.adoc
@@ -1,0 +1,7 @@
+
+
+// [id="ref-OCP-system-requirements_{context}"]
+
+= System requirements for installing on {OCPShort}
+
+For system requirements for installing {PlatformNameShort} on {OCPShort}, see the link:{URLTopologies}[Tested system configurations] section of _{TitleTopologies}_.

--- a/downstream/modules/platform/ref-RPM-system-requirements.adoc
+++ b/downstream/modules/platform/ref-RPM-system-requirements.adoc
@@ -1,0 +1,7 @@
+
+
+// [id="ref-RPM-system-requirements_{context}"]
+
+= System requirements for RPM installation
+
+For system requirements for the RPM installation method of {PlatformNameShort}, see the link:{URLInstallationGuide}/platform-system-requirements[System requirements] section of _{TitleInstallationGuide}_.

--- a/downstream/modules/platform/ref-containerized-system-requirements.adoc
+++ b/downstream/modules/platform/ref-containerized-system-requirements.adoc
@@ -1,0 +1,7 @@
+
+
+// [id="ref-containerized-system-requirements_{context}"]
+
+= System requirements for containerized installation
+
+For system requirements for the containerized installation method of {PlatformNameShort}, see the link:{URLContainerizedInstall}/platform-system-requirements#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.


### PR DESCRIPTION
2.5 backport of [PR 1915](https://github.com/ansible/aap-docs/pull/1915)

AAP-29296-A: child of [AAP-29296](https://issues.redhat.com/browse/AAP-29296)

Updated system requirements section of the Planning guide. See [[WIP] v2.5 Red Hat Ansible Automation Platform planning guide](https://docs.google.com/document/d/1tCXiQxr0WspctajD7Hxwji9zsaOaPMl-WhRsB1sF-qs/edit).

Files added:

ref-OCP-system-requirements.adoc
ref-RPM-system-requirements.adoc
ref-containerized-system-requirements.adoc
Files modified:

assemblies/platform/assembly-system-requirements.adoc