### PR TITLE
AAP-29295-A updated network ports and protocols table

### DIFF
--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -34,14 +34,28 @@ The following default destination ports and installer inventory listed are confi
 | 22 | TCP | SSH | Installer node | Hybrid node | Installation (temporary) | `ansible_port`
 | 22 | TCP | SSH | Installer node | PostgreSQL database| Remote access during installation (temporary) | `pg_port`
 | 80/443 | TCP | HTTP/HTTPS | Installer node | {HubNameStart} | Allows installer node to push the execution environment image to {HubName} when using the bundle installer. | Fixed value
+| 80/443 | TCP | HTTP/HTTPS | EDA node | {HubNameStart} | | Fixed value
+| 80/443 | TCP | HTTP/HTTPS | EDA node | {ControllerNameStart} |  | Fixed value
+| 80/443 | TCP | HTTP/HTTPS | {ControllerNameStart} | {HubNameStart} |  | Fixed value
 | 80/443 | TCP | HTTP/HTTPS | Execution node | {HubNameStart} | Allows execution nodes to pull the execution environment image from {HubName}. | Fixed value
 | 443 | TCP | HTTPS | Controller node | Client | Web UI/API
 
 This exposes the mesh ingress receptor entry point for inbound connections.| `nginx_https_port`
 | 443 | TCP | HTTPS | Controller node | {OCPShort} |  Only required when using container groups to run jobs. | Host name of OpenShift API server
+| 443 | TCP | HTTPS | HA Proxy load balancer | Platform gateway |  This is the ingress above the gateway that's customer controlled and can load balance requests to multiple gateways. | 
+| 443 | TCP | HTTPS | Platform gateway | {ControllerNameStart} |  | 
+| 443 | TCP | HTTPS | Platform gateway | {HubNameStart} |  | 
+| 443 | TCP | HTTPS | Platform gateway | {EDAName} |  | 
+| 443 | HTTPS | Receptor | Execution node | OCP Mesh ingress |  | 
+| 443 | HTTPS | Receptor | Hop node | OCP Mesh ingress |  | 
 | 5432 | TCP | PostgreSQL | Controller node | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationcontroller_pg_port`
 | 5432 | TCP | PostgreSQL | EDA node | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationedacontroller_pg_port`
 | 5432 | TCP | PostgreSQL | {HubNameStart} | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationhub_pg_port`
+| 5432 | TCP | PostgreSQL | Platform gateway | External database |  | `automationgateway_pg_port`
+| 6379 | TCP | PostgreSQL | {EDAName} | Redis node |  | 
+| 6379 | TCP | PostgreSQL | Platform gateway | Redis node |  | 
+| 8443 | TCP | HTTPS | Platform gateway | Platform gateway | nginx | 
+| 16379 | TCP | Redis | Redis nodes | Redis nodes | Redis cluster bus port for a resilient redis configuration | 
 | 27199 | TCP | Receptor | Controller node | Execution node | Configurable
 
 Mesh nodes directly peered to controllers. 
@@ -69,6 +83,9 @@ ALLOW connection from controller(s) to Receptor port |
 `receptor_listener_port`
 
 `peers`
+| 27199 | TCP | Receptor | Hop node | Execution node |  | `Receptor_listener_port`
+
+`peers`
 | 27199 | TCP | Receptor | Execution node | Controller node | Configurable
 
 Mesh 27199 communication can be both ways (depending on installation inventory) for execution nodes
@@ -77,6 +94,8 @@ ALLOW connection from controller(s) to Receptor port |
 `receptor_listener_port`
 
 `peers`
+| 27199 | TCP | Receptor | OCP cluster | Execution node |  | 
+| 50051 | TCP | GRPC | Platform gateway | Platform gateway |  | 
 |===
 
 [NOTE]

--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -28,34 +28,34 @@ The following default destination ports and installer inventory listed are confi
 | Port | Protocol | Service | Source | Destination | Required for | Installer Inventory Variable 
 | 22 | TCP | SSH | Installer node | {HubNameStart} | Installation (temporary) | `ansible_port`
 | 22 | TCP | SSH | Installer node | Controller node | Installation (temporary) | `ansible_port`
-| 22 | TCP | SSH | Installer node | EDA node | Installation (temporary) | `ansible_port`
+| 22 | TCP | SSH | Installer node | {EDAName} node | Installation (temporary) | `ansible_port`
 | 22 | TCP | SSH | Installer node | Execution node | Installation (temporary) | `ansible_port`
 | 22 | TCP | SSH | Installer node | Hop node | Installation (temporary) | `ansible_port`
 | 22 | TCP | SSH | Installer node | Hybrid node | Installation (temporary) | `ansible_port`
 | 22 | TCP | SSH | Installer node | PostgreSQL database| Remote access during installation (temporary) | `pg_port`
 | 80/443 | TCP | HTTP/HTTPS | Installer node | {HubNameStart} | Allows installer node to push the execution environment image to {HubName} when using the bundle installer. | Fixed value
-| 80/443 | TCP | HTTP/HTTPS | EDA node | {HubNameStart} | | Fixed value
-| 80/443 | TCP | HTTP/HTTPS | EDA node | {ControllerNameStart} |  | Fixed value
+| 80/443 | TCP | HTTP/HTTPS | {EDAName} node | {HubNameStart} | | Fixed value
+| 80/443 | TCP | HTTP/HTTPS | {EDAName} node | {ControllerNameStart} |  | Fixed value
 | 80/443 | TCP | HTTP/HTTPS | {ControllerNameStart} | {HubNameStart} |  | Fixed value
 | 80/443 | TCP | HTTP/HTTPS | Execution node | {HubNameStart} | Allows execution nodes to pull the execution environment image from {HubName}. | Fixed value
 | 443 | TCP | HTTPS | Controller node | Client | Web UI/API
 
 This exposes the mesh ingress receptor entry point for inbound connections.| `nginx_https_port`
 | 443 | TCP | HTTPS | Controller node | {OCPShort} |  Only required when using container groups to run jobs. | Host name of OpenShift API server
-| 443 | TCP | HTTPS | HA Proxy load balancer | Platform gateway |  This is the ingress above the gateway that's customer controlled and can load balance requests to multiple gateways. | This port is customer managed outside of Ansible Automation Platform.
+| 443 | TCP | HTTPS | HA Proxy load balancer | Platform gateway |  This is the ingress above the gateway that is customer controlled and can load balance requests to multiple gateways. | This port is customer managed outside of Ansible Automation Platform.
 | 443 | TCP | HTTPS | Platform gateway | {ControllerNameStart} |  | 
 | 443 | TCP | HTTPS | Platform gateway | {HubNameStart} |  | 
 | 443 | TCP | HTTPS | Platform gateway | {EDAName} |  | 
 | 443 | HTTPS | Receptor | Execution node | OCP Mesh ingress |  | 
 | 443 | HTTPS | Receptor | Hop node | OCP Mesh ingress |  | 
 | 5432 | TCP | PostgreSQL | Controller node | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationcontroller_pg_port`
-| 5432 | TCP | PostgreSQL | EDA node | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationedacontroller_pg_port`
+| 5432 | TCP | PostgreSQL | {EDAName} node | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationedacontroller_pg_port`
 | 5432 | TCP | PostgreSQL | {HubNameStart} | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationhub_pg_port`
 | 5432 | TCP | PostgreSQL | Platform gateway | External database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationgateway_pg_port`
 | 6379 | TCP | PostgreSQL | {EDAName} | Redis node |  | 
 | 6379 | TCP | PostgreSQL | Platform gateway | Redis node |  | 
 | 8443 | TCP | HTTPS | Platform gateway | Platform gateway | nginx | 
-| 16379 | TCP | Redis | Redis nodes | Redis nodes | Redis cluster bus port for a resilient redis configuration | 
+| 16379 | TCP | Redis | Redis nodes | Redis nodes | Redis cluster bus port for a resilient Redis configuration | 
 | 27199 | TCP | Receptor | Controller node | Execution node | Configurable
 
 Mesh nodes directly peered to controllers. 
@@ -83,7 +83,7 @@ ALLOW connection from controller(s) to Receptor port |
 `receptor_listener_port`
 
 `peers`
-| 27199 | TCP | Receptor | Hop node | Execution node |  | `Receptor_listener_port`
+| 27199 | TCP | Receptor | Hop node | Execution node |  | `receptor_listener_port`
 
 `peers`
 | 27199 | TCP | Receptor | Execution node | Controller node | Configurable

--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -51,7 +51,7 @@ This exposes the mesh ingress receptor entry point for inbound connections.| `ng
 | 5432 | TCP | PostgreSQL | Controller node | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationcontroller_pg_port`
 | 5432 | TCP | PostgreSQL | EDA node | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationedacontroller_pg_port`
 | 5432 | TCP | PostgreSQL | {HubNameStart} | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationhub_pg_port`
-| 5432 | TCP | PostgreSQL | Platform gateway | External database |  | `automationgateway_pg_port`
+| 5432 | TCP | PostgreSQL | Platform gateway | External database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationgateway_pg_port`
 | 6379 | TCP | PostgreSQL | {EDAName} | Redis node |  | 
 | 6379 | TCP | PostgreSQL | Platform gateway | Redis node |  | 
 | 8443 | TCP | HTTPS | Platform gateway | Platform gateway | nginx | 

--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -42,7 +42,7 @@ The following default destination ports and installer inventory listed are confi
 
 This exposes the mesh ingress receptor entry point for inbound connections.| `nginx_https_port`
 | 443 | TCP | HTTPS | Controller node | {OCPShort} |  Only required when using container groups to run jobs. | Host name of OpenShift API server
-| 443 | TCP | HTTPS | HA Proxy load balancer | Platform gateway |  This is the ingress above the gateway that's customer controlled and can load balance requests to multiple gateways. | 
+| 443 | TCP | HTTPS | HA Proxy load balancer | Platform gateway |  This is the ingress above the gateway that's customer controlled and can load balance requests to multiple gateways. | This port is customer managed outside of Ansible Automation Platform.
 | 443 | TCP | HTTPS | Platform gateway | {ControllerNameStart} |  | 
 | 443 | TCP | HTTPS | Platform gateway | {HubNameStart} |  | 
 | 443 | TCP | HTTPS | Platform gateway | {EDAName} |  | 


### PR DESCRIPTION
[AAP-29295](https://issues.redhat.com/browse/AAP-29295?filter=-1)

Updated **Table 2. Network ports and protocols** within the _Planning guide_. See  [[WIP] v2.5 Red Hat Ansible Automation Platform planning guide](https://docs.google.com/document/d/1tCXiQxr0WspctajD7Hxwji9zsaOaPMl-WhRsB1sF-qs/edit) for source.

Files modified:
- assembly-network-ports-protocols.adoc