### PR TITLE
Backport-2.5-1784 (AAP-25510) Create safe plugin variable for various plugins

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -73,7 +73,7 @@ include::platform/proc-install-ha-hub-selinux.adoc[leveloffset=+3]
 include::platform/proc-configure-pulpcore-service.adoc[leveloffset=+4]
 include::platform/proc-apply-selinux-context.adoc[leveloffset=+4]
 include::hub/hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+3]
-
+include::platform/proc-add-eda-safe-plugin-var.adoc[leveloffset=+3]
 include::platform/proc-running-setup-script.adoc[leveloffset=+1]
 include::platform/proc-verify-aap-installation.adoc[leveloffset=+1]
 include::platform/con-adding-subscription-manifest.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-add-eda-safe-plugin-var.adoc
+++ b/downstream/modules/platform/proc-add-eda-safe-plugin-var.adoc
@@ -1,0 +1,25 @@
+
+[id="proc-add-eda-safe-plugin-var"]
+
+= Adding a safe plugin variable to {EDAcontroller}
+
+When using redhat.insights_eda or similar plug-ins to run rulebook activations in {EDAcontroller}, you must add a safe plugin variable to a directory in {PlatformNameShort}. This would ensure connecton between {EDAcontroller} and the source plugin, and display port mappings correctly. 
+
+.Procedure
+
+. Create a directory for the safe plugin variable: `mkdir -p ./group_vars/automationedacontroller`
+. Create a file within that directory for your new setting (for example, `touch ./group_vars/automationedacontroller/custom.yml`)
+. Add the variable `automationedacontroller_additional_settings` to extend the default `settings.yaml` template for {EDAcontroller} and add the *SAFE_PLUGINS* field with a list of plugins to enable. For example: 
++
+----
+automationedacontroller_additional_settings:
+   SAFE_PLUGINS:
+     - ansible.eda.webhook
+     - ansible.eda.alertmanager
+----
++
+[NOTE]
+====
+You can also extend the `automationedacontroller_additional_settings` variable beyond SAFE_PLUGINS in the django configuration file, /etc/ansible-automation-platform/eda/settings.yaml 
+====
+


### PR DESCRIPTION
Added a new procedure to installation scenarios section of the Installation guide:

- downstream/titles/aap-installation-guide/platform/platform/proc-add-eda-safe-plugin-var.adoc