### PR TITLE
[Backport] AAP-31745 - Reconcile chapter 6 of the Access management guide (#2023)

### DIFF
--- a/downstream/modules/platform/proc-gw-create-roles.adoc
+++ b/downstream/modules/platform/proc-gw-create-roles.adoc
@@ -15,6 +15,6 @@ include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Click btn:[Create role].
 . Provide a *Name* and optionally include a *Description* for the role.
-. Select a *Content type*.
+. Select a *Content Type*.
 . Select the *Permissions* you want assigned to this role.
 . Click btn:[Create role] to create your new role.

--- a/downstream/modules/platform/proc-gw-delete-roles.adoc
+++ b/downstream/modules/platform/proc-gw-delete-roles.adoc
@@ -14,4 +14,4 @@ Built in roles can not be deleted, however, you can delete custom roles from the
 include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Click the *More Actions* icon *{MoreActionsIcon}* next to the role you want and select *Delete role*.
-. To delete roles in bulk, select the roles you want to delete from the *Roles* list view, click the *More Actions* icon *{MoreActionsIcon}*, and select *Delete selected roles*.
+. To delete roles in bulk, select the roles you want to delete from the *Roles* list view, click the *More Actions* icon *{MoreActionsIcon}*, and select *Delete roles*.

--- a/downstream/modules/platform/proc-gw-edit-roles.adoc
+++ b/downstream/modules/platform/proc-gw-edit-roles.adoc
@@ -4,12 +4,12 @@
 
 = Editing a role
 
-Built in roles can not be changed, however, you can modify custom roles from the *Roles* list view.
+Built in roles can not be changed, however, you can modify custom roles from the *Roles* list view. The *Editable* column in the *Roles* list view indicates whether a role is _Built-in_ or _Editable_. 
 
 .Procedure
 
 . From the navigation panel, select {MenuAMRoles}.
-. Select a tab for the component resource for which you want to create custom roles.
+. Select a tab for the component resource for which you want to modify a custom roles.
 +
 include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +

--- a/downstream/modules/platform/proc-gw-roles.adoc
+++ b/downstream/modules/platform/proc-gw-roles.adoc
@@ -13,5 +13,5 @@ You can display the roles assigned for component resources from the menu:Access 
 +
 include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
-. From the table header, you can sort the list of roles by using the arrows for *Role*, *Description*, *Created* and *Editable* or by making sort selections in the *Sort* list.
+. From the table header, you can sort the list of roles by using the arrows for *Name*, *Description*, *Created* and *Editable* or by making sort selections in the *Sort* list.
 . You can filter the list of roles by selecting *Name* or *Editable* from the filter list and clicking the arrow.

--- a/downstream/snippets/snip-gw-roles-note-multiple-components.adoc
+++ b/downstream/snippets/snip-gw-roles-note-multiple-components.adoc
@@ -1,4 +1,4 @@
 [NOTE]
 ====
-If you have multiple {PlatformNameShort} components installed, you will see selections for the roles associated with each component in the *Roles* menu bar. For example, Automation Execution for {ControllerName} roles, Automation Content for {HubName} and Automation Decisions for {EDAName} roles.
+If you have multiple {PlatformNameShort} components installed, you will see selections for the roles associated with each component in the *Roles* menu bar. For example, Automation Execution for {ControllerName} roles, Automation Decisions for {EDAName} roles and Automation Content for {HubName} roles.
 ====


### PR DESCRIPTION
This PR backports the changes from #2023 to the 2.5 branch.