### PR TITLE
AAP-30402 Set docker path in dev containers extension

### DIFF
--- a/downstream/modules/devtools/proc-devtools-install-container.adoc
+++ b/downstream/modules/devtools/proc-devtools-install-container.adoc
@@ -77,6 +77,9 @@ You must use different settings depending on whether you are using Podman or Doc
   }
 }
 ----
+. In the Dev Containers extension settings, configure the `Dev > Containers:Docker path`.
+** If you are using Podman or Podman desktop, set `Dev > Containers:Docker path` to `podman`. 
+** If you are using Docker or Docker desktop, set `Dev > Containers:Docker path` to `docker`. 
 . Reopen the directory in a container.
 ** If {VSCode} detects that your directory contains the `devcontainer.json` file, the following notification appears:
 +


### PR DESCRIPTION
AAP-30402 Set docker path to `docker` or `podman` in dev containers extension

Affects `/titles/develop-automation-content/`