### PR TITLE
AAP-30411 Set up ansible.cfg for devtools project

### DIFF
--- a/downstream/assemblies/devtools/assembly-writing-running-playbook.adoc
+++ b/downstream/assemblies/devtools/assembly-writing-running-playbook.adoc
@@ -1,11 +1,12 @@
-ifdef::context[:parent-context: {context}]
-[id="writing-running-playbook"]
+ifdef::context[:parent-context_of_writing-running-playbook: {context}]
+[id="writing-running-playbook_{context}"]
 
 = Writing and running a playbook with {ToolsName}
 
 :context: writing-running-playbook
 [role="_abstract"]
 
+include::devtools/proc-devtools-set-up-ansible-config.adoc[leveloffset=+1]
 include::devtools/proc-devtools-writing-first-playbook.adoc[leveloffset=+1]
 include::devtools/proc-devtools-inspect-playbook.adoc[leveloffset=+1]
 include::devtools/proc-devtools-run-playbook-extension.adoc[leveloffset=+1]
@@ -15,6 +16,6 @@ include::devtools/proc-devtools-working-with-ee.adoc[leveloffset=+2]
 include::devtools/proc-debugging-playbook.adoc[leveloffset=+1]
 include::devtools/proc-devtools-testing-playbook.adoc[leveloffset=+1]
 
-ifdef::parent-context[:context: {parent-context}]
-ifndef::parent-context[:!context:]
+ifdef::parent-context_of_writing-running-playbook[:context: {parent-context_of_writing-running-playbook}]
+ifndef::parent-context_of_writing-running-playbook[:!context:]
 

--- a/downstream/modules/devtools/proc-devtools-set-up-ansible-config.adoc
+++ b/downstream/modules/devtools/proc-devtools-set-up-ansible-config.adoc
@@ -1,0 +1,15 @@
+[id="devtools-set-up-ansible-config_{context}"]
+
+= Setting up the Ansible configuration file for your playbook project
+
+[role="_abstract"]
+When you scaffolded your playbook project, an Ansible configuration file, `ansible.cfg`,
+was added to the root directory of your project.
+
+If you have configured a default Ansible configuration file in `/etc/ansible/ansible.cfg`,
+copy any settings that you want to reuse in your project from your default Ansible configuration file
+to the `ansible.cfg` file in your project's root directory.
+
+To learn more about the Ansible configuration file, see
+link:https://docs.ansible.com/ansible/latest/reference_appendices/config.html[Ansible Configuration Settings]
+in the Ansible documentation.

--- a/downstream/modules/devtools/proc-devtools-writing-first-playbook.adoc
+++ b/downstream/modules/devtools/proc-devtools-writing-first-playbook.adoc
@@ -1,4 +1,4 @@
-[id="writing-playbook"]
+[id="writing-playbook_{context}"]
 
 = Writing your first playbook
 

--- a/downstream/modules/devtools/proc-scaffolding-playbook-project.adoc
+++ b/downstream/modules/devtools/proc-scaffolding-playbook-project.adoc
@@ -1,4 +1,4 @@
-[id="scaffolding-playbook-project_context"]
+[id="scaffolding-playbook-project_{context}"]
 
 = Scaffolding a playbook project
 


### PR DESCRIPTION
AAP-30411 Add description of how to set up ansible.cfg for devtools project.
Fixed some ID and context tags.

Affects `/titles/develop-automation-content`