### PR TITLE
Update port numbers in topology docs

### DIFF
--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -64,13 +64,8 @@ a|
 | 5432 | TCP | PostgreSQL | {ControllerNameStart} | External database
 | 27199 | TCP | Receptor | {ControllerNameStart} | Hop node and execution node
 | 27199 | TCP | Receptor | Hop node | Execution node
-| 6379 | TCP | Redis | {EDAName} | Platform gateway
-| 6379 | TCP | Redis | {EDAName} | {HubNameStart}
-| 6379 | TCP | Redis | {EDAName} | {EDAName}
-| 6379 | TCP | Redis | Platform gateway | Platform gateway
-| 6379 | TCP | Redis | Platform gateway | {HubNameStart}
-| 6379 | TCP | Redis | Platform gateway | {EDAName}
-| 16379 | TCP | Redis | Redis | Redis cluster node
+| 6379 | TCP | Redis | {EDAName} | Redis node
+| 6379 | TCP | Redis | Platform gateway | Redis node
 | 8433 | TCP | HTTPS | Platform gateway | Platform gateway
 | 50051 | TCP | gRPC | Platform gateway | Platform gateway
 |====

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -66,6 +66,7 @@ a|
 | 27199 | TCP | Receptor | Hop node | Execution node
 | 6379 | TCP | Redis | {EDAName} | Redis node
 | 6379 | TCP | Redis | Platform gateway | Redis node
+| 16379 | TCP | Redis | Redis | Redis cluster node
 | 8433 | TCP | HTTPS | Platform gateway | Platform gateway
 | 50051 | TCP | gRPC | Platform gateway | Platform gateway
 |====

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -62,8 +62,8 @@ Red Hat has tested the following configurations to install and run {PlatformName
 | 5432 | TCP | PostgreSQL | {ControllerNameStart} | External database
 | 27199 | TCP | Receptor | {ControllerNameStart} | Hop node and execution node
 | 27199 | TCP | Receptor | Hop node | Execution node
-| 6379 | TCP | Redis | {EDAName} | Platform gateway
-| 6379 | TCP | Redis | Platform gateway | Platform gateway
+| 6379 | TCP | Redis | {EDAName} | Redis node
+| 6379 | TCP | Redis | Platform gateway | Redis node
 | 8443 | TCP | HTTPS | Platform gateway | Platform gateway
 | 50051 | TCP | gRPC | Platform gateway | Platform gateway
 |====

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -62,8 +62,8 @@ Red Hat has tested the following configurations to install and run {PlatformName
 | 5432 | TCP | PostgreSQL | {ControllerNameStart} | External database
 | 27199 | TCP | Receptor | {ControllerNameStart} | Hop node and Execution node
 | 27199 | TCP | Receptor | Hop node | Execution node
-| 6379 | TCP | Redis | {EDAName} | Platform gateway
-| 6379 | TCP | Redis | Platform gateway | Platform gateway
+| 6379 | TCP | Redis | {EDAName} | Redis node
+| 6379 | TCP | Redis | Platform gateway | Redis node
 | 8443 | TCP | HTTPS | Platform gateway | Platform gateway
 | 50051 | TCP | gRPC | Platform gateway | Platform gateway
 |====


### PR DESCRIPTION
Update the Redis port numbers in the Network ports and protocols tables for the following topologies:
- RPM-B-ENV-A
- RPM-B-ENV-B
- CONT-B-ENV-A

Create a document for supported topologies

https://issues.redhat.com/browse/AAP-28228