### PR TITLE
Add install-related note to operator install doc

### DIFF
--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -11,6 +11,12 @@
 . Select *Installation Mode*, *Installed Namespace*, and *Approval Strategy*.
 . Click btn:[Install].
 
-The installation process will begin. When installation is complete, a modal will appear notifying you that the {OperatorPlatform} is installed in the specified namespace.
+The installation process begins. When installation finishes, a modal appears notifying you that the {OperatorPlatform} is installed in the specified namespace.
 
 * Click btn:[View Operator] to view your newly installed {OperatorPlatform}.
+
+[IMPORTANT]
+====
+You can only install a single instance of the {OperatorPlatform} into a single namespace. 
+Installing multiple instances in the same namespace can lead to improper operation for both operator instances. 
+====

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -8,6 +8,12 @@
 
 Use this procedure to subscribe a namespace to an operator.
 
+[IMPORTANT]
+====
+You can only subscribe a single instance of the {OperatorPlatform} into a single namespace. 
+Subscribing multiple instances in the same namespace can lead to improper operation for both operator instances. 
+====
+
 .Procedure
 
 . Create a project for the operator.


### PR DESCRIPTION
[AAP-31823](https://issues.redhat.com/browse/AAP-31823)

Adding the following 'Important note' to both install chapters (chapter 2 and 3):

"You can only install a single instance of the {OperatorPlatform} into a single namespace. 
Installing multiple instances in the same namespace can lead to improper operation for both operator instances."

Also made some minor tweaks to word choice and active voice. 