### PR TITLE
pg-image - Fix image case to eliminate build errors

### DIFF
--- a/downstream/modules/platform/ref-example-OCP-architecture.adoc
+++ b/downstream/modules/platform/ref-example-OCP-architecture.adoc
@@ -5,4 +5,4 @@
 The following reference architecture provides an example setup of an enterprise deployment of {PlatformNameShort} on {OCPShort}.
 
 .Example enterprise Operator-based deployment architecture
-image::OCP_B_Env_A.png[Reference architecture for an example setup of an enterprise Operator-based {PlatformNameShort} deployment]
+image::ocp_b_env_a.png[Reference architecture for an example setup of an enterprise Operator-based {PlatformNameShort} deployment]


### PR DESCRIPTION
This PR fixes the case for the image callin in the planning guide to successfully build the document. 