### PR TITLE
Backport-2.5-2040 Added missing part of 3rd bullet for EDA controller sys reqs

### DIFF
--- a/downstream/modules/platform/ref-eda-system-requirements.adoc
+++ b/downstream/modules/platform/ref-eda-system-requirements.adoc
@@ -14,7 +14,7 @@ Use the following minimum requirements to run, by default, a maximum of 12 simul
 | *Local disk* a| 
 * Hard drive must be 40 GB minimum with at least 20 GB available under /var.
 * Storage volume must be rated for a minimum baseline of 1500 IOPS.
-* If the cluster has many large projects, consider doubling the GB in /var to avoid disk space errors.
+* If the cluster has many large projects or decision environment images, consider doubling the GB in /var to avoid disk space errors.
 |===
 
 [IMPORTANT]


### PR DESCRIPTION
Adding an important part of the EDA controller system requirements to downstream/modules/platform/ref-eda-system-requirements.adoc