### PR TITLE
AAP-30714 Devtools container package manager is microdnf (#2078)

### DIFF
--- a/downstream/modules/devtools/proc-devtools-install-container.adoc
+++ b/downstream/modules/devtools/proc-devtools-install-container.adoc
@@ -92,3 +92,14 @@ The *Remote ()* status in the {VSCode} Status bar displays `opening Remote` and 
 .Verification
 When the directory reopens in a container, the *Remote ()* status displays `Dev Container: ansible-dev-container`.
 
+
+[NOTE]
+====
+The base image for the container is a Universal Base Image Minimal (UBI Minimal) image that uses `microdnf` as a package manager.
+The `dnf` and `yum` package managers are not available in the container.
+
+For information about using `microdnf` in containers based on UBI Minimal images, see 
+link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/building_running_and_managing_containers/assembly_adding-software-to-a-ubi-container_building-running-and-managing-containers#proc_adding-software-in-a-minimal-ubi-container_assembly_adding-software-to-a-ubi-container[Adding software in a minimal UBI container]
+in the Red Hat Enterprise Linux _Building, running, and managing containers_ guide.
+====
+


### PR DESCRIPTION
Backports #2078 to 2.4

AAP-30714 The devtools container is based on a UBI minimal image, which uses microdnf as a package manager, not yum or dnf.

Affects titles/develop-automation-content