### PR TITLE
AAP-31856 Added the HS assembly to Containerized Install Guide

### DIFF
--- a/downstream/titles/aap-containerized-install/master.adoc
+++ b/downstream/titles/aap-containerized-install/master.adoc
@@ -11,6 +11,7 @@ include::attributes/attributes.adoc[]
 include::{Boilerplate}[]
 
 include::platform/assembly-aap-containerized-installation.adoc[leveloffset=+1]
+include::platform/assembly-horizontal-scaling.adoc[leveloffset=+1]
 
 [appendix]
 include::platform/assembly-appendix-troubleshoot-containerized-aap.adoc[leveloffset=1]


### PR DESCRIPTION
Add new topic on Horizontal Scaling that was already added to the RPM Installation Guide to the Containerized Installation Guide. 

Note to @michellemacrh : Since this topic is in it's own assembly and will likely be expanded to include procedures to use HS in separate subsections for controller, hub, and possibly mesh, I added the HS assembly right after the first assembly. 