### PR TITLE
AAP-31861 Add the safe plugin for EDA procedure to the Containerized Install guide

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -62,6 +62,7 @@ include::platform/ref-using-custom-tls-certificates.adoc[leveloffset=+1]
 include::platform/ref-using-custom-receptor-signing-keys.adoc[leveloffset=+1]
 include::platform/ref-enabling-automation-hub-collection-and-container-signing.adoc[leveloffset=+1]
 include::platform/ref-adding-execution-nodes.adoc[leveloffset=+1]
+include::platform/proc-add-eda-safe-plugin-var.adoc[leveloffset=+1]
 include::platform/proc-uninstalling-containerized-aap.adoc[leveloffset=+1]
 
 


### PR DESCRIPTION
Add the new chapter that was originally added to the RPM installation guide, titled "Adding the EDA safe plugins var" (downstream/assemblies/platform/assembly-aap-containerized-installation.adoc) to the Containerized Install guide. 