### PR TITLE
backport to 2.5: AAP-29069 populates remaining modules for automation operator section (#2091)

### DIFF
--- a/downstream/modules/platform/con-gs-auto-op-about-inv.adoc
+++ b/downstream/modules/platform/con-gs-auto-op-about-inv.adoc
@@ -2,7 +2,7 @@
 
 = About inventories
 
-An inventory is a file listing the collection of hosts managed by automation controller. 
+An inventory is a file listing the collection of hosts managed by {PlatformNameShort}. 
 Organizations are assigned to inventories, while permissions to launch playbooks against inventories are controlled at the user or team level.
 
 Platform administrators and automation developers have the permissions to create inventories. 

--- a/downstream/modules/platform/con-gs-auto-op-execute-inv.adoc
+++ b/downstream/modules/platform/con-gs-auto-op-execute-inv.adoc
@@ -6,6 +6,14 @@
 
 . From the navigation panel, select {MenuInfrastructureInventories}. 
 The *Inventories* window displays a list of inventories that are currently available, along with the following information:
+* *Name*: The inventory name.
+* *Status*: The statuses are: 
+** *Success*: The inventory sync completed successfully.
+** *Disabled*: No inventory source added to the inventory.
+** *Error*: The inventory source completed with error.
+* *Type*: Identifies whether the inventory is a standard inventory, a smart inventory, or a constructed inventory. 
+* *Organization*: The organization to which the inventory belongs. 
+. Select an inventory name to display the *Details* page for the inventory, including the inventory's groups and hosts.
 
-//ADD CONTENT
+For more information about inventories, see the link:{URLControllerUserGuide}/index#controller-inventories[Inventories] section of the {TitleControllerUserGuide} guide.
 

--- a/downstream/modules/platform/con-gs-auto-op-job-templates.adoc
+++ b/downstream/modules/platform/con-gs-auto-op-job-templates.adoc
@@ -4,6 +4,6 @@
 
 A job template is a definition and set of parameters for running an Ansible job.
 
-A job template combines an Ansible Playbook from a project and the settings required to launch it. Job templates are useful to run the same job many times. Job templates also encourage the reuse of Ansible Playbook content and collaboration between teams. For more information, see [ADD2.5 LINK][Job Templates] in the Automation controller User Guide.
+A job template combines an Ansible Playbook from a project with the settings required to launch the job. Job templates are useful for running the same job many times. Job templates also encourage the reuse of Ansible Playbook content and collaboration between teams. For more information, see link:{URLControllerUserGuide}/index#controller-job-templates[Job Templates] in the {TitleControllerUserGuide} guide.
 
-Platform administrators and automation developers have the permissions to create job templates. As an automation operator you can launch job templates  and view their details.
+Platform administrators and automation developers have the permissions to create job templates. As an automation operator you can launch job templates and view their details.

--- a/downstream/modules/platform/con-gs-automation-execution-jobs.adoc
+++ b/downstream/modules/platform/con-gs-automation-execution-jobs.adoc
@@ -2,4 +2,4 @@
 
 = Automation execution jobs
 
-A job is an instance of {ControllerName} launching an Ansible Playbook against an inventory of hosts.
+A job is an instance of {PlatformNameShort} launching an Ansible Playbook against an inventory of hosts.

--- a/downstream/modules/platform/proc-gs-auto-op-launch-template.adoc
+++ b/downstream/modules/platform/proc-gs-auto-op-launch-template.adoc
@@ -8,7 +8,13 @@ In addition to the playbooks, the template passes the inventory, credentials, ex
 
 .Procedure
 
-From the navigation panel, select {MenuAETemplates}.
+. From the navigation panel, select {MenuAETemplates}.
+. Select a template to view its details. A default job template is created during your initial setup to help you get started, but you can also create your own. 
+. From the *Templates* page, click the launch icon to run your job template. 
 
-//ADD CONTENT
+The *Templates* list view shows job templates that are currently available. The default view is collapsed (Compact), showing the template name, template type, and the timestamp of the last job that ran using that template. You can click the arrow icon next to each entry to expand and view more information. This list is sorted alphabetically by name, but you can sort by other criteria, or search by various template fields and attributes. 
+
+From this screen you can launch, edit, and copy a job template. 
+
+For more information about templates see the link:{URLControllerUserGuide}/index#controller-job-templates[Job templates] and link:{URLControllerUserGuide}/index#controller-workflow-job-templates[Workflow job templates] sections of the {TitleControllerUserGuide}.
 

--- a/downstream/modules/platform/proc-gs-auto-op-projects.adoc
+++ b/downstream/modules/platform/proc-gs-auto-op-projects.adoc
@@ -2,11 +2,15 @@
 
 = Automation execution projects
 
-A project is a logical collection of Ansible playbooks, represented in {ControllerName}. 
+A project is a logical collection of Ansible playbooks that you can manage in {PlatformNameShort}. 
 
 Platform administrators and automation developers have the permissions to create projects. 
 As an automation operator you can view and sync projects.
 
-== Executing a project 
+== Viewing project details 
 
-//ADD CONTENT
+The *Projects* page displays a list of projects that are currently available. 
+
+. From the navigation panel, select {MenuAEProjects}.
+. Click a project to view its details.
+. For each project listed, you can sync the latest revision, edit the project, or copy the project's attributes using the icons next to each project. 

--- a/downstream/modules/platform/proc-gs-auto-op-review-job-output.adoc
+++ b/downstream/modules/platform/proc-gs-auto-op-review-job-output.adoc
@@ -1,11 +1,12 @@
 [id="proc-gs-auto-op-review-job-output"]
 
-= Reviewing a job output
+= Reviewing job output
 
 When you relaunch a job, the jobs *Output* view is displayed. 
  
 .Procedure
 
 . From the navigation panel, select {MenuAEJobs}.
-
-//ADD CONTENT
+. Select a job. This takes you to the *Output* view for that job, where you can filter job output by these criteria:
+* The *Search output* option allows you to search by keyword.
+* The *Event* option enables you to filter by the events of interest, such as errors, host failures, host retries, and items skipped. You can include as many events in the filter as necessary. 

--- a/downstream/modules/platform/proc-gs-auto-op-review-job-status.adoc
+++ b/downstream/modules/platform/proc-gs-auto-op-review-job-status.adoc
@@ -7,5 +7,11 @@ The *Jobs* list view displays a list of jobs and their statuses, shown as comple
 .Procedure
 
 . From the navigation panel, select {MenuAEJobs}.
++
+The default view is collapsed (Compact) with the job name, status, job type, start, and finish times. You can click the arrow icon to expand and see more information. You can sort this list by various criteria, and perform a search to filter the jobs of interest.
+. From this screen, you can complete the following tasks: 
+* View a job's details and standard output.
+* Relaunch jobs.
+* Remove selected jobs. 
 
-/ADD CONTENT
+The relaunch operation only applies to relaunches of playbook runs and does not apply to project or inventory updates, system jobs, or workflow jobs.


### PR DESCRIPTION
This PR backports the changes from [PR 2091](https://github.com/ansible/aap-docs/pull/2091) to the 2.5 branch. See [AAP-29069](https://github.com/ansible/aap-docs/pull/2091) for more info.