### PR TITLE
2.5 Update abstract of Containerized installation guide

### DIFF
--- a/downstream/titles/aap-containerized-install/docinfo.xml
+++ b/downstream/titles/aap-containerized-install/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>2.5</productnumber>
 <subtitle>Install the containerized version of Ansible Automation Platform</subtitle>
 <abstract>
-<para>Containerized Ansible Automation Platform Installation Guide</para>
+<para>This guide helps you to understand the installation requirements and processes behind our containerized version of Ansible Automation Platform.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>


### PR DESCRIPTION
Backporting the change of abstract to 2.5 so it's correct for GA.