### PR TITLE
2.5 Add link to ansible/test-topologies repo (#2103)

### DIFF
--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -39,10 +39,7 @@ Red Hat has tested the following configurations to install and run {PlatformName
 [options="header"]
 |====
 | Type | Description 
-| Subscription 
-a| 
-* Valid {PlatformName} subscription
-* Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
+| Subscription | Valid {PlatformName} subscription
 | Operating system | {RHEL} 9.2 or later 64-bit (x86_64)
 | Red Hat OpenShift  
 a| 
@@ -63,7 +60,7 @@ Use the following example custom resource (CR) to add your {PlatformNameShort} i
 apiVersion: aap.ansible.com/v1alpha1
 kind: AnsibleAutomationPlatform
 metadata:
- name: <aap instance name>
+  name: <aap instance name>
 spec:
   eda:
     automation_server_ssl_verify: 'no'

--- a/downstream/titles/topologies/master.adoc
+++ b/downstream/titles/topologies/master.adoc
@@ -22,3 +22,8 @@ include::topologies/assembly-ocp-topologies.adoc[leveloffset=+1]
 
 //Automation mesh nodes 
 include::topologies/topologies/ref-mesh-nodes.adoc[leveloffset=+1]
+
+[NOTE]
+====
+For additional information about each of the tested topologies described in this document, see the link:https://github.com/ansible/test-topologies/[test-topologies GitHub repo].
+====


### PR DESCRIPTION
- Add link to test-topologies repo (will be made public at GA)
- Correct typo in OCP-A-ENV-A topology

Create a document for supported topologies

https://issues.redhat.com/browse/AAP-28228