### PR TITLE
Update tested OS architecture for relevant topologies

### DIFF
--- a/downstream/modules/topologies/ref-cont-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-a-env-a.adoc
@@ -36,7 +36,7 @@ Red Hat has tested the following configurations to install and run {PlatformName
 a| 
 * Valid {PlatformName} subscription
 * Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
-| Operating system | {RHEL} 9.2 or later 64-bit (x86_64)
+| Operating system | {RHEL} 9.2 or later x86_64
 | Ansible-core | Ansible-core version 2.15 or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | PostgreSQL version 15

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -37,7 +37,7 @@ Red Hat has tested the following configurations to install and run {PlatformName
 a| 
 * Valid {PlatformName} subscription
 * Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
-| Operating system | {RHEL} 9.2 or later 64-bit (x86_64)
+| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
 | Ansible-core | Ansible-core version 2.15 or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome.
 | Database | PostgreSQL version 15

--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -40,7 +40,7 @@ Red Hat has tested the following configurations to install and run {PlatformName
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later 64-bit (x86_64)
+| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
 | Red Hat OpenShift  
 a| 
 * Version: 4.14

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -35,7 +35,7 @@ Red Hat has tested the following configurations to install and run {PlatformName
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later 64-bit (x86)
+| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
 | Ansible-core | Ansible-core version 2.15 or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | PostgreSQL version 15

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -35,7 +35,7 @@ Red Hat has tested the following configurations to install and run {PlatformName
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later 64-bit (x86_64)
+| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
 | Ansible-core | Ansible-core version 2.15 or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | PostgreSQL version 15


### PR DESCRIPTION
Update OS to include AArch64 support in addition to x86_64 for relevant topologies.

Create a document for supported topologies

https://issues.redhat.com/browse/AAP-28228