### PR TITLE
Backport to 2.5: aap-20548: UI parity update for managing content in hub (#1609)

### DIFF
--- a/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
+++ b/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
@@ -6,56 +6,70 @@ ifdef::context[:parent-context: {context}]
 :context: managing-cert-validated-content
 
 [role="_abstract"]
-{CertifiedName} are included in your subscription to {PlatformName}. Red Hat Ansible content includes two types of content: {CertifiedName} and {Valid}.
-Using {HubNameMain}, you can access and curate a unique set of collections from all forms of Ansible content.
+{CertifiedName} are included in your subscription to {PlatformName}. Using {HubNameMain}, you can access and curate a unique set of collections from all forms of Ansible content.
 
 Red Hat Ansible content contains two types of content:
 
 * {CertifiedName}
 * {Valid} collections
 
-Ansible validated collections are available in your {PrivateHubName} through the Platform Installer.
-When you download {PlatformName} with the bundled installer, validated content is pre-populated into the {PrivateHubName} by default, but only if you enable the {PrivateHubName} as part of the inventory.
+You can use both {CertifiedName} or {Valid} collections to build your automation library. For more information on the differences between {CertifiedName} and {Valid} collections, see the Knowledgebase article link:https://access.redhat.com/support/articles/ansible-automation-platform-certified-content[{CertifiedName} and {Valid}], or xref:assembly-validated-content[{Valid}] in this guide.
 
-If you are not using the bundle installer, you can use a Red Hat supplied Ansible playbook to install validated content.
-For further information, see xref:assembly-validated-content[{Valid}].
+// hherbly--removed, see aap-20548  
+// Ansible validated collections are available in your {PrivateHubName} through the platform installer.
+// When you download {PlatformName} with the bundled installer, validated content is pre-populated into the {PrivateHubName} by default, but only if you enable the {PrivateHubName} as part of the inventory.
+
+// If you are not using the bundle installer, you can use a Red Hat supplied Ansible playbook to install validated content.
+
+// For further information, see xref:assembly-validated-content[{Valid}].
 
 You can update these collections manually by downloading their packages.
 
-[discrete]
-== Why certify Ansible collections?
-
-The Ansible certification program enables a shared statement of support for {CertifiedCon} between Red Hat and the ecosystem partner.
-An end customer, experiencing trouble with Ansible and certified partner content, can open a support ticket, for example, a request for information, or a problem with Red Hat, and expect the ticket to be resolved by Red Hat and the ecosystem partner.
-
-Red Hat offers go-to-market benefits for Certified Partners to grow market awareness, generate demand, and sell collaboratively.
-
-Red Hat {CertifiedName} are distributed through {HubNameMain} (subscription required), a centralized repository for jointly supported Ansible Content.
-As a certified partner, publishing collections to {HubNameMain} provides end customers the power to manage how trusted automation content is used in their production environment with a well-known support life cycle.
-
-For more information about getting started with certifying a solution, see link:https://connect.redhat.com/en/partner-with-us/red-hat-ansible-automation-certification[Red Hat Partner Connect].
+//hherbly: removing as this is specific to partners, not a general user audience. see aap-20548  
 
 [discrete]
-== How do I get a collection certified?
 
-For instructions on certifying your collection, see the Ansible certification policy guide on link:http://www.ansible.com/partners[Red Hat Partner Connect].
+// == Why certify Ansible collections?
 
-[discrete]
-== How does the joint support agreement on Certified Collections work?
+// The Ansible certification program represents a shared statement of support for {CertifiedCon} between Red Hat and the ecosystem partner.
+// An end customer experiencing trouble with Ansible and certified partner content can, for example, open a support ticket describing a request for information, or a problem with Red Hat, and expect the ticket to be resolved by Red Hat and the ecosystem partner.
 
-If a customer raises an issue with the Red Hat support team about a certified collection, Red Hat support assesses the issue and checks whether the problem exists within Ansible or Ansible usage.
-They also check whether the issue is with a certified collection.
-If there is a problem with the certified collection, support teams transfer the issue to the vendor owner of the certified collection through an agreed upon tool such as TSANet.
+// Red Hat offers go-to-market benefits for Certified Partners to grow market awareness, generate demand, and sell collaboratively.
 
-[discrete]
-== Can I create and certify a collection containing only Ansible Roles?
+// Red Hat {CertifiedName} are distributed through {HubNameMain} (subscription required), a centralized repository for jointly supported Ansible Content.
+// As a certified partner, publishing collections to {HubNameMain} gives end customers the power to manage how trusted automation content is used in their production environment with a well-known support life cycle.
 
-You can create and certify collections that contain only roles.
-Current testing requirements are focused on collections containing modules, and additional resources are currently in progress for testing collections only containing roles.
-Contact ansiblepartners@redhat.com for more information.
+// For more information about getting started with certifying a solution, see link:https://connect.redhat.com/en/partner-with-us/red-hat-ansible-automation-certification[Red Hat Partner Resources].
 
-include::assembly-synclists.adoc[leveloffset=+1]
+// [discrete]
+// == How do I get a collection certified?
+
+// For instructions on certifying your collection, see the Ansible certification policy guide on link:http://www.ansible.com/partners[Red Hat Partner Connect].
+
+// [discrete]
+// == How does the joint support agreement on Certified Collections work?
+
+// If a customer raises an issue with the Red Hat support team about a certified collection, Red Hat support assesses the issue and checks whether the problem is with Ansible or Ansible usage.
+// They also check whether the issue is with a certified collection.
+// If there is a problem with the certified collection, support teams transfer the issue to the vendor owner of the certified collection through an agreed-upon tool such as TSANet.
+
+// [discrete]
+// == Can I create and certify a collection containing only Ansible Roles?
+
+// You can create and certify collections that contain only roles.
+// Current testing requirements are focused on collections containing modules, and additional resources are currently in progress for testing collections containing only roles.
+// Contact ansiblepartners@redhat.com for more information.
+
+You can use {HubNameMain} to distribute the relevant {CertifiedColl}s to your users by creating a requirements file or a synclist. Use a requirements file to install collections to your {HubName}, as synclists can only be managed by users with platform administrator privileges. 
+
+Before you can use a requirements file to install content, you must: 
+
+. xref:proc-obtaining-org-collection-url[Obtain an automation hub API token]
+. xref:proc-set-rhcertified-remote.adoc[Use the API token to configure a remote repository in your local hub]
+. Then, xref:proc-create-requirements-file[Create a requirements file].
+
 include::assembly-syncing-to-cloud-repo.adoc[leveloffset=+1]
+include::assembly-synclists.adoc[leveloffset=+1]
 include::assembly-collections-and-content-signing-in-pah.adoc[leveloffset=+1]
 //include::assembly-faq.adoc[leveloffset=+1]
 include::assembly-validated-content.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-managing-collections-hub.adoc
+++ b/downstream/assemblies/hub/assembly-managing-collections-hub.adoc
@@ -6,9 +6,9 @@ ifdef::context[:parent-context: {context}]
 :context: managing-collections-hub
 
 [role="_abstract"]
-As a content creator, you can use namespaces in {HubName} to curate and manage collections for the following purposes:
+As a content creator, you can use namespaces in {HubName} to curate and manage collections. For example, you can:
 
-* Create groups with permissions to curate namespaces and upload collections to {PrivateHubName}
+* Create teams with permissions to curate namespaces and upload collections to {PrivateHubName}
 * Add information and resources to the namespace to help end users of the collection in their automation tasks
 * Upload collections to the namespace
 * Review the namespace import logs to determine the success or failure of uploading the collection and its current approval status

--- a/downstream/assemblies/hub/assembly-repo-management.adoc
+++ b/downstream/assemblies/hub/assembly-repo-management.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 :context: repo-management
 
 [role="_abstract"]
-As an {HubName} administrator, you can create, edit, delete, and move automation content collections between repositories.
+As a platform administrator, you can create, edit, delete, and move automation content collections between repositories.
 
 == Types of repositories in automation hub
 
@@ -16,7 +16,7 @@ Staging repositories:: Any user with permission to upload to a namespace can pub
 
 Custom repositories:: Any user with write permissions on the repository can publish collections to these repositories. Custom repositories can be public where all users can see them, or private  where only users with view permissions can see them. These repositories are not displayed on the approval dashboard. If the repository owner enables search, the collection can appear in search results.
 
-By default, {HubName} ships with one staging repository that is automatically used when a repository is not specified for uploading collections. Users can create new staging repositories during xref:proc-create-repository[repository creation].
+By default, {HubName} includes one staging repository that is automatically used when a repository is not specified for uploading collections. Users can create new staging repositories during xref:proc-create-repository[repository creation].
 
 include::hub/con-approval-pipeline.adoc[leveloffset=+1]
 include::hub/con-repo-rbac.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
+++ b/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
@@ -5,22 +5,20 @@ Use remote configurations to configure your {PrivateHubName} to synchronize with
 
 [IMPORTANT]
 ====
+To synchronize content, you can now upload a manually-created requirements file from the rh-certified remote. Remotes are configurations that allow you to synchronize content to your custom repositories from an external collection source.
+
 As of the 2.4 release you can still synchronize content, but synclists are deprecated, and will be removed in a future version.
-
-To synchronize content, you can now upload a manually-created requirements file from the rh-certified remote. 
-
-Remotes are configurations that allow you to synchronize content to your custom repositories from an external collection source.
 ====
 
 [discrete]
 == What’s the difference between {Galaxy} and {HubNameMain}?
 
 Collections published to {Galaxy} are the latest content published by the Ansible community and have no joint support claims associated with them. 
-{Galaxy} is the recommended frontend directory for the Ansible community accessing content.
+{Galaxy} is the recommended frontend directory for the Ansible community to access content.
 
-Collections published to {HubNameMain} are targeted for joint customers of Red Hat and selected partners. 
+Collections published to {HubNameMain} are targeted to joint customers of Red Hat and selected partners. 
 Customers need an Ansible subscription to access and download collections on {HubNameMain}. 
-A certified collection means that Red Hat and partners have a strategic relationship in place and are ready to support joint customers, and may have had additional testing and validation done against them.
+A certified collection means that Red Hat and partners have a strategic relationship in place and are ready to support joint customers, and that the collections may have had additional testing and validation done against them.
 
 [discrete]
 == How do I request a namespace on {Galaxy}?
@@ -37,11 +35,13 @@ After users are added as administrators of the namespace, you can use the self-s
 [discrete]
 == Are there any restrictions for {Galaxy} namespace naming?
 
-Collection namespaces must follow python module name convention. 
+Collection namespaces must follow Python module name convention. 
 This means collections should have short, all lowercase names. 
 You can use underscores in the collection name if it improves readability.
 
 include::hub/con-remote-repos.adoc[leveloffset=+1]
+
+include::hub/proc-create-requirements-file.adoc[leveloffset=+1]
 
 include::hub/proc-obtaining-org-collection-url.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/hub/assembly-synclists.adoc
+++ b/downstream/assemblies/hub/assembly-synclists.adoc
@@ -3,14 +3,11 @@
 
 [IMPORTANT]
 ====
-As of the 2.4 release you can still synchronize content, but synclists are deprecated, and will be removed in a future version.
-
 To synchronize content, you can now upload a manually-created requirements file from the rh-certified remote.
-
 Remotes are configurations that enable you to synchronize content to your custom repositories from an external collection source.
-====
 
-You can use {HubNameMain} to distribute the relevant {CertifiedColl}s to your users by creating synclists or a requirements file. For more information about using requirements files, see link:https://docs.ansible.com/ansible/latest/collections_guide/collections_installing.html#install-multiple-collections-with-a-requirements-file[Install multiple collections with a requirements file] in the _Using Ansible collections_ guide.
+As of the 2.4 release you can still synchronize content, but synclists are deprecated, and will be removed in a future version.
+====
 
 include::hub/con-rh-certified-synclist.adoc[leveloffset=+1]
 include::hub/proc-create-synclist.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -14,17 +14,17 @@ Validated collections are uploaded into the `validated` repository.
 You can change to default configuration by using two variables:
 
 * `automationhub_seed_collections` is a boolean that defines whether or not preloading is enabled.
-* `automationhub_collection_seed_repository`. A variable that enables you to specify the type of content to upload when it is set to `true`.
+* `automationhub_collection_seed_repository`is a variable that enables you to specify the type of content to upload when it is set to `true`.
 Possible values are `certified` or `validated`.
-If missing both content sets will be uploaded.
+If this variable is missing, both content sets will be uploaded.
 
 == Installing validated content using the tarball
 
-If you are not using the bundle installer, you can use a standalone tarball, `ansible-validated-content-bundle-1.tar.gz`.
-You can also use this standalone tarball later to update validated contents in any environment, when a newer tarball becomes available, without having to re-run the bundle installer.
+If you are not using the bundle installer, you can use a standalone .tar file, `ansible-validated-content-bundle-1.tar.gz`.
+You can also use this standalone .tar file later to update validated contents in any environment, when a newer .tar file becomes available, without having to re-run the bundle installer.
 
 .Prerequisites
-You require the following variables to run the playbook.
+Use the following required variables to run the playbook.
 
 [cols="50%,50%",options="header"]
 |====
@@ -40,7 +40,7 @@ This variable is set to `true` by the installer.
 |====
 
 .Procedure
-. To obtain the tarball, navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page and select *Ansible Validated Content*.
+. To obtain the .tar file, navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page and select *Ansible Validated Content*.
 . Upload the content and define the variables (this example uses `automationhub_api_token`):
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/downstream/assemblies/hub/assembly-working-with-namespaces.adoc
+++ b/downstream/assemblies/hub/assembly-working-with-namespaces.adoc
@@ -6,7 +6,7 @@ Namespaces are unique locations in {HubName} to which you can upload and publish
 
 You can use namespaces in {HubName} to organize collections developed within your organization for internal distribution and use.
 
-If you are working with namespaces, you must have a group that has permissions to create, edit and upload collections to namespaces. Collections uploaded to a namespace require administrative approval before you can publish them and make them available for use.
+If you are working with namespaces, you must have a team that has permissions to create, edit and upload collections to namespaces. Collections uploaded to a namespace require administrative approval before you can publish them and make them available for use.
 
 include::hub/proc-create-content-developers.adoc[leveloffset=+1]
 
@@ -14,7 +14,7 @@ include::hub/proc-create-namespace.adoc[leveloffset=+1]
 
 include::hub/proc-edit-namespace.adoc[leveloffset=+1]
 
-When you create a namespace, groups with permissions to upload to it can start adding their collections for approval. Collections in the namespace appear in the *Published* repository after approval.
+When you create a namespace, teams with permissions to upload to it can start adding their collections for approval. Collections in the namespace appear in the *Published* repository after approval.
 
 include::hub/proc-uploading-collections.adoc[leveloffset=+1]
 

--- a/downstream/modules/hub/con-rh-certified-synclist.adoc
+++ b/downstream/modules/hub/con-rh-certified-synclist.adoc
@@ -2,10 +2,10 @@
 
 = Explanation of Red Hat {CertifiedName} synclists
 
-A synclist is a curated group of Red Hat Certified Collections that is assembled by your organization administrator.
+A synclist is a curated group of Red Hat Certified Collections assembled by your organization administrator.
 It synchronizes with your local {HubNameMain}. 
 Use synclists to manage only the content that you want and exclude unnecessary collections.
 Design and manage your synclist from the content available as part of Red Hat content on {Console}
 
-Each synclist has its own unique repository URL that you can use to designate as a remote source for content in {HubName}.
+Each synclist has its own unique repository URL that you can designate as a remote source for content in {HubName}.
 You securely access each synclist by using an API token.

--- a/downstream/modules/hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -24,7 +24,7 @@ gpg --import --no-default-keyring --keyring ~/.ansible/pubring.kbx my-public-key
 +
 [NOTE]
 ====
-In addition to any signatures provided by the {HubName}, signature sources can also be provided in the requirements file and on the command line. 
+In addition to any signatures provided by {HubName}, signature sources can also be provided in the requirements file and on the command line. 
 Signature sources should be URIs.
 ====
 +
@@ -61,8 +61,8 @@ Create a collection with `company_name.product` format.
 This format means that multiple products can have different collections under the company namespace.
 
 [discrete]
-= How do I get a namespace on {HubNameMain}?
+= How do I get a namespace on {HubName}?
 
-By default namespaces used on {Galaxy} are also used on {HubNameMain} by the Ansible partner team. 
+By default namespaces used on {Galaxy} are also used on {HubName} by the Ansible partner team. 
 For any queries and clarifications contact ansiblepartners@redhat.com.
 

--- a/downstream/modules/hub/proc-configure-proxy-remote.adoc
+++ b/downstream/modules/hub/proc-configure-proxy-remote.adoc
@@ -16,7 +16,7 @@ For more information on permissions, see link:{BaseURL}/red_hat_ansible_automati
 
 .Procedure
 //[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {PrivateHubName}.
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRemotes}.
 . In either the *rh-certified* or *Community* remote, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Edit*.
 . Expand the *Show advanced options* drop-down menu.

--- a/downstream/modules/hub/proc-create-content-developers.adoc
+++ b/downstream/modules/hub/proc-create-content-developers.adoc
@@ -1,26 +1,34 @@
 [id="proc-create-content-developers"]
 
-= Creating a new group for content curators
+= Creating a new team for content curators
 
-You can create a new group in {PrivateHubName} designed to support content curation in your organization. This group can contribute internally developed collections for publication in {PrivateHubName}.
+You can create a new team in {PlatformNameShort} designed to support content curation in your organization. This team can contribute internally-developed collections for publication in {PrivateHubName}.
 
-To help content developers create a namespace and upload their internally developed collections to {PrivateHubName}, you must first create and edit a group and assign the required permissions.
+To help content developers create a namespace and upload their internally developed collections to {PrivateHubName}, you must first create and edit a team and assign the required permissions.
 
 .Prerequisites
 
-* You have administrative permissions in {PrivateHubName} and can create groups.
+* You have administrative permissions in {PlatformNameShort} and can create teams.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to your {PrivateHubName}.
-. From the navigation panel, select {MenuHubGroups} and click btn:[Create].
-. Enter *Content Engineering* as a *Name* for the group in the modal and click btn:[Create]. You have created the new group and the *Groups* page opens.
-. On the *Permissions* tab, click btn:[Edit].
-. Under *Namespaces*, add permissions for *Add Namespace*, *Upload to Namespace*, and *Change Namespace*.
-. Click btn:[Save].
+
+. Log in to your {PlatformNameShort}.
+. From the navigation panel, select {MenuAMTeams} and click btn:[Create team].
+. Enter *Content Engineering* as a *Name* for the team.
+. Select an *Organization* for the team. 
+. Click btn:[Create team]. You have created the new team and the team Details page opens.
+. Select the *Roles* tab and then select the *Automation Content* tab.
+. Click btn:[Add roles].
+. Select *Namespace* from the *Resource type* list and click btn:[Next].
+. Select the namespaces that will receive the new roles and click btn:[Next].
+. Select the roles to apply to the selected namespaces and click btn:[Next].
+. Review your selections and click btn:[Finish].
+. Click btn:[Close] to complete the process.
 +
-The new group is created with the permissions that you assigned. You can then add users to the group.
+The new team is created with the permissions that you assigned. You can then add users to the team.
 +
-. Click the *Users* tab on the *Groups* page.
-. Click btn:[Add].
-. Select users and click btn:[Add].
+. Click the *Users* tab on the *Teams* page.
+. Click btn:[Add users].
+. Select users and click btn:[Add users].
+
+For further instructions on managing access with teams, see link:{URLCentralAuth}/index#assembly-controller-teams_gw-manage-rbac[Teams] in the {TitleCentralAuth} guide.

--- a/downstream/modules/hub/proc-create-namespace.adoc
+++ b/downstream/modules/hub/proc-create-namespace.adoc
@@ -3,18 +3,23 @@
 = Creating a namespace
 
 You can create a namespace to organize collections that your content developers upload to {HubName}.
-When creating a namespace, you can assign a group in {HubName} as owners of that namespace.
+When creating a namespace, you can assign a team in {HubName} as owners of that namespace.
 
 .Prerequisites
 
 * You have *Add Namespaces* and *Upload to Namespaces* permissions.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to your {PrivateHubName}.
-. From the navigation panel, select {MenuACNamespaces}.
-. Click btn:[Create] and enter a *namespace name*.
-. Assign a group of *Namespace owners*.
-. Click btn:[Create].
 
-Your content developers can now upload collections to your new namespace and allow users in groups assigned as owners to upload collections.
+. Log in to your {PlatformNameShort}.
+. From the navigation panel, select {MenuACNamespaces}.
+. Click btn:[Create namespace] and enter a *Name* for your namespace.
+. Optional: enter a description, company, logo URL, resources, or useful links in the appropriate fields.
+. Click btn: [Create namespace].
+. Select the *Team Access* tab and click btn:[Add roles] to assign roles to your namespace.
+. Select the team to which you want to grant a role, then click btn:[Next].
+. Select the roles you want to apply to the selected team, and then click btn:[Next].
+. Review your selections and click btn:[Finish].
+. Click btn:[Close] to complete the process.
+
+Your content developers can now upload collections to your new namespace and allow users in teams assigned as owners to upload collections.

--- a/downstream/modules/hub/proc-create-repository.adoc
+++ b/downstream/modules/hub/proc-create-repository.adoc
@@ -9,7 +9,7 @@ When you use {PlatformName} to create a repository, you can configure the reposi
 
 .Procedure
 //[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {HubName}.
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRepositories}.
 . Click btn:[Add repository].
 . Enter a *Repository name*.

--- a/downstream/modules/hub/proc-create-requirements-file.adoc
+++ b/downstream/modules/hub/proc-create-requirements-file.adoc
@@ -1,0 +1,42 @@
+:_newdoc-version: 2.18.3
+:_template-generated: 2024-09-18
+:_mod-docs-content-type: PROCEDURE
+
+[id="create-requirements-file_{context}"]
+= Creating a requirements file
+
+We recommend using a requirements file to add collections to your {HubName}. Requirements files are in YAML format and list the collections that you want to install in your {HubName}. After you create your requirements.yml file listing the collections you want to install, you will then run the install command to add the collections to your hub instance. 
+
+A standard `requirements.yml` file contains the following parameters:
+
+* `name`: the name of the collection formatted as `<namespace>.<collection_name>`
+* `version`: the collection version number
+
+.Procedure
+
+. Create your requirements file.
++
+In YAML format, collection information in your requirements file should look like this:
++
+[source,bash]
+----
+collections:
+ name: namespace.collection_name
+ version: 1.0.0
+----
++
+. After you have created your requirements file listing information for each collection that you want to install, navigate to the directory where the file is located and run the following command:
+
+[source,bash]
+----
+$ ansible-galaxy collection install -r requirements.yml
+----
+
+== Installing an individual collection from the command line
+
+To install an individual collection to your {HubName}, run the following command: 
+
+[source,bash]
+----
+$ ansible-galaxy collection install namespace.collection_name
+----

--- a/downstream/modules/hub/proc-create-synclist.adoc
+++ b/downstream/modules/hub/proc-create-synclist.adoc
@@ -13,7 +13,7 @@ All {CertifiedName} are included by default in your initial organization synclis
 .Prerequisites
 
 * You have a valid {PlatformNameShort} subscription.
-* You have Organization Administrator permissions for {Console}.
+* You have organization administrator permissions for {Console}.
 * The following domain names are part of either the firewall or the proxy's allowlist.
 They are required for successful connection and download of collections from {HubName} or Galaxy server:
 ** `galaxy.ansible.com`
@@ -27,10 +27,16 @@ The following domain names must be in the allow list:
 * SSL inspection is disabled either when using self signed certificates or for the Red Hat domains.
 
 .Procedure
-// ddacosta I don't know if a change will be needed here for Gateway as this is referring to the Console version of Hub. Will console pull in nav changes? Also, there is no repositories selection on the console version right now. 
+
 . Log in to `{Console}`.
 . Navigate to menu:Automation Hub[Collections].
-. Set the toggle switch on each collection to exclude or include it on your synclist.
-. To initiate the remote repository synchronization, navigate to {HubName} and select {MenuACAdminRepositories}.
-. Click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync* to initiate the remote repository synchronization to your {PrivateHubName}.
+. Set the *Sync* toggle switch on each collection to exclude or include it on your synclist.
++
+[NOTE]
+====
+You will only see the *Sync* toggle switch if you have administrator permissions.
+====
++
+. To initiate the remote repository synchronization, navigate to your {PlatformNameShort} and select {MenuACAdminRepositories}.
+. In the row containing the repository you want to sync, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync repository* to initiate the remote repository synchronization to your {PrivateHubName}. 
 . Optional: If your remote repository is already configured, update the collections content that you made available to local users by manually synchronizing Red Hat {CertifiedName} to your {PrivateHubName}.

--- a/downstream/modules/hub/proc-delete-namespace.adoc
+++ b/downstream/modules/hub/proc-delete-namespace.adoc
@@ -5,7 +5,7 @@
 = Deleting a namespace
 
 You can delete unwanted namespaces to manage storage on your {HubName} server.
-You must first ensure that the namespace does not contain a collection with dependencies.
+You must first ensure that the namespace you want to delete does not contain a collection with dependencies.
 
 .Prerequisites
 * The namespace you are deleting does not have a collection with dependencies.
@@ -13,7 +13,7 @@ You must first ensure that the namespace does not contain a collection with depe
 
 .Procedure
 //[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to your {PrivateHubName}.
+. Log in to your {PlatformNameShort}.
 . From the navigation panel, select {MenuACNamespaces}.
 . Click the namespace to be deleted.
 . Click the btn:[More Actions] icon *{MoreActionsIcon}*, then click btn:[Delete namespace].

--- a/downstream/modules/hub/proc-downloading-signature-public-keys.adoc
+++ b/downstream/modules/hub/proc-downloading-signature-public-keys.adoc
@@ -4,12 +4,12 @@
 
 = Downloading signature public keys
 
-After you sign and approve collections, download the signature public keys from the {HubName} UI.
+After you sign and approve collections, download the signature public keys from the {PlatformNameShort} UI.
 You must download the public key before you add it to the local system keyring.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to your {HubName}.
+
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminSignatureKeys}.
 The Signature Keys dashboard displays a list of multiple keys: collections and container images.
 
@@ -19,8 +19,7 @@ The Signature Keys dashboard displays a list of multiple keys: collections and c
 
 . Choose one of the following methods to download your public key:
 
-* Select the menu icon and click btn:[Download Key] to download the public key.
-* Select the public key from the list and click the _Copy to clipboard_ icon.
-* Click the drop-down menu under the *_Public Key_* tab and copy the entire public key block.
+* Click the btn:[Download Key] icon to download the public key.
+* Click the btn:[Copy to clipboard] next to the public key you want to copy.
 
 Use the public key that you copied to verify the content collection that you are installing.

--- a/downstream/modules/hub/proc-edit-namespace.adoc
+++ b/downstream/modules/hub/proc-edit-namespace.adoc
@@ -4,19 +4,20 @@
 
 = Adding additional information and resources to a namespace
 
-You can add information and provide resources for your users to accompany collections included in the namespace. Add a logo and a description, and link users to your GitHub repository, issue tracker, or other online assets. You can also enter markdown text in the *Edit resources* tab to include more information. This is helpful to users who use your collection in their automation tasks.
+You can add information and provide resources for your users to accompany collections included in the namespace. For example, you can add a logo and a description, and link users to your GitHub repository, issue tracker, or other online assets. You can also enter markdown text in the *Resources* field to include more information. This is helpful to users who use your collection in their automation tasks.
 
 .Prerequisites
 
 * You have *Change Namespaces* permissions.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to your {PrivateHubName}.
-. From the navigation panel, select {MenuACNamespaces}.
-. Click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Edit namespace*.
-. In the *Edit details* tab, enter information in the fields.
-. Click the *Edit resources* tab to enter markdown in the text field.
-. Click btn:[Save].
 
-Your content developers can now upload collections to your new namespace, or allow users in groups assigned as owners to upload collections.
+. Log in to {PlatformNameShort}.
+. From the navigation panel, select {MenuACNamespaces}.
+. Select the namespace you want to edit.
+. Click the btn:[Edit namespace].
+. Enter the relevant information in the fields.
+. Optional: enter markdown information in the *Resources* field.
+. Click btn:[Save namespace].
+
+Your content developers can now upload collections to your new namespace, or allow users in teams assigned as owners to upload collections.

--- a/downstream/modules/hub/proc-review-collection-imports.adoc
+++ b/downstream/modules/hub/proc-review-collection-imports.adoc
@@ -15,10 +15,10 @@ Import log:: activities executed during the collection import
 
 .Procedure
 //[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to your {PrivateHubName}.
+. Log in to your {PlatformNameShort}.
 . From the navigation panel, select {MenuACNamespaces}.
 . Select a namespace.
-. Click the btn:[More Actions] icon *{MoreActionsIcon}* and select *My imports*.
+. Click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Imports*.
 . Use the search field or locate an imported collection from the list.
 . Click the imported collection.
 . Review collection import details to determine the status of the collection in your namespace.

--- a/downstream/modules/hub/proc-set-community-remote.adoc
+++ b/downstream/modules/hub/proc-set-community-remote.adoc
@@ -23,15 +23,15 @@ collections:
 
 .Procedure
 //[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {HubName}.
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRemotes}.
-. In the *Community* remote, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Edit*.
+. In the *Details* tab in the *Community* remote, click btn:[Edit].
 . In the *YAML requirements* field, click btn:[Browse] and locate the `requirements.yml` file on your local machine.
 . Click btn:[Save].
 +
 You can now synchronize collections identified in your `requirements.yml` file from {Galaxy} to your {PrivateHubName}.
 
-. Click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync* to sync collections from {Galaxy} and {HubNameMain}.
+. From the navigation panel, select {MenuACAdminRepositories}. Next to the *community* repository, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync* to sync collections from {Galaxy} and {HubNameMain}.
 
 .Verification
 The *Sync status* notification updates to notify you of completion or failure of {Galaxy} collections synchronization to your {HubNameMain}.

--- a/downstream/modules/hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/hub/proc-set-rhcertified-remote.adoc
@@ -22,16 +22,16 @@ For more information on permissions, see link:{BaseURL}/red_hat_ansible_automati
 
 .Procedure
 //[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to your {PrivateHubName}.
+. Log in to your {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRemotes}.
-. In the *rh-certified* remote repository, click the btn:[More Actions] icon *{MoreActionsIcon}* and click btn:[Edit].
+. In the *rh-certified* remote repository, click btn:[Edit remote].
 . In the *URL* field, paste the *Sync URL*.
 . In the *Token* field, paste the token you acquired from {Console}.
-. Click btn:[Save].
+. Click btn:[Save remote].
 +
 You can now synchronize collections between your organization synclist on {Console} and your {PrivateHubName}.
 +
-. Click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync*.
+. From the navigation panel, select {MenuACAdminRepositories}. Next to *rh-certified* click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync*.
 
 .Verification
 The *Sync status* notification updates to notify you that the Red Hat Certified Content Collections synchronization is complete.

--- a/downstream/modules/hub/proc-uploading-collections.adoc
+++ b/downstream/modules/hub/proc-uploading-collections.adoc
@@ -16,8 +16,9 @@ Format your collection file name as follows: <my_namespace-my_collection-1.0.0.t
 
 .Procedure
 //[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to your {PrivateHubName}.
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACNamespaces} and select a namespace.
+. Select the *Collections* tab.
 . Click btn:[Upload collection].
 . Click btn:[Select file] from the *New collection* dialog.
 . Select the collection to upload.

--- a/downstream/modules/hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/hub/proc-using-content-signing-services-in-pah.adoc
@@ -14,11 +14,11 @@ You can use content signing on {PrivateHubName} in the following scenarios:
 
 .Procedure
 //[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to your {PlatformNameShort}.
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminCollectionApproval}.
 The Approval dashboard opens and displays a list of collections.
 
-. Click btn:[Sign and approve] for each collection that you want to sign.
+. Click btn:[Approve] for each collection that you want to sign.
 
 .Verification
 * Verify that the collections you signed and manually approved are displayed in the *Collections* tab.


### PR DESCRIPTION
This PR backports the changes from [PR 1609](https://github.com/ansible/aap-docs/pull/1609) to the 2.5 branch. See [AAP-20548](https://issues.redhat.com/browse/AAP-20548) for more info. 