### PR TITLE
2.4 Fix URL attribute to use multi-page on docs.redhat.com

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -246,178 +246,178 @@
 //
 // titles/troubleshooting-aap
 :TitleTroubleshootingAAP: Troubleshooting Ansible Automation Platform
-:URLTroubleshootingAAP: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/troubleshooting_ansible_automation_platform
+:URLTroubleshootingAAP: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/troubleshooting_ansible_automation_platform
 :LinkTroubleshootingAAP: {URLTroubleshootingAAP}[{TitleTroubleshootingAAP}]
 //
 // titles/aap-operations-guide
 :TitleAAPOperationsGuide: Red Hat Ansible Automation Platform operations guide
-:URLAAPOperationsGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_operations_guide
+:URLAAPOperationsGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_operations_guide
 :LinkAAPOperationsGuide: {URLAAPOperationsGuide}[{TitleAAPOperationsGuide}]
 //
 // titles/eda/eda-user-guide
 :TitleEDAUserGuide: Event-Driven Ansible controller user guide
-:URLEDAUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/event-driven_ansible_controller_user_guide
+:URLEDAUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/event-driven_ansible_controller_user_guide
 :LinkEDAUserGuide: {URLEDAUserGuide}[{TitleEDAUserGuide}]
 //
 // titles/eda/eda-getting-started-guide
 :TitleEDAGettingStarted: Getting started with Event-Driven Ansible guide
-:URLEDAGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/getting_started_with_event-driven_ansible_guide
+:URLEDAGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_event-driven_ansible_guide
 :LinkEDAGettingStarted: {URLEDAGettingStarted}[{TitleEDAGettingStarted}]
 //
 // titles/upgrade
 :TitleUpgrade: Red Hat Ansible Automation Platform upgrade and migration guide
-:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_upgrade_and_migration_guide
+:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_upgrade_and_migration_guide
 :LinkUpgrade: {URLUpgrade}[{TitleUpgrade}]
 //
 // titles/aap-operator-installation
 :TitleOperatorInstallation: Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform
-:URLOperatorInstallation: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform
+:URLOperatorInstallation: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform
 :LinkOperatorInstallation: {URLOperatorInstallation}[{TitleOperatorInstallation}]
 //
 // titles/aap-installation-guide
 :TitleInstallationGuide: Red Hat Ansible Automation Platform installation guide
-:URLInstallationGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_installation_guide
+:URLInstallationGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide
 :LinkInstallationGuide: {URLInstallationGuide}[{TitleInstallationGuide}]
 //
 // titles/aap-planning-guide
 :TitlePlanningGuide: Red Hat Ansible Automation Platform planning guide
-:URLPlanningGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_planning_guide
+:URLPlanningGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide
 :LinkPlanningGuide: {URLPlanningGuide}[{TitlePlanningGuide}]
 //
 // titles/operator-mesh
 :TitleOperatorMesh: Red Hat Ansible Automation Platform automation mesh for operator-based installations
-:URLOperatorMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_automation_mesh_for_operator-based_installations
+:URLOperatorMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_for_operator-based_installations
 :LinkOperatorMesh: {URLOperatorMesh}[{TitleOperatorMesh}]
 //
 // titles/automation-mesh
 :TitleAutomationMesh: Red Hat Ansible Automation Platform automation mesh guide for VM-based installations
-:URLAutomationMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_automation_mesh_guide_for_vm-based_installations
+:URLAutomationMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide_for_vm-based_installations
 :LinkAutomationMesh: {URLAutomationMesh}[{TitleAutomationMesh}]
 //
 // titles/ocp_performance_guide
 :TitleOCPPerformanceGuide: Red Hat Ansible Automation Platform performance considerations for operator based installations
-:URLOCPPerformanceGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_performance_considerations_for_operator_based_installations
+:URLOCPPerformanceGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_performance_considerations_for_operator_based_installations
 :LinkOCPPerformanceGuide: {URLOCPPerformanceGuide}[{TitleOCPPerformanceGuide}]
 //
 // titles/aap-plugin-rhdh-using
 :TitlePluginRHDHUsing: Using Ansible plug-ins for Red Hat Developer Hub
-:URLPluginRHDHUsing: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/using_ansible_plug-ins_for_red_hat_developer_hub
+:URLPluginRHDHUsing: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_ansible_plug-ins_for_red_hat_developer_hub
 :LinkPluginRHDHUsing: {URLPluginRHDHUsing}[{TitlePluginRHDHUsing}]
 //
 // titles/security-guide
 :TitleSecurityGuide: Red Hat Ansible security automation guide
-:URLSecurityGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_security_automation_guide
+:URLSecurityGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_security_automation_guide
 :LinkSecurityGuide: {URLSecurityGuide}[{TitleSecurityGuide}]
 //
 // titles/playbooks/playbooks-getting-started
 :TitlePlaybooksGettingStarted: Getting started with Ansible playbooks
-:URLPlaybooksGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/getting_started_with_ansible_playbooks
+:URLPlaybooksGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_ansible_playbooks
 :LinkPlaybooksGettingStarted: {URLPlaybooksGettingStarted}[{TitlePlaybooksGettingStarted}]
 //
 // titles/playbooks/playbooks-reference
 // Not published in 2.4 
 :TitlePlaybooksReference: Reference guide for Ansible Playbooks
-:URLPlaybooksReference: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/reference_guide_for_ansible_playbooks
+:URLPlaybooksReference: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/reference_guide_for_ansible_playbooks
 :LinkPlaybooksReference: {URLPlaybooksReference}[{TitlePlaybooksReference}]
 //
 // titles/release-notes
 :TitleReleaseNotes: Red Hat Ansible Automation Platform release notes
-:URLReleaseNotes: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_release_notes
+:URLReleaseNotes: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_release_notes
 :LinkReleaseNotes: {URLReleaseNotes}[{TitleReleaseNotes}]
 //
 // titles/controller/controller-user-guide
 :TitleControllerUserGuide: Automation controller user guide
-:URLControllerUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_user_guide
+:URLControllerUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_user_guide
 :LinkControllerUserGuide: {URLControllerUserGuide}[{TitleControllerUserGuide}]
 //
 // titles/controller/controller-admin-guide
 :TitleControllerAdminGuide: Automation controller administration guide
-:URLControllerAdminGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_administration_guide
+:URLControllerAdminGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_administration_guide
 :LinkControllerAdminGuide: {URLControllerAdminGuide}[{TitleControllerAdminGuide}]
 //
 // titles/controller/controller-getting-started
 :TitlePlaybooksGettingStarted: Getting started with automation controller
-:URLPlaybooksGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/getting_started_with_automation_controller
+:URLPlaybooksGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_controller
 :LinkPlaybooksGettingStarted: {URLPlaybooksGettingStarted}[{TitlePlaybooksGettingStarted}]
 //
 // titles/controller/controller-api-overview
 :TitleControllerAPIOverview: Automation controller API overview
-:URLControllerAPIOverview: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_api_overview
+:URLControllerAPIOverview: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_api_overview
 :LinkControllerAPIOverview: {URLControllerAPIOverview}[{TitleControllerAPIOverview}]
 //
 // titles/aap-operator-backup
 :TitleOperatorBackup: Red Hat Ansible Automation Platform operator backup and recovery guide
-:URLOperatorBackup: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_operator_backup_and_recovery_guide
+:URLOperatorBackup: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_operator_backup_and_recovery_guide
 :LinkOperatorBackup: {URLOperatorBackup}[{TitleOperatorBackup}]
 //
 // titles/central-auth
 :TitleCentralAuth: Installing and configuring central authentication for the Ansible Automation Platform
-:URLCentralAuth: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_and_configuring_central_authentication_for_the_ansible_automation_platform
+:URLCentralAuth: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/installing_and_configuring_central_authentication_for_the_ansible_automation_platform
 :LinkCentralAuth: {URLCentralAuth}[{TitleCentralAuth}]
 //
 // titles/aap-containerized-install
 :TitleContainerizedInstall: Containerized Ansible Automation Platform installation guide
-:URLContainerizedInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/containerized_ansible_automation_platform_installation_guide
+:URLContainerizedInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_ansible_automation_platform_installation_guide
 :LinkContainerizedInstall: {URLContainerizedInstall}[{TitleContainerizedInstall}]
 //
 // titles/navigator-guide
 :TitleNavigatorGuide: Automation content navigator creator guide
-:URLNavigatorGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_content_navigator_creator_guide
+:URLNavigatorGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_content_navigator_creator_guide
 :LinkNavigatorGuide: {URLNavigatorGuide}[{TitleNavigatorGuide}]
 //
 // titles/eda-controller/eda-controller-install
 :TitleEDAControllerInstall: Using Event-Driven Ansible 2.5 with Ansible Automation Platform 2.4
-:URLEDAControllerInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/using_event-Driven_ansible_2.5_with_ansible_automation_platform_2.4
+:URLEDAControllerInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_event-Driven_ansible_2.5_with_ansible_automation_platform_2.4
 :LinkEDAControllerInstall: {URLEDAControllerInstall}[{TitleEDAControllerInstall}]
 //
 // titles/dev-guide
 :TitleDevGuide: Red Hat Ansible Automation Platform creator guide
-:URLDevGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_creator_guide
+:URLDevGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_creator_guide
 :LinkDevGuide: {URLDevGuide}[{TitleDevGuide}]
 //
 // titles/aap-hardening
 :TitleHardening: Red Hat Ansible Automation Platform hardening guide
-:URLHardening: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_hardening_guide
+:URLHardening: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_hardening_guide
 :LinkHardening: {URLHardening}[{TitleHardening}]
 //
 // titles/aap-plugin-rhdh-install
 :TitlePluginRHDHInstall: Installing Ansible plug-ins for Red Hat Developer Hub
-:URLPluginRHDHInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_ansible_plug-ins_for_red_hat_developer_hub
+:URLPluginRHDHInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/installing_ansible_plug-ins_for_red_hat_developer_hub
 :LinkPluginRHDHInstall: {URLPluginRHDHInstall}[{TitlePluginRHDHInstall}]
 //
 // titles/builder
 :TitleBuilder: Creating and consuming execution environments
-:URLBuilder: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/creating_and_consuming_execution_environments
+:URLBuilder: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_consuming_execution_environments
 :LinkBuilder: {URLBuilder}[{TitleBuilder}]
 //
 // titles/hub/managing-content
 :TitleHubManagingContent: Managing content in automation hub
-:URLHubManagingContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/managing_content_in_automation_hub
+:URLHubManagingContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_content_in_automation_hub
 :LinkHubManagingContent: {URLHubManagingContent}[{TitleHubManagingContent}]
 //
 // titles/hub/getting-started
 :TitleHubGettingStarted: Getting started with automation hub
-:URLHubGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/getting_started_with_automation_hub
+:URLHubGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub
 :LinkHubGettingStarted: {URLHubGettingStarted}[{TitleHubGettingStarted}]
 //
 // titles/analytics/job-explorer
 :TitleAnalyticsJobExplorer: Evaluating your automation controller job runs using the job explorer
-:URLAnalyticsJobExplorer: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/evaluating_your_automation_controller_job_runs_using_the_job_explorer
+:URLAnalyticsJobExplorer: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/evaluating_your_automation_controller_job_runs_using_the_job_explorer
 :LinkAnalyticsJobExplorer: {URLAnalyticsJobExplorer}[{TitleAnalyticsJobExplorer}]
 //
 // titles/analytics/automation-savings ; Using the automation calculator
 :TitleAnalyticsSavingsPlanner: Planning your automation jobs using the automation savings planner
-:URLAnalyticsSavingsPlanner: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/planning_your_automation_jobs_using_the_automation_savings_planner
+:URLAnalyticsSavingsPlanner: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/planning_your_automation_jobs_using_the_automation_savings_planner
 :LinkAnalyticsSavingsPlanner: {URLAnalyticsSavingsPlanner}[{TitleAnalyticsSavingsPlanner}]
 //
 //
 // titles/develop-automation-content
 :TitleDevelopAutomationContent: Developing Ansible automation content
-:URLDevelopAutomationContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/developing_ansible_automation_content
+:URLDevelopAutomationContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/developing_ansible_automation_content
 :LinkDevelopAutomationContent: {URLDevelopAutomationContent}[{TitleDevelopAutomationContent}]
 //
 // titles/analytics/reports ; Viewing reports about your Ansible automation environment
 :TitleAnalyticsReports: Viewing reports about your Ansible automation environment
-:URLAnalyticsReports: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/viewing_reports_about_your_ansible_automation_environment
+:URLAnalyticsReports: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/viewing_reports_about_your_ansible_automation_environment
 :LinkAnalyticsReports: {URLAnalyticsReports}[{TitleAnalyticsReports}]
 //

--- a/downstream/modules/devtools/proc-devtools-working-with-ee.adoc
+++ b/downstream/modules/devtools/proc-devtools-working-with-ee.adoc
@@ -31,6 +31,6 @@ For more information about working with execution environments locally, see
 link:{LinkBuilder}.
 
 After customizing your execution environment, you can push your new image to the container registry in automation hub. See
-link:{URLBuilder}/index#assembly-publishing-exec-env[Publishing an automation execution environment]
+link:{URLBuilder}/assembly-publishing-exec-env[Publishing an automation execution environment]
 in the _{TitleBuilder}_ documentation.
 


### PR DESCRIPTION
2.4 Fix URL attribute to use multi-page on docs.redhat.com

URL attributes were using `html-single` for docs.redhat.com (ie whole doc is shown) instead of `html` (multi-page).
Previous links used multi-page.
However, the URLs for assemblies / modules change depending on whether `html` or `html-single` is used in a link.

For example

**multi-page (`html`):**
https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/assembly-controller-applications#proc-controller-apps-create-tokens

**single-page (`html-single`):**
https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_user_guide/index#proc-controller-apps-create-tokens

All of our links were configured for all releases up to and including 2.4 for the multi-page version.
This PR will make it easier to convert links to use the doc URL attribute - the link within the doc won't need to be updated.

The PR also fixes the only link in the repo that used the URL attribute.