### PR TITLE
gsfix - Fixed broken formatting preventing successful build (#2134)

### DIFF
--- a/downstream/assemblies/platform/assembly-gs-auto-dev.adoc
+++ b/downstream/assemblies/platform/assembly-gs-auto-dev.adoc
@@ -53,5 +53,5 @@ include::eda/proc-eda-restart-rulebook-activations.adoc[leveloffset=+2]
 include::eda/proc-eda-delete-rulebook-activations.adoc[leveloffset=+2]
 include::eda/proc-eda-activate-webhook.adoc[leveloffset=+2]
 
-ifdef::parent-context-of-assembly-gs-auto-dev[:context: {parent-context-of-assembly-gs-auto-dev}}]
+ifdef::parent-context-of-assembly-gs-auto-dev[:context: {parent-context-of-assembly-gs-auto-dev}]
 ifndef::parent-context-of-assembly-gs-auto-dev[:!context:]

--- a/downstream/modules/platform/proc-controller-use-an-exec-env.adoc
+++ b/downstream/modules/platform/proc-controller-use-an-exec-env.adoc
@@ -3,8 +3,8 @@
 = Adding an {ExecEnvShort} to a job template
 
 .Prerequisites
-
-* An {ExecEnvShort} must have been created using ansible-builder as described in xref:ref-controller-building-exec-env[Build an {ExecEnvShort}].
+//[ddacosta converting xref to a link because this content is shared in multiple docs]
+* An {ExecEnvShort} must have been created using ansible-builder as described in link:{URLControllerUserGuide}/assembly-controller-execution-environments#ref-controller-build-exec-envs[Build an {ExecEnvShort}].
 When an {ExecEnvShort} has been created, you can use it to run jobs.
 Use the {ControllerName} UI to specify the {ExecEnvShort} to use in your job templates.
 * Depending on whether an {ExecEnvShort} is made available for global use or tied to an organization, you must have the appropriate level of administrator privileges to use an {ExecEnvShort} in a job.


### PR DESCRIPTION
This PR backports the changes from #2134 to the 2.5 branch and includes the following:

* gsfix - Fixed broken formatting preventing successful build

* gsfix Removed extraneous closing bracket