### PR TITLE
[Backport] Update link to EDA 2.5 with 2.4 controller doc (#2138)

### DIFF
--- a/downstream/modules/platform/ref-eda-system-requirements.adoc
+++ b/downstream/modules/platform/ref-eda-system-requirements.adoc
@@ -4,7 +4,7 @@
 
 The {EDAcontroller} is a single-node system capable of handling a variable number of long-running processes (such as rulebook activations) on-demand, depending on the number of CPU cores. 
 
-[NOTE] If you want to use {EDAName} 2.5 with a 2.4 {ControllerName} version, see Link:https://content-preview.docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/using_event-driven_ansible_2.5_with_ansible_automation_platform_2.4/index[Using {EDAName} 2.5 with {PlatformNameShort} 2.4].  
+[NOTE] If you want to use {EDAName} 2.5 with a 2.4 {ControllerName} version, see link:{BaseURL}/red_hat_ansible_automation_platform/2.4/html-single/using_event-driven_ansible_2.5_with_ansible_automation_platform_2.4/index[Using {EDAName} 2.5 with {PlatformNameShort} 2.4].   
  
 Use the following minimum requirements to run, by default, a maximum of 12 simultaneous activations:
 


### PR DESCRIPTION
This PR backports the changes from #2138 to the 2.5 branch.