### PR TITLE
Getting started with AAP: small link fix

### DIFF
--- a/downstream/modules/platform/proc-gs-auto-dev-create-template.adoc
+++ b/downstream/modules/platform/proc-gs-auto-dev-create-template.adoc
@@ -141,7 +141,7 @@ If you want to be able to specify `extra_vars` on a schedule, you must select *P
 * *Privilege escalation*: If checked, you enable this playbook to run as an administrator.
 This is the equal of passing the `--become` option to the `ansible-playbook` command.
 * *Provisioning callback*: If checked, you enable a host to call back to {ControllerName} through the REST API and start a job from this job template.
-For more information, see link:https://docs.ansible.com/automation-controller/latest/html/userguide/job_templates.html#ug-provisioning-callbacks[Provisioning Callbacks].
+For more information, see link:{URLControllerUserGuide}/controller-job-templates#controller-provisioning-callbacks[Provisioning Callbacks].
 * *Enable webhook*: If checked, you turn on the ability to interface with a predefined SCM system web service that is used to launch a job template.
 GitHub and GitLab are the supported SCM systems.
 ** If you enable webhooks, other fields display, prompting for additional information:


### PR DESCRIPTION
Fixes "provisioning callbacks" link -- was missed in [PR 2136](https://github.com/ansible/aap-docs/pull/2136)