### PR TITLE
Update URL attribute to use html instead of html-single (#2118)

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -285,155 +285,155 @@
 //
 // titles/troubleshooting-aap
 :TitleTroubleshootingAAP: Troubleshooting Ansible Automation Platform
-:URLTroubleshootingAAP: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/troubleshooting_ansible_automation_platform
+:URLTroubleshootingAAP: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/troubleshooting_ansible_automation_platform
 :LinkTroubleshootingAAP: {URLTroubleshootingAAP}[{TitleTroubleshootingAAP}]
 //
 // titles/aap-plugin-rhdh-install
 :TitlePluginRHDHInstall: Installing Ansible plug-ins for Red Hat Developer Hub
-:URLPluginRHDHInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_ansible_plug-ins_for_red_hat_developer_hub
+:URLPluginRHDHInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/installing_ansible_plug-ins_for_red_hat_developer_hub
 :LinkPluginRHDHInstall: {URLPluginRHDHInstall}[{TitlePluginRHDHInstall}]
 //
 // titles/aap-plugin-rhdh-using
 :TitlePluginRHDHUsing: Using Ansible plug-ins for Red Hat Developer Hub
-:URLPluginRHDHUsing: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/using_ansible_plug-ins_for_red_hat_developer_hub
+:URLPluginRHDHUsing: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_ansible_plug-ins_for_red_hat_developer_hub
 :LinkPluginRHDHUsing: {URLPluginRHDHUsing}[{TitlePluginRHDHUsing}]
 //
 // titles/aap-operations-guide
 :TitleAAPOperationsGuide: Operating Ansible Automation Platform
-:URLAAPOperationsGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/operating_ansible_automation_platform
+:URLAAPOperationsGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/operating_ansible_automation_platform
 :LinkAAPOperationsGuide: {URLAAPOperationsGuide}[{TitleAAPOperationsGuide}]
 //
 // titles/eda/eda-user-guide
 :TitleEDAUserGuide: Using automation decisions 
-:URLEDAUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/using_automation_decisions 
+:URLEDAUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_decisions 
 :LinkEDAUserGuide: {URLEDAUserGuide}[{TitleEDAUserGuide}]
 //
 // titles/upgrade
 :TitleUpgrade: Upgrade and migration
-:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/upgrade_and_migration
+:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/upgrade_and_migration
 :LinkUpgrade: {URLUpgrade}[{TitleUpgrade}]
 //
 // titles/aap-operator-installation
 :TitleOperatorInstallation: Installing on OpenShift Container Platform
-:URLOperatorInstallation: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_openshift_container_platform
+:URLOperatorInstallation: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/installing_on_openshift_container_platform
 :LinkOperatorInstallation: {URLOperatorInstallation}[{TitleOperatorInstallation}]
 //
 // titles/aap-installation-guide
 :TitleInstallationGuide: RPM installation
-:URLInstallationGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/rpm_installation
+:URLInstallationGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation
 :LinkInstallationGuide: {URLInstallationGuide}[{TitleInstallationGuide}]
 //
 // titles/aap-planning-guide
 :TitlePlanningGuide: Planning your installation
-:URLPlanningGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/planning_your_installation
+:URLPlanningGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/planning_your_installation
 :LinkPlanningGuide: {URLPlanningGuide}[{TitlePlanningGuide}]
 //
 // titles/operator-mesh
 :TitleOperatorMesh: Automation mesh for managed cloud or operator environments
-:URLOperatorMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_mesh_for_managed_cloud_or_operator_environments
+:URLOperatorMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_managed_cloud_or_operator_environments
 :LinkOperatorMesh: {URLOperatorMesh}[{TitleOperatorMesh}]
 //
 // titles/automation-mesh
 :TitleAutomationMesh: Automation mesh for VM environments
-:URLAutomationMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_mesh_for_vm_environments
+:URLAutomationMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_vm_environments
 :LinkAutomationMesh: {URLAutomationMesh}[{TitleAutomationMesh}]
 //
 // titles/ocp_performance_guide
 :TitleOCPPerformanceGuide: Performance considerations for operator environments
-:URLOCPPerformanceGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/performance_considerations_for_operator_environments
+:URLOCPPerformanceGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/performance_considerations_for_operator_environments
 :LinkOCPPerformanceGuide: {URLOCPPerformanceGuide}[{TitleOCPPerformanceGuide}]
 //
 // titles/security-guide
 :TitleSecurityGuide: Implementing security automation
-:URLSecurityGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/implementing_security_automation
+:URLSecurityGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/implementing_security_automation
 :LinkSecurityGuide: {URLSecurityGuide}[{TitleSecurityGuide}]
 //
 // titles/playbooks/playbooks-getting-started
 :TitlePlaybooksGettingStarted: Getting started with playbooks
-:URLPlaybooksGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/getting_started_with_playbooks
+:URLPlaybooksGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_playbooks
 :LinkPlaybooksGettingStarted: {URLPlaybooksGettingStarted}[{TitlePlaybooksGettingStarted}]
 //
 // titles/playbooks/playbooks-reference
 :TitlePlaybooksReference: Reference guide to Ansible Playbooks
-:URLPlaybooksReference: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/reference_guide_to_ansible_playbooks
+:URLPlaybooksReference: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/reference_guide_to_ansible_playbooks
 :LinkPlaybooksReference: {URLPlaybooksReference}[{TitlePlaybooksReference}]
 //
 // titles/release-notes
 :TitleReleaseNotes: Release notes
-:URLReleaseNotes: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/release_notes
+:URLReleaseNotes: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/release_notes
 :LinkReleaseNotes: {URLReleaseNotes}[{TitleReleaseNotes}]
 //
 // titles/controller/controller-user-guide
 :TitleControllerUserGuide: Using automation execution
-:URLControllerUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/using_automation_execution
+:URLControllerUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution
 :LinkControllerUserGuide: {URLControllerUserGuide}[{TitleControllerUserGuide}]
 //
 // titles/controller/controller-admin-guide
 :TitleControllerAdminGuide: Configuring automation execution
-:URLControllerAdminGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/configuring_automation_execution
+:URLControllerAdminGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/configuring_automation_execution
 :LinkControllerAdminGuide: {URLControllerAdminGuide}[{TitleControllerAdminGuide}]
 //
 // titles/controller/controller-api-overview
 :TitleControllerAPIOverview: Automation execution API overview
-:URLControllerAPIOverview: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_execution_api_overview
+:URLControllerAPIOverview: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_execution_api_overview
 :LinkControllerAPIOverview: {URLControllerAPIOverview}[{TitleControllerAPIOverview}]
 //
 // titles/aap-operator-backup
 :TitleOperatorBackup: Backup and recovery for operator environments
-:URLOperatorBackup: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/backup_and_recovery_for_operator_environments
+:URLOperatorBackup: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/backup_and_recovery_for_operator_environments
 :LinkOperatorBackup: {URLOperatorBackup}[{TitleOperatorBackup}]
 //
 // titles/central-auth
 :TitleCentralAuth: Access management and authentication
-:URLCentralAuth: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/access_management_and_authentication
+:URLCentralAuth: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/access_management_and_authentication
 :LinkCentralAuth: {URLCentralAuth}[{TitleCentralAuth}]
 //
 // titles/getting-started
 :TitleGettingStarted: Getting started with Ansible Automation Platform
-:URLGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/getting_started_with_ansible_automation_platform
+:URLGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_ansible_automation_platform
 :LinkGettingStarted: {URLGettingStarted}[{TitleGettingStarted}]
 //
 // titles/aap-containerized-install
 :TitleContainerizedInstall: Containerized installation
-:URLContainerizedInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/containerized_installation
+:URLContainerizedInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation
 :LinkContainerizedInstall: {URLContainerizedInstall}[{TitleContainerizedInstall}]
 //
 // titles/navigator-guide
 :TitleNavigatorGuide: Using content navigator
-:URLNavigatorGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/using_content_navigator
+:URLNavigatorGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_content_navigator
 :LinkNavigatorGuide: {URLNavigatorGuide}[{TitleNavigatorGuide}]
 //
 // titles/aap-hardening
 :TitleHardening: Hardening and compliance
-:URLHardening: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/hardening_and_compliance
+:URLHardening: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/hardening_and_compliance
 :LinkHardening: {URLHardening}[{TitleHardening}]
 //
 // titles/builder
 :TitleBuilder: Creating and using execution environments
-:URLBuilder: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/creating_and_using_execution_environments
+:URLBuilder: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_using_execution_environments
 :LinkBuilder: {URLBuilder}[{TitleBuilder}]
 //
 // titles/hub/managing-content
 :TitleHubManagingContent: Managing automation content
-:URLHubManagingContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/managing_automation_content
+:URLHubManagingContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_automation_content
 :LinkHubManagingContent: {URLHubManagingContent}[{TitleHubManagingContent}]
 //
 // titles/analytics
 :TitleAnalytics: Using automation analytics
-:URLAnalytics: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/using_automation_analytics
+:URLAnalytics: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_analytics
 :LinkAnalytics: {URLAnalytics}[{TitleAnalytics}]
 //
 // titles/develop-automation-content
 :TitleDevelopAutomationContent: Developing automation content
-:URLDevelopAutomationContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/developing_automation_content
+:URLDevelopAutomationContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/developing_automation_content
 :LinkDevelopAutomationContent: {URLDevelopAutomationContent}[{TitleDevelopAutomationContent}]
 //
 // titles/topologies
 :TitleTopologies: Tested deployment models
-:URLTopologies: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/tested_deployment_models
+:URLTopologies: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models
 :LinkTopologies: {URLTopologies}[{TitleTopologies}]
 //
 // Lightspeed branch titles/lightspeed-user-guide
 :TitleLightspeedUserGuide: Red Hat Ansible Lightspeed with IBM watsonx Code Assistant User Guide
-:URLLightspeedUserGuide: {BaseURL}/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html-single/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide
+:URLLightspeedUserGuide: {BaseURL}/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide
 :LinkLightspeedUserGuide: {URLLightspeedUserGuide}[{TitleLightspeedUserGuide}]


### PR DESCRIPTION
URL attributes were using `html-single` for docs.redhat.com (ie whole doc is shown) instead of `html` (multi-page).
Previous links used multi-page.
However, the URLs for assemblies / modules change depending on whether html or html-single is used in a link.

For example

**multi-page (`html`):**
https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/assembly-controller-applications#proc-controller-apps-create-tokens

**single-page (`html-single`):**
https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/automation_controller_user_guide/index#proc-controller-apps-create-tokens

All of our links were configured for all releases up to and including 2.4 for the multi-page version.
This PR will make it easier to convert links to use the doc URL attribute - the link within the doc won't need to be updated.