### PR TITLE
Backport to 2.5: AAP-20548: Managing automation content doc updates (#2117)

### DIFF
--- a/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
+++ b/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
@@ -11,7 +11,7 @@ As of the 2.4 release you can still synchronize content, but synclists are depre
 ====
 
 [discrete]
-== What’s the difference between {Galaxy} and {HubNameMain}?
+== What's the difference between {Galaxy} and {HubNameMain}?
 
 Collections published to {Galaxy} are the latest content published by the Ansible community and have no joint support claims associated with them. 
 {Galaxy} is the recommended frontend directory for the Ansible community to access content.
@@ -41,8 +41,6 @@ You can use underscores in the collection name if it improves readability.
 
 include::hub/con-remote-repos.adoc[leveloffset=+1]
 
-include::hub/proc-create-requirements-file.adoc[leveloffset=+1]
-
 include::hub/proc-obtaining-org-collection-url.adoc[leveloffset=+1]
 
 include::hub/proc-set-rhcertified-remote.adoc[leveloffset=+1]
@@ -50,3 +48,5 @@ include::hub/proc-set-rhcertified-remote.adoc[leveloffset=+1]
 include::hub/proc-set-community-remote.adoc[leveloffset=+1]
 
 include::hub/proc-configure-proxy-remote.adoc[leveloffset=+1]
+
+include::hub/proc-create-requirements-file.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -7,58 +7,63 @@
 
 == Configuring validated collections with the installer
 
-When you download and run the bundle installer, certified and validated collections are automatically uploaded.
+When you download and run the RPM bundle installer, certified and validated collections are automatically uploaded.
 Certified collections are uploaded into the `rh-certified` repository.
 Validated collections are uploaded into the `validated` repository.
 
-You can change to default configuration by using two variables:
+You can change the default configuration by using two variables:
 
 * `automationhub_seed_collections` is a boolean that defines whether or not preloading is enabled.
 * `automationhub_collection_seed_repository`is a variable that enables you to specify the type of content to upload when it is set to `true`.
 Possible values are `certified` or `validated`.
 If this variable is missing, both content sets will be uploaded.
 
-== Installing validated content using the tarball
-
-If you are not using the bundle installer, you can use a standalone .tar file, `ansible-validated-content-bundle-1.tar.gz`.
-You can also use this standalone .tar file later to update validated contents in any environment, when a newer .tar file becomes available, without having to re-run the bundle installer.
-
-.Prerequisites
-Use the following required variables to run the playbook.
-
-[cols="50%,50%",options="header"]
-|====
-| Name | Description
-| *`automationhub_admin_password`* | Your administration password.
-| *`automationhub_api_token`* | The API token generated for your {HubName}.
-| *`automationhub_main_url`* | For example, `\https://automationhub.example.com`
-| *`automationhub_require_content_approval`* | Boolean (`true` or `false`)
-
-This must match the value used during {HubName} deployment.
-
-This variable is set to `true` by the installer.
-|====
-
-.Procedure
-. To obtain the .tar file, navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page and select *Ansible Validated Content*.
-. Upload the content and define the variables (this example uses `automationhub_api_token`):
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-ansible-playbook collection_seed.yml
--e automationhub_api_token=<api_token>
--e automationhub_main_url=https://automationhub.example.com
--e automationhub_require_content_approval=true
-----
-+
 [NOTE]
 ====
-Use either `automationhub_admin_password` or `automationhub_api_token`, not both.
+Changing the default configuration may require further platform configuration changes for other content you may use. 
 ====
 
-When complete, the collections are visible in the validated collection section of {PrivateHubName}.
-Users can now view and download collections from your {PrivateHubName}.
+// == Installing validated content using the tarball
 
-[role="_additional-resources"]
-.Additional Resources
-For more information on running ansible playbooks, see link:https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html[ansible-playbook].
+// If you are not using the bundle installer, you can use a standalone .tar file, `ansible-validated-content-bundle-1.tar.gz`.
+// You can also use this standalone .tar file later to update validated contents in any environment, when a newer .tar file becomes available, without having to re-run the bundle installer.
+
+// .Prerequisites
+// Use the following required variables to run the playbook.
+
+// [cols="50%,50%",options="header"]
+// |====
+// | Name | Description
+// | *`automationhub_admin_password`* | Your administration password.
+// | *`automationhub_api_token`* | The API token generated for your {HubName}.
+// | *`automationhub_main_url`* | For example, `\https://automationhub.example.com`
+// | *`automationhub_require_content_approval`* | Boolean (`true` or `false`)
+//
+// This must match the value used during {HubName} deployment.
+//
+// This variable is set to `true` by the installer.
+// |====
+
+// .Procedure
+// . To obtain the .tar file, navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page and select // *Ansible Validated Content*.
+// . Upload the content and define the variables (this example uses `automationhub_api_token`):
+// +
+// [options="nowrap" subs="+quotes,attributes"]
+// ----
+// ansible-playbook collection_seed.yml
+// -e automationhub_api_token=<api_token>
+// -e automationhub_main_url=https://automationhub.example.com
+// -e automationhub_require_content_approval=true
+// ----
+// +
+// [NOTE]
+// ====
+// Use either `automationhub_admin_password` or `automationhub_api_token`, not both.
+// ====
+
+// When complete, the collections are visible in the validated collection section of {PrivateHubName}.
+// Users can now view and download collections from your {PrivateHubName}.
+
+// [role="_additional-resources"]
+// .Additional Resources
+// For more information on running ansible playbooks, see link:https://docs.ansible.com/ansible/latest/cli/ansible-playbook.html[ansible-playbook].

--- a/downstream/modules/hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -5,7 +5,7 @@
 You can configure Ansible-Galaxy CLI to verify collections. 
 This ensures that downloaded collections are approved by your organization and have not been changed after they were uploaded to {HubName}.
 
-If a collection has been signed by {HubName}, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of `MANIFEST.json` before using it to verify the collection’s contents. 
+If a collection has been signed by {HubName}, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of `MANIFEST.json` before using it to verify the collection's contents. 
 You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
 
 .Prerequisites

--- a/downstream/modules/hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/hub/proc-configure-content-signing-on-pah.adoc
@@ -53,7 +53,6 @@ else
    exit $STATUS
 fi
 ----
-
 +
 After you deploy a {PrivateHubName} with signing enabled to your {PlatformNameShort} cluster, new UI additions are displayed in collections.
 

--- a/downstream/modules/hub/proc-configure-proxy-remote.adoc
+++ b/downstream/modules/hub/proc-configure-proxy-remote.adoc
@@ -11,14 +11,14 @@ If your {PrivateHubName} is behind a network proxy, you can configure proxy sett
 .Prerequisites
 
 * You have valid *Modify Ansible repo content* permissions.
-For more information on permissions, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Configuring user access for your {PrivateHubName}].
+For more information on permissions, see link:{LinkCentralAuth}
 * You have a proxy URL and credentials from your local network administrator.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
+
 . Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRemotes}.
-. In either the *rh-certified* or *Community* remote, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Edit*.
+. In either the *rh-certified* or *Community* remote, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Edit remote*.
 . Expand the *Show advanced options* drop-down menu.
 . Enter your proxy URL, proxy username, and proxy password in the appropriate fields.
-. Click btn:[Save].
+. Click btn:[Save remote].

--- a/downstream/modules/hub/proc-set-community-remote.adoc
+++ b/downstream/modules/hub/proc-set-community-remote.adoc
@@ -9,7 +9,7 @@ By default, your {PrivateHubName} community repository directs to `galaxy.ansibl
 .Prerequisites
 
 * You have *Modify Ansible repo content* permissions.
-For more information on permissions, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Configuring user access for your {PrivateHubName}].
+For more information on permissions, see link:{LinkCentralAuth}.
 * You have a `requirements.yml` file that identifies those collections to synchronize from {Galaxy} as in the following example:
 +
 .Requirements.yml example
@@ -22,18 +22,24 @@ collections:
 -----
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
+
 . Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRemotes}.
-. In the *Details* tab in the *Community* remote, click btn:[Edit].
-. In the *YAML requirements* field, click btn:[Browse] and locate the `requirements.yml` file on your local machine.
-. Click btn:[Save].
+. In the *Details* tab in the *Community* remote, click btn:[Edit remote].
+. In the *YAML requirements* field, paste the contents of your `requirements.yml` file.
+. Click btn:[Save remote].
 +
 You can now synchronize collections identified in your `requirements.yml` file from {Galaxy} to your {PrivateHubName}.
 
-. From the navigation panel, select {MenuACAdminRepositories}. Next to the *community* repository, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync* to sync collections from {Galaxy} and {HubNameMain}.
+. From the navigation panel, select {MenuACAdminRepositories}. Next to the *community* repository, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync repository* to sync collections between {Galaxy} and {HubNameMain}.
+. On the modal that appears, you can toggle the following options:
+* *Mirror*: Select if you want your repository content to mirror the remote repository's content.
+* *Optimize*: Select if you want to sync only when no changes are reported by the remote server.
+. Click btn:[Sync] to complete the sync.
 
 .Verification
-The *Sync status* notification updates to notify you of completion or failure of {Galaxy} collections synchronization to your {HubNameMain}.
+The *Sync status* column updates to notify you whether the {Galaxy} collections synchronization to your {HubNameMain} is successful.
 
-* Select *Community* from the collections content drop-down list to confirm successful synchronization.
+* Navigate to {MenuACCollections} and select *Community* to confirm successful synchronization.
+
+

--- a/downstream/modules/hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/hub/proc-set-rhcertified-remote.adoc
@@ -8,20 +8,17 @@ By default, your {PrivateHubName} `rh-certified` repository includes the URL for
 
 To use only those collections specified by your organization, a {PrivateHubName} administrator can upload manually-created requirements files from the `rh-certified` remote.
 
-For more information about using requirements files, see link:https://docs.ansible.com/ansible/latest/collections_guide/collections_installing.html#install-multiple-collections-with-a-requirements-file[Install multiple collections with a requirements file] in the _Using Ansible collections_ guide.
-
 If you have collections `A`, `B`, and `C` in your requirements file, and a new collection `X` is added to {Console} that you want to use, you must add `X` to your requirements file for {PrivateHubName} to synchronize it.
-
 
 .Prerequisites
 
 * You have valid *Modify Ansible repo content* permissions.
-For more information on permissions, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Configuring user access for your {PrivateHubName}].
+For more information on permissions, see link:{LinkCentralAuth}.
 * You have retrieved the Sync URL and API Token from the {HubName} hosted service on {Console}.
-* You have configured access to port 443. This is required for synchronizing certified collections. For more information, see the {HubName} table in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/ref-network-ports-protocols_planning[Network ports and protocols] chapter of the {PlatformName} Planning Guide.
+* You have configured access to port 443. This is required for synchronizing certified collections. For more information, see the {HubName} table in the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[Network ports and protocols] chapter of {TitlePlanningGuide}.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
+
 . Log in to your {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRemotes}.
 . In the *rh-certified* remote repository, click btn:[Edit remote].
@@ -31,9 +28,13 @@ For more information on permissions, see link:{BaseURL}/red_hat_ansible_automati
 +
 You can now synchronize collections between your organization synclist on {Console} and your {PrivateHubName}.
 +
-. From the navigation panel, select {MenuACAdminRepositories}. Next to *rh-certified* click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync*.
+. From the navigation panel, select {MenuACAdminRepositories}. Next to *rh-certified* click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync repository*.
+. On the modal that appears, you can toggle the following options:
+* *Mirror*: Select if you want your repository content to mirror the remote repository's content.
+* *Optimize*: Select if you want to sync only when no changes are reported by the remote server.
+. Click btn:[Sync] to complete the sync.
 
 .Verification
-The *Sync status* notification updates to notify you that the Red Hat Certified Content Collections synchronization is complete.
+The *Sync status* column updates to notify you whether the Red Hat Certified Content Collections synchronization is successful.
 
-* Select *Red Hat Certified* from the collections content drop-down list to confirm that your collections content has synchronized successfully.
+* Navigate to {MenuACCollections} to confirm that your collections content has synchronized successfully.

--- a/downstream/modules/hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/hub/proc-using-content-signing-services-in-pah.adoc
@@ -13,12 +13,12 @@ You can use content signing on {PrivateHubName} in the following scenarios:
 * You want to rotate signatures on your collections.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
+
 . Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminCollectionApproval}.
 The Approval dashboard opens and displays a list of collections.
 
-. Click btn:[Approve] for each collection that you want to sign.
+. Click the thumbs up icon next to the collection you want to approve. On the modal that appears, check the box confirming that you want to approve the collection, and click btn:[Approve and sign collections].
 
 .Verification
-* Verify that the collections you signed and manually approved are displayed in the *Collections* tab.
+* Navigate to {MenuACCollections} to verify that the collections you signed and approved are displayed. 


### PR DESCRIPTION
This PR ports the changes from [PR 2117](https://github.com/ansible/aap-docs/pull/2117) to the 2.5 branch. See [AAP-20548](https://issues.redhat.com/browse/AAP-20548) for more.