### PR TITLE
AAP-30912 Devtools - Add roles collections chapter

### DIFF
--- a/downstream/assemblies/devtools/assembly-devtools-create-roles-collection.adoc
+++ b/downstream/assemblies/devtools/assembly-devtools-create-roles-collection.adoc
@@ -1,0 +1,50 @@
+ifdef::context[:parent-context-of-devtools-create-roles-collection: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+ifndef::context[]
+[id="devtools-create-roles-collection"]
+endif::[]
+ifdef::context[]
+[id="devtools-create-roles-collection_{context}"]
+endif::[]
+
+= Creating a collection for distributing roles
+
+:context: devtools-create-roles-collection
+
+An Ansible role is a self-contained unit of Ansible automation content that groups related
+tasks and associated variables, files, handlers, and other assets in a defined directory structure. 
+
+You can run Ansible roles in one or more plays, and reuse them across playbooks.
+Invoking roles instead of tasks simplifies playbooks.
+You can migrate existing standalone roles into collections,
+and push them to private automation hub to share them with other users in your organization.
+Distributing roles in this way is a typical way to use collections.
+
+With Ansible collections, you can store and distribute multiple roles in a single unit of reusable automation.
+Inside a collection, you can share custom plug-ins across all roles in the collection instead of duplicating them in each role.
+
+You must move roles into collections if you want to use them in {PlatformNameShort}.
+
+You can add existing standalone roles to a collection, or add new roles to it.
+Push the collection to source control and configure credentials for the repository in {PlatformNameShort}. 
+
+include::devtools/con-devtools-plan-roles-collection.adoc[leveloffset=+1]
+include::devtools/con-devtools-roles-collection-prerequisites.adoc[leveloffset=+1]
+
+include::devtools/proc-devtools-scaffold-roles-collection.adoc[leveloffset=+1]
+
+include::devtools/proc-devtools-migrate-existing-roles-collection.adoc[leveloffset=+1]
+include::devtools/proc-devtools-create-new-role-in-collection.adoc[leveloffset=+1]
+include::devtools/proc-devtools-docs-roles-collection.adoc[leveloffset=+1]
+
+// include::devtools/proc-devtools-run-roles-collection.adoc[leveloffset=+1]
+// include::devtools/proc-devtools-molecule-test-roles-collection.adoc[leveloffset=+1]
+
+include::devtools/proc-devtools-publish-roles-collection-pah.adoc[leveloffset=+1]
+include::devtools/proc-devtools-use-roles-collections-aap.adoc[leveloffset=+2]
+
+ifdef::parent-context-of-devtools-create-roles-collection[:context: {parent-context-of-devtools-create-roles-collection}]
+ifndef::parent-context-of-devtools-create-roles-collection[:!context:]
+

--- a/downstream/assemblies/devtools/assembly-devtools-develop-collections.adoc
+++ b/downstream/assemblies/devtools/assembly-devtools-develop-collections.adoc
@@ -1,0 +1,28 @@
+ifdef::context[:parent-context-of-devtools-develop-collections: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+ifndef::context[]
+[id="devtools-develop-collections"]
+endif::[]
+ifdef::context[]
+[id="devtools-develop-collections_{context}"]
+endif::[]
+= Developing collections
+
+:context: devtools-develop-collections
+
+Collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. 
+Red Hat provides Ansible Content Collections on Ansible automation hub that contain both {CertifiedCon} and {Valid}.
+
+If you have installed private automation hub, you can create collections for your organization and push them
+to {PrivateHubName} so that you can use them in job templates in {PlatformNameShort}. 
+You can use collections to package and distribute plug-ins. These plug-ins are written in Python.
+
+You can also create collections to package and distribute Ansible roles, which are expressed in YAML.
+You can also include playbooks and custom plug-ins that are required for these roles in the collection.
+Typically, collections of roles are distributed for use within your organization.
+
+ifdef::parent-context-of-devtools-develop-collections[:context: {parent-context-of-devtools-develop-collections}]
+ifndef::parent-context-of-devtools-develop-collections[:!context:]
+

--- a/downstream/modules/devtools/con-devtools-plan-roles-collection.adoc
+++ b/downstream/modules/devtools/con-devtools-plan-roles-collection.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="plan-roles-collection_{context}"]
+= Planning your collection
+
+Organize smaller bundles of curated automation into separate collections for specific functions, rather than creating one big general collection for all of your roles.
+
+For example, you could store roles that manage the networking for an internal system called `myapp` in a `company_namespace.myapp_network` collection,
+and store roles that manage and deploy networking in AWS in a collection called `company_namespace.aws_net`.
+

--- a/downstream/modules/devtools/con-devtools-roles-collection-prerequisites.adoc
+++ b/downstream/modules/devtools/con-devtools-roles-collection-prerequisites.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="devtools-roles-collection-prerequisites_{context}"]
+= Prerequisites
+
+* You have installed {VSCode} and the Ansible extension.
+* You have installed the Microsoft Dev Containers extension in {{VSCode}.
+* You have installed {ToolsName}.
+* You have installed a containerization platform, for example Podman, Podman Desktop, Docker, or Docker Desktop.
+* You have a Red Hat account and you can log in to the Red Hat container registry at `registry.redhat.io`.
+For information about logging in to `registry.redhat.io`, see
+xref:devtools-setup-registry-redhat-io_installing-devtools[Authenticating with the Red Hat container registry].
+// * Considerations about environments / isolation (ADE / devcontainer files)
+
+

--- a/downstream/modules/devtools/proc-devtools-create-new-role-in-collection.adoc
+++ b/downstream/modules/devtools/proc-devtools-create-new-role-in-collection.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="devtools-create-new-role-in-collection_{context}"]
+= Creating a new role in your collection
+
+.Procedure
+
+. To create a new role, copy the default `run` role directory that was scaffolded when you created the collection.
+. Define the tasks that you want your role to perform in the `tasks/main.yml` file.
+If you are creating a role to reuse tasks in an existing playbook,
+copy the content in the tasks block of your playbook YAML file.
+Remove the whitespace to the left of the tasks.
+Use `ansible-lint` in {VSCode} to check your YAML code.
+. If your role depends on another role, add the dependency in the `meta/main.yml` file.

--- a/downstream/modules/devtools/proc-devtools-docs-roles-collection.adoc
+++ b/downstream/modules/devtools/proc-devtools-docs-roles-collection.adoc
@@ -1,0 +1,37 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="devtools-docs-roles-collection_{context}"]
+= Adding documentation for your roles collection
+
+It is important to provide documentation for your roles so that other users understand what your roles do and how to use them. 
+
+== Documenting your roles
+
+When you scaffolded your collection directory, a `README.md` file was added in the role directory.
+Add your documentation for your role in this file.
+Provide the following information in the `README.md` files for every role in your collection:
+
+* Role description: A brief summary of what the role does
+* Requirements: List the collections, libraries, and required installations
+* Dependencies 
+* Role variables: Provide the following information about the variables your role uses.
+**  Description
+**  Defaults
+**  Example values
+**  Required variables
+* Example playbook: Show an example of a playbook that uses your role.
+Use comments in the playbook to help users understand where to set variables.
+
+The `README.md` file in link:https://github.com/redhat-cop/controller_configuration/tree/devel/roles/ad_hoc_command_cancel[`controller_configuration.ad_hoc_command_cancel`] is an example of a role with standard documentation:
+
+== Documenting your collection
+
+In the `README.md` file for your collection, provide the following information:
+
+* Collection description: Describe what the collection does.
+* Requirements: List required collections.
+* List the roles as a component of the collection.
+* Using the collection: Describe how to run the components of the collection.
+* Add a troubleshooting section.
+* Versioning: Describe the release cycle of your collection.
+

--- a/downstream/modules/devtools/proc-devtools-migrate-existing-roles-collection.adoc
+++ b/downstream/modules/devtools/proc-devtools-migrate-existing-roles-collection.adoc
@@ -1,0 +1,89 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="devtools-migrate-existing-roles-collection_{context}"]
+= Migrating existing roles to your collection
+
+The directory for a standalone role has the following structure.
+Your role might not contain all of these directories.
+
+----
+my_role
+├── README.md
+├── defaults
+│   └── main.yml
+├── files
+├── handlers
+│   └── main.yml
+├── meta
+│   └── main.yml
+├── tasks
+│   └── main.yml
+├── templates
+├── tests
+│   ├── inventory
+│   └── test.yml
+└── vars
+    └── main.yml
+
+----
+
+An Ansible role has a defined directory structure with seven main standard directories.
+Each role must must include at least one of these directories.
+You can omit any directories the role does not use.
+Each directory contains a `main.yml` file.
+
+.Procedure
+
+. If necessary, rename the directory that contains your role to reflect its content, for example, `acl_config` or `tacacs`. 
++
+Roles in collections cannot have hyphens in their names. Use the underscore character (`_`) instead.
+. Copy the roles directories from your standalone role into the `roles/` directory in your collection.
++
+For example, in a collection called `myapp_network`, add your roles to the `myapp_network/roles/` directory. 
+. Copy any plug-ins from your standalone roles into the `plugins directory/` for your new collection.
+The collection directory structure resembles the following.
++
+----
+company_namespace
+└── myapp_network
+    ├── ...
+    ├── galaxy.yml
+    ├── docs
+    ├── extensions
+    ├── meta
+    ├── plugins
+    ├── roles
+    │   ├── acl_config
+    │   │   ├── README.md
+    │   │   ├── defaults
+    │   │   ├── files
+    │   │   ├── handlers
+    │   │   ├── meta
+    │   │   ├── tasks
+    │   │   ├── templates
+    │   │   ├── tests
+    │   │   └── vars
+    │   └── tacacs
+    │       ├── README.md
+    │       ├── default
+    │       ├── files
+    │       ├── handlers
+    │       ├── meta
+    │       ├── tasks
+    │       ├── templates
+    │       ├── tests
+    │       └── vars
+    │   ├── run
+    ├── ...
+    ├── tests
+    └── vars
+
+----
++
+The `run` role is a default role directory that is created when you scaffold the collection.
+. Update your playbooks to use the fully qualified collection name (FQDN) for your new roles in your collection.
+
+Not every standalone role will seamlessly integrate into your collection without modification of the code.
+For example, if a third-party standalone role from Galaxy that contains a plug-in uses the `module_utils/` directory,
+then the plug-in itself has import statements.
+

--- a/downstream/modules/devtools/proc-devtools-molecule-test-roles-collection.adoc
+++ b/downstream/modules/devtools/proc-devtools-molecule-test-roles-collection.adoc
@@ -1,0 +1,41 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="devtools-molecule-test-roles-collection_{context}"]
+= Using Molecule to test your roles
+
+It is useful to run your automation content in a test environment before using it to automate production infrastructure.
+Testing ensures the automation works as designed.
+
+Molecule is a complete testing framework designed to help you automate the testing of Ansible roles in different environments,
+ensuring that the roles behave as expected across various platforms and configurations.
+
+A Molecule scenario is a set of configurations and tests for roles within a collection.
+You can have as many scenarios as you like and Molecule will run one after the other.
+
+* `molecule.yml` is the central configuration entry point for Molecule per scenario.
+With this file, you can configure each tool that Molecule will employ when testing your role.
+* `create.yml` is a playbook file used for creating the instances and storing data in `instance-config`.
+* `converge.yml` is the playbook file that contains the call for your role.
+Molecule will invoke this playbook with `ansible-playbook` and run it against an instance created by the driver.
+* `destroy.yml` contains the Ansible code for destroying the instances and removing them from `instance-config`.
+
+. Navigate to the `extensions/` directory in your collection and initialize a new default molecule scenario:
++
+----
+molecule init scenario <name>
+
+---
+- name: Include a role from a collection
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Testing role
+      ansible.builtin.include_role:
+        name: foo.bar.my_role
+        tasks_from: main.yml
+
+----
+
+// https://www.ansible.com/blog/developing-and-testing-ansible-roles-with-molecule-and-podman-part-1/
+// https://www.ansible.com/blog/developing-and-testing-ansible-roles-with-molecule-and-podman-part-2/
+

--- a/downstream/modules/devtools/proc-devtools-publish-roles-collection-pah.adoc
+++ b/downstream/modules/devtools/proc-devtools-publish-roles-collection-pah.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="devtools-publish-roles-collection-pah_{context}"]
+= Publishing your collection in {PrivateHubName}
+
+. Prerequisite
+
+* Package your collection into a tarball.
+Format your collection file name as follows:
+
+`<my_namespace-my_collection-x.y.z.tar.gz>`
+
+For example, `company_namespace-myapp_network-1.0.0.tar.gz`
+
+.Procedure
+
+. Create a namespace for your collection in {PrivateHubName}. See
+link:{URLHubManagingContent}/managing-collections-hub#proc-create-namespace[Creating a namespace]
+in the _{TitleHubManagingContent}_ guide.
+. Optional: Add information to your namespace. See
+link:{URLHubManagingContent}/managing-collections-hub#proc-edit-namespace[Adding additional information and resources to a namespace]
+in the _{TitleHubManagingContent}_ guide.
+. Upload your roles collections tarballs to your namespace. See
+link:{URLHubManagingContent}/managing-collections-hub#proc-uploading-collections[Uploading collections to your namespaces]
+in the _{TitleHubManagingContent}_ guide.
+. Approve your collection for internal publication. See
+link:{URLHubManagingContent}/managing-collections-hub#proc-approve-collection[Uploading collections to your namespaces]
+in the _{TitleHubManagingContent}_ guide.
+

--- a/downstream/modules/devtools/proc-devtools-run-roles-collection.adoc
+++ b/downstream/modules/devtools/proc-devtools-run-roles-collection.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="devtools-run-roles-collection_{context}"]
+= Running and testing your collection
+
+the Ansible VS 
+When you are developing your roles, you can use `ansible-lint` in the Ansible
+extension to display potential rule violations in the terminal in {VSCode}.
+
+When you package your collection and install it into your playbook projects,
+the code extension autocomplete feature is available for your collection.
+// This helps you write functional playbooks.
+
+If you have your Ansible collection PATH set, you can use Ansible Navigator
+to browse your collection and its contents. 
+
+Use ansible-navigator to run your playbooks because it is useful for troubleshooting. 
+You can explore the output at various depth levels.
+
+== Using your collection in playbooks
+
+//<Add dependencies to your playbook collection - how do you do this when testing locally?>
+Collection path
+
+// == Navigator
+
+Autocompletion in playbooks - connect scaffolding of both projects
+

--- a/downstream/modules/devtools/proc-devtools-scaffold-roles-collection.adoc
+++ b/downstream/modules/devtools/proc-devtools-scaffold-roles-collection.adoc
@@ -1,0 +1,80 @@
+:_newdoc-version: 2.18.3
+:_template-generated: 2024-09-26
+:_mod-docs-content-type: PROCEDURE
+
+[id="devtools-scaffold-roles-collection_{context}"]
+= Scaffolding a collection for your roles
+
+You can scaffold a collection for your roles from the Ansible extension in {VSCode}.
+
+.Procedure
+
+. Open {VSCode}.
+. Navigate to the directory where you want to create your roles collection.
+. Click the Ansible icon in the {VSCode} activity bar to open the Ansible extension.
+. Select *Get started* in the *Ansible content creator* section.
++
+The *Ansible content creator* tab opens.
+. In the *Create* section, click *Ansible collection project*.
++
+The *Create new Ansible project* tab opens.
+. In the form in the *Create Ansible project* tab, enter the following:
+** *Namespace*: Enter a name for your namespace, for example `company_namespace`.
+** *Collection*: Enter a name for your collection, for example, `myapp_network`.
+** *Init path*: Enter the path to the directory where you want to scaffold your new collection.
++
+If you enter an existing directory name, the scaffolding process overwrites the contents of that directory.
+The scaffold process only allows you to use an existing directory if you enable the Force option.
+
+*** If you are using the containerized version of Ansible development tools,
+the destination directory path is relative to the container, not a path in your local system.
+To discover the current directory name in the container, run the pwd command in a terminal in {VSCode}.
+If the current directory in the container is `workspaces`, enter `workspaces/<current_project>/collections`.
+*** If you are using a locally installed version of Ansible Dev tools,
+enter the full path to the directory, for example `/user/<username>/path/to/<collection_directory>`.
+. Click btn:[Create].
+
+.Verification
+
+The following message appears in the *Logs* pane of the *Create Ansible collection* tab.
+// In this example, the destination directory name is 
+
+----
+--------------------- ansible-creator logs ---------------------
+
+    Note: collection company_namespace.myapp_network created at /path/to/collections/directory
+----
+
+The following directories and files are created in your `collections/` directory:
+
+----
+├── .devcontainer
+├── .github
+├── .gitignore
+├── .isort.cfg
+├── .pre-commit-config.yaml
+├── .prettierignore
+├── .vscode
+├── CHANGELOG.rst
+├── CODE_OF_CONDUCT.md
+├── CONTRIBUTING
+├── LICENSE
+├── MAINTAINERS
+├── README.md
+├── changelogs
+├── devfile.yaml
+├── docs
+├── extensions
+├── galaxy.yml
+├── meta
+├── plugins
+├── pyproject.toml
+├── requirements.txt
+├── roles
+├── test-requirements.txt
+├── tests
+└── tox-ansible.ini
+
+----
+
+

--- a/downstream/modules/devtools/proc-devtools-use-roles-collections-aap.adoc
+++ b/downstream/modules/devtools/proc-devtools-use-roles-collections-aap.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="devtools-use-roles-collections-aap_{context}"]
+= Using your collection in projects in {PlatformName}
+
+To use your collection in {ControllerName}, you must add your collection to an
+{ExecEnvShort} and push it to {PrivateHubName}.  
+
+The following procedure describes the workflow to add a collection to an {ExecEnvShort}.
+Refer to
+link:{URLBuilder}/assembly-publishing-exec-env#proc-customize-ee-image[Customizing an existing automation executions environment image]
+in the _{TitleBuilder}_ guide for the commands to execute these steps.
+
+. You can pull an {ExecEnvShort} base image from {HubName},
+or you can add your collection to your own custom {ExecEnvShort}.
+. Add the collections that you want to include in the {ExecEnvShort}.
+. Build the new {ExecEnvShort}.
+. Verify that the collections are in the {ExecEnvShort}.
+. Tag the image and push it to {PrivateHubName}.
+. Pull your new image into your {ControllerName} instance.
+. The playbooks that use the roles in your collection must use the fully qualified domain name (FQDN) for the roles.
+

--- a/downstream/titles/develop-automation-content/master.adoc
+++ b/downstream/titles/develop-automation-content/master.adoc
@@ -19,9 +19,14 @@ include::{Boilerplate}[]
 include::devtools/assembly-devtools-intro.adoc[leveloffset=+1]
 include::devtools/assembly-developer-workflow.adoc[leveloffset=+1]
 include::devtools/assembly-devtools-install.adoc[leveloffset=+1]
-// include::devtools/assembly-devtools-setup.adoc[leveloffset=+1]
+// ----- include::devtools/assembly-devtools-setup.adoc[leveloffset=+1]
 include::devtools/assembly-creating-playbook-project.adoc[leveloffset=+1]
 include::devtools/assembly-writing-running-playbook.adoc[leveloffset=+1]
-// include::devtools/assembly-testing-playbooks.adoc[leveloffset=+1]
+// ----- include::devtools/assembly-testing-playbooks.adoc[leveloffset=+1]
 include::devtools/assembly-publishing-playbook-collection-aap.adoc[leveloffset=+1]
+
+// Roles collections
+
+include::devtools/assembly-devtools-develop-collections.adoc[leveloffset=+1]
+include::devtools/assembly-devtools-create-roles-collection.adoc[leveloffset=+1]
 


### PR DESCRIPTION
AAP-30912  Add roles collections chapter to the Devtools guide.
Affects `titles/develop-automation-content`

Build preview here: https://ariordan-redhat.github.io/aap-builds/develop-automation-content-aap-30912-2024-09-27.html
