### PR TITLE
AAP-32141 Add Installing on Operator chapter to RHDH install guide

### DIFF
--- a/downstream/assemblies/devtools/assembly-rhdh-install-ocp-operator.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-install-ocp-operator.adoc
@@ -1,0 +1,45 @@
+ifdef::context[:parent-context-of-rhdh-install-ocp-operator: {context}]
+[id="rhdh-install-ocp-operator_{context}"]
+
+= Installing the {AAPRHDHShort} with the Operator on {OCPShort}
+
+:context: rhdh-install-ocp-operator
+[role="_abstract"]
+The following procedures describe how to install {AAPRHDHShort} in {RHDH} instances on {OCP} using the Operator.
+
+// The workflow is as follows:
+// 
+// . Download the Ansible plug-ins files.
+// . Create a plug-in registry in your OpenShift cluster to host the Ansible plug-ins.
+// . Create a local backup copy of the ConfigMap for the {RHDHShort} Operator.
+// . Create a custom ConfigMap.
+// . Add your custom ConfigMap to your Helm chart.
+// . Edit your custom ConfigMap and Helm chart according to the required and optional configuration procedures.
+
+include::devtools/con-rhdh-recommended-preconfig.adoc[leveloffset=+1]
+
+// Create custom ConfigMap
+include::devtools/proc-rhdh-backup-operator-configmap.adoc[leveloffset=+1]
+include::devtools/proc-rhdh-create-custom-configmap-operator-install.adoc[leveloffset=+1]
+// Add sidecar container to custom ConfigMap
+include::devtools/proc-rhdh-operator-add-custom-configmap-cr.adoc[leveloffset=+1]
+
+// Plug-in registry
+include::devtools/proc-rhdh-download-plugins.adoc[leveloffset=+1]
+include::devtools/proc-rhdh-create-plugin-registry.adoc[leveloffset=+1]
+
+// Install the dynamic plug-ins
+include::devtools/proc-rhdh-install-dynamic-plugins-operator.adoc[leveloffset=+1]
+//Add dynamic plug-ins to rhaap-dynamic-plugins-config
+include::devtools/proc-rhdh-operator-install-add-plugins-app-config.adoc[leveloffset=+1]
+
+// Required config
+//
+// Optional config 
+//
+// Full example configuration
+//
+
+ifdef::parent-context-of-rhdh-install-ocp-operator[:context: {parent-context-of-rhdh-install-ocp-operator}]
+ifndef::parent-context-of-rhdh-install-ocp-operator[:!context:]
+

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -116,6 +116,7 @@
 // Ansible development tools
 :ToolsName: Ansible development tools
 :AAPRHDH: Ansible plug-ins for Red Hat Developer Hub
+:AAPRHDHShort: Ansible plug-ins
 :RHDH: Red Hat Developer Hub
 :RHDHVers: 1.2
 :RHDHShort: RHDH

--- a/downstream/modules/devtools/con-rhdh-recommended-preconfig.adoc
+++ b/downstream/modules/devtools/con-rhdh-recommended-preconfig.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="rhdh-recommended-preconfig_{context}"]
+= Recommended {RHDHShort} preconfiguration
+
+Red Hat recommends performing the following initial configuration tasks in {RHDHShort}.
+However, you can install the {AAPRHDH} before completing these tasks.
+
+* link:{BaseURL}/red_hat_developer_hub/{RHDHVers}/html/authentication/index[Setting up authentication in {RHDHShort}] 
+* link:{BaseURL}/red_hat_developer_hub/{RHDHVers}/html/authorization/index[Installing and configuring RBAC in {RHDHShort}] 
+
+
+[role="_additional-resources"]
+.Additional resources
+
+

--- a/downstream/modules/devtools/proc-rhdh-backup-operator-configmap.adoc
+++ b/downstream/modules/devtools/proc-rhdh-backup-operator-configmap.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="rhdh-backup-operator-configmap_{context}"]
+= Backing up your {RHDHShort} Operator ConfigMap
+
+Before you install {AAPRHDH}, create a local copy of the ConfigMap for the {RHDHShort} Operator.
+You can use a section of the ConfigMap when you are populating a custom ConfigMap.
+
+.Procedure
+
+// Is export KUBECONFIG=/home/secrets/rosa/kubeconfig needed?
+
+. Find the namespace for your {RHDHShort} Operator.
++
+When you installed the {RHDHShort} Operator, a namespace was created for it.
+Select *Topology* and look for the {RHDHShort} Operator in the *Project* dropdown list.
+The default namespace is `rhdh-operator`.
+. Run the following command to make a copy of the ConfigMap for your {RHDHShort} Operator, `backstage-default-config`.
++
+Replace `<rhdh-operator-namespace>` with your {RHDHShort} Operator namespace, and `<CopyOfRhdhOperatorConfig>` with
+the filename you want to use for your copy of the {RHDHShort} Operator.
++
+----
+$ oc get configmap backstage-default-config -n <rhdh-operator-namespace> -o yaml > <CopyOfRhdhOperatorConfig>
+----
+

--- a/downstream/modules/devtools/proc-rhdh-configure-aap-details.adoc
+++ b/downstream/modules/devtools/proc-rhdh-configure-aap-details.adoc
@@ -13,7 +13,8 @@ The Ansible plug-ins continue to function regardless of the {PlatformNameShort} 
 .Procedure
 
 . Create a Personal Access Token (PAT) with “Read” scope in automation controller, following the
-link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_user_guide/index#assembly-controller-applications[Applications] section of the _Automation controller user guide_. 
+link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_user_guide/assembly-controller-applications#proc-controller-apps-create-tokens[Adding tokens]
+section of the _Automation controller user guide_. 
 . Edit your custom {RHDH} config map, for example `app-config-rhdh`.
 . Add your {PlatformNameShort} details to `app-config-rhdh.yaml`.
 ..  Set the `baseURL` key with your automation controller URL.

--- a/downstream/modules/devtools/proc-rhdh-create-custom-configmap-operator-install.adoc
+++ b/downstream/modules/devtools/proc-rhdh-create-custom-configmap-operator-install.adoc
@@ -1,0 +1,72 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="rhdh-create-custom-configmap-operator-install_{context}"]
+= Creating a custom ConfigMap
+
+Create a ConfigMap, for instance `rhdh-custom-config`, for your project.
+For more details about creating a custom ConfigMap, see the
+link:{BaseURL}/red_hat_developer_hub/{RHDHVers}/html-single/administration_guide_for_red_hat_developer_hub/index#proc-add-custom-app-config-file-ocp-operator_admin-rhdh[Adding a custom application configuration file to OpenShift Container Platform using the Operator]
+in the _Administration guide for Red Hat Developer Hub_.
+
+Populate the ConfigMap with YAML from the backup that you made of the {RHDHShort} Operator ConfigMap.
+// This enables the dynamic plug-ins specific to the backstage showcase.
+
+.Prerequisites
+
+* You have saved a backup copy of the Configmap for the {RHDHShort} Operator.
+
+.Procedure
+
+. In the OpenShift web console, navigate to the project you created.
+. Click *ConfigMaps* in the navigation pane.
+. Click *Create ConfigMap*.
+. Replace the default YAML code in the new ConfigMap with the following code:
++
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rhdh-custom-config
+data:
+  deployment.yaml: |-  # Replace with RHDH Operator ConfigMap deployment.yaml block
+
+----
+. Copy the `deployment.yaml:` section from your local copy of the RHDH Operator ConfigMap.
+. Paste the `deployment.yaml:` section into the `rhdh-custom-config` ConfigMap, replacing the `deployment.yaml:` line.
+. Add a sidecar container (`ansible-devtools-server`)  to the list of containers under `resources` in the `deployment.spec.template.spec.[containers]` block of the ConfigMap:
++
+----
+   spec:
+     replicas: 1
+     selector:
+       matchLabels:
+         rhdh.redhat.com/app:  
+     template:
+       metadata:
+         labels:
+           rhdh.redhat.com/app:  
+       spec:\
+           ...
+           containers:
+           - name: backstage-backend
+		...
+           - resources: {}  # Add sidecar container for Ansible plug-ins
+             terminationMessagePath: /dev/termination-log
+             name: ansible-devtools-server
+             command:
+               - adt
+               - server
+             ports:
+               - containerPort: 8000
+                 protocol: TCP
+             imagePullPolicy: IfNotPresent
+             terminationMessagePolicy: File
+             image: 'ghcr.io/ansible/community-ansible-dev-tools:latest'
+
+----
+. Click btn:[Create] to create the ConfigMap.
+
+.Verification
+
+To view your new ConfigMap, click *ConfigMaps* in the navigation pane.
+

--- a/downstream/modules/devtools/proc-rhdh-create-plugin-registry.adoc
+++ b/downstream/modules/devtools/proc-rhdh-create-plugin-registry.adoc
@@ -3,7 +3,7 @@
 [id="rhdh-create-plugin-registry_{context}"]
 = Creating a plug-in registry
 
-Set up a plug-in registry in your OpenShift cluster to host the Ansible plug-ins and make them available for installation in Red Hat Developer Hub.
+Set up a plug-in registry in your OpenShift cluster to host the {AAPRHDHShort} and make them available for installation in {RHDH} ({RHDHShort}).
 
 .Procedure
 
@@ -36,11 +36,9 @@ image::rhdh-plugin-registry.png[Developer perspective]
 . In the terminal, run `ls` to confirm that the .tar files are in the plugin registry.
 +
 ----
-sh-4.45 $1s -l
-total 3392
--rw-rw-r-- 1 default root 3376269 Jul 22 13:48 ansible-plugin-backstagc-rhaap-1.0.0.tgz
--rw-rw-r-- 1 default root 25156 Jul 22 13:48 ansible-plugin-backstage-rhaap-backend-1.0.0.tgz
--rw-rw-r-- 1 default root 61520 Jul 22 13:48 ansible-plugin-scaffolder-backend-modulc-backstagc-rhaap-1.0.0.tgz
+ansible-plugin-backstagc-rhaap-x.y.z.tgz
+ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
+ansible-plugin-scaffolder-backend-modulc-backstagc-rhaap-x.y.z.tgz
 ----
 +
 The version numbers and file names can differ.

--- a/downstream/modules/devtools/proc-rhdh-install-dynamic-plugins-operator.adoc
+++ b/downstream/modules/devtools/proc-rhdh-install-dynamic-plugins-operator.adoc
@@ -1,0 +1,74 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="rhdh-install-dynamic-plugins-operator_{context}"]
+= Installing the dynamic plug-ins
+
+To install the dynamic plugins, add them to the `rhaap-dynamic-plugins-config` ConfigMap.
+
+.Procedure
+
+. Select *ConfigMaps* in the navigation pane of the OpenShift console.
+. Select the `rhaap-dynamic-plugins-config` ConfigMap from the list.
+. Select the *YAML* tab to edit the `rhaap-dynamic-plugins-config` ConfigMap.
+. In the `data.dynamic-plugins.yaml.plugins` block, add the three dynamic plug-ins from the plug-in registry.
+** For the `integrity` hash values, use the `.integrity` files in your `$DYNAMIC_PLUGIN_ROOT_DIR` directory that correspond to each plug-in, for example use `ansible-plugin-backstage-rhaap-x.y.z.tgz.integrity` for the `ansible-plugin-backstage-rhaap-x.y.z.tgz` plug-in.
+** Replace `x.y.z` with the correct version of the plug-ins.
++
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+ name: rhaap-dynamic-plugins-config
+data:
+ dynamic-plugins.yaml: |
+   ...
+   plugins:
+     - disabled: false
+       package: 'http://registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz'
+       integrity: sha512-<REDACTED>== # Use hash in ansible-plugin-backstage-rhaap-x.y.z.tgz.integrity
+       pluginConfig:
+         dynamicPlugins:
+           frontend:
+             ansible.plugin-backstage-rhaap:
+               appIcons:
+                 - importName: AnsibleLogo
+                   name: AnsibleLogo
+               dynamicRoutes:
+                 - importName: AnsiblePage
+                   menuItem:
+                     icon: AnsibleLogo
+                     text: Ansible
+                   path: /ansible
+     - disabled: false
+       package: >-
+         http://registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
+       integrity: sha512-E<REDACTED>w== # Use hash in ansible-plugin-backstage-rhaap-backend-x.y.z.tgz.integrity
+       pluginConfig:
+         dynamicPlugins:
+           backend:
+             ansible.plugin-backstage-rhaap-backend: null
+     - disabled: false
+       package: >-
+         http://registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+       integrity: sha512-<REDACTED>Q== # Use hash in ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz.integrity
+       pluginConfig:
+         dynamicPlugins:
+           backend:
+             ansible.plugin-scaffolder-backend-module-backstage-rhaap: null
+     - ...<REDACTED>
+
+----
+. Click btn:[Save].
+. To view the progress of the rolling restart:
+.. In the *Topology* view, select the deployment pod and click *View logs*.
+.. Select `install-dynamic-plugins` from the list of containers.
+
+.Verification
+
+. In the OpenShift console, select the *Topology* view.
+. Click the *Open URL* icon on the deployment pod to open your {RHDH} instance in a browser window.
+
+The Ansible plug-in is present in the navigation pane, and if you select *Administration*,
+the installed plug-ins are listed in the *Plugins* tab.
+
+ 

--- a/downstream/modules/devtools/proc-rhdh-operator-add-custom-configmap-cr.adoc
+++ b/downstream/modules/devtools/proc-rhdh-operator-add-custom-configmap-cr.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="rhdh-operator-add-custom-configmap-cr_{context}"]
+= Adding the rhdh-custom-config file to the {RHDHShort} Operator Custom Resource
+
+Update the {RHDHShort} Operator Custom Resource to add the `rhdh-custom-config` file.
+
+. In the OpenShift console, select the *Topology* view.
+. Click *More actions {MoreActionsIcon}* on the {RHDHShort} Operator Custom Resource and select *Edit backstage* to edit the Custom Resource.
+. Add a `rawRuntimeConfig:` block for your custom ConfigMap `spec:` block.
+It must have the same indentation level as the `spec.application:` block.
++
+----
+spec:
+ application:
+	...
+ database:
+  	...
+ rawRuntimeConfig:
+   backstageConfig: rhdh-custom-config
+
+----
+. Click btn:[Save].
+. The {RHDHShort} Operator redeploys the pods to reflect the updated Custom Resource.
+
+
+// .Verification
+
+// We should be able to see existing config maps that handle the app-config for rhdh instance and a different configMap that would serve the dynamic plugins that are being installed.
+
+// Considering the custom ConfigMaps are named - 
+// - rhdh-app-config  - Holds baseUrl, template config, plugin-specific config, and RBAC configuration
+// - rhaap-dynamic-plugins-config - contains dynamic plugins to be installed
+

--- a/downstream/modules/devtools/proc-rhdh-operator-install-add-plugins-app-config.adoc
+++ b/downstream/modules/devtools/proc-rhdh-operator-install-add-plugins-app-config.adoc
@@ -1,0 +1,109 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="rhdh-operator-install-add-plugins-app-config_{context}"]
+= Adding the {AAPRHDHShort} configuration to rhdh-app-config 
+
+Add the Ansible plugin-specific configuration to the `rhdh-app-config` ConfigMap,
+and add a route for the templates for the automation content scaffolder plugin.
+
+
+.Procedure
+
+. In the OpenShift web console, select *ConfigMaps*.
+. Select the `rhdh-app-config` ConfigMap.
+. Select the *YAML* tab to edit the ConfigMap.
+. In the `data.app-config-custom.yaml.catalog` block, add a `locations:` block for the GitHub repository for the templates that are used to scaffold collections and playbooks. The `locations:` block must have the same indentation as the `rules:` block that precedes it.
++
+----
+     locations:
+       - type: url 
+         target: https://github.com/ansible/ansible-rhdh-templates/blob/main/all.yaml
+         rules:
+           - allow: [Template]
+----
+. In the `data.app-config-custom.yaml` block, add an `ansible: block with the same indentation as `catalog`, to point to your Dev Spaces instance and your {PlatformNameShort} instance.
+Replace `baseUrl` with the URLs for your own instances.
++
+----
+   ansible: 
+     devSpaces:
+       baseUrl: 'https://devspaces.apps.example-cluster.com/'
+     creatorService:
+       baseUrl: '127.0.0.1'
+       port: '8000'
+     rhaap:
+       baseUrl: 'https://controller.acme.demoredhat.com'
+       token: ...<REDACTED>
+       checkSSL: false
+----
++
+After you have added both blocks, the ConfigFile resembles the following:
++
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+ name: rhdh-app-config
+data:
+ app-config-custom.yaml: |
+   app:
+     baseUrl: https://<RHDH_ROUTE>
+   backend:
+     baseUrl: https://<RHDH_ROUTE>
+     cors:
+       origin: https://<RHDH_ROUTE>
+   catalog:
+     rules:
+       - allow: [Component, System, Group, Resource, Location, Template, API, User]
+     locations: 
+       - type: url         # Add RHDH templates URL
+         target: https://github.com/ansible/ansible-rhdh-templates/blob/main/all.yaml
+         rules:
+           - allow: [Template]
+   ansible:               # Add Dev Spaces and AAP URLs
+     devSpaces:
+       baseUrl: 'https://devspaces.apps.example-cluster.com/'
+     creatorService:
+       baseUrl: '127.0.0.1'
+       port: '8000'
+     rhaap:
+       baseUrl: 'https://controller.acme.demoredhat.com'
+       token: ...<REDACTED>
+       checkSSL: false
+   auth:
+     environment: development
+     providers:
+       guest:
+         dangerouslyAllowOutsideDevelopment: true
+       github:
+         development:
+           clientId: '...<REDACTED>'
+           clientSecret: '...<REDACTED>'
+   integrations:
+     github:
+       - host: github.com
+         token: ...<REDACTED>
+   enabled:
+     github: true
+   signInPage: github
+   permission:
+     enabled: true
+     rbac:
+       admin:
+         users:
+           - name: ...<REDACTED>
+         superUsers:
+           - name: ...<REDACTED>
+----
+. Click btn:[Save].
++
+Your {RHDHShort} instance reloads.
+
+.Verification
+
+. Select the *Topology* in the OpenShift web console to monitor the rolling update.
+. When the update is complete, click the *Open URL* icon on the deployment pod to open your {RHDH} instance in a browser window.
+. Select *Create* in the navigation pane.
+The *Create Ansible Collection Project* and *Create Ansible Playbook Project* are displayed.
+//When you perform a rolling update in OpenShift, the new pods are baked with the updated image or configuration before being deployed. 
+

--- a/downstream/titles/aap-plugin-rhdh-install/master.adoc
+++ b/downstream/titles/aap-plugin-rhdh-install/master.adoc
@@ -16,14 +16,18 @@ This document has been updated to include information for the latest release of 
 
 include::{Boilerplate}[]
 
-[IMPORTANT]
-==== 
-{AAPRHDH} is a Technology Preview feature only.
-include::snippets/technology-preview.adoc[]
-==== 
+// [IMPORTANT]
+// ==== 
+// {AAPRHDH} is a Technology Preview feature only.
+// include::snippets/technology-preview.adoc[]
+// ==== 
 
 include::devtools/assembly-rhdh-intro.adoc[leveloffset=+1]
+
+// Installation
 include::devtools/assembly-rhdh-install-ocp-helm.adoc[leveloffset=+1]
+include::devtools/assembly-rhdh-install-ocp-operator.adoc[leveloffset=+1]
+
 include::devtools/assembly-rhdh-subscription-warnings.adoc[leveloffset=+1]
 include::devtools/assembly-rhdh-upgrade-ocp.adoc[leveloffset=+1]
 include::devtools/assembly-rhdh-uninstall-ocp.adoc[leveloffset=+1]


### PR DESCRIPTION
AAP-32141 Add Installing on Operator chapter to RHDH install guide

Affects titles/aap-plugin-rhdh-install/

Preview here: https://ariordan-redhat.github.io/aap-builds/aap-plugin-rhdh-install-scaffold-plugin-operator-install-2024-09-26.html