### PR TITLE
Fixed broken formatting preventing successful build

### DIFF
--- a/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
+++ b/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
@@ -27,7 +27,7 @@ You can update these collections manually by downloading their packages.
 
 //hherbly: removing as this is specific to partners, not a general user audience. see aap-20548  
 
-[discrete]
+//[discrete]
 
 // == Why certify Ansible collections?
 
@@ -64,9 +64,13 @@ You can use {HubNameMain} to distribute the relevant {CertifiedColl}s to your us
 
 Before you can use a requirements file to install content, you must: 
 
-. xref:proc-obtaining-org-collection-url[Obtain an automation hub API token]
-. xref:proc-set-rhcertified-remote.adoc[Use the API token to configure a remote repository in your local hub]
-. Then, xref:proc-create-requirements-file[Create a requirements file].
+//[Michelle - converting xref to links to ensure docs build successfully]
+. link:{URLHubManagingContent}/assembly-creating-tokens-in-automation-hub#proc-create-api-token[Obtain an automation hub API token]
+. link:{URLHubManagingContent}/assembly-creating-tokens-in-automation-hub#proc-set-rhcertified-remote[Use the API token to configure a remote repository in your local hub]
+. Then, link:{URLHubManagingContent}/assembly-creating-tokens-in-automation-hub#create-requirements-file[Create a requirements file].
+//. xref:proc-obtaining-org-collection-url[Obtain an automation hub API token]
+//. xref:proc-set-rhcertified-remote.adoc[Use the API token to configure a remote repository in your local hub]
+//. Then, xref:proc-create-requirements-file[Create a requirements file].
 
 include::assembly-syncing-to-cloud-repo.adoc[leveloffset=+1]
 include::assembly-synclists.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR changes xrefs to links in the Managing automation content guide.