### PR TITLE
Fix broken xrefs in Managing automation content

### DIFF
--- a/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
+++ b/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
@@ -27,8 +27,7 @@ You can update these collections manually by downloading their packages.
 
 //hherbly: removing as this is specific to partners, not a general user audience. see aap-20548  
 
-//[discrete]
-
+// [discrete]
 // == Why certify Ansible collections?
 
 // The Ansible certification program represents a shared statement of support for {CertifiedCon} between Red Hat and the ecosystem partner.
@@ -64,13 +63,9 @@ You can use {HubNameMain} to distribute the relevant {CertifiedColl}s to your us
 
 Before you can use a requirements file to install content, you must: 
 
-//[Michelle - converting xref to links to ensure docs build successfully]
-. link:{URLHubManagingContent}/assembly-creating-tokens-in-automation-hub#proc-create-api-token[Obtain an automation hub API token]
-. link:{URLHubManagingContent}/assembly-creating-tokens-in-automation-hub#proc-set-rhcertified-remote[Use the API token to configure a remote repository in your local hub]
-. Then, link:{URLHubManagingContent}/assembly-creating-tokens-in-automation-hub#create-requirements-file[Create a requirements file].
-//. xref:proc-obtaining-org-collection-url[Obtain an automation hub API token]
-//. xref:proc-set-rhcertified-remote.adoc[Use the API token to configure a remote repository in your local hub]
-//. Then, xref:proc-create-requirements-file[Create a requirements file].
+. xref:retrieve-api-token_managing-cert-validated-content[Obtain an automation hub API token]
+. xref:proc-set-rhcertified-remote[Use the API token to configure a remote repository in your local hub]
+. Then, xref:create-requirements-file_managing-cert-validated-content[Create a requirements file].
 
 include::assembly-syncing-to-cloud-repo.adoc[leveloffset=+1]
 include::assembly-synclists.adoc[leveloffset=+1]

--- a/downstream/modules/hub/proc-obtaining-org-collection-url.adoc
+++ b/downstream/modules/hub/proc-obtaining-org-collection-url.adoc
@@ -1,4 +1,4 @@
-[id="proc-create-api-token"]
+[id="retrieve-api-token_{context}"]
 = Retrieving the API token for your Red Hat Certified Collection
 
 You can synchronize {CertifiedName} curated by your organization from `{Console}` to your {PrivateHubName}.


### PR DESCRIPTION
Fixes `xref`s that were causing the Managing automation content build to fail in Pantheon.

Affects `hub/managing-content/`