### PR TITLE
Backport to 2.5: AAP-20548pt4: Managing automation content updates  (#2150)

### DIFF
--- a/downstream/assemblies/hub/assembly-container-user-access.adoc
+++ b/downstream/assemblies/hub/assembly-container-user-access.adoc
@@ -9,17 +9,17 @@ ifdef::context[:parent-context: {context}]
 :context: configuring-user-access-containers
 
 [role="_abstract"]
-To determine who can access and manage images in your {PlatformNameShort}, you must configure user access for container repositories in your {PrivateHubName}.
+To determine who can access and manage {ExecEnvShort}s in your {PlatformNameShort}, you must configure user access for container repositories in your {PrivateHubName}.
 
 include::hub/ref-container-permissions.adoc[leveloffset=+1]
 include::hub/proc-create-groups.adoc[leveloffset=+1]
-include::hub/proc-assigning-permissions.adoc[leveloffset=+1]
+// [hherbly]: proc-assigning-permissions seems to repeat proc-create-groups.adoc include::hub/proc-assigning-permissions.adoc[leveloffset=+1]
 
-.Additional resources
+// .Additional resources
 
-* See <<container-registry-group-permissions, Container registry group permissions>> to learn more about specific permissions.
+// [hherbly] LINK SHOULD BE REPLACED when we find a better one * See <<container-registry-group-permissions, Container registry team permissions>> to learn more about specific permissions.
 
-include::hub/proc-add-user-to-group.adoc[leveloffset=+1]
+// [hherbly]: this module also seems redundant include::hub/proc-add-user-to-group.adoc[leveloffset=+1]
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/hub/assembly-delete-container.adoc
+++ b/downstream/assemblies/hub/assembly-delete-container.adoc
@@ -6,21 +6,21 @@ ifdef::context[:parent-context: {context}]
 :context: delete-container
 
 [role="_abstract"]
-Delete a container repository from your {PrivateHubName} to manage your disk space.
-You can delete repositories from the {PlatformName} interface in the *Container Repository* list view.
+Delete a remote repository from your {PlatformNameShort} to manage your disk space.
+You can delete repositories from the {PlatformName} interface in the *Execution Environment* list view.
 
 .Prerequisites
 * You have permissions to manage repositories.
 
 .Procedure
-. Navigate to {HubName}.
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACExecEnvironments}.
 . On the container repository that you want to delete, click the btn:[More Actions] icon *{MoreActionsIcon}*, and click btn:[Delete].
 . When the confirmation message is displayed, click the checkbox and click btn:[Delete].
 
 .Verification
-* Return to the *Execution Environments* list view.
-If the container repository has been successfully deleted, the container repository is no longer on the list.
+* Return to the *{ExecEnvName}s* list view.
+If the {ExecEnvName} has been successfully deleted, it will no longer be in the list.
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/hub/assembly-managing-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-managing-container-registry.adoc
@@ -2,22 +2,19 @@
 ifdef::context[:parent-context: {context}]
 
 
-
 [id="managing-container-registry"]
-= Manage your {PrivateHubName} container registry
+= Manage your {PrivateHubName} remote registry
 
 :context: managing-container-registry
 
 [role="_abstract"]
-Manage container image repositories in your {PlatformNameShort} infrastructure by using the {HubName} container registry.
+Manage container image repositories in your {PlatformNameShort} infrastructure by using the {HubName} remote registry.
 You can perform the following tasks with {HubNameStart}:
 
 * Control who can access individual container repositories
 * Change tags on images
 * View activity and image layers
 * Provide additional information related to each container repository
-
-
 
 ////
 The following include statements pull in the module files that comprise the assembly. Include any combination of concept, procedure, or reference modules required to cover the user story. You can also include other assemblies.

--- a/downstream/assemblies/hub/assembly-managing-containers-hub.adoc
+++ b/downstream/assemblies/hub/assembly-managing-containers-hub.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 :context: managing-containers
 
 [role="_abstract"]
-Learn the administrator workflows and processes for configuring {PrivateHubName} container registry and repositories.
+Learn the administrator workflows and processes for configuring {PrivateHubName} remote registry and repositories.
 
 include::assembly-managing-container-registry.adoc[leveloffset=+1]
 include::assembly-container-user-access.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -10,27 +10,27 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-By default, {PrivateHubName} does not include container images.
-To populate your container registry, you must push a container image to it.
+By default, {PrivateHubName} does not include {ExecEnvShort}s.
+To populate your container registry, you must push a {ExecEnvShort} to it.
 
-You must follow a specific workflow to populate your {PrivateHubName} container registry:
+You must follow a specific workflow to populate your {PrivateHubName} remote registry:
 
-* Pull images from the Red Hat Ecosystem Catalog (registry.redhat.io)
+* Pull {ExecEnvShort}s from the Red Hat Ecosystem Catalog (registry.redhat.io)
 * Tag them
-* Push them to your {PrivateHubName} container registry
+* Push them to your {PrivateHubName} remote registry
 
 [IMPORTANT]
 ====
 Image manifests and filesystem blobs were both originally served directly from `registry.redhat.io` and `registry.access.redhat.com`.
 As of 1 May 2023, filesystem blobs are served from `quay.io` instead.
 
-* Ensure that the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/ref-network-ports-protocols_planning[Network ports and protocols] listed in _Table 6.4. Execution Environments (EE)_ are available to avoid problems pulling container images.
+* Ensure that the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[Network ports and protocols] listed in _Table 5.4. Execution Environments (EE)_ are available to avoid problems pulling container images.
 
 Make this change to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
 
 Use the hostnames instead of IP addresses when configuring firewall rules.
 
-After making this change you can continue to pull images from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+After making this change you can continue to pull {ExecEnvShort}s from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
 
 However, manifests, sometimes called “subscription allocations”, on the web-based Red Hat Subscription Management are no longer supported as of early 2024 with one exception: If a system is part of a closed network or “air gapped” system that does not receive its updates from Red Hat’s servers directly, manifests are supported until the release of Red Hat Satellite 6.16. Keep up to date with link:access.redhat.com/articles/1365633[Red Hat Satellite Release Dates] for the announcement for Red Hat Satellite 6.16's release date announcement.
 ====

--- a/downstream/assemblies/hub/assembly-pull-image.adoc
+++ b/downstream/assemblies/hub/assembly-pull-image.adoc
@@ -6,9 +6,9 @@ ifdef::context[:parent-context: {context}]
 :context: pulling-images-container-repository
 
 [role="_abstract"]
-Pull images from the {HubName} container registry to make a copy to your local machine. 
-{HubNameStart} provides the `podman pull` command for each `latest` image in the container repository. 
-You can copy and paste this command into your terminal, or use `podman pull` to copy an image based on an image tag.
+Pull {ExecEnvName}s from the {HubName} remote registry to make a copy to your local machine. 
+{HubNameStart} provides the `podman pull` command for each `latest` {ExecEnvName} in the container repository. 
+You can copy and paste this command into your terminal, or use `podman pull` to copy an {ExecEnvName} based on an {ExecEnvName} tag.
 
 include::hub/proc-pull-image.adoc[leveloffset=+1]
 include::hub/proc-sync-image.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-setup-container-repository.adoc
+++ b/downstream/assemblies/hub/assembly-setup-container-repository.adoc
@@ -7,17 +7,15 @@ ifdef::context[:parent-context: {context}]
 [id="setting-up-container-repository"]
 = Setting up your container repository
 
-
 :context: assembly-keyword
 
 
-
 [role="_abstract"]
-When you set up your container repository, you must add a description, include a README, add groups that can access the repository, and tag images.
+When you set up your container repository, you must add a description, include a README, add teams that can access the repository, and tag {ExecEnvName}s.
 
-== Prerequisites to setting up your container registry
+== Prerequisites to setting up your remote registry
 
-* You are logged in to a {PrivateHubName}.
+* You are logged in to {PlatformNameShort}.
 * You have permissions to change the repository.
 
 

--- a/downstream/assemblies/hub/assembly-working-with-signed-containers.adoc
+++ b/downstream/assemblies/hub/assembly-working-with-signed-containers.adoc
@@ -9,7 +9,7 @@ ifdef::context[:parent-context: {context}]
 
 :context: working-with-signed-containers
 
-{ExecEnvNameStart} are container images used by Ansible {ControllerName} to run jobs. 
+{ExecEnvNameStart} are container images used by {PlatformNameShort} to run jobs. 
 You can download this content to {PrivateHubName}, and publish it within your organization.
 
 include::hub/proc-deploying-your-system-for-container-signing.adoc[leveloffset=+1]

--- a/downstream/modules/hub/con-container-registry.adoc
+++ b/downstream/modules/hub/con-container-registry.adoc
@@ -6,13 +6,13 @@
 
 [role="_abstract"]
 
-The {HubName} container registry is used for storing and managing container images.
-When you have built or sourced a container image, you can push that container image to the registry portion of {PrivateHubName} to create a container repository.
+The {HubName} remote registry is used for storing and managing {ExecEnvShort}s.
+When you have built or sourced an {ExecEnvShort}, you can push that {ExecEnvShort} to the registry portion of {PrivateHubName} to create a container repository.
 
 [role="_additional-resources"]
 .Next steps
 
-* Push a container image to the {HubName} container registry.
+* Push a {ExecEnvShort} to the {HubName} remote registry.
 * Create a group with access to the container repository in the registry.
 * Add the new group to the container repository.
 * Add a README to the container repository to provide users with information and relevant links.

--- a/downstream/modules/hub/proc-add-container-readme.adoc
+++ b/downstream/modules/hub/proc-add-container-readme.adoc
@@ -26,8 +26,8 @@ By default, the README is empty.
 * You have permissions to change containers.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {HubName}.
+
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACExecEnvironments}.
 . Select your container repository.
 . On the *Detail* tab, click btn:[Add].

--- a/downstream/modules/hub/proc-add-group-to-container-repo.adoc
+++ b/downstream/modules/hub/proc-add-group-to-container-repo.adoc
@@ -1,22 +1,22 @@
 [id="providing-access-to-containers"]
 
-= Providing access to your container repository
+= Providing access to your {ExecEnvName}s
 
 [role="_abstract"]
-Provide access to your container repository for users who need to work with the images.
-Adding a group allows you to modify the permissions the group can have to the container repository.
-You can use this option to extend or restrict permissions based on what the group is assigned.
+Provide access to your {ExecEnvName}s for users who need to work with the images.
+Adding a team allows you to modify the permissions the team can have to the container repository.
+You can use this option to extend or restrict permissions based on what the team is assigned.
 
 .Prerequisites
 
 * You have *change container namespace* permissions.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {HubName}.
+
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACExecEnvironments}.
-. Select your container repository.
-. From the *Access* tab, click btn:[Select a group].
-. Select the group or groups to which you want to grant access and click btn:[Next].
+. Select your {ExecEnvName}.
+. From the *Team Access* tab, click btn:[Add roles].
+. Select the team or teams to which you want to grant access and click btn:[Next].
 . Select the roles that you want to add to this {ExecEnvShort} and click btn:[Next].
-. Click btn:[Add].
+. Click btn:[Finish].

--- a/downstream/modules/hub/proc-adding-an-execution-environment.adoc
+++ b/downstream/modules/hub/proc-adding-an-execution-environment.adoc
@@ -2,30 +2,25 @@
 [id="adding-an-execution-environment"]
 
 = Adding an {ExecEnvShort}
-{ExecEnvNameStart} are container images that make it possible to incorporate system-level dependencies and collection-based content.
-Each {ExecEnvShort} allows you to have a customized image to run jobs, and each of them contain only what you need when running the job.
+{ExecEnvNameStart} are container images that make it possible to incorporate system-level dependencies and collection-based content. Each {ExecEnvShort} allows you to have a customized image to run jobs, and each of them contain only what you need when running the job.
 
 .Procedure
 . From the navigation panel, select {MenuACExecEnvironments}.
 
-. Click btn:[Add execution environment].
+. Click btn:[Create execution environment].
 
 . Enter the name of the {ExecEnvShort}.
 
-. Optional: Enter the upstream name.
+. Enter the upstream name.
 
 . Under *Registry*, select the name of the registry from the drop-down menu.
 
 . Enter tags in the *Add tag(s) to include* field.
 If the field is blank, all the tags are passed.
-You must specify which repository specific tags to pass.
+You must specify which repository-specific tags to pass.
 
-. The remaining fields are optional:
-* *Currently included tags*
-* *Add tag(s) to exclude*
-* *Currently excluded tag(s)*
-* *Description*
+. Optional: Enter tags to exclude in *Add tag(s) to exclude*. 
 
-. Click btn:[Save].
+. Click btn:[Create {ExecEnvName}].
 
 . Synchronize the image.

--- a/downstream/modules/hub/proc-adding-containers-remotely-to-the-automation-hub.adoc
+++ b/downstream/modules/hub/proc-adding-containers-remotely-to-the-automation-hub.adoc
@@ -10,13 +10,12 @@ You can add containers remotely to {HubName} in one of the following two ways:
 * Execution Environment
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
 
-. Log in to {HubName}.
+. Log in to {PlatformNameShort}.
 
 . From the navigation panel, select {MenuACAdminRemoteRegistries}.
 
-. Click btn:[Add remote registry].
+. Click btn:[Create remote registry].
 
 * In the *Name* field, enter the name of the registry where the container resides.
 
@@ -26,4 +25,4 @@ You can add containers remotely to {HubName} in one of the following two ways:
 
 * In the *Password* field, enter the password if necessary.
 
-* Click btn:[Save].
+* Click btn:[Create remote registry].

--- a/downstream/modules/hub/proc-basic-repo-sync.adoc
+++ b/downstream/modules/hub/proc-basic-repo-sync.adoc
@@ -5,10 +5,10 @@
 
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {HubName}.
+
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRepositories}.
-. Locate your repository in the list and click *Sync*.
+. Locate your repository in the list and click btn:[More Actions] icon *{MoreActionsIcon}*, then select *Sync repository*.
 +
 All collections in the configured remote are downloaded to your custom repository. To check the status of the collection sync, select {MenuACAdminTasks} from the navigation panel.
 +
@@ -19,4 +19,4 @@ To limit repository synchronization to specific collections within a remote, you
 
 [role="_additional-resources"]
 .Additional resources
-For more information about using requirements files, see link:https://docs.ansible.com/ansible/latest/collections_guide/collections_installing.html#install-multiple-collections-with-a-requirements-file[Install multiple collections with a requirements file] in the _Using Ansible collections_ guide.
+For more information about using requirements files, see xref:proc-create-requirements-file[Creating a requirements file].

--- a/downstream/modules/hub/proc-configuring-the-client-to-verify-signatures.adoc
+++ b/downstream/modules/hub/proc-configuring-the-client-to-verify-signatures.adoc
@@ -3,7 +3,7 @@
 
 = Configuring the client to verify signatures
 
-To ensure a container image pulled from the remote registry is properly signed, you must first configure the image with the proper public key in a policy file. 
+To ensure an {ExecEnvName} pulled from the remote registry is properly signed, you must first configure the {ExecEnvName} with the proper public key in a policy file. 
 
 .Prerequisites
 * The client must have sudo privileges configured to verify signatures.
@@ -75,7 +75,7 @@ name of your key file.
 > podman pull <server-address>/<container-name>:<tag name> --tls-verify=false
 ----
 
-This response verifies the image has been signed with no errors. If the image is not signed, the command fails.
+This response verifies the {ExecEnvName} has been signed with no errors. If the {ExecEnvName} is not signed, the command fails.
 
 .Additional resources
 * For more information about policy.json, see link:https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#signedby[documentation for containers-policy.json]. 

--- a/downstream/modules/hub/proc-create-credential.adoc
+++ b/downstream/modules/hub/proc-create-credential.adoc
@@ -1,25 +1,25 @@
 [id="proc-create-credential"]
 
-= Creating a credential in {ControllerName}
+= Creating a credential
 
-To pull container images from a password or token-protected registry, you must create a credential in {ControllerName}.
+To pull {ExecEnvName} images from a password or token-protected registry, you must create a credential.
 
 In earlier versions of {PlatformNameShort}, you were required to deploy a registry to store {ExecEnvShort} images.
-On {PlatformNameShort} 2.0 and later, the system operates as if you already have a container registry up and running.
-To store {ExecEnvShort} images, add the credentials of only your selected container registries.
+On {PlatformNameShort} 2.0 and later, the system operates as if you already have a remote registry up and running.
+To store {ExecEnvShort} images, add the credentials of only your selected remote registries.
 
 .Procedure
 // For 2.5 this will be Log in to Ansible Automation Platform. From the navigation panel select Access Management > Credentials. Select the Automation Execution tab
-. Navigate to {ControllerName}.
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuAECredentials}.
 . Click btn:[Add] to create a new credential.
 . Enter an authorization *Name*, *Description*, and *Organization*.
 . Select the *Credential Type*.
-. Enter the *Authentication URL*. This is the container registry address.
-. Enter the *Username* and *Password or Token* required to log in to the container registry.
+. Enter the *Authentication URL*. This is the remote registry address.
+. Enter the *Username* and *Password or Token* required to log in to the remote registry.
 . Optional: To enable SSL verification, select *Verify SSL*.
 . Click btn:[Save].
 
-Filling in at least one of the fields organization, user, or team is mandatory, and can be done through the user interface
+Filling in at least one of the fields organization, user, or team is mandatory, and can be done through the user interface.
 
 //[dcd-This should be replaced with a link; otherwise, it's not helpful]For more information, please reference the Pulling from Protected Registries section of the Execution Environment documentation.

--- a/downstream/modules/hub/proc-create-groups.adoc
+++ b/downstream/modules/hub/proc-create-groups.adoc
@@ -2,9 +2,9 @@
 // obtaining-token/master.adoc
 [id="proc-create-group"]
 
-= Creating a new group in {PrivateHubName}
+= Creating a new team in {PrivateHubName}
 
-You can create and assign permissions to a group in {PrivateHubName} that enables users to access specified features in the system.
-By default, the *Admin* group in the {HubName} has all permissions assigned and is available on initial login. Use the credentials created when installing {PrivateHubName}.
+You can create and assign permissions to a team in {PrivateHubName} that enables users to access specified features in the system.
+By default, new teams do not have any assigned permissions. You can add permissions when first creating a team or edit an existing team to add or remove permissions. 
 
-For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/getting_started_with_automation_hub/index#proc-create-group[Creating a new group in {PrivateHubName}] in the Getting started with {HubName} guide.
+For more information, see link:{URLCentralAuth}/gw-managing-access#assembly-controller-teams_gw-manage-rbac[Teams] in the {TitleCentralAuth} guide.

--- a/downstream/modules/hub/proc-create-remote.adoc
+++ b/downstream/modules/hub/proc-create-remote.adoc
@@ -8,16 +8,16 @@
 You can use {PlatformName} to create a remote configuration to an external collection source. Then, you can sync the content from those collections to your custom repositories.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {HubName}.
+
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRemotes}.
-. Click btn:[Add Remote].
+. Click btn:[Create Remote].
 . Enter a *Name* for the remote configuration.
 . Enter the *URL* for the remote server, including the path for the specific repository.
 +
 [NOTE]
 ====
-To find the remote server URL and repository path, navigate to {MenuACAdminRepositories}, select your repository, and click btn:[Copy CLI configuration].
+To find the remote server URL and repository path, navigate to {MenuACAdminRepositories}, select the btn:[More Actions] icon *{MoreActionsIcon}*, and select btn:[Copy CLI configuration].
 ====
 +
 . Configure the credentials to the remote server by entering a *Token* or *Username* and *Password* required to access the external collection.
@@ -28,7 +28,7 @@ To generate a token from the navigation panel, select {MenuACAPIToken}, click bt
 ====
 +
 . To access collections from {Console}, enter the *SSO URL* to sign in to the identity provider (IdP).
-. Select or create a *YAML requirements* file to identify the collections and version ranges to synchronize with your custom repository. For example, to download only the kubernetes and AWS collection versions 5.0.0 or later the requirements file would look like this:
+. Select or create a *Requirements file* to identify the collections and version ranges to synchronize with your custom repository. For example, to download only the kubernetes and AWS collection versions 5.0.0 or later the requirements file would look like this:
 +
 -----
 Collections:
@@ -42,7 +42,7 @@ Collections:
 All collection dependencies are downloaded during the Sync process.
 ====
 +
-. Optional: To configure your remote further, use the options available under *Advanced configuration*:
+. Optional: To configure your remote further, use the options available under *Show advanced options*:
 .. If there is a corporate proxy in place for your organization, enter a *Proxy URL*, *Proxy Username* and *Proxy Password*.
 .. Enable or disable transport layer security using the *TLS validation* checkbox.
 .. If digital certificates are required for authentication, enter a *Client key* and *Client certificate*.

--- a/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
+++ b/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
@@ -58,10 +58,8 @@ automationhub_container_signing_service_key = /absolute/path/to/key/to/sign
 automationhub_container_signing_service_script = /absolute/path/to/script/that/signs
 -----
 +
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Once installation is complete, navigate to your {HubName}.
 
-. From the navigation panel, select {MenuACAdminSignatureKeys}.
+. Once installation is complete, log in to {PlatformNameShort} and navigate to {MenuACAdminSignatureKeys}.
 
 . Ensure that you have a key titled *container-default*, or *container*-_anyname_.
 

--- a/downstream/modules/hub/proc-export-collection.adoc
+++ b/downstream/modules/hub/proc-export-collection.adoc
@@ -8,8 +8,8 @@
 After collections are finalized, you can import them to a location where they can be distributed to others across your organization.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {PrivateHubName}.
+
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACCollections}. The *Collections* page displays all collections across all repositories. You can search for a specific collection.
 . Select the collection that you want to export. The collection details page opens.
 . From the *Install* tab, select *Download tarball*. The .tar file is downloaded to your default browser downloads folder. You can now import it to the location of your choosing.

--- a/downstream/modules/hub/proc-import-collection.adoc
+++ b/downstream/modules/hub/proc-import-collection.adoc
@@ -8,15 +8,17 @@
 As an automation content creator, you can import a collection to use in a custom repository. To use a collection in your custom repository, you must first import the collection into your namespace so the {HubName} administrator can approve it.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {HubName}.
+
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACNamespaces}. The *Namespaces* page displays all of the namespaces available.
-. Click btn:[View Collections].
+. Select the namespace to which you want to add your collection.
+. Select the *Collections* tab.
 . Click btn:[Upload Collection].
-. Navigate to the collection tarball file, select the file and click btn:[Open].
-. Click btn:[Upload].
+. Enter or browse to select a collection file.
+. Select the repository pipeline to add the collection. The choices are *Staging repos* and *Repositories without pipeline*.
+. Click btn:[Upload collection].
 +
-The *My Imports* screen displays a summary of tests and notifies you if the collection upload is successful or has failed.
+The *Imports* screen displays a summary of tests and notifies you if the collection upload is successful or has failed. To find your imports, on your namespace click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Imports*.
 +
 [NOTE]
 ====

--- a/downstream/modules/hub/proc-obtain-images.adoc
+++ b/downstream/modules/hub/proc-obtain-images.adoc
@@ -3,22 +3,22 @@
 [id="obtain-images"]
 
 
-= Pulling images for use in {HubName}
+= Pulling {ExecEnvShort}s for use in {HubName}
 
 [role="_abstract"]
-Before you can push container images to your {PrivateHubName}, you must first pull them from an existing registry and tag them for use. The following example details how to pull an image from the Red Hat Ecosystem Catalog (registry.redhat.io).
+Before you can push {ExecEnvShort}s to your {PrivateHubName}, you must first pull them from an existing registry and tag them for use. The following example details how to pull an {ExecEnvShort} from the Red Hat Ecosystem Catalog (registry.redhat.io).
 
 [IMPORTANT]
 ====
 As of early 2024, Red Hat no longer supports manifests or manifest lists on the Red Hat Subscription Management web platform, which has also been used interchangeably with “subscription allocations.” Red Hat also no longer supports most manifest functionality in Red Hat Satellite with one exception:
 * Red Hat Satellite users in closed network or “air gapped” networks that do not receive their updates directly from Red Hat servers can currently still use `access.redhat.com` until the release of Red Hat Satellite 6.16.
 
-New Red Hat accounts automatically use Simple Content Access for their subscription tooling. New Red Hat accounts and existing Satellite customers who can connect to Red Hat’s servers can find their manifests at `console.redhat.com`.
+New Red Hat accounts automatically use Simple Content Access for their subscription tooling. New Red Hat accounts and existing Satellite customers who can connect to Red Hat's servers can find their manifests at `console.redhat.com`.
 ====
 
 .Prerequisites
 
-* You have permissions to pull images from registry.redhat.io.
+* You have permissions to pull {ExecEnvShort}s from registry.redhat.io.
 
 * A Red Hat account with Simple Content Access enabled.
 
@@ -26,7 +26,7 @@ New Red Hat accounts automatically use Simple Content Access for their subscript
 
 . If you need to access your manifest for your container images log in to link:console.redhat.com/subscriptions/manifests[Red Hat Console].
 
-. Click the three-dot menu for the manifest you need for your container images, and click btn:[Export manifest].
+. Click the three-dot menu for the manifest you need for your {ExecEnvShort}s, and click btn:[Export manifest].
 
 . Log in to Podman by using your registry.redhat.io credentials:
 +
@@ -35,17 +35,17 @@ $ podman login registry.redhat.io
 -----
 +
 . Enter your username and password.
-. Pull a container image:
+. Pull an {ExecEnvShort}:
 +
 [subs="+quotes"]
 -----
-$ podman pull registry.redhat.io/__<container_image_name>__:__<tag>__
+$ podman pull registry.redhat.io/__<ee_name>__:__<tag>__
 -----
 
 
 .Verification
 
-To verify that the image you recently pulled is contained in the list, take these steps:
+To verify that the {ExecEnvShort} you recently pulled is contained in the list, take these steps:
 
 . List the images in local storage:
 +
@@ -53,11 +53,11 @@ To verify that the image you recently pulled is contained in the list, take thes
 $ podman images
 -----
 +
-. Check the image name, and verify that the tag is correct.
+. Check the {ExecEnvShort} name, and verify that the tag is correct.
 
 [role="_additional-resources"]
 .Additional resources
 
-* See link:redhat-connect.gitbook.io/catalog-help/[Red Hat Ecosystem Catalog Help] for information on registering and getting images.
+* See link:redhat-connect.gitbook.io/catalog-help/[Red Hat Ecosystem Catalog Help] for information on registering and getting {ExecEnvShort}s.
 
-* See link:{BaseURL}/subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] to learn more about the changes coming to Red Hat subscription tooling
+* See link:{BaseURL}/subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] to learn more about the changes coming to Red Hat subscription tooling.

--- a/downstream/modules/hub/proc-provide-remote-access.adoc
+++ b/downstream/modules/hub/proc-provide-remote-access.adoc
@@ -8,11 +8,12 @@
 After you create a remote configuration, you must provide access to it before anyone can use it.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
-. Log in to {PrivateHubName}.
+
+. Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACAdminRemotes}.
-. Locate your repository in the list, click the btn:[More Actions] icon *{MoreActionsIcon}*, and select *Edit*.
-. Select the *Access* tab.
-. Select a group for *Repository owners*. See link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_automation_hub/assembly-user-access[Configuring user access for your {PrivateHubName}] for information about implementing user access.
-. Select the appropriate roles for the selected group.
-. Click btn:[Save].
+. Click into your repository in the list, and then select the *Team Access* tab.
+. Click btn:[Add roles].
+. Select the team to which you want to grant a role, then click btn:[Next].
+. Select the roles you want to apply to the selected team, and then click btn:[Next].
+. Review your selections and click btn:[Finish].
+. Click btn:[Close] to complete the process.

--- a/downstream/modules/hub/proc-pull-image.adoc
+++ b/downstream/modules/hub/proc-pull-image.adoc
@@ -4,7 +4,7 @@
 
 
 [role="_abstract"]
-You can pull images from the {HubName} container registry to make a copy to your local machine.
+You can pull {ExecEnvName}s from the {HubName} remote registry to make a copy to your local machine.
 
 .Prerequisites
 
@@ -12,9 +12,9 @@ You can pull images from the {HubName} container registry to make a copy to your
 
 .Procedure
 
-. If you are pulling container images from a password or token-protected registry, xref:proc-create-credential[create a credential in {ControllerName}] before pulling the image.
+. If you are pulling {ExecEnvName}s from a password or token-protected registry, xref:proc-create-credential[create a credential] before pulling the {ExecEnvName}.
 . From the navigation panel, select {MenuACExecEnvironments}.
-. Select your container repository.
+. Select your {ExecEnvName}.
 . In the *Pull this image* entry, click btn:[Copy to clipboard].
 . Paste and run the command in your terminal.
 

--- a/downstream/modules/hub/proc-push-container.adoc
+++ b/downstream/modules/hub/proc-push-container.adoc
@@ -3,11 +3,11 @@
 [id="push-containers"]
 
 
-= Pushing a container image to {PrivateHubName}
+= Pushing an {ExecEnvShort} to {PrivateHubName}
 
 
 [role="_abstract"]
-You can push tagged container images to {PrivateHubName} to create new containers and populate the container registry.
+You can push tagged {ExecEnvShort}s to {PrivateHubName} to create new containers and populate the remote registry.
 
 .Prerequisites
 
@@ -28,11 +28,11 @@ $ podman login -u=__<username>__ -p=__<password>__ __<automation_hub_url>__
 Let Podman prompt you for your password when you log in. Entering your password at the same time as your username can expose your password to the shell history.
 ====
 +
-. Push your container image to your {HubName} container registry:
+. Push your {ExecEnvShort} to your {HubName} remote registry:
 +
 [subs="+quotes"]
 -----
-$ podman push __<automation_hub_url>__/__<container_image_name>__
+$ podman push __<automation_hub_url>__/__<ee_name>__
 -----
 
 .Troubleshooting
@@ -42,8 +42,8 @@ This may lead to image-layer digest changes and a failed push operation, resulti
 
 .Verification
 
-. Log in to your {HubName}.
+. Log in to your {PlatformNameShort}.
 //[ddacosta] I see no such selection. Should this be changed to Execution Environments > Remote Registries? If so, replace with {MenuACAdminRemoteRegistries}
-. Navigate to menu:Container Registry[].
+. Navigate to {MenuACAdminRemoteRegistries}.
 
 . Locate the container in the container repository list.

--- a/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
+++ b/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
@@ -3,7 +3,7 @@
 
 = Pushing container images from your local environment
 
-Use the following procedure to sign images on a local system and push those signed images to the {HubName} registry.
+Use the following procedure to sign {ExecEnvName}s on a local system and push those signed {ExecEnvName}s to the {HubName} registry.
 
 .Procedure
 . From a terminal, log in to Podman, or any container client currently in use:
@@ -12,37 +12,35 @@ Use the following procedure to sign images on a local system and push those sign
 > podman pull <container-name>
 ----
 +
-. After the image is pulled, add tags (for example: latest, rc, beta, or version numbers, such as 1.0; 2.3, and so on):
+. After the {ExecEnvName} is pulled, add tags (for example: latest, rc, beta, or version numbers, such as 1.0; 2.3, and so on):
 +
 ----
 > podman tag <container-name> <server-address>/<container-name>:<tag name>
 ----
 +
-. Sign the image after changes have been made, and push it back up to the {HubName} registry:
+. Sign the {ExecEnvName} after changes have been made, and push it back up to the {HubName} registry:
 +
 ----
 > podman push <server-address>/<container-name>:<tag name> --tls-verify=false --sign-by <reference to the gpg key on your local>
 ----
 +
-If the image is not signed, it can only be pushed with any current signature embedded. Alternatively, you can use the following script to push the image without signing it:
+If the {ExecEnvName} is not signed, it can only be pushed with any current signature embedded. Alternatively, you can use the following script to push the {ExecEnvName} without signing it:
 +
 ----
 > podman push <server-address>/<container-name>:<tag name> --tls-verify=false
 ----
 +
-. Once the image has been pushed, navigate to your {HubName}.
-
-. From the navigation panel, select {MenuACExecEnvironments}.
+. Once the {ExecEnvName} has been pushed, navigate to {MenuACExecEnvironments}.
 
 . To display the new {ExecEnvShort}, click the *Refresh* icon.
 
-. Click the name of the image  to view your pushed image.
+. Click the name of the image to view your pushed image.
 
 .Troubleshooting
 
-The details page in {HubName} indicates whether or not an image has been signed. If the details page indicates that an image is *Unsigned*, you can sign the image from {HubName}  using the following steps:
+The details page for each {ExecEnvName} indicates whether it has been signed. If the details page indicates that an image is *Unsigned*, you can sign the {ExecEnvName} from {HubName} using the following steps:
 
-. Click the image name to navigate to the details page.
+. Click the {ExecEnvName} name to navigate to the details page.
 
 . Click the btn:[More Actions] icon *{MoreActionsIcon}*.
 Three options are available:
@@ -52,5 +50,5 @@ Three options are available:
 
 . Click *Sign* from the drop-down menu.
 
-The signing service signs the image.
-After the image is signed, the status changes to "signed".
+The signing service signs the {ExecEnvName}.
+After the {ExecEnvName} is signed, the status changes to "signed".

--- a/downstream/modules/hub/proc-sync-image.adoc
+++ b/downstream/modules/hub/proc-sync-image.adoc
@@ -3,8 +3,8 @@
 [id="proc-sync-image-adoc_{context}"]
 = Syncing images from a container repository
 
-You can pull images from the {HubName} container registry to sync an image to your local machine.
-To sync an image from a remote container registry, you must first configure a remote registry.
+You can pull {ExecEnvName}s from the {HubName} remote registry to sync an image to your local machine.
+To sync an {ExecEnvName} from a remote registry, you must first configure a remote registry.
 
 .Prerequisites
 
@@ -20,7 +20,7 @@ You must have permission to view and pull from a private container repository.
 +
 [NOTE]
 ====
-Some container registries are aggressive with rate limiting.
+Some remote registries are aggressive with rate limiting.
 Set a rate limit under *Advanced Options*.
 ====
 +
@@ -29,7 +29,7 @@ Set a rate limit under *Advanced Options*.
 . Click btn:[Add execution environment] in the page header.
 
 . Select the registry you want to pull from.
-The *Name* field displays the name of the image displayed on your local registry.
+The *Name* field displays the name of the {ExecEnvName} displayed on your local registry.
 +
 [NOTE]
 ====
@@ -38,7 +38,7 @@ For example, if the upstream name is set to "alpine" and the *Name* field is "lo
 ====
 +
 . Set a list of tags to include or exclude.
-Syncing images with a large number of tags is time consuming and uses a lot of disk space.
+Syncing {ExecEnvName}s with a large number of tags is time consuming and uses a lot of disk space.
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/hub/proc-tag-image.adoc
+++ b/downstream/modules/hub/proc-tag-image.adoc
@@ -5,16 +5,16 @@
 = Tagging container images
 
 [role="_abstract"]
-Tag images to add an additional name to images stored in your {HubName} container repository. If no tag is added to an image, {HubName} defaults to `latest` for the name.
+Tag {ExecEnvName}s to add an additional name to {ExecEnvName}s stored in your {HubName} container repository. If no tag is added to an {ExecEnvName}, {HubName} defaults to `latest` for the name.
 
 .Prerequisites
 
-* You have *change image tags* permissions.
+* You have *change {ExecEnvName} tags* permissions.
 
 .Procedure
 
 . From the navigation panel, select {MenuACExecEnvironments}.
-. Select your container repository.
+. Select {ExecEnvName}.
 . Click the *Images* tab.
 . Click the btn:[More Actions] icon *{MoreActionsIcon}*, and click btn:[Manage tags].
 . Add a new tag in the text field and click btn:[Add].

--- a/downstream/modules/hub/proc-tag-pulled-image.adoc
+++ b/downstream/modules/hub/proc-tag-pulled-image.adoc
@@ -3,29 +3,28 @@
 [id="tag-pulled-images"]
 
 
-= Tagging images for use in {HubName}
+= Tagging {ExecEnvShort}s for use in {HubName}
 
 
 [role="_abstract"]
-After you pull images from a registry, tag them for use in your {PrivateHubName} container registry.
+After you pull {ExecEnvShort}s from a registry, tag them for use in your {PrivateHubName} remote registry.
 
 .Prerequisites
 
-* You have pulled a container image from an external registry.
+* You have pulled an {ExecEnvShort} from an external registry.
 * You have the FQDN or IP address of the {HubName} instance.
 
 .Procedure
 
-* Tag a local image with the {HubName} container repository:
+* Tag a local {ExecEnvShort} with the {HubName} container repository:
 +
 [subs="+quotes"]
 -----
-$ podman tag registry.redhat.io/__<container_image_name>__:__<tag>__ __<automation_hub_hostname>__/__<container_image_name>__
+$ podman tag registry.redhat.io/__<ee_name>__:__<tag>__ __<automation_hub_hostname>__/__<ee_name>__
 -----
 
 
 .Verification
-
 
 . List the images in local storage:
 +
@@ -33,4 +32,4 @@ $ podman tag registry.redhat.io/__<container_image_name>__:__<tag>__ __<automati
 $ podman images
 -----
 +
-. Verify that the image you recently tagged with your {HubName} information is contained in the list.
+. Verify that the {ExecEnvShort} you recently tagged with your {HubName} information is contained in the list.

--- a/downstream/modules/hub/proc-using-podman-ensure-image-signed.adoc
+++ b/downstream/modules/hub/proc-using-podman-ensure-image-signed.adoc
@@ -1,13 +1,10 @@
 [id="using-podman-ensure-image-signed"]
 
 = Using podman to ensure an image is signed by a specific signature
-When ensuring a signature is signed by specific signatures, the signature must be on your local environment.
+When ensuring an {ExecEnvName} is signed by specific signatures, the signature must be on your local environment.
 
 .Procedure
 
 . From the navigation panel, select {MenuACAdminSignatureKeys}.
-. Click the btn:[More Actions] icon *{MoreActionsIcon}* next to the signature that you are using.
-. Select *Download key* from the drop-down menu.
-A new window opens.
-. In the *Name* field, enter the name of the key.
-. Click btn:[Save].
+. Click the btn:[Download key] icon next to the signature that you are using. A new window should open to indicate you have downloaded the key.
+

--- a/downstream/modules/hub/ref-container-permissions.adoc
+++ b/downstream/modules/hub/ref-container-permissions.adoc
@@ -1,13 +1,13 @@
 
 [id="container-registry-group-permissions"]
 
-= Container registry group permissions
+= Remote registry team permissions
 
 [role="_abstract"]
-You can control how users can interact with containers managed in {PrivateHubName}. 
-Use the following list of permissions to create groups with the right privileges for your container registries.
+You can control how users can interact with {ExecEnvShort}s managed in {PrivateHubName}. 
+Use the following list of permissions to create teams with the right privileges for your remote registries.
 
-.List of group permissions used to manage containers in {PrivateHubName}
+.List of team permissions used to manage containers in {PrivateHubName}
 [cols="1,1"]
 |===
 |Permission name|Description
@@ -21,15 +21,9 @@ Use the following list of permissions to create groups with the right privileges
 |Change container
 |Users can change information on a container
 
-|Change image tags
-|Users can modify image tags
-
-|Pull private containers
-|Users can pull images from a private container
+|Change {ExecEnvShort} tags
+|Users can modify {ExecEnvShort} tags
 
 |Push to existing container
-|Users can push an image to an existing container
-
-|View private containers
-|Users can view containers marked as private
+|Users can push an {ExecEnvShort} to an existing container
 |===


### PR DESCRIPTION
This PR backports the changes from [PR 2150](https://github.com/ansible/aap-docs/pull/2150) to the 2.5 branch. See [AAP-20548](https://issues.redhat.com/browse/AAP-20548) for more info. 