### PR TITLE
AAP-30117 Add link to user permissions in the Using automation decisions guide

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -26,4 +26,4 @@ The following procedures form the user configuration:
 For information on how to set user permissions for {EDAcontroller}, see the following in the link:{URLCentralAuth}/index[Access management and authentication guide]: 
 
 * link:{URLCentralAuth}/index#ref-controller-user-roles[Adding roles for a user]
-* link:{URLCentralAuth}/index#assembly-gw-roles[Roles]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/access_management_and_authentication/assembly-gw-roles[Roles]

--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -25,5 +25,5 @@ The following procedures form the user configuration:
 .Additional resources
 For information on how to set user permissions for {EDAcontroller}, see the following in the link:{URLCentralAuth}/index[Access management and authentication guide]: 
 
-* link:{URLCentralAuth}/index#ref-controller-user-roles[Adding roles for a user]
+* link:{URLCentralAuth}/ref-controller-user-roles[Adding roles for a user]
 * link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/access_management_and_authentication/assembly-gw-roles[Roles]

--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -20,3 +20,10 @@ The following procedures form the user configuration:
 * API documentation for {EDAcontroller} is available at \https://<eda-server-host>/api/eda/v1/docs
 * To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable, you will not be able to create or sync projects, or enable rulebook activations.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+For information on how to set user permissions for {EDAcontroller}, see the following in the link:{URLCentralAuth}/index[Access management and authentication guide]: 
+
+* link:{URLCentralAuth}/index#ref-controller-user-roles[Adding roles for a user]
+* link:{URLCentralAuth}/index#assembly-gw-roles[Roles]

--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -25,5 +25,5 @@ The following procedures form the user configuration:
 .Additional resources
 For information on how to set user permissions for {EDAcontroller}, see the following in the link:{URLCentralAuth}/index[Access management and authentication guide]: 
 
-* link:{URLCentralAuth}/ref-controller-user-roles[Adding roles for a user]
-* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/access_management_and_authentication/assembly-gw-roles[Roles]
+* link:{URLCentralAuth}/gw-managing-access#ref-controller-user-roles[Adding roles for a user]
+* link:{URLCentralAuth}/assembly-gw-roles[Roles]


### PR DESCRIPTION
Added an "Additional resources" section to the overview of the Using automation decisions guide that includes links to the **Roles** and **Adding roles for a user** sections in the Access management and authentication guide.