### PR TITLE
AAP-31661-update: Updated AAP 2.5 Release Notes

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25-deprecated-features.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-deprecated-features.adoc
@@ -5,7 +5,7 @@ include::../snippets/deprecated-features.adoc[]
 
 The following table provides information about features that were deprecated in {PlatformNameShort} 2.5:
 
-[cols="30%,70%"]
+[cols="20%,80%"]
 |===
 | Component | Feature
 

--- a/downstream/titles/release-notes/topics/aap-25-known-issues.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-known-issues.adoc
@@ -9,6 +9,7 @@ This section provides information about known issues in {PlatformNameShort} 2.5.
 
 * Setting the `pg_host=` value without any other context no longer results in an empty HOST section of the *settings.py* in the {ControllerName}. As a workaround, delete the `pg_host=` value or set it to `pg_host=''`. (AAP-31915) 
 
+* Using *Prompt on launch* for variables for job templates, workflow job templates, workflow visualizer nodes, and schedules will not show the default variables when launching the job, or when configuring the workflows and schedules. (AAP-30585)
 
 == {EDAName}
 
@@ -17,9 +18,8 @@ This section provides information about known issues in {PlatformNameShort} 2.5.
 * If a primary Redis node enters a `failed` state and a new primary node is promoted, {EDAName} workers and scheduler are unable to reconnect to the cluster. This causes activations to fail until the containers or pods are recycled. (AAP-30722) +
 For more information, see the KCS article link:https://access.redhat.com/articles/7088545[Redis failover causes {EDAName} activation failures].
 
-
 == {AAPRHDH}
 
 * Python VS Code extension v2024.14.1 does not work in OpenShift Dev Spaces version 1.9.3, prohibiting the Ansible VS Code extension from loading. As a workaround, downgrade the Python VS Code extension version to 2024.12.3.
 
-* The Ansible Content Creator *Get Started* page links do not work in OpenShift Dev Spaces version 1.9.3. As a workaround, use the link:https://code.visualstudio.com/docs/getstarted/userinterface#:~:text=VS%20Code%20is%20equally%20accessible,for%20the%20most%20common%20operations.[Ansible VS Code Command Palette] to access the features.
+* The Ansible Content Creator *Get Started* page links do not work in OpenShift Dev Spaces version 1.9.3. As a workaround, use the link:https://code.visualstudio.com/docs/getstarted/userinterface#:~:text=VS%20Code%20is%20equally%20accessible,for%20the%20most%20common%20operations[Ansible VS Code Command Palette] to access the features.

--- a/downstream/titles/release-notes/topics/aap-25.adoc
+++ b/downstream/titles/release-notes/topics/aap-25.adoc
@@ -17,7 +17,7 @@ At the time of the {PlatformNameShort} 2.5 GA release, a limited set of topologi
 
 The following table shows the tested topologies for {PlatformNameShort} 2.5:
 
-[cols="10%,20%,40%,30%"]
+[%autowidth]
 |===
 | Mode | Infrastructure | Description | Tested topologies
 

--- a/downstream/titles/release-notes/topics/platform-intro.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro.adoc
@@ -4,17 +4,18 @@
 {PlatformName} simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. {PlatformNameShort} works across multiple IT domains, including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, {PlatformNameShort} provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
 
 == Upgrades are unsupported at this time
-At the initial release of {PlatformNameShort} 2.5, upgrades from earlier releases are unsupported. Only new installations are supported. Upgrade support will follow shortly after the initial 2.5 release. However, you can deploy {EDAName} 2.5 with an existing 2.4 {ControllerName}. For more information, see xref:aap-25.adoc#eda-2.5-with-automation-controller-2.4[{EDAName} 2.5 with {ControllerName} 2.4]
+At the initial release of {PlatformNameShort} 2.5, upgrades from earlier releases are unsupported. Only new installations are supported. Upgrade support will follow shortly after the initial 2.5 release. However, you can deploy {EDAName} 2.5 with an existing 2.4 {ControllerName}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/release_notes/index#eda-2.5-with-automation-controller-2.4[{EDAName} 2.5 with {ControllerName} 2.4].
 
 [[whats-included]]
 == What is included in the {PlatformNameShort}
 
-[%header, cols="a,a,a,a,a,a"]
+[%header, %autowidth]
 |===
 | {PlatformNameShort} | {ControllerNameStart} | {HubNameStart} | {EDAcontroller} | {InsightsShort} | Platform gateway +
 (Unified UI)
 
-|2.5 | 4.6.0|
+|2.5 | 4.6.0
+a|
 * 4.10.0
 * hosted service|
 1.1.0


### PR DESCRIPTION
This PR is an update to AAP 2.5 release notes work (https://github.com/ansible/aap-docs/pull/2034, and JIRA  https://issues.redhat.com/browse/AAP-31661). 

Changes made:

- Added new known issue AAP-30585.
- Adjusted table width of 2 tables
- Updated a hyperlink.