### PR TITLE
Managing automation content guide: broken xref fix (#2180)

### DIFF
--- a/downstream/modules/hub/proc-basic-repo-sync.adoc
+++ b/downstream/modules/hub/proc-basic-repo-sync.adoc
@@ -19,4 +19,4 @@ To limit repository synchronization to specific collections within a remote, you
 
 [role="_additional-resources"]
 .Additional resources
-For more information about using requirements files, see xref:proc-create-requirements-file[Creating a requirements file].
+For more information about using requirements files, see link:{URLHubManagingContent}/managing-cert-valid-content#create-requirements-file_managing-cert-validated-content[Creating a requirements file].


### PR DESCRIPTION
This PR ports the changes from [PR 2180 ](https://github.com/ansible/aap-docs/pull/2180)to the 2.5 branch. 