### PR TITLE
[Backport] Late update to correct content for triggers (#2175)

### DIFF
--- a/downstream/modules/platform/con-gw-authenticator-map-triggers.adoc
+++ b/downstream/modules/platform/con-gw-authenticator-map-triggers.adoc
@@ -10,26 +10,26 @@ Always:: The trigger should always be fired.
 Never:: The trigger should never be fired.
 Group:: The map is true or false  based on a user having, not having or having multiple groups in the source system. When defining a group trigger, the authentication mapping expands to include the following selections:
 +
-* *Operation:* This field includes conditional settings that trigger the handling of the rule based on the specified *Groups* criteria. The choices include *and* and *or*. For example, if you select and the user logging in must be a member of all of the groups specified in the *Groups* field for this trigger to be true. Alternatively, if you select *or* the user logging in must be a member of any of the specified *Groups* in order for the trigger to fire. 
+* *Operation:* This field includes conditional settings that trigger the handling of the rule based on the specified *Groups* criteria. The choices include *and* and *or*. For example, if you select *and* the user logging in must be a member of all of the groups specified in the *Groups* field for this trigger to be true. Alternatively, if you select *or* the user logging in must be a member of any of the specified *Groups* in order for the trigger to fire. 
 +
 [NOTE]
 ====
 If you are only keying off one group it doesn’t matter if you select *"and"* or *"or"*.
 ====
 +
-* *Groups:* This is a list of one or more groups coming from the authentication system that the user must be a member of. See the Operation field to determine the behavior of the trigger if more than one group is specified in the trigger.
+* *Groups:* This is a list of one or more groups coming from the authentication system that the user must be a member of. See the *Operation* field to determine the behavior of the trigger if more than one group is specified in the trigger.
 
 Attribute:: The map is true or false based on a users attributes coming from the source system. When defining an attribute trigger, the authentication mapping expands to include the following selections:
 +
-* *Operation:* This field includes conditional settings that trigger the handling of the rule based on the specified *Attribute* criteria. In version 2.5.0 this field needs to be set but is ignored. In the future, attribute based maps will allow for the processing of multiple attributes. 
+* *Operation:* This field includes conditional settings that trigger the handling of the rule based on the specified *Attribute* criteria. In version {PlatformVers} this field indicates what will happen if the source system returns a list of  attributes instead of a single value. For example, if the source system returns multiple emails for a user and *Operation* was set to *and*, all of the given emails must match the *Comparison* for the trigger to be _True_. If *Operation* was set to *or*, any of the returned emails will set the trigger to _True_ if they match the *Comparison* in the trigger. 
 +
 [NOTE]
 ====
-If you would like to experiment with multiple attribute maps you can do that through the API but the UI form will remove multi-attribute maps if the authenticator is saved through the UI.
+If you would like to experiment with multiple attribute maps you can do that through the API but the UI form will remove multi-attribute maps if the authenticator is saved through the UI. When adding multiple attributes to a map, the *Operation* will also apply to the attributes.
 ====
 +
 * *Attribute:* The name of the attribute coming from the source system this trigger will be evaluated against. For example, if you wanted the trigger to fire based on the user's last name and the last name field in the source system was called `users_last_name` you would enter the value ‘users_last_name’ in this field.
-* *Comparison:* Tells the trigger how to evaluate the value of the users. *Attribute* in the source system compared to the *Value* specified on the trigger. Available options are: *contains*, *matches*, *ends with*, *in*, or *equals*. Below is a breakdown of each comparison type:
+* *Comparison:* Tells the trigger how to evaluate the value of the users. *Attribute* in the source system compared to the *Value* specified on the trigger. Available options are: *contains*, *matches*, *ends with*, *in*, or *equals*. Below is a breakdown of each *Comparison* type:
 +
 ** *contains*: The specified character sequence in *Value* is contained within the attributes value returned from the source. For example, given an attribute value of ‘John’ from the source the contains *Comparison* would set the trigger to _True_ if the trigger *Value* was set to ‘Jo’ and _False_ if the trigger *Value* was ‘Joy’.
 ** *matches*: The *Value* on the trigger is treated as a python regular expression and does an link:https://docs.python.org/3/library/re.html#re.match[Regular expression match (re.match)] (with case ignore on) between the specified *Value* and the value returned from the source system. For example, if the trigger's *Value* was ‘Jo’ the trigger would return _True_ if the value from the source was ‘John‘ or ‘Joanne‘ or any other value which matched the regular expression ‘Jo’. The trigger would return _False_ if the sources value for the attribute was ‘Dan’ because ‘Dan’ does not match the regular expression ‘Jo’. 


### PR DESCRIPTION
This PR backports the changes from #2175 to the 2.5 branch and includes the following:

* Late update to correct content for triggers

* Added peer review change

* Comparison fixed to be bold

* fixed comparison to uppercase