### PR TITLE
Backport-2.5-2176 (AAP-30117) Add link to user permissions in the Using automation decisions guide (#2176)

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -20,3 +20,10 @@ The following procedures form the user configuration:
 * API documentation for {EDAcontroller} is available at \https://<eda-server-host>/api/eda/v1/docs
 * To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable, you will not be able to create or sync projects, or enable rulebook activations.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+For information on how to set user permissions for {EDAcontroller}, see the following in the link:{URLCentralAuth}/index[Access management and authentication guide]: 
+
+* link:{URLCentralAuth}/gw-managing-access#ref-controller-user-roles[Adding roles for a user]
+* link:{URLCentralAuth}/assembly-gw-roles[Roles]


### PR DESCRIPTION
Added a link to two sections in the Access management and authentication guide: Roles and Adding roles for a user.