### PR TITLE
Fix broken links in the Access management guide

### DIFF
--- a/downstream/modules/platform/proc-gw-organizations-exec-env.adoc
+++ b/downstream/modules/platform/proc-gw-organizations-exec-env.adoc
@@ -6,7 +6,7 @@
 
 When {ControllerName} is enabled on the platform, you can review any {ExecEnvShort}s you have set up and manage their settings within the organization resource.
 
-For more information about execution environments, see link:{BaseURL}/{PlatformVers}/html/using_automation_execution/index#assembly-controller-execution-environments[Execution environments] in _Using automation execution_ guide.
+For more information about execution environments, see link:{URLControllerUserGuide}/assembly-controller-execution-environments[Execution environments] in _{TitleControllerUserGuide}_ guide.
 
 
 .Procedure

--- a/downstream/modules/platform/ref-controller-clear-sessions.adoc
+++ b/downstream/modules/platform/ref-controller-clear-sessions.adoc
@@ -6,4 +6,4 @@ Use this command to delete all sessions that have expired.
 
 For more information, see link:https://docs.djangoproject.com/en/4.2/topics/http/sessions/#clearing-the-session-store[Clearing the session store] in Django's Oauth Toolkit documentation.
 
-For more information on OAuth2 token management in the UI, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_controller_user_guide/assembly-controller-applications[Applications] section of _{ControllerUG}_.
+For more information on OAuth2 token management in the UI, see the xref:assembly-controller-applications[Applications].

--- a/downstream/modules/platform/ref-controller-organization-notifications.adoc
+++ b/downstream/modules/platform/ref-controller-organization-notifications.adoc
@@ -11,7 +11,7 @@ When {ControllerName} is enabled on the platform, you can review any notifier in
 . From the *Organizations* list view, select the organization to which you want to manage notifications.
 //ddacosta - this might change to Notifiers tab.
 . Select the *Notification* tab. 
-. Use the toggles to enable or disable the notifications to use with your particular organization. For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution/controller-enable-disable-notifications[Enable and disable notifications].
+. Use the toggles to enable or disable the notifications to use with your particular organization. For more information, see link:{URLControllerUserGuide}/controller-notifications#controller-enable-disable-notifications[Enable and disable notifications].
 . If no notifiers have been set up, select {MenuAEAdminJobNotifications} from the navigation panel.
 
-For information on configuring notification types, see link:{URLControllerUserGuide}/controller-notification-types[Notification types].
+For information on configuring notification types, see link:{URLControllerUserGuide}/controller-notifications#controller-notification-types[Notification types].

--- a/downstream/modules/platform/ref-controller-organization-notifications.adoc
+++ b/downstream/modules/platform/ref-controller-organization-notifications.adoc
@@ -14,4 +14,4 @@ When {ControllerName} is enabled on the platform, you can review any notifier in
 . Use the toggles to enable or disable the notifications to use with your particular organization. For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution/controller-enable-disable-notifications[Enable and disable notifications].
 . If no notifiers have been set up, select {MenuAEAdminJobNotifications} from the navigation panel.
 
-For information on configuring notification types, see link:{URLControllerUserGuide}/index#controller-notification-types[Notification types].
+For information on configuring notification types, see link:{URLControllerUserGuide}/controller-notification-types[Notification types].


### PR DESCRIPTION
This PR fixes the broken links in the Access management guide that were flagged by the link checker script. 