### PR TITLE
AAP-31800 updated self-referencing link (#2168)

### DIFF
--- a/downstream/assemblies/platform/assembly-inventory-introduction.adoc
+++ b/downstream/assemblies/platform/assembly-inventory-introduction.adoc
@@ -68,7 +68,7 @@ registry_password='<registry password>'
 
 The first part of the inventory file specifies the hosts or groups that Ansible can work with.
 
-For more information on `registry_username` and `registry_password`, see {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/planning_your_installation/about_the_installer_inventory_file#about_the_installer_inventory_file[Setting registry_username and registry_password].
+For more information on `registry_username` and `registry_password`, see {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/rpm_installation/index#proc-set-registry-username-password[Setting registry_username and registry_password].
 
 include::snippets/snip-gateway-component-description.adoc[leveloffset=+1]
 include::platform/ref-guidelines-hosts-groups.adoc[leveloffset=+1]


### PR DESCRIPTION
2.5 backport of [PR 2168](https://github.com/ansible/aap-docs/pull/2168)

[AAP-31800](https://issues.redhat.com/browse/AAP-31800)

Updated self-referencing link in Planning your installation

Files modified:

assembly-inventory-introduction.adoc