### PR TITLE
Remove reference to controller UI in troubleshooting guide

### DIFF
--- a/downstream/titles/troubleshooting-aap/master.adoc
+++ b/downstream/titles/troubleshooting-aap/master.adoc
@@ -18,7 +18,8 @@ include::troubleshooting-aap/assembly-troubleshoot-backup-recovery.adoc[leveloff
 include::troubleshooting-aap/assembly-troubleshoot-execution-environments.adoc[leveloffset=+1]
 include::troubleshooting-aap/assembly-troubleshoot-installation.adoc[leveloffset=+1]
 include::troubleshooting-aap/assembly-troubleshoot-jobs.adoc[leveloffset=+1]
-include::troubleshooting-aap/assembly-troubleshoot-login.adoc[leveloffset=+1]
+// Michelle - commenting out as it refers to controller UI which should no longer be accessed
+//include::troubleshooting-aap/assembly-troubleshoot-login.adoc[leveloffset=+1]
 include::troubleshooting-aap/assembly-troubleshoot-networking.adoc[leveloffset=+1]
 include::troubleshooting-aap/assembly-troubleshoot-playbooks.adoc[leveloffset=+1]
 // Michelle - commenting out for now as this content doesn't appear to exist anymore in a published doc


### PR DESCRIPTION
Comment out a troubleshooting section that is relevant to the controller UI which should no longer be accessed.