### PR TITLE
backport to 2.5: broken link fix for Getting started with AAP

### DIFF
--- a/downstream/modules/platform/ref-gs-install-config.adoc
+++ b/downstream/modules/platform/ref-gs-install-config.adoc
@@ -5,7 +5,7 @@
 {PlatformName} offers flexible installation and configuration options. 
 Depending on your organization's needs, you can install {PlatformName} using one of the following methods, based on your environment:
 
-* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_virtual_machines/index[Traditional virtual machine]
-* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_openshift_container_platform/index[Red Hat Ansible Automation Platform operator on OpenShift Container Platform]
+* link:{LinkInstallationGuide}
+* link:{LinkOperatorInstallation}
 * link:{BaseURL}/ansible_on_clouds/2.x[Cloud environments]
-* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/containerized_installation/index[Containerized environments]
+* link:{LinkContainerizedInstall}


### PR DESCRIPTION
This PR ports the changes from [PR 2222](https://github.com/ansible/aap-docs/pull/2222) to the 2.5 branch. 