### PR TITLE
Backport-2.5-2225 (AAP-32260) Minor corrections found in Using automation decisions guide. (#2225)

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -11,7 +11,7 @@ The following procedures form the user configuration:
 * xref:eda-credential-types[Credential types]
 * xref:eda-projects[Projects]
 * xref:eda-decision-environments[Decision environments]
-* xref:simplified-event-routing[Simplfied event routing]
+* xref:simplified-event-routing[Simplified event routing]
 * xref:eda-set-up-rhaap-credential-type[Red Hat Ansible Automation Platform credential]
 * xref:eda-rulebook-activations[Rulebook activations]
 * xref:eda-rule-audit[Rule audit]
@@ -31,7 +31,7 @@ The following procedures form the user configuration:
 .Additional resources
 * For information on how to set user permissions for {EDAcontroller}, see the following in the link:{URLCentralAuth}/index[Access management and authentication guide]: 
 
-** link:{URLCentralAuth}/gw-managing-access#ref-controller-user-roles[Adding roles for a user]
-** link:{URLCentralAuth}/assembly-gw-roles[Roles]
+. link:{URLCentralAuth}/gw-managing-access#ref-controller-user-roles[Adding roles for a user]
+. link:{URLCentralAuth}/assembly-gw-roles[Roles]
 
-* If you plan to use {EDAName} 2.5 with a 2.4 {ControllerName}, see link:docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/using_event-driven_ansible_2.5_with_ansible_automation_platform_2.4/index[Using Event-Driven Ansible 2.5 with Ansible Automation Platform 2.4].
+* If you plan to use {EDAName} 2.5 with a 2.4 {PlatformNameShort}, see link:docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/using_event-driven_ansible_2.5_with_ansible_automation_platform_2.4/index[Using Event-Driven Ansible 2.5 with Ansible Automation Platform 2.4].

--- a/downstream/assemblies/eda/assembly-simplified-event-routing.adoc
+++ b/downstream/assemblies/eda/assembly-simplified-event-routing.adoc
@@ -1,7 +1,7 @@
 
 [id="simplified-event-routing"]
 
-= Simplfied event routing
+= Simplified event routing
 
 Simplified event routing enables {EDAcontroller} to capture and analyze data from various remote systems using event streams. With event streams, you can send events from a remote system like GitHub or GitLab into {EDAcontroller}. You can attach 1 or more event streams to an activation by swapping out sources in a rulebook. 
 

--- a/downstream/modules/eda/proc-eda-set-up-rhaap-credential.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rhaap-credential.adoc
@@ -30,9 +30,9 @@ When you select the credential type, the *Type Details* section is displayed wit
 +
 [NOTE]
 ====
-For {EDAcontroller} 2.5 with {ControllerName} 2.4, use the following example: https://<your_controller_host>
+For {EDAcontroller} {PlatformVers} with {ControllerName} 2.4, use the following example: \https://<your_controller_host>
 
-For {PlatformNameShort} {PlatformVers}, use the following example: https://<your_gateway_host>/api/controller/
+For {PlatformNameShort} {PlatformVers}, use the following example: \https://<your_gateway_host>/api/controller/
 ====
 . Enter a valid *Username* and *Password* or *Oauth Token*. 
 . Click btn:[Create credential].

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -24,7 +24,7 @@ Credential:: Select 0 or more credentials for this rulebook activation. This fie
 +
 [NOTE]
 ====
-The credentials that display in this field are customized based on your rulebook activation and only include the following credential types: Vault, {PlatformName}, or any custom credential types that you have created. For more information about credentials, see xref:eda-credentials[Setting up credentials for {EDAcontroller}].
+The credentials that display in this field are customized based on your rulebook activation and only include the following credential types: Vault, {PlatformName}, or any custom credential types that you have created. For more information about credentials, see xref:eda-credentials[Credentials].
 ====
 //[J. Self] Might need to update the link above for the updated Credentials section.
 Decision environment:: Decision environments are a container image to run Ansible rulebooks.


### PR DESCRIPTION
Found minor errors (typos, link titles, etc.) in the following modules:

- downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
- downstream/assemblies/eda/assembly-simplified-event-routing.adoc
- downstream/modules/eda/proc-eda-set-up-rhaap-credential.adoc
- downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc