### PR TITLE
Fixing assembly ID to be unique in Organizations content

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-organizations.adoc
+++ b/downstream/assemblies/platform/assembly-controller-organizations.adoc
@@ -2,7 +2,7 @@ ifdef::context[:parent-context: {context}]
 
 :_mod-docs-content-type: ASSEMBLY
 
-[id="assembly-my-user-story_{context}"]
+[id="assembly-controller-organizations_{context}"]
 
 = Organizations
 


### PR DESCRIPTION
Changed generic template assembly id [assembly-my-user-story_{context}] to something unique. 