### PR TITLE
Fixed problem with Automation Content menu attribute

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -234,7 +234,7 @@
 :MenuACAdminTasks: menu:{MenuTopAC}[Task Management]
 :MenuACAdminCollectionApproval: menu:{MenuTopAC}[Collection Approvals]
 :MenuACAdminRemotes: menu:{MenuTopAC}[Remotes]
-:MenuACAPIToken: menu:Collections[API token]MenuTopAC
+:MenuACAPIToken: menu:{MenuTopAC}[API token]
 //Each of the services previously had selections for access which will be centralized, ultimately these should be changed to use the attributes in Access Management menu selections once automation hub is provide in the full ui platform experience in 2.5-next
 :MenuHubUsers: menu:{MenuAM}[Users]
 :MenuHubGroups: menu:User Access[Groups]

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -228,13 +228,13 @@
 :MenuACExecEnvironments: menu:{MenuTopAC}[Execution Environments]
 
 // Automation Content > Administration
-:MenuACAdminSignatureKeys: menu:MenuTopAC[Signature Keys]
-:MenuACAdminRepositories: menu:MenuTopAC[Repositories]
+:MenuACAdminSignatureKeys: menu:{MenuTopAC}[Signature Keys]
+:MenuACAdminRepositories: menu:{MenuTopAC}[Repositories]
 :MenuACAdminRemoteRegistries: menu:{MenuTopAC}[Remote Registries]
 :MenuACAdminTasks: menu:{MenuTopAC}[Task Management]
 :MenuACAdminCollectionApproval: menu:{MenuTopAC}[Collection Approvals]
 :MenuACAdminRemotes: menu:{MenuTopAC}[Remotes]
-:MenuACAPIToken: menu:Collections[API token]
+:MenuACAPIToken: menu:Collections[API token]MenuTopAC
 //Each of the services previously had selections for access which will be centralized, ultimately these should be changed to use the attributes in Access Management menu selections once automation hub is provide in the full ui platform experience in 2.5-next
 :MenuHubUsers: menu:{MenuAM}[Users]
 :MenuHubGroups: menu:User Access[Groups]


### PR DESCRIPTION
This PR fixes a formatting issue with the Automation Content menu attribute for Signature Keys and Repositories.