### PR TITLE
Fixing assembly ID to be unique in Organizations content (#2229)

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-organizations.adoc
+++ b/downstream/assemblies/platform/assembly-controller-organizations.adoc
@@ -2,7 +2,7 @@ ifdef::context[:parent-context: {context}]
 
 :_mod-docs-content-type: ASSEMBLY
 
-[id="assembly-my-user-story_{context}"]
+[id="assembly-controller-organizations_{context}"]
 
 = Organizations
 


### PR DESCRIPTION
This PR backports the changes from #2229 to the 2.5 branch. 