### PR TITLE
[2.5] RPM installation guide: Add enterprise inventory file link (#2228)

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -14,12 +14,12 @@ ifdef::context[:parent-context: {context}]
 
 For more information about the components provided with {PlatformNameShort}, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#ref-platform-components[{PlatformName} components] in link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/planning_your_installation[{TitlePlanningGuide}]. 
 
-There are several supported installation scenarios for {PlatformName}. To install {PlatformName}, you must edit the inventory file parameters to specify your installation scenario. You can use one of the following as a basis for your own inventory file:
+There are several supported installation scenarios for {PlatformName}. To install {PlatformName}, you must edit the inventory file parameters to specify your installation scenario. You can use the link:{LinkTopologies}/rpm-topologies#example_enterprise_inventory_file}[enterprise installer] as a basis for your own inventory file.
 
 // New install scenarios including platform gateway AAP-17771
-* xref:ref-gateway-controller-ext-db[Single platform gateway and {ControllerName} with an external (installer managed) database]
-* xref:ref-gateway-controller-hub-ext-db[Single platform gateway, {ControllerName}, and {HubName} with an external (installer managed) database]
-* xref:ref-gateway-controller-hub-eda-ext-db[Single platform gateway, {ControllerName}, {HubName}, and {EDAcontroller} node with an external (installer managed) database]
+//* xref:ref-gateway-controller-ext-db[Single platform gateway and {ControllerName} with an external (installer managed) database]
+//* xref:ref-gateway-controller-hub-ext-db[Single platform gateway, {ControllerName}, and {HubName} with an external (installer managed) database]
+//* xref:ref-gateway-controller-hub-eda-ext-db[Single platform gateway, {ControllerName}, {HubName}, and {EDAcontroller} node with an external (installer managed) database]
 
 .Additional resources
 For a comprehensive list of pre-defined variables used in Ansible installation inventory files, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-ansible-inventory-variables[Ansible variables].


### PR DESCRIPTION
There was an [ongoing discussion](https://docs.google.com/document/d/1fIrlSrj8bSSWBVptXWmm0ZFixhZ4mM5pW2CQx_3Oh7A/edit#heading=h.iaypu8e8mkj4) in this RPM install draft regarding RPM enterprise and growth inventory files.

I've replaced the 3 specific examples with the enterprise inventory file to be consistent with the supported topologies listed in the [Tested deployment models](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/tested_deployment_models/rpm-topologies#example_enterprise_inventory_file) guide.

I will need to raise the question of adding the RPM growth inventory file to confirm that it belongs in event 1 and not 2 of the RPM installation guide.