### PR TITLE
Correct typo in appendix variables section

### DIFF
--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -59,7 +59,7 @@ Default = `false`
 
 Default = `false`
 
-| |`cat_tls_cert` |TLS CA certificate.
+| |`ca_tls_cert` |TLS CA certificate.
 | |`ca_tls_key` | TLS CA key.
 | |`ca_tls_remote` |TLS CA remote files.
 


### PR DESCRIPTION
Correct variable typo in ref-general-inventory-variables.adoc

docs - ca_tls_cert is incorrect in appendix-inventory-file-vars

https://issues.redhat.com/browse/AAP-32358