### PR TITLE
AAP-32244 updated links (#2235)

### DIFF
--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -122,10 +122,10 @@ ALLOW connection from controller(s) to Receptor port |
 |link:https://console.redhat.com[https://console.redhat.com:443] |General account services, subscriptions
 |link:https://catalog.redhat.com[https://catalog.redhat.com:443] |Indexing execution environments
 |link:https://sso.redhat.com[https://sso.redhat.com:443] |TCP
-|link:https://automation-hub-prd.s3.amazonaws.com[https://automation-hub-prd.s3.amazonaws.com:443] +
-link:https://automation-hub-prd.s3.us-east-2.amazonaws.com/[https://automation-hub-prd.s3.us-east-2.amazonaws.com:443/]| Firewall access
+|\https://automation-hub-prd.s3.amazonaws.com +
+\https://automation-hub-prd.s3.us-east-2.amazonaws.com| Firewall access
 |link:https://galaxy.ansible.com[https://galaxy.ansible.com:443] |Ansible Community curated Ansible content
-|link:https://ansible-galaxy-ng.s3.dualstack.us-east-1.amazonaws.com[https://ansible-galaxy-ng.s3.dualstack.us-east-1.amazonaws.com:443] | Dual Stack IPv6 endpoint for Community curated Ansible content repository
+|\https://ansible-galaxy-ng.s3.dualstack.us-east-1.amazonaws.com | Dual Stack IPv6 endpoint for Community curated Ansible content repository
 |link:https://registry.redhat.io[https://registry.redhat.io:443] |Access to container images provided by Red Hat and partners
 |link:https://cert.console.redhat.com[https://cert.console.redhat.com:443] |Red Hat and partner curated Ansible Collections
 |===


### PR DESCRIPTION
2.5 backport of [PR 2235](https://github.com/ansible/aap-docs/pull/2235)

[AAP-32244](https://issues.redhat.com/browse/AAP-32244) 3

Files modified:
assembly-network-ports-protocols.adoc