### PR TITLE
AAP-29062 RHDH Add requirement for developer hub portal account (#2241)

### DIFF
--- a/downstream/assemblies/devtools/assembly-rhdh-using.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-using.adoc
@@ -11,6 +11,13 @@ From the {RHDH} UI, you can navigate to your {PlatformNameShort} instance, where
 This document describes how to use the {AAPRHDH}.
 It presents a worked example of developing a playbook project for automating updates to your firewall configuration on RHEL systems.
 
+== Optional requirement
+
+The {AAPRHDH} link to Learning Paths on the Red{nbsp}Hat developer portal,
+link:https://developers.redhat.com/learn[developers.redhat.com/learn].
+
+To access the Learning Paths, you must have a Red{nbsp}Hat account and you must be able to log in to link:https://developers.redhat.com[developers.redhat.com].
+
 include::devtools/ref-rhdh-dashboard.adoc[leveloffset=+1]
 include::devtools/ref-rhdh-learning.adoc[leveloffset=+1]
 include::devtools/ref-rhdh-discover-collections.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-28962

Add optional requirement for a developer gub account so that users can access the learning paths linked from the Ansible plug-ins on RHDH.

Affects `titles/aap-plugin-rhdh-using/`