### PR TITLE
2.5 AAP-30989 RHDH Add collection naming convention requirements (#2242)

### DIFF
--- a/downstream/modules/devtools/proc-rhdh-create.adoc
+++ b/downstream/modules/devtools/proc-rhdh-create.adoc
@@ -47,5 +47,14 @@ This is a Red Hat Developer Hub field.
 |System (Optional)
 |This is a {RHDH} field
 |===
++
+[NOTE]
+====
+Collection namespaces must follow Python module naming conventions.
+Collections must have short, all lowercase names.
+You can use underscores in the collection name if it improves readability.
+
+For more information, see the link:https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_in_groups.html#naming-conventions[Ansible Collection naming conventions documentation].
+====
 . Click *Review*.
 


### PR DESCRIPTION
AAP-30989

Add requirements for collection namespaces

Affects `titles/aap-plugin-rhdh-using/`