### PR TITLE
Fix broken link in RPM install guide 

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -14,7 +14,7 @@ ifdef::context[:parent-context: {context}]
 
 For more information about the components provided with {PlatformNameShort}, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/planning-installation#ref-platform-components[{PlatformName} components] in link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/planning_your_installation[{TitlePlanningGuide}]. 
 
-There are several supported installation scenarios for {PlatformName}. To install {PlatformName}, you must edit the inventory file parameters to specify your installation scenario. You can use the link:{LinkTopologies}/rpm-topologies#example_enterprise_inventory_file}[enterprise installer] as a basis for your own inventory file.
+There are several supported installation scenarios for {PlatformName}. To install {PlatformName}, you must edit the inventory file parameters to specify your installation scenario. You can use the link:{URLTopologies}/rpm-topologies#example_enterprise_inventory_file[enterprise installer] as a basis for your own inventory file.
 
 // New install scenarios including platform gateway AAP-17771
 //* xref:ref-gateway-controller-ext-db[Single platform gateway and {ControllerName} with an external (installer managed) database]


### PR DESCRIPTION
Fixed broken link by replacing {linkTopologies} with {URLTopologies}