### PR TITLE
AAP-31661-update2: Added known issue and deprecated APIs

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25-deprecated-features.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-deprecated-features.adoc
@@ -65,7 +65,7 @@ Import the helpers from the source definition.
 
 API endpoints that will be removed in a future release either because their functionality is being removed or superseded with other capabilities. For example, with the platform moving to a centralized authentication system in the platform gateway, the existing authorization APIs in the {ControllerName} and {HubName} are being deprecated for future releases as all authentication operations should occur in the platform gateway.
 
-[cols="25%,25%,50%"]
+[cols="20%,40%,40%"]
 |===
 | Component | Endpoint | Capability
 
@@ -92,5 +92,46 @@ API endpoints that will be removed in a future release either because their func
 |{ControllerNameStart}
 |`*/api/v2/users*`
 |Moving to the platform gateway.
+
+|{ControllerNameStart}
+|`*/api/v2/roles*`
+|Controller-specific role definitions are moving to `*/api/controller/v2/role_definitions*`.
+
+|{ControllerNameStart}
+a|
+The following roles lists:
+
+* `*/api/v2/teams/{id}/roles/*`
+* `*/api/v2/users/{id}/roles/*`
+|Controller-specific resource permissions are moving to `*/api/controller/v2/role_user_assignments*` and `*/api/controller/v2/role_team_assignments*`.
+
+|{ControllerNameStart}
+a|
+The following object roles lists:
+
+* `*/api/v2/credentials/{id}/object_roles/*`
+* `*/api/v2/instance_groups/{id}/object_roles/*`
+* `*/api/v2/inventories/{id}/object_roles/*`
+* `*/api/v2/job_templates/{id}/object_roles/*`
+* `*/api/v2/organizations/{id}/object_roles/*`
+* `*/api/v2/projects/{id}/object_roles/*`
+* `*/api/v2/teams/{id}/object_roles/*`
+* `*/api/v2/workflow_job_templates/{id}/object_roles/*`
+|Controller-specific resource permissions are moving to `*/api/controller/v2/role_user_assignments*` and `*/api/controller/v2/role_team_assignments*`.
+
+|{ControllerNameStart}
+a|
+The following resource access lists:
+
+* `*/api/v2/credentials/{id}/access_list/*`
+* `*/api/v2/instance_groups/{id}/access_list/*`
+* `*/api/v2/inventories/{id}/access_list/*`
+* `*/api/v2/job_templates/{id}/access_list/*`
+* `*/api/v2/organizations/{id}/access_list/*`
+* `*/api/v2/projects/{id}/access_list/*`
+* `*/api/v2/teams/{id}/access_list/*`
+* `*/api/v2/users/{id}/access_list/*`
+* `*/api/v2/workflow_job_templates/{id}/access_list/*`
+|No replacements yet.
 
 |===

--- a/downstream/titles/release-notes/topics/aap-25-known-issues.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-known-issues.adoc
@@ -11,6 +11,8 @@ This section provides information about known issues in {PlatformNameShort} 2.5.
 
 * Using *Prompt on launch* for variables for job templates, workflow job templates, workflow visualizer nodes, and schedules will not show the default variables when launching the job, or when configuring the workflows and schedules. (AAP-30585)
 
+* The unused *ANSIBLE_BASE_* settings are included as environment variables in the job execution. These variables suffixed with *SECRET* are no longer used in the {PlatformNameShort} and might be ignored until they are removed in a future patch. (AAP-32208)
+
 == {EDAName}
 
 * mTLS event stream creation should be disallowed on all installation methods by default. It is currently disallowed on {OCPShort} installation, but not disallowed in the containerized installations or on RPM installations. (AAP-31337)


### PR DESCRIPTION
This PR addresses a few updates to the AAP 2.5 release notes per recent update requests. Once this PR is merged, the changes must be backported to 2.5 branch. 

Changes made:

- Added a new known issue (https://issues.redhat.com/browse/AAP-32208)
- Added more deprecated APIs (JIRA: https://issues.redhat.com/browse/AAP-32298) 

Google doc: [[Draft AAP 2.5 release notes](https://docs.google.com/document/d/1R795y4V8p_UzNCaBmKpaG1lmJQDH4JTFZ_axh05fCI0/edit?usp=sharing)]