### PR TITLE
2.5 Update inventory files to allow for copy/paste (#2262)

### DIFF
--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -18,7 +18,7 @@ To use the example inventory files, replace the `< >` placeholders with your spe
 
 Use the following example inventory file to perform an online installation for the containerized growth topology:
 
-[subs="+attributes"]
+[source,subs="+attributes"]
 ----
 # This is the {PlatformNameShort} growth installer inventory file
 # Please consult the documentation if you are unsure what to add
@@ -96,7 +96,7 @@ eda_pg_password=<set your own>
 
 Use the following example inventory file to perform an online installation for the containerized enterprise topology:
 
-[subs="+attributes"]
+[source, subs="+attributes"]
 ----
 # This is the {PlatformNameShort} installer inventory file
 # Please consult the documentation if you are unsure what to add


### PR DESCRIPTION
Update the inventory files in the containerized install guide to allow for copy and paste of each inventory file correctly.

Containerized AAP install guide and installer need to be reconciled

https://issues.redhat.com/browse/AAP-32473