### PR TITLE
Update inventory file code blocks to allow copy paste

### DIFF
--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -18,7 +18,7 @@ To use the example inventory files, replace the `< >` placeholders with your spe
 
 Use the following example inventory file to perform an online installation for the containerized growth topology:
 
-[source,subs="+attributes"]
+[source,yaml,subs="+attributes"]
 ----
 # This is the {PlatformNameShort} growth installer inventory file
 # Please consult the documentation if you are unsure what to add
@@ -96,7 +96,7 @@ eda_pg_password=<set your own>
 
 Use the following example inventory file to perform an online installation for the containerized enterprise topology:
 
-[source, subs="+attributes"]
+[source,yaml,subs="+attributes"]
 ----
 # This is the {PlatformNameShort} installer inventory file
 # Please consult the documentation if you are unsure what to add

--- a/downstream/modules/topologies/ref-cont-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-a-env-a.adoc
@@ -67,7 +67,7 @@ a|
 == Example growth inventory file
 Use the following example inventory file to perform an installation for this topology: 
 
-[subs="+attributes"]
+[source,yaml,subs="+attributes"]
 ----
 # This is the growth installer inventory file
 # Please consult the docs if you are unsure what to add

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -74,7 +74,7 @@ a|
 == Example enterprise inventory file
 Use the following example inventory file to perform an installation for this topology: 
 
-[subs="+attributes"]
+[source,yaml,subs="+attributes"]
 ----
 # This is the enterprise installer inventory file
 # Please consult the docs if you are unsure what to add

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -71,7 +71,7 @@ Red Hat has tested the following configurations to install and run {PlatformName
 == Example enterprise inventory file
 Use the following example inventory file to perform an installation for this topology: 
 
-[subs="+attributes"]
+[source,yaml,subs="+attributes"]
 ----
 # This is the enterprise installer inventory file
 # Please consult the docs if you are unsure what to add

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -71,7 +71,7 @@ Red Hat has tested the following configurations to install and run {PlatformName
 == Example enterprise inventory file
 Use the following example inventory file to perform an installation for this topology: 
 
-[subs="+attributes"]
+[source,yaml,subs="+attributes"]
 ----
 # This is the enterprise installer inventory file
 # Please consult the docs if you are unsure what to add


### PR DESCRIPTION
Update the AsciiDoc syntax for the code blocks for inventory file examples to ensure the copy and paste command on docs.redhat.com works correctly.

Corrected for containerized install guide and topologies documentation.

Containerized AAP install guide and installer need to be reconciled

https://issues.redhat.com/browse/AAP-32473