### PR TITLE
2.4 Correct formatting issue in 2.4 async release notes

### DIFF
--- a/downstream/titles/release-notes/topics/rpm-24-74.adoc
+++ b/downstream/titles/release-notes/topics/rpm-24-74.adoc
@@ -9,6 +9,7 @@ link:https://access.redhat.com/errata/RHSA-2024:7312[RHSA-2024:7312]
 == General
 
 With this update, the following CVEs have been addressed:
+
 // (AAP-26186)
 * link:https://access.redhat.com/security/cve/CVE-2024-21520[CVE-2024-21520] - Cross-site Scripting (XSS) through `break_long_headers`.
 ** Packages updated: `automation-controller: djangorestframework`.


### PR DESCRIPTION
Correct a formatting issue for the 2.4 async release notes

Affected file: rpm-24-74.adoc