### PR TITLE
backport-2.5-2267

### DIFF
--- a/downstream/assemblies/topologies/assembly-overview-tested-deployment-models.adoc
+++ b/downstream/assemblies/topologies/assembly-overview-tested-deployment-models.adoc
@@ -15,19 +15,19 @@ The following table outlines the different ways to install or deploy {PlatformNa
 | Mode | Infrastructure | Description | Tested topologies
 | RPM | Virtual machines and bare metal | The RPM installer deploys {PlatformNameShort} on {RHEL} by using RPMs to install the platform on host machines. Customers manage the product and infrastructure lifecycle.
 a| 
-* link:{URLTopologies}/rpm-topologies#rpm-b-env-a[RPM enterprise topology]
-* link:{URLTopologies}/rpm-topologies#rpm-b-env-b[RPM mixed enterprise topology]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models/rpm-topologies#rpm-b-env-a[RPM enterprise topology]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models/rpm-topologies#rpm-b-env-b[RPM mixed enterprise topology]
 | Containers
 | Virtual machines and bare metal
 | The containerized installer deploys {PlatformNameShort} on {RHEL} by using Podman which runs the platform in containers on host machines. Customers manage the product and infrastructure lifecycle.
 a| 
-* link:{URLTopologies}/container-topologies#cont-a-env-a[Container growth topology]
-* link:{URLTopologies}/container-topologies#cont-b-env-a[Container enterprise topology]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models/container-topologies#cont-a-env-a[Container growth topology]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models/container-topologies#cont-b-env-a[Container enterprise topology]
 
 | Operator
 | Red Hat OpenShift
 | The Operator uses Red Hat OpenShift Operators to deploy {PlatformNameShort} within Red Hat OpenShift. Customers manage the product and infrastructure lifecycle.
 a| 
-* link:{URLTopologies}/ocp-topologies#ocp-a-env-a[Operator growth topology]
-* link:{URLTopologies}/ocp-topologies#ocp-b-env-a[Operator enterprise topology]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models/ocp-topologies#ocp-a-env-a[Operator growth topology]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models/ocp-topologies#ocp-b-env-a[Operator enterprise topology] 
 |====

--- a/downstream/modules/platform/ref-OCP-system-requirements.adoc
+++ b/downstream/modules/platform/ref-OCP-system-requirements.adoc
@@ -4,4 +4,4 @@
 
 = System requirements for installing on {OCPShort}
 
-For system requirements for installing {PlatformNameShort} on {OCPShort}, see the link:{URLTopologies}[Tested system configurations] section of _{TitleTopologies}_.
+For system requirements for installing {PlatformNameShort} on {OCPShort}, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models/ocp-topologies#tested_system_configurations_6[Tested system configurations] section of _{TitleTopologies}_. 

--- a/downstream/modules/platform/ref-containerized-system-requirements.adoc
+++ b/downstream/modules/platform/ref-containerized-system-requirements.adoc
@@ -4,4 +4,4 @@
 
 = System requirements for containerized installation
 
-For system requirements for the containerized installation method of {PlatformNameShort}, see the link:{URLContainerizedInstall}/aap-containerized-installation#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.
+For system requirements for the containerized installation method of {PlatformNameShort}, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/aap-containerized-installation#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.


### PR DESCRIPTION
2.5 backport of [PR 2267](https://github.com/ansible/aap-docs/pull/2267)

AP-32244 updated incorrect links

Files modified:
- topologies/assembly-overview-tested-deployment-models.adoc
- ref-OCP-system-requirements.adoc
- ref-containerized-system-requirements.adoc