### PR TITLE
AAP-31240: Updated the Telemetry docs per customer ask

### DIFF
--- a/lightspeed/assemblies/assembly_managing-admin-dashboard-telemetry.adoc
+++ b/lightspeed/assemblies/assembly_managing-admin-dashboard-telemetry.adoc
@@ -15,10 +15,22 @@ ifdef::context[:parent-context: {context}]
 * *Operational telemetry data*
 +
 This is the data that is required to operate and troubleshoot the Ansible Lightspeed service. For more information, refer the Enterprise Agreement. You cannot disable the collection of operational telemetry data. 
++
+This includes the following data:
+
+** Organization you are logged into (Organization ID, account number)
+** Large language model (or models) that you are connected to 
 
 * *Admin dashboard telemetry data*
 +
-This is the data that provides insight into how your organization users are using the Ansible Lightspeed service, and the metrics are displayed on the Admin dashboard. You can also disable the Admin dashboard telemetry if you no longer want to collect and monitor the telemetry data.  
+This is the data that provides insight into how your organization users are using the Ansible Lightspeed service, and the metrics are displayed on the Admin dashboard. 
++
+This includes the following data:
+
+** Prompts and content suggestions, including accept or reject of the content suggestions
+** User sentiment feedback
++
+You can also disable the Admin dashboard telemetry if you no longer want to collect and monitor the telemetry data. 
 
 [NOTE]
 ====

--- a/lightspeed/modules/con_telemetry-data-collection-notice.adoc
+++ b/lightspeed/modules/con_telemetry-data-collection-notice.adoc
@@ -9,10 +9,30 @@ In connection with your use of this Red Hat offering, Red Hat may collect teleme
 
 Tools within the software monitor various metrics and this information is transmitted to Red Hat.  The following metrics are monitored:
 
-* Organization you are logged into (Organization ID, account number)
-* Large language model (or models) that you are connected to 
-* Prompts and content suggestions, including accept or reject of the content suggestions
-* User sentiment feedback
+* *Operational telemetry data*
++
+This is the data that is required to operate and troubleshoot the Ansible Lightspeed service. For more information, refer the Enterprise Agreement. You cannot disable the collection of operational telemetry data.
++ 
+This includes the following data:
+
+** Organization you are logged into (Organization ID, account number)
+** Large language model (or models) that you are connected to 
+
+* *Admin dashboard telemetry data*
++
+This is the data that provides insight into how your organization users are using the Ansible Lightspeed service, and the metrics are displayed on the Admin dashboard. 
++
+This includes the following data:
+
+** Prompts and content suggestions, including accept or reject of the content suggestions
+** User sentiment feedback
++
+You can also disable the Admin dashboard telemetry if you no longer want to collect and monitor the telemetry data. For more information about Admin dashboard telemetry, see xref:managing-admin-dashboard-telemetry_lightspeed-user-guide[Viewing and managing Admin dashboard telemetry].
+
+[NOTE]
+====
+No telemetry data is collected in an {LightspeedShortName} on-premise deployment.
+====
 
 == Personal Data
 Red Hat does not intend to collect personal information. If Red Hat discovers that personal information has been inadvertently received, Red Hat will delete such information. To the extent that any telemetry data constitutes personal data, refer to the link:https://www.redhat.com/en/about/privacy-policy[Red Hat Privacy Statement] for more information about Red Hat's privacy practices. 

--- a/lightspeed/modules/con_training-data.adoc
+++ b/lightspeed/modules/con_training-data.adoc
@@ -18,12 +18,12 @@ If you publish content to {Galaxy} and want to restrict your {Galaxy} content fr
 
 {LightspeedshortName} collects the following telemetry data by default:
 
-* *Operational telemetry data*
-+
-This is the data that is required to operate and troubleshoot the Ansible Lightspeed service. For more information, refer the Enterprise Agreement. You cannot disable the collection of operational telemetry data. 
+* Operational telemetry data
+* Admin dashboard telemetry data
 
-* *Admin dashboard telemetry data*
-+
-This is the data that provides insight into how your organization users are using the Ansible Lightspeed service, and the metrics are displayed on the Admin dashboard. You can also disable the Admin dashboard telemetry if you no longer want to collect and monitor the telemetry data. For more information about Admin dashboard telemetry, see xref:managing-admin-dashboard-telemetry_lightspeed-user-guide[Viewing and managing Admin dashboard telemetry].
+[NOTE]
+====
+No telemetry data is collected in an {LightspeedShortName} on-premise deployment.
+====
 
 include::con_telemetry-data-collection-notice.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-31240.

Changes made:

- Specified what's categorized as 'operational telemetry' and 'admin dashboard telemetry'.
- Added a note stating that no telemetry data is collected in an Ansible Lightspeed on-premise deployment.