### PR TITLE
2.5 Update module reference link to ensure title builds successfully (#2275)

### DIFF
--- a/downstream/titles/updating-aap/master.adoc
+++ b/downstream/titles/updating-aap/master.adoc
@@ -25,4 +25,4 @@ include::platform/assembly-update-rpm.adoc[leveloffset=+1]
 
 == {PlatformNameShort} on {OCPShort}
 
-include::../../modules/platform/proc-update-aap-on-ocp.adoc[leveloffset=+2]
+include::platform/platform/proc-update-aap-on-ocp.adoc[leveloffset=+2]


### PR DESCRIPTION
Update module reference link in Updating from Ansible Automation Platform 2.5 to 2.5.x as it resulted in a docs build failure.

Updated from `include::../../modules/platform/proc-update-aap-on-ocp.adoc[leveloffset=+2]`

To `include::platform/platform/proc-update-aap-on-ocp.adoc[leveloffset=+2]`