### PR TITLE
Update ansible-core version and PostgreSQL version in topologies

### DIFF
--- a/downstream/modules/topologies/ref-cont-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-a-env-a.adoc
@@ -37,9 +37,9 @@ a|
 * Valid {PlatformName} subscription
 * Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
 | Operating system | {RHEL} 9.2 or later x86_64
-| Ansible-core | Ansible-core version 2.15 or later
+| Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
-| Database | PostgreSQL version 15
+| Database | {PostgresVers}
 |====
 
 == Network ports

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -38,9 +38,9 @@ a|
 * Valid {PlatformName} subscription
 * Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
 | Operating system | {RHEL} 9.2 or later x86_64 and AArch64
-| Ansible-core | Ansible-core version 2.15 or later
+| Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome.
-| Database | PostgreSQL version 15
+| Database | {PostgresVers}
 |====
 
 == Network ports

--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -46,9 +46,9 @@ a|
 * Version: 4.14
 * num_of_control_nodes: 1
 * num_of_worker_nodes: 1 
-| Ansible-core | Ansible-core version 2.15 or later
+| Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome.
-| Database | PostgreSQL version 15
+| Database | {PostgresVers}
 |====
 
 == Example custom resource file 

--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -49,7 +49,7 @@ Red Hat has tested the following configurations to install and run {PlatformName
 a| 
 * Red Hat OpenShift on AWS Hosted Control Planes 4.15.16
 ** 2 worker nodes in different AZs at t3.xlarge
-| Ansible-core | Ansible-core version 2.15 or later
+| Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome.
 | AWS RDS PostgreSQL service 
 a|

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -36,9 +36,9 @@ Red Hat has tested the following configurations to install and run {PlatformName
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
 | Operating system | {RHEL} 9.2 or later x86_64 and AArch64
-| Ansible-core | Ansible-core version 2.15 or later
+| Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
-| Database | PostgreSQL version 15
+| Database | {PostgresVers}
 |====
 
 == Network ports

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -36,9 +36,9 @@ Red Hat has tested the following configurations to install and run {PlatformName
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
 | Operating system | {RHEL} 9.2 or later x86_64 and AArch64
-| Ansible-core | Ansible-core version 2.15 or later
+| Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
-| Database | PostgreSQL version 15
+| Database | {PostgresVers}
 |====
 
 == Network ports


### PR DESCRIPTION
Update the ansible-core version and the PostgreSQL versions in Tested deployment models.

I made use of the relevant attributes `{CoreInstVers}` and `{PostgresVers}` to make these easier to update in the future.

Incorrect Ansible Core in AAP 2.5 documentation

https://issues.redhat.com/browse/AAP-32814