### PR TITLE
Added twp modules AAP-31734

### DIFF
--- a/downstream/modules/platform/proc-update-aap-container.adoc
+++ b/downstream/modules/platform/proc-update-aap-container.adoc
@@ -1,0 +1,81 @@
+[id="proc-update-aap-container"]
+
+= Container-based {PlatformNameShort}
+
+== Updating container-based {PlatformNameShort}
+
+Perform a patch update for a container-based installation of Ansible Automation Platform.
+
+.Prerequisites
+
+* Reviewed the release notes for the associated patch release.
+
+* Created a backup of your {PlatformNameShort} deployment. For more information, see Backing up container-based <<Backing up controller-based {PlatformNameShort}>>.
+
+.Procedure
+
+. Download the latest version of the containerized installer from the link:access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software[{PlatformNameShort}] download page.
+
+. . For online installations *{PlatformNameShort} 2.5 Containerized Setup*
+
+. . For offline or bundled installations: *{PlatformNameShort} 2.5 Containerized Setup Bundle*
+
+. Copy the installer `.tar` file onto your {RHEL} host.
+
+. Decide where you want the installer to reside on the filesystem. Installation related files will be created under this location and require at least 10 GB for the initial installation.
+
+. Unpack the installer `.tar` file into your installation directory, and go to the unpacked directory.
+
+. . To unpack the online installer:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+$ tar xfvz ansible-automation-platform-containerized-setup-<version>.tar.gz
+----
++
+. . To unpack the offline or bundled installer:
++ 
+----
+$ tar xfvz ansible-automation-platform-containerized-setup-bundle-<version>-<arch name>.tar.gz
+----
+
+. Edit the `inventory` file so that it matches your desired configuration. You can keep the same parameters from your existing {PlatformNameShort} deployment or you can modify the parameters to match any changes to your environment.
+
+. Run the `install` command:
++
+----
+$ ansible-playbook -i inventory ansible.containerized_installer.install
+----
++
+* If your privilege escalation requires a password to be entered, append -K to the command. You will then be prompted for the BECOME password.
++
+* If your privilege escalation requires a password to be entered, append `-K` to the command. You will then be prompted for the `BECOME password.
++
+* You can use increasing verbosity, up to 4 v’s (`-vvvv`) to see the details of the installation process. However it is important to note that this can significantly increase installation time, so it is recommended that you use it only as needed or requested by Red Hat support.
+
+The installation will begin.
+
+== Backing up container-based {PlatformNameShort}
+
+Perform a back up of your container-based {PlatformNameShort} installer.
+
+. Procedure
+
+. . Go to the Ansible Automation Platform installation directory on your RHEL host.
+
+. . Run the `backup.yml` playbook:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+$ ansible-playbook -i inventory ansible.containerized_installer.backup
+----
+
+This will backup the important data deployed by the containerized installer such as:
+
+* PostgreSQL databases
+
+* Configuration files
+
+* Data files
+
+By default, the backup directory is set to ~/backups but this can be changed by using the backup_dir variable in your `inventory` file.

--- a/downstream/modules/platform/proc-update-aap-rpm.adoc
+++ b/downstream/modules/platform/proc-update-aap-rpm.adoc
@@ -1,0 +1,135 @@
+[id="proc-update-aap-rpm"]
+
+= RPM-based {PlatformNameShort}
+
+To update your RPM-based {PlatformNameShort}, start by reviewing the update considerations. You can then download the latest version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
+
+== Update planning
+
+Before you begin the update process, review the following considerations to plan and prepare your {PlatformNameShort} deployment:
+
+* Even if you have a valid license from a previous version, you must provide your credentials or a subscription manifest upon upgrading to the latest version of {PlatformNameShort}. For more information, see link:docs.redhat.com/en/documentation/{PlatformName}/2.5/html/access_management_and_authentication/assembly-gateway-licensing#proc-attaching-subscriptions[Attaching your {PlatformName} subscription].
+
+* Clustered upgrades require special attention to instance and instance groups before upgrading. Ensure you capture your inventory or instance group details before upgrading. For more information, see link:docs.redhat.com/en/documentation/{PlatformName}/2.5/html-single/configuring_automation_execution/index#controller-clustering[Clustering].
+
+* If you are currently running {EDAcontroller}, it is recommended that you disable all rulebook activations before upgrading to ensure that only new activations run after the upgrade process has completed. This prevents possibilities of orphaned containers running activations from the previous version. For more information, see link:docs.redhat.com/en/documentation/{PlatformName}/2.5/html-single/using_automation_decisions/index#eda-enable-rulebook-activations[Enabling and disabling rulebook activations].
+
+== Choosing and obtaining a {PlatformName}installer
+
+Choose the {PlatformName} installer you need based on your {RHEL} environment internet connectivity. Review the following scenarios and decide on which {PlatformNameShort} installer meets your needs.
+Note
+
+A valid Red Hat customer account is required to access {PlatformName} installer downloads on the Red Hat Customer Portal.
+
+== Installing with internet access
+
+*Tarball install*
+
+.Procedure
+
+. Navigate to the link:access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.5/x86_64/product-software[{PlatformName} download download] page.
+
+. Click btn:[Download Now] for the {PlatformNameShort} <latest-version> Setup.
+
+. Extract the files:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+$ tar xvzf ansible-automation-platform-setup-<latest-version>.tar.gz
+----
++
+*RPM install*
+
+* Install {PlatformNameShort} Installer Package
++
+[literal, options="nowrap" subs="+attributes"]
+v.2.5 for RHEL 8 for x86_64
++
+----
+$ sudo dnf install --enablerepo=ansible-automation-platform-2.5-for-rhel-8-x86_64-rpms ansible-automation-platform-installer
+----
++
+v.2.5 for RHEL 9 for x86-64
++
+----
+$ sudo dnf install --enablerepo=ansible-automation-platform-2.5-for-rhel-9-x86_64-rpms ansible-automation-platform-installer
+----
+
+Note: `dnf install` enables the repo as the repo is disabled by default.
+
+== Installing without internet access
+
+Use the {PlatformNameShort} bundle installer if you are unable to access the internet, or would prefer not to install separate components and dependencies from online repositories. Access to {RHEL} repositories is still needed. All other dependencies are included in the tar archive.
+
+.Procedure
+
+. Navigate to the link:access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.5/x86_64/product-software[{PlatformName} download download] page.
+
+. Click btn:[Download Now] for the {PlatformNameShort} <latest-version> Setup.
+
+. Extract the files:
++
+[literal, options="nowrap" subs="+attributes"]
+----
++$ tar xvzf ansible-automation-platform-setup-bundle-<latest-version>.tar.gz
+----
+
+== Setting up the inventory file
+
+Before upgrading your {PlatformName} installation, edit the `inventory file so that it matches your desired configuration. You can keep the same parameters from your existing Ansible Automation Platform deployment or you can modify the parameters to match any changes to your environment.
+
+.Procedure
+
+. Navigate to the installation program directory.
+
+*Bundled installer*
++
+[literal, options="nowrap" subs="+attributes"]
+----
+$ cd ansible-automation-platform-setup-bundle-<version_number>-<arch_version>
+----
++
+*Online installer*
+----
+$ cd ansible-automation-platform-setup-<version_number>
+----
+
+. Update the `inventory` file to match your desired configuration. You can use the same inventory file from an existing {PlatformNameShort} installation if there are no changes to the environment.
+
+Note: Provide a reachable IP address or fully qualified domain name (FQDN) for all hosts to ensure that users can synchronize and install content from Ansible automation hub from a different node. Do not use localhost. If localhost is used, the upgrade will be stopped as part of preflight checks.
+
+== Backing up RPM-based Ansible Automation Platform
+
+Back up an existing {PlatformNameShort} instance by running the `setup.sh` script with the `backup_dir` flag, which saves the content and configuration of your current environment:
+
+. Go to your Ansible Automation Platform installation directory.
+
+. Run the setup.sh script following the example below:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+$ ./setup.sh -e ‘backup_dir=/ansible/mybackup’ -e ‘use_compression=True’ @credentials.yml -b
++
+* `backup_dir` specifies a directory to save your backup to.
++
+* `@credentials.yml` passes the password variables and their values that are encrypted by `ansible-vault`.
+
+With a successful backup, a backup file is created at `/ansible/mybackup/<platform_installation_directory_name>.tar.gz`.
+
+*Additional resources*
+
+* For more information about backup and restore, see [Backup and restore] in link:docs.redhat.com/en/documentation/{PlatformNameShort}/2.5/html-single/configuring_automation_execution/index#controller-backup-and-restore_Configuring automation execution_.
+
+== Running the {RHEL} installer setup script
+
+You can run the setup script once you have finished updating the `inventory` file.
+
+.Procedure
+. Run the `setup.sh` script:
+[literal, options="nowrap" subs="+attributes"]
++
+----
+$ ./setup.sh
+----
+
+The installation will begin.

--- a/downstream/titles/updating-aap/master.adoc
+++ b/downstream/titles/updating-aap/master.adoc
@@ -25,4 +25,6 @@ include::platform/assembly-update-rpm.adoc[leveloffset=+1]
 
 == {PlatformNameShort} on {OCPShort}
 
+include::platform/platform/proc-update-aap-rpm.adoc[leveloffset=+2]
+include::platform/platform/proc-update-aap-container.adoc[leveloffset=+2]
 include::platform/platform/proc-update-aap-on-ocp.adoc[leveloffset=+2]


### PR DESCRIPTION
Added two modules on:
 - Container-based installation of aap 2.5 to 2.x
 - RPM-based installation of aap of 2.5 to 2.x
 for the Ansible Automation Platform guide and updated the master.adoc to include the two titles as.