### PR TITLE
Updating operator title attributes

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-backup.adoc
+++ b/downstream/assemblies/platform/assembly-aap-backup.adoc
@@ -11,7 +11,7 @@ ifdef::context[:parent-context: {context}]
 
 Backing up your {PlatformName} deployment involves creating backup resources for your deployed instances. 
 Use the following procedures to create backup resources for your {PlatformName} deployment. 
-We recommend taking backups before upgrading the {OperatorPlatform}. 
+We recommend taking backups before upgrading the {OperatorPlatformNameShort}. 
 Take a backup regularly in case you want to restore the platform to a previous state.
 
 

--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -2,15 +2,15 @@
 ifdef::context[:parent-context: {context}]
 
 [id="aap-migration"]
-= Migrating {PlatformName} to {OperatorPlatform}
+= Migrating {PlatformName} to {OperatorPlatformName}
 
 :context: aap-migration
 
 [role="_abstract"]
 
-Migrating your {PlatformName} deployment to the {OperatorPlatform} allows you to take advantage of the benefits provided by a Kubernetes native operator, including simplified upgrades and full lifecycle support for your {PlatformName} deployments.
+Migrating your {PlatformName} deployment to the {OperatorPlatformNameShort} allows you to take advantage of the benefits provided by a Kubernetes native operator, including simplified upgrades and full lifecycle support for your {PlatformName} deployments.
 
-Use these procedures to migrate any of the following deployments to the {OperatorPlatform}:
+Use these procedures to migrate any of the following deployments to the {OperatorPlatformNameShort}:
 
 * A VM-based installation of Ansible Tower 3.8.6, {ControllerName}, or {HubName}
 * An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2)

--- a/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
@@ -4,7 +4,7 @@ ifdef::context[:parent-context: {context}]
 
 :context: configure-aap-operator
 
-= Configuring the Red Hat {OperatorPlatform} on {OCP}
+= Configuring the {OperatorPlatformName} on {OCP}
 
 The platform gateway for {PlatformNameShort} enables you to manage the following {PlatformNameShort} components to form a single user interface:
 
@@ -13,15 +13,15 @@ The platform gateway for {PlatformNameShort} enables you to manage the following
 * {EDAName}
 * {LightspeedShortName} (This feature is disabled by default, you must opt in to use it.)
 
-Before you can deploy the platform gateway you must have {OperatorPlatform} installed in a namespace. 
-If you have not installed {OperatorPlatform} see <<Installing the Red Hat Ansible Automation Platform operator on Red Hat OpenShift Container Platform>>.
+Before you can deploy the platform gateway you must have {OperatorPlatformNameShort} installed in a namespace. 
+If you have not installed {OperatorPlatformNameShort} see xref:install-aap-operator_operator-platform-doc[Installing the {OperatorPlatformName} on {OCP}].
 
 [NOTE] 
 ====
-Platform gateway is only available under {OperatorPlatform} version 2.5. Every component deployed under {OperatorPlatform} 2.5 will also default to version 2.5.
+Platform gateway is only available under {OperatorPlatformNameShort} version 2.5. Every component deployed under {OperatorPlatformNameShort} 2.5 will also default to version 2.5.
 ====
 
-If you have the {OperatorPlatform} and some or all of the {PlatformNameShort} components installed see <<Deploying the platform gateway with existing {PlatformNameShort} components>> for how to proceed. 
+If you have the {OperatorPlatformNameShort} and some or all of the {PlatformNameShort} components installed see xref:operator-deploy-central-config_{context}[Deploying the platform gateway with existing {PlatformNameShort} components]for how to proceed. 
 
 include::platform/proc-operator-link-components.adoc[leveloffset=+1]
 include::platform/proc-operator-access-aap.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-deploy-eda-controller-on-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-deploy-eda-controller-on-aap-operator.adoc
@@ -3,14 +3,14 @@ ifdef::context[:parent: {context}]
 
 [id="deploy-eda-controller-on-aap-operator-ocp"]
 
-= Deploying {EDAcontroller} with {OperatorPlatform} on {OCPShort}
+= Deploying {EDAcontroller} with {OperatorPlatformName} on {OCP}
 
 :context: deploying
 
 [role="_abstract"]
 {EDAcontroller} is the interface for event-driven automation and introduces automated resolution of IT requests. This component helps you connect to sources of events and acts on those events using rulebooks. When you deploy {EDAcontroller}, you can automate decision making, use numerous event sources, implement event-driven automation within and across multiple IT use cases, and achieve more efficient service delivery. 
 
-Use the following instructions to install {EDAName} with your {OperatorPlatform} on {OCPShort}.
+Use the following instructions to install {EDAName} with your {OperatorPlatformNameShort} on {OCPShort}.
 
 include::platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-install-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-install-aap-operator.adoc
@@ -4,8 +4,8 @@ ifdef::context[:parent-context: {context}]
 
 
 
-[id="assembly-install-aap-operator"]
-= Installing the {PlatformName} operator on {OCP}
+[id="install-aap-operator_{context}"]
+= Installing the {PlatformName} on {OCP}
 
 [role="_abstract"]
 

--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -9,12 +9,12 @@ See also the complementary step on the last line of this file.
 ifdef::context[:parent-context: {context}]
 
 [id="installing-aap-operator-cli"]
-= Installing {OperatorPlatform} from the {OCPShort} CLI
+= Installing {OperatorPlatformName}  from the {OCPShort} CLI
 
 :context: installing-aap-operator-cli
 
 [role="_abstract"]
-Use these instructions to install the {OperatorPlatform} on {OCP} from the {OCPShort} command-line interface (CLI) using the [command]`oc` command.
+Use these instructions to install the {OperatorPlatformNameShort} on {OCP} from the {OCPShort} command-line interface (CLI) using the [command]`oc` command.
 
 == Prerequisites
 

--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -27,7 +27,7 @@ When an instance of {HubName} is removed, the PVCs are not automatically deleted
 
 == Prerequisites
 
-* You have installed the {OperatorPlatform} in Operator Hub.
+* You have installed the {OperatorPlatformNameShort} in Operator Hub.
 
 // commenting out below as encouraging users to use platform gateway for installation, only covering configuration here [gmurray]
 // == Installing the {HubName} operator

--- a/downstream/assemblies/platform/assembly-operator-add-execution-nodes.adoc
+++ b/downstream/assemblies/platform/assembly-operator-add-execution-nodes.adoc
@@ -2,11 +2,11 @@ ifdef::context[:parent-context: {context}]
 
 [id="operator-add-execution-nodes_{context}"]
 
-= Adding execution nodes to {PlatformNameShort} Operator
+= Adding execution nodes to {OperatorPlatformName}
 
 :context: operator-upgrade
 
-You can enable the {OperatorPlatform} with execution nodes by downloading and installing the install bundle.  
+You can enable the {OperatorPlatformNameShort} with execution nodes by downloading and installing the install bundle.  
 
 
 include::platform/proc-add-operator-execution-nodes.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-operator-install-planning.adoc
+++ b/downstream/assemblies/platform/assembly-operator-install-planning.adoc
@@ -4,7 +4,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [id="operator-install-planning"]
-= Planning your {PlatformName} operator installation on {OCP}
+= Planning your {OperatorPlatformName} on {OCP}
 
 
 :context: operator-install-planning
@@ -12,7 +12,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 {PlatformName} is supported on both Red Hat Enterprise Linux and Red Hat Openshift.
 
-OpenShift operators help install and automate day-2 operations of complex, distributed software on {OCP}. The {OperatorPlatform} enables you to deploy and manage {PlatformNameShort} components on {OCP}.
+OpenShift operators help install and automate day-2 operations of complex, distributed software on {OCP}. The {OperatorPlatformNameShort} enables you to deploy and manage {PlatformNameShort} components on {OCP}.
 
 You can use this section to help plan your {PlatformName} installation on your {OCP} environment. Before installing, review the supported installation scenarios to determine which meets your requirements.
 

--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -3,13 +3,13 @@ ifdef::context[:parent-context: {context}]
 
 [id="operator-upgrade_{context}"]
 
-= Upgrading {OperatorPlatform} on {OCPShort}
+= Upgrading {OperatorPlatformName} on {OCPShort}
 
 :context: operator-upgrade
 
 [role="_abstract"]
 
-The {OperatorPlatform} simplifies the installation, upgrade and deployment of new {PlatformName} instances in your {OCPShort} environment.
+The {OperatorPlatformNameShort} simplifies the installation, upgrade and deployment of new {PlatformName} instances in your {OCPShort} environment.
 
 include::platform/con-operator-upgrade-considerations.adoc[leveloffset=+1]
 include::platform/con-operator-upgrade-prereq.adoc[leveloffset=+1]

--- a/downstream/assemblies/topologies/assembly-ocp-topologies.adoc
+++ b/downstream/assemblies/topologies/assembly-ocp-topologies.adoc
@@ -2,7 +2,7 @@
 
 = Operator topologies
 
-The {OperatorPlatform} uses Red Hat OpenShift operators to deploy {PlatformNameShort} within Red Hat OpenShift. Customers manage the product and infrastructure lifecycle.
+The {OperatorPlatformNameShort} uses Red Hat OpenShift operators to deploy {PlatformNameShort} within Red Hat OpenShift. Customers manage the product and infrastructure lifecycle.
 
 //OCP growth topology
 include::topologies/ref-ocp-a-env-a.adoc[leveloffset=+1]

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-backup-recovery.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-backup-recovery.adoc
@@ -5,4 +5,4 @@
 
 * For information about performing a backup and recovery of {PlatformNameShort}, see link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] in _{TitleControllerAdminGuide}_.
 
-* For information about troubleshooting backup and recovery for installations of {OperatorPlatform} on {OCPShort}, see the link:{URLOperatorBackup}/aap-troubleshoot-backup-recover[Troubleshooting] section in _{TitleOperatorBackup}_.
+* For information about troubleshooting backup and recovery for installations of {OperatorPlatformNameShort} on {OCPShort}, see the link:{URLOperatorBackup}/aap-troubleshoot-backup-recover[Troubleshooting] section in _{TitleOperatorBackup}_.

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -48,7 +48,8 @@
 :RunnerRpm: Ansible-runner rpm/container
 
 // Operators
-:OperatorPlatform: Ansible Automation Platform Operator
+:OperatorPlatformName: Red Hat Ansible Automation Platform Operator
+:OperatorPlatformNameShort: Ansible Automation Platform Operator
 :OperatorHub: Ansible Automation Platform Hub Operator
 :OperatorController: Ansible Automation Platform Controller Operator
 :OperatorResource: Ansible Automation Platform Resource Operator

--- a/downstream/modules/eda/ref-deploy-eda-controller-with-aap-operator-on-ocp.adoc
+++ b/downstream/modules/eda/ref-deploy-eda-controller-with-aap-operator-on-ocp.adoc
@@ -1,7 +1,7 @@
 [id="deploying-eda-controller-with-aap-operator-on-ocp"]
 
-= Deploying {EDAcontroller} with {OperatorPlatform} on {OCPShort}
+= Deploying {EDAcontroller} with {OperatorPlatformNameShort} on {OCPShort}
 
-{EDAName} is not limited to {PlatformNameShort} on VMs. You can also access this feature on {OperatorPlatform} on {OCPShort}. To deploy {EDAName} with {OperatorPlatform}, follow the instructions in link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index#deploy-eda-controller-on-aap-operator-ocp[Deploying Event-Driven Ansible controller with Ansible Automation Platform Operator on OpenShift Container Platform]. 
+{EDAName} is not limited to {PlatformNameShort} on VMs. You can also access this feature on {OperatorPlatformNameShort} on {OCPShort}. To deploy {EDAName} with {OperatorPlatformNameShort}, follow the instructions in link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index#deploy-eda-controller-on-aap-operator-ocp[Deploying Event-Driven Ansible controller with Ansible Automation Platform Operator on OpenShift Container Platform]. 
 
 After successful deployment, you can connect to event sources and resolve issues more efficiently.

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 
-Before migrating your current {PlatformNameShort} deployment to {OperatorPlatform}, you need to back up your existing data, create k8s secrets for your secret key and postgresql configuration.
+Before migrating your current {PlatformNameShort} deployment to {OperatorPlatformNameShort}, you need to back up your existing data, create k8s secrets for your secret key and postgresql configuration.
 
 [NOTE]
 ====

--- a/downstream/modules/platform/con-about-operator.adoc
+++ b/downstream/modules/platform/con-about-operator.adoc
@@ -1,16 +1,16 @@
 [id="con-about-operator_{context}"]
 
-= About {OperatorPlatform}
+= About {OperatorPlatformNameShort}
 
 [role="_abstract"]
-The {OperatorPlatform} provides cloud-native, push-button deployment of new {PlatformNameShort} instances in your OpenShift environment.
-The {OperatorPlatform} includes resource types to deploy and manage instances of {ControllerName} and {PrivateHubName}.
+The {OperatorPlatformNameShort} provides cloud-native, push-button deployment of new {PlatformNameShort} instances in your OpenShift environment.
+The {OperatorPlatformNameShort} includes resource types to deploy and manage instances of {ControllerName} and {PrivateHubName}.
 It also includes {ControllerName} job resources for defining and launching jobs inside your {ControllerName} deployments.
 
 Deploying {PlatformNameShort} instances with a Kubernetes native operator offers several advantages over launching instances from a playbook deployed on {OCP}, including upgrades and full lifecycle support for your {PlatformName} deployments.
 
-You can install the {OperatorPlatform} from the Red Hat Operators catalog in OperatorHub.
+You can install the {OperatorPlatformNameShort} from the Red Hat Operators catalog in OperatorHub.
 
-For information about the {OperatorPlatform} infrastructure topology see {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models/index#container-topologies[Container topologies] in _{TitleTopologies}_.
+For information about the {OperatorPlatformNameShort} infrastructure topology see {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models/index#container-topologies[Container topologies] in _{TitleTopologies}_.
 
 

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -3,11 +3,11 @@
 = Supported installation scenarios for {OCP}
 
 
-You can use the OperatorHub on the {OCP} web console to install {OperatorPlatform}.
+You can use the OperatorHub on the {OCP} web console to install {OperatorPlatformNameShort}.
 
-Alternatively, you can install {OperatorPlatform} from the {OCPShort} command-line interface (CLI), `oc`. See <<installing-aap-operator-cli>> for help with this. 
+Alternatively, you can install {OperatorPlatformNameShort} from the {OCPShort} command-line interface (CLI), `oc`. See <<installing-aap-operator-cli>> for help with this. 
 
-After you have installed {OperatorPlatform} you must create an *{PlatformNameShort}* custom resource (CR). This enables you to manage {PlatformNameShort} components from a single unified interface known as the platform gateway. As of version 2.5, you must create an {PlatformNameShort} CR, even if you have an existing {ControllerName},  {HubName}, or {EDAName}, components.
+After you have installed {OperatorPlatformNameShort} you must create an *{PlatformNameShort}* custom resource (CR). This enables you to manage {PlatformNameShort} components from a single unified interface known as the platform gateway. As of version 2.5, you must create an {PlatformNameShort} CR, even if you have an existing {ControllerName},  {HubName}, or {EDAName}, components.
 
 If existing components have already been deployed, you must specify these components on the {PlatformNameShort} CR. You must create the custom resource in the same namespace as the existing components.
 

--- a/downstream/modules/platform/con-operator-upgrade-considerations.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-considerations.adoc
@@ -4,7 +4,7 @@
 
 
 [role="_abstract"]
-{PlatformName} version 2.0 was the first release of the {OperatorPlatform}. If you are upgrading from version 2.0, continue to the xref:upgrading-operator_operator-upgrade[Upgrading the {OperatorPlatform}] procedure.
+{PlatformName} version 2.0 was the first release of the {OperatorPlatformNameShort}. If you are upgrading from version 2.0, continue to the xref:upgrading-operator_operator-upgrade[Upgrading the {OperatorPlatformNameShort}] procedure.
 
 If you are using a version of {OCPShort} that is not supported by the version of {PlatformName} to which you are upgrading, you must upgrade your {OCPShort} cluster to a supported version before upgrading.
 

--- a/downstream/modules/platform/con-operator-upgrade-prereq.adoc
+++ b/downstream/modules/platform/con-operator-upgrade-prereq.adoc
@@ -4,7 +4,7 @@
 
 
 [role="_abstract"]
-To upgrade to a newer version of {OperatorPlatform}, it is recommended that you do the following:
+To upgrade to a newer version of {OperatorPlatformNameShort}, it is recommended that you do the following:
 
 * Create AutomationControllerBackup and AutomationHubBackup objects. For help with this see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_operator_backup_and_recovery_guide/index#aap-backup-recommendations[Creating Red Hat Ansible Automation Platform backup resources]
 //See (Backup and Restore) for information on creating backup objects. [add link to new backup and restore doc when complete]

--- a/downstream/modules/platform/con-storage-options-for-operator-installation-on-ocp.adoc
+++ b/downstream/modules/platform/con-storage-options-for-operator-installation-on-ocp.adoc
@@ -1,11 +1,11 @@
 [id="con-storage-options-for-operator-installation-on-ocp_{context}"]
-= Storage options for {OperatorPlatform} installation on {OCP}
+= Storage options for {OperatorPlatformNameShort} installation on {OCP}
 
 {HubNameStart} requires `ReadWriteMany` file-based storage, Azure Blob storage, or Amazon S3-compliant storage for operation so that multiple pods can access shared content, such as collections.
 
 The process for configuring object storage on the `AutomationHub` CR is similar for Amazon S3 and Azure Blob Storage.
 
-If you are using file-based storage and your installation scenario includes {HubName}, ensure that the storage option for {OperatorPlatform} is set to `ReadWriteMany`.
+If you are using file-based storage and your installation scenario includes {HubName}, ensure that the storage option for {OperatorPlatformNameShort} is set to `ReadWriteMany`.
 `ReadWriteMany` is the default storage option.
 
 In addition, {ODFShort} provides a `ReadWriteMany` or S3-compliant implementation. Also, you can set up NFS storage configuration to support `ReadWriteMany`. This, however, introduces the NFS server as a potential, single point of failure.

--- a/downstream/modules/platform/proc-aap-controller-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-backup.adoc
@@ -8,13 +8,13 @@ Use this procedure to back up a deployment of the controller, including jobs, in
 .Prerequisites
 
 * You must be authenticated with an OpenShift cluster.
-* You have installed {OperatorPlatform} on the cluster.
-* You have deployed {ControllerName} using the {OperatorPlatform}.
+* You have installed {OperatorPlatformNameShort} on the cluster.
+* You have deployed {ControllerName} using the {OperatorPlatformNameShort}.
 
 .Procedure
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Automation Controller Backup* tab.
 . Click btn:[Create AutomationControllerBackup].
 . Enter a *Name* for the backup.
@@ -45,7 +45,7 @@ A backup tarball of the specified deployment is created and available for data r
 .Verification
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform}.
+. Select your {OperatorPlatformNameShort}.
 . Select the *AutomationControllerBackup* tab.
 . Select the backup resource you want to verify.
 . Scroll to *Conditions* and check that the *Successful* status is `True`.

--- a/downstream/modules/platform/proc-aap-controller-restore.adoc
+++ b/downstream/modules/platform/proc-aap-controller-restore.adoc
@@ -21,7 +21,7 @@ If the backup custom resource being restored is a backup of a currently running 
 .Procedure
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Automation Controller Restore* tab.
 . Click btn:[Create AutomationControllerRestore].
 . Enter a *Name* for the recovery deployment.
@@ -42,7 +42,7 @@ A new deployment is created and your backup is restored to it. This can take app
 .Verification
 . Log in to Red Hat {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *AutomationControllerRestore* tab.
 . Select the restore resource you want to verify.
 . Scroll to *Conditions* and check that the *Successful* status is `True`.

--- a/downstream/modules/platform/proc-aap-controller-yaml-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-yaml-backup.adoc
@@ -7,8 +7,8 @@ See the following procedure for how to back up a deployment of the {ControllerNa
 .Prerequisites
 
 * You must be authenticated with an OpenShift cluster.
-* You have installed {OperatorPlatform} on the cluster.
-* You have deployed {ControllerName} using the {OperatorPlatform}.
+* You have installed {OperatorPlatformNameShort} on the cluster.
+* You have deployed {ControllerName} using the {OperatorPlatformNameShort}.
 
 .Procedure
 

--- a/downstream/modules/platform/proc-aap-create_controller.adoc
+++ b/downstream/modules/platform/proc-aap-create_controller.adoc
@@ -9,7 +9,7 @@ Use the following steps to create an AutomationController custom resource object
 .Procedure
 . Log in to *{OCP}*.
 . Navigate to menu:Operators[Installed Operators].
-. Select the {OperatorPlatform} installed on your project namespace.
+. Select the {OperatorPlatformNameShort} installed on your project namespace.
 . Select the *Automation Controller* tab.
 . Click btn:[Create AutomationController].
 . Enter a name for the new deployment.

--- a/downstream/modules/platform/proc-aap-create_hub.adoc
+++ b/downstream/modules/platform/proc-aap-create_hub.adoc
@@ -9,7 +9,7 @@ Use the following steps to create an AutomationHub custom resource object.
 .Procedure
 . Log in to *{OCP}*.
 . Navigate to menu:Operators[Installed Operators].
-. Select the {OperatorPlatform} installed on your project namespace.
+. Select the {OperatorPlatformNameShort} installed on your project namespace.
 . Select the *Automation Hub* tab.
 . Click btn:[Create AutomationHub].
 . Enter a name for the new deployment.

--- a/downstream/modules/platform/proc-aap-hub-backup.adoc
+++ b/downstream/modules/platform/proc-aap-hub-backup.adoc
@@ -8,13 +8,13 @@ Use this procedure to back up a deployment of the hub, including all hosted Ansi
 .Prerequisites
 
 * You must be authenticated with an OpenShift cluster.
-* You have installed {OperatorPlatform} on the cluster.
-* You have deployed {HubName} using the {OperatorPlatform}.
+* You have installed {OperatorPlatformNameShort} on the cluster.
+* You have deployed {HubName} using the {OperatorPlatformNameShort}.
 
 .Procedure
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Automation Hub Backup* tab.
 . Click btn:[Create AutomationHubBackup].
 . Enter a *Name* for the backup.

--- a/downstream/modules/platform/proc-aap-hub-restore.adoc
+++ b/downstream/modules/platform/proc-aap-hub-restore.adoc
@@ -19,7 +19,7 @@ The name specified for the new AutomationHub custom resource must not match an e
 .Procedure
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Automation Hub Restore* tab.
 . Click btn:[Create AutomationHubRestore].
 . Enter a *Name* for the recovery deployment.

--- a/downstream/modules/platform/proc-aap-migration-backup.adoc
+++ b/downstream/modules/platform/proc-aap-migration-backup.adoc
@@ -5,7 +5,7 @@
 
 .Prerequisites
 
-To migrate {PlatformNameShort} deployment to {OperatorPlatform}, you must have the following:
+To migrate {PlatformNameShort} deployment to {OperatorPlatformNameShort}, you must have the following:
 
 * Secret key secret
 * Postgresql configuration

--- a/downstream/modules/platform/proc-aap-migration.adoc
+++ b/downstream/modules/platform/proc-aap-migration.adoc
@@ -4,4 +4,4 @@
 
 [role=_abstract]
 
-After you have set your secret key, postgresql credentials, verified network connectivity and installed the {OperatorPlatform}, you must create a custom resource controller object before you can migrate your data.
+After you have set your secret key, postgresql credentials, verified network connectivity and installed the {OperatorPlatformNameShort}, you must create a custom resource controller object before you can migrate your data.

--- a/downstream/modules/platform/proc-aap-platform-gateway-backup.adoc
+++ b/downstream/modules/platform/proc-aap-platform-gateway-backup.adoc
@@ -5,13 +5,13 @@ Regularly backing up your *{PlatformNameShort}* deployment is vital to protect a
 
 .Prerequisites
 * You must be authenticated on OpenShift cluster.
-* You have installed {OperatorPlatform} on the cluster.
-* You have deployed a *{PlatformNameShort}* instance using the {OperatorPlatform}.
+* You have installed {OperatorPlatformNameShort} on the cluster.
+* You have deployed a *{PlatformNameShort}* instance using the {OperatorPlatformNameShort}.
 
 .Procedure 
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Go to your *All Instances* tab, and click btn:[Create New].
 . Select *{PlatformNameShort} Backup* from the list.
 +
@@ -42,7 +42,7 @@ To verify that your backup was successful you can:
 
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Click *All Instances*.
 
 The *All Instances* page displays the main backup and the backups for each component with the name you specified when creating your backup resource. 

--- a/downstream/modules/platform/proc-aap-platform-gateway-restore.adoc
+++ b/downstream/modules/platform/proc-aap-platform-gateway-restore.adoc
@@ -3,7 +3,7 @@
 = Recovering your {PlatformNameShort} deployment
 *{PlatformNameShort}* manages any enabled components (such as, {ControllerName}, {HubName}, and {EDAName}), when you recover *{PlatformNameShort}* you also restore these components.
 
-In previous versions of the {OperatorPlatform}, it was necessary to create a restore object for each component of the platform. 
+In previous versions of the {OperatorPlatformNameShort}, it was necessary to create a restore object for each component of the platform. 
 Now, you create a single *AnsibleAutomationPlatformRestore* resource, which  creates and manages the other restore objects: 
 
 * AutomationControllerRestore
@@ -12,13 +12,13 @@ Now, you create a single *AnsibleAutomationPlatformRestore* resource, which  cre
 
 .Prerequisites
 * You must be authenticated with an OpenShift cluster.
-* You have installed the {OperatorPlatform} on the cluster.
+* You have installed the {OperatorPlatformNameShort} on the cluster.
 * The *AnsibleAutomationPlatformBackups* deployment is available in your cluster.
 
 .Procedure 
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Go to your *All Instances* tab, and click btn:[Create New].
 . Select *{PlatformNameShort} Restore* from the list.
 . For *Name* enter the name for the recovery deployment. 

--- a/downstream/modules/platform/proc-configuring-controller-image-pull-policy.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-image-pull-policy.adoc
@@ -7,7 +7,7 @@ Use this procedure to configure the image pull policy on your {ControllerName}.
 
 . Log in to {OCP}.
 . Go to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Automation Controller* tab. 
 . For new instances, click btn:[Create AutomationController].
 .. For existing instances, you can edit the YAML view by clicking the  {MoreActionsIcon} icon and then btn:[Edit AutomationController].

--- a/downstream/modules/platform/proc-configuring-controller-route-options.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-route-options.adoc
@@ -7,7 +7,7 @@ The {PlatformName} operator installation form allows you to further configure yo
 .Procedure
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Automation Controller* tab. 
 . For new instances, click btn:[Create AutomationController].
 .. For existing instances, you can edit the YAML view by clicking the {MoreActionsIcon} icon and then btn:[Edit AutomationController].

--- a/downstream/modules/platform/proc-controller-ingress-options.adoc
+++ b/downstream/modules/platform/proc-controller-ingress-options.adoc
@@ -2,13 +2,13 @@
 
 = Configuring the ingress type for your {ControllerName} operator
 
-The {OperatorPlatform} installation form allows you to further configure your {ControllerName} operator ingress under *Advanced configuration*.
+The {OperatorPlatformNameShort} installation form allows you to further configure your {ControllerName} operator ingress under *Advanced configuration*.
 
 .Procedure
 
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Automation Controller* tab. 
 . For new instances, click btn:[Create AutomationController].
 .. For existing instances, you can edit the YAML view by clicking the {MoreActionsIcon} icon and then btn:[Edit AutomationController].

--- a/downstream/modules/platform/proc-create-secret-key-secret.adoc
+++ b/downstream/modules/platform/proc-create-secret-key-secret.adoc
@@ -4,7 +4,7 @@
 
 [role=_abstract]
 
-To migrate your data to {OperatorPlatform} on {OCPShort}, you must create a secret key that matches the secret key defined in the inventory file during your initial installation. Otherwise, the migrated data will remain encrypted and unusable after migration.
+To migrate your data to {OperatorPlatformNameShort} on {OCPShort}, you must create a secret key that matches the secret key defined in the inventory file during your initial installation. Otherwise, the migrated data will remain encrypted and unusable after migration.
 
 .Procedure
 

--- a/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
+++ b/downstream/modules/platform/proc-deploy-eda-controller-with-aap-operator-ocp.adoc
@@ -5,7 +5,7 @@
 
 .Prerequisites
 
-* You have installed {OperatorPlatform} on {OCPShort}.
+* You have installed {OperatorPlatformNameShort} on {OCPShort}.
 * You have installed and configured {ControllerName}.
 
 .Procedure

--- a/downstream/modules/platform/proc-hub-ingress-options.adoc
+++ b/downstream/modules/platform/proc-hub-ingress-options.adoc
@@ -2,13 +2,13 @@
 
 = Configuring the ingress type for your {HubName} operator
 
-The {OperatorPlatform} installation form allows you to further configure your {HubName} operator ingress under *Advanced configuration*.
+The {OperatorPlatformNameShort} installation form allows you to further configure your {HubName} operator ingress under *Advanced configuration*.
 
 .Procedure
 
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Automation Hub* tab. 
 . For new instances, click btn:[Create AutomationHub].
 .. For existing instances, you can edit the YAML view by clicking the {MoreActionsIcon} icon and then btn:[Edit AutomationHub].

--- a/downstream/modules/platform/proc-hub-route-options.adoc
+++ b/downstream/modules/platform/proc-hub-route-options.adoc
@@ -8,7 +8,7 @@ The {PlatformName} operator installation form allows you to further configure yo
 
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Automation Hub* tab. 
 . For new instances, click btn:[Create AutomationHub].
 .. For existing instances, you can edit the YAML view by clicking the {MoreActionsIcon} icon and then btn:[Edit AutomationHub].

--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -11,12 +11,12 @@
 . Select *Installation Mode*, *Installed Namespace*, and *Approval Strategy*.
 . Click btn:[Install].
 
-The installation process begins. When installation finishes, a modal appears notifying you that the {OperatorPlatform} is installed in the specified namespace.
+The installation process begins. When installation finishes, a modal appears notifying you that the {OperatorPlatformNameShort} is installed in the specified namespace.
 
-* Click btn:[View Operator] to view your newly installed {OperatorPlatform}.
+* Click btn:[View Operator] to view your newly installed {OperatorPlatformNameShort}.
 
 [IMPORTANT]
 ====
-You can only install a single instance of the {OperatorPlatform} into a single namespace. 
+You can only install a single instance of the {OperatorPlatformNameShort} into a single namespace. 
 Installing multiple instances in the same namespace can lead to improper operation for both operator instances. 
 ====

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -10,7 +10,7 @@ Use this procedure to subscribe a namespace to an operator.
 
 [IMPORTANT]
 ====
-You can only subscribe a single instance of the {OperatorPlatform} into a single namespace. 
+You can only subscribe a single instance of the {OperatorPlatformNameShort} into a single namespace. 
 Subscribing multiple instances in the same namespace can lead to improper operation for both operator instances. 
 ====
 

--- a/downstream/modules/platform/proc-installing-hub-using-operator.adoc
+++ b/downstream/modules/platform/proc-installing-hub-using-operator.adoc
@@ -1,14 +1,14 @@
 [id="proc-installing-hub-using-operator_{context}"]
 
-= Installing {HubName} using the {OperatorPlatform}
+= Installing {HubName} using the {OperatorPlatformNameShort}
 
-Use the following procedure to install {HubName} using the {OperatorPlatform}.
+Use the following procedure to install {HubName} using the {OperatorPlatformNameShort}.
 
 .Procedure
 
 . Log in to {OCP}.
 . Navigate to menu:Operator[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the {HubNameStart} tab.
 . Click btn:[Create {HubNameStart}].
 . Select btn:[YAML view].

--- a/downstream/modules/platform/proc-installing-the-ansible-platform-operator.adoc
+++ b/downstream/modules/platform/proc-installing-the-ansible-platform-operator.adoc
@@ -6,8 +6,8 @@
 
 . Log in to {OCP}.
 . Navigate to menu:Operator[Operator Hub]. 
-. Search for the {OperatorPlatform}.
-. Select the {OperatorPlatform} project.
+. Search for the {OperatorPlatformNameShort}.
+. Select the {OperatorPlatformNameShort} project.
 . Click on the Operator tile.
 . Click btn:[Install].
 . Select a Project to install the Operator into.

--- a/downstream/modules/platform/proc-operator-deploy-central-config.adoc
+++ b/downstream/modules/platform/proc-operator-deploy-central-config.adoc
@@ -8,7 +8,7 @@ The following procedure simulates a scenario where you have {ControllerName} as 
 .Procedure 
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Click btn:[Subscriptions] and edit your *Update channel* to *stable-2.5*.
 . Click btn:[Details] and on the *{PlatformNameShort}* tile click btn:[Create instance].
 . From the *Create {PlatformNameShort}* page enter a name for your instance in the *Name* field.

--- a/downstream/modules/platform/proc-operator-deploy-redis.adoc
+++ b/downstream/modules/platform/proc-operator-deploy-redis.adoc
@@ -1,18 +1,18 @@
-= Deploying clustered Redis on {OperatorPlatform}
+= Deploying clustered Redis on {OperatorPlatformName}
 
-When you create an {PlatformNameShort} instance through the {OperatorPlatform}, standalone Redis is assigned by default. 
+When you create an {PlatformNameShort} instance through the {OperatorPlatformNameShort}, standalone Redis is assigned by default. 
 To deploy clustered Redis, use the following procedure.
 
 //Add a link to the section when ready
 For more information about Redis, refer to Caching and queueing system in the _Planning your installation_ guide.
 
 .Prerequisites
-* You have installed an {OperatorPlatform} deployment.
+* You have installed an {OperatorPlatformNameShort} deployment.
 
 .Procedure
 . Log in to {OCP}. 
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Details* tab. 
 . On the *{PlatformNameShort}* tile click btn:[Create instance].
 .. For existing instances, you can edit the YAML view by clicking the {MoreActionsIcon} icon and then btn:[Edit AnsibleAutomationPlatform].

--- a/downstream/modules/platform/proc-operator-external-db-controller.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-controller.adoc
@@ -1,12 +1,12 @@
 
 [id="proc-operator-external-db-controller"]
 
-= Configuring an external database for {ControllerName} on {PlatformName} operator
+= Configuring an external database for {ControllerName} on {OperatorPlatformName}
 
 [role="_abstract"]
 For users who prefer to deploy {PlatformNameShort} with an external database, they can do so by configuring a secret with instance credentials and connection information, then applying it to their cluster using the `oc create` command.
 
-By default, the {OperatorPlatform} automatically creates and configures a managed PostgreSQL pod in the same namespace as your {PlatformNameShort} deployment. You can deploy {PlatformNameShort} with an external database instead of the managed PostgreSQL pod that the {OperatorPlatform} automatically creates.
+By default, the {OperatorPlatformNameShort} automatically creates and configures a managed PostgreSQL pod in the same namespace as your {PlatformNameShort} deployment. You can deploy {PlatformNameShort} with an external database instead of the managed PostgreSQL pod that the {OperatorPlatformNameShort} automatically creates.
 
 Using an external database lets you share and reuse resources and manually manage backups, upgrades, and performance optimizations.
 
@@ -15,7 +15,7 @@ Using an external database lets you share and reuse resources and manually manag
 The same external database (PostgreSQL instance) can be used for both {HubName} and {ControllerName} as long as the database names are different. In other words, you can have multiple databases with different names inside a single PostgreSQL instance.
 ====
 
-The following section outlines the steps to configure an external database for your {ControllerName} on a {OperatorPlatform}.
+The following section outlines the steps to configure an external database for your {ControllerName} on a {OperatorPlatformNameShort}.
 
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.

--- a/downstream/modules/platform/proc-operator-external-db-hub.adoc
+++ b/downstream/modules/platform/proc-operator-external-db-hub.adoc
@@ -1,12 +1,12 @@
 
 [id="proc-operator-external-db-hub"]
 
-= Configuring an external database for {HubName} on {OperatorPlatform}
+= Configuring an external database for {HubName} on {OperatorPlatformName}
 
 [role="_abstract"]
 For users who prefer to deploy {PlatformNameShort} with an external database, they can do so by configuring a secret with instance credentials and connection information, then applying it to their cluster using the `oc create` command.
 
-By default, the {OperatorPlatform} automatically creates and configures a managed PostgreSQL pod in the same namespace as your {PlatformNameShort} deployment.
+By default, the {OperatorPlatformNameShort} automatically creates and configures a managed PostgreSQL pod in the same namespace as your {PlatformNameShort} deployment.
 
 You can choose to use an external database instead if you prefer to use a dedicated node to ensure dedicated resources or to manually manage backups, upgrades, or performance tweaks.
 
@@ -15,7 +15,7 @@ You can choose to use an external database instead if you prefer to use a dedica
 The same external database (PostgreSQL instance) can be used for both {HubName} and {ControllerName} as long as the database names are different. In other words, you can have multiple databases with different names inside a single PostgreSQL instance.
 ====
 
-The following section outlines the steps to configure an external database for your {HubName} on a {OperatorPlatform}.
+The following section outlines the steps to configure an external database for your {HubName} on a {OperatorPlatformNameShort}.
 
 .Prerequisite
 The external database must be a PostgreSQL database that is the version supported by the current release of {PlatformNameShort}.

--- a/downstream/modules/platform/proc-operator-link-components.adoc
+++ b/downstream/modules/platform/proc-operator-link-components.adoc
@@ -2,14 +2,14 @@
 
 = Linking your components to the platform gateway  
 
-After installing the {OperatorPlatform} in your namespace you can set up your *{PlatformNameShort}* instance.
+After installing the {OperatorPlatformNameShort} in your namespace you can set up your *{PlatformNameShort}* instance.
 Then link all the platform components to a single user interface. 
 
 .Procedure 
 
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
-. Select your {OperatorPlatform} deployment.
+. Select your {OperatorPlatformNameShort} deployment.
 . Select the *Details* tab. 
 
 . On the *{PlatformNameShort}* tile click btn:[Create instance].
@@ -34,7 +34,7 @@ spec:
 . Click btn:[Create].
 
 .Verification
-Go to your {OperatorPlatform} deployment and click btn:[All instances] to verify if all instances deployed correctly.
+Go to your {OperatorPlatformNameShort} deployment and click btn:[All instances] to verify if all instances deployed correctly.
 You should see the *{PlatformNameShort}* instance and the deployed *AutomationController*, *EDA*, and *AutomationHub* instances here.
 
 Alternatively you can check by the command line, run: `oc get route` 

--- a/downstream/modules/platform/proc-operator-upgrade.adoc
+++ b/downstream/modules/platform/proc-operator-upgrade.adoc
@@ -1,11 +1,11 @@
 [id="upgrading-operator_{context}"]
 
-= Upgrading the {OperatorPlatform}
+= Upgrading the {OperatorPlatformNameShort}
 
 
 [role=_abstract]
 
-To upgrade to the latest version of {OperatorPlatform} on {OCPShort}, do the following:
+To upgrade to the latest version of {OperatorPlatformNameShort} on {OCPShort}, do the following:
 
 .Prodedure
 . Log in to {OCPShort}.

--- a/downstream/modules/platform/proc-provision-ocp-storage-with-readwritemany.adoc
+++ b/downstream/modules/platform/proc-provision-ocp-storage-with-readwritemany.adoc
@@ -3,7 +3,7 @@
 
 = Provisioning OCP storage with `ReadWriteMany` access mode
 
-To ensure successful installation of {OperatorPlatform}, you must provision your storage type for {HubName} initially to `ReadWriteMany` access mode.
+To ensure successful installation of {OperatorPlatformNameShort}, you must provision your storage type for {HubName} initially to `ReadWriteMany` access mode.
 
 .Procedure
 

--- a/downstream/modules/platform/proc-update-aap-on-ocp.adoc
+++ b/downstream/modules/platform/proc-update-aap-on-ocp.adoc
@@ -9,7 +9,7 @@ When you perform a patch update for an installation of {PlatformNameShort} on {O
 +
 [NOTE]
 ====
-It is recommended that you set a manual install strategy on your {OperatorPlatform} subscription (set when installing or upgrading the Operator) and you will be prompted to approve an upgrade when it becomes available in your selected update channel. Stable channels for each X.Y release (for example, stable-2.5) are available.
+It is recommended that you set a manual install strategy on your {OperatorPlatformNameShort} subscription (set when installing or upgrading the Operator) and you will be prompted to approve an upgrade when it becomes available in your selected update channel. Stable channels for each X.Y release (for example, stable-2.5) are available.
 ====
 +
 . A new Subscription, CSV, and Operator containers will be created alongside the old Subscription, CSV, and containers. Then the old resources will be cleaned up if the new install was successful.

--- a/downstream/modules/platform/ref-operator-ocp-version.adoc
+++ b/downstream/modules/platform/ref-operator-ocp-version.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 
-The {OperatorPlatform} to install {PlatformNameShort} {PlatformVers} is available on {OCPShort} 4.9 and later versions.
+The {OperatorPlatformNameShort} to install {PlatformNameShort} {PlatformVers} is available on {OCPShort} 4.9 and later versions.
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -13,7 +13,7 @@ include::attributes/attributes.adoc[]
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
-This guide helps you to understand the installation, migration and upgrade requirements for deploying the {OperatorPlatform} on {OCPShort}.
+This guide helps you to understand the installation, migration and upgrade requirements for deploying the {OperatorPlatformNameShort} on {OCPShort}.
 
 include::{Boilerplate}[]
 

--- a/downstream/titles/release-notes/topics/aap-25-fixed-issues.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-fixed-issues.adoc
@@ -77,6 +77,6 @@ This section provides information about fixed issues in {PlatformNameShort} 2.5.
 
 * Instead of the target service only, all {EDAName} services are enabled after installation is completed. The {EDAName} services will always start after the setup is complete. (AAP-15889)
 
-== {OperatorPlatform}
+== {OperatorPlatformNameShort}
 
 * Fixed Django REST Framework (DRF) browsable views. (AAP-25508)


### PR DESCRIPTION
[AAP-32778](https://issues.redhat.com/browse/AAP-32778)

- Some chapter titles use the full "Red Hat Ansible Automation Platform Operator" title while others use "Ansible Automation Platform Operator". We need to update this for a consistent approach throughout. 
- The main title "Installing on Openshift Container Platform" uses an incorrect lower case 's'.
- The title attribute for operator "{OperatorPlatform}" is inconsistent with the naming convention used in other product attributes, e.g {PlatformName} and {PlatformNameShort}
- Need to change {OperatorPlatform} to {OperatorPlatformShort}, and create a {OperatorPlatformName} attribute.