### PR TITLE
This commit fixes links for the errata advsories in patch release 2.5…

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25-2-patch-release-7-oct-2024.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-2-patch-release-7-oct-2024.adoc
@@ -14,7 +14,7 @@ This release includes a few enhancements and fixes that have been implemented in
 
 == Fixed issues
 
-== {PlatformNameShort}
+=== {PlatformNameShort}
 
 * Fixed conditional that was skipping necessary tasks in the restore role, which was causing restores to not finish reconciling. (AAP-30437)
 
@@ -27,7 +27,7 @@ This release includes a few enhancements and fixes that have been implemented in
 * Filtered out the unused *ANSIBLE_BASE_* settings from the environment variable in job execution. (AAP-32208)
 
 
-== {EDAName}
+=== {EDAName}
 
 * Configured the setting *EVENT_STREAM_MTLS_BASE_URL* to the correct default to ensure MTLS is disallowed in the RPM installer. (AAP-32027)
 
@@ -47,13 +47,13 @@ This section lists the various errata advisories contained in this release.
 | {PlatformNameShort} 2.5-2 - October 7, 2024
 
 |
-link:https://errata.engineering.redhat.com/advisory/139519[RHBA-2024:139519-03 RPM]
+link:https://access.redhat.com/errata/RHBA-2024:7756[RHBA-2024:139519-03 RPM]
 
-link:https://errata.engineering.redhat.com/advisory/139531[RHBA-2024:139531-04 Container (namespace-scoped)]
+link:https://access.redhat.com/errata/RHBA-2024:7760[RHBA-2024:139531-04 Container (namespace)]
 
-link:https://errata.engineering.redhat.com/advisory/139532[RHBA-2024:139532-04 Container (cluster-scoped)]
+link:https://access.redhat.com/errata/RHBA-2024:7766[RHBA-2024:139532-04 Container (cluster)]
 
-link:https://errata.engineering.redhat.com/advisory/xxxx[RHBA-2024:139623-01 Bundle Installer (VM and Containerized)]
+link:https://access.redhat.com/errata/RHBA-2024:7810[RHBA-2024:139623-01 Bundle Installer (VM and Containerized)]
 
 |===
 


### PR DESCRIPTION
…-2. (#2305)

RPM
Container (namespace)
Container (cluster)
Bundle Installer