### PR TITLE
Removed extraneous internal numeration from the errata. (#2318)

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25-2-patch-release-7-oct-2024.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-2-patch-release-7-oct-2024.adoc
@@ -47,13 +47,13 @@ This section lists the various errata advisories contained in this release.
 | {PlatformNameShort} 2.5-2 - October 7, 2024
 
 |
-link:https://access.redhat.com/errata/RHBA-2024:7756[RHBA-2024:139519-03 RPM]
 
-link:https://access.redhat.com/errata/RHBA-2024:7760[RHBA-2024:139531-04 Container (namespace)]
+link:https://access.redhat.com/errata/RHBA-2024:7756[RHBA-2024:7756]
 
-link:https://access.redhat.com/errata/RHBA-2024:7766[RHBA-2024:139532-04 Container (cluster)]
+link:https://access.redhat.com/errata/RHBA-2024:7760[>RHBA-2024:7760]
 
-link:https://access.redhat.com/errata/RHBA-2024:7810[RHBA-2024:139623-01 Bundle Installer (VM and Containerized)]
+link:https://access.redhat.com/errata/RHBA-2024:7766[RHBA-2024:7766]
+
+link:https://access.redhat.com/errata/RHBA-2024:7810[RHBA-2024:7810]
 
 |===
-


### PR DESCRIPTION
* Removed extraneous internal numeration from the errata.

Fixes an issue raised by Satoe.

* Update aap-25-2-patch-release-7-oct-2024.adoc

* Update aap-25-2-patch-release-7-oct-2024.adoc