### PR TITLE
Event 2 migration content updates

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -10,10 +10,16 @@ ifdef::context[:parent-context: {context}]
 
 Migrating your {PlatformName} deployment to the {OperatorPlatformNameShort} allows you to take advantage of the benefits provided by a Kubernetes native operator, including simplified upgrades and full lifecycle support for your {PlatformName} deployments.
 
+[NOTE]
+====
+Upgrades of {EDAName} version 2.4 to 2.5 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.5 are not compatible.
+====
+
 Use these procedures to migrate any of the following deployments to the {OperatorPlatformNameShort}:
 
-* A VM-based installation of Ansible Tower 3.8.6, {ControllerName}, or {HubName}
-* An Openshift instance of Ansible Tower 3.8.6 ({PlatformNameShort} 1.2)
+* OpenShift cluster A to OpenShift cluster B
+* OpenShift namespace A to OpenShift namespace B
+* Virtual machine (VM) based or containerized VM {PlatformNameShort} 2.5 → {PlatformNameShort} 2.5
 
 include::platform/con-aap-migration-considerations.adoc[leveloffset=+1]
 include::platform/con-aap-migration-prepare.adoc[leveloffset=+1]
@@ -24,6 +30,7 @@ include::platform/proc-verify-network-connectivity.adoc[leveloffset=+2]
 include::platform/proc-aap-migration.adoc[leveloffset=+1]
 include::platform/proc-aap-create_controller.adoc[leveloffset=+2]
 include::platform/proc-aap-create_hub.adoc[leveloffset=+2]
+include::platform/proc-aap-create_eda.adoc[leveloffset=+2]
 include::platform/proc-post-migration-cleanup.adoc[leveloffset=+1]
 
 

--- a/downstream/modules/platform/con-aap-migration-considerations.adoc
+++ b/downstream/modules/platform/con-aap-migration-considerations.adoc
@@ -4,4 +4,6 @@
 
 
 [role="_abstract"]
-If you are upgrading from {PlatformNameShort} 1.2 on {OCPShort} 3 to {PlatformNameShort} 2.x on {OCPShort} 4, you must provision a fresh {OCPShort} version 4 cluster and then migrate the {PlatformNameShort} to the new cluster. 
+If you are upgrading from any version of {PlatformNameShort} older than 2.4, you must upgrade through {PlatformNameShort} first.
+If you are on {OCPShort} 3 and you want to upgrade to {OCPShort} 4, you must provision a fresh {OCPShort} version 4 cluster and then migrate the {PlatformNameShort} to the new cluster.
+

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 
-Before migrating your current {PlatformNameShort} deployment to {OperatorPlatformNameShort}, must back up your existing data, and create Kubernetes secrets for your secret key and postgresql configuration.
+Before migrating your current {PlatformNameShort} deployment to {OperatorPlatformNameShort}, you must back up your existing data, and create Kubernetes secrets for your secret key and postgresql configuration.
 
 [NOTE]
 ====

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 
-Before migrating your current {PlatformNameShort} deployment to {OperatorPlatformNameShort}, must to back up your existing data, create Kubernetes secrets for your secret key and postgresql configuration.
+Before migrating your current {PlatformNameShort} deployment to {OperatorPlatformNameShort}, must back up your existing data, and create Kubernetes secrets for your secret key and postgresql configuration.
 
 [NOTE]
 ====

--- a/downstream/modules/platform/con-aap-migration-prepare.adoc
+++ b/downstream/modules/platform/con-aap-migration-prepare.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 
-Before migrating your current {PlatformNameShort} deployment to {OperatorPlatformNameShort}, you need to back up your existing data, create k8s secrets for your secret key and postgresql configuration.
+Before migrating your current {PlatformNameShort} deployment to {OperatorPlatformNameShort}, must to back up your existing data, create Kubernetes secrets for your secret key and postgresql configuration.
 
 [NOTE]
 ====

--- a/downstream/modules/platform/proc-aap-create_controller.adoc
+++ b/downstream/modules/platform/proc-aap-create_controller.adoc
@@ -12,8 +12,8 @@ Use the following steps to create an *AutomationController* custom resource obje
 . Select the {OperatorPlatformNameShort} installed on your project namespace.
 . Select the *Automation Controller* tab.
 . Click btn:[Create AutomationController]. You can create the object through the *Form view* or *YAML view*. The following inputs are available through the *Form view*.
-. Enter a name for the new deployment.
-. In *Advanced configurations*:
-.. From the *Admin Password Secret* list, select your xref:create-secret-key-secret_aap-migration[secret key secret].
-.. From the *Database Configuration Secret* list, select the xref:create-postresql-secret_aap-migration[postgres configuration secret].
-. Click btn:[Create].
+.. Enter a name for the new deployment.
+.. In *Advanced configurations*:
+... From the *Admin Password Secret* list, select your xref:create-secret-key-secret_aap-migration[secret key secret].
+... From the *Database Configuration Secret* list, select the xref:create-postresql-secret_aap-migration[postgres configuration secret].
+.. Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-create_eda.adoc
+++ b/downstream/modules/platform/proc-aap-create_eda.adoc
@@ -1,17 +1,17 @@
-[id="aap-create_controller"]
+[id="aap-create_eda"]
 
-= Creating an AutomationController object
+= Creating an EDA object
 
 [role=_abstract]
 
-Use the following steps to create an *AutomationController* custom resource object.
+Use the following steps to create an *EDA* custom resource object.
 
 .Procedure
 . Log in to *{OCP}*.
 . Navigate to menu:Operators[Installed Operators].
 . Select the {OperatorPlatformNameShort} installed on your project namespace.
-. Select the *Automation Controller* tab.
-. Click btn:[Create AutomationController]. You can create the object through the *Form view* or *YAML view*. The following inputs are available through the *Form view*.
+. Select the *Automation Hub* tab.
+. Click btn:[Create AutomationHub]. You can create the object through the *Form view* or *YAML view*. The following inputs are available through the *Form view*.
 . Enter a name for the new deployment.
 . In *Advanced configurations*:
 .. From the *Admin Password Secret* list, select your xref:create-secret-key-secret_aap-migration[secret key secret].

--- a/downstream/modules/platform/proc-aap-create_eda.adoc
+++ b/downstream/modules/platform/proc-aap-create_eda.adoc
@@ -12,8 +12,8 @@ Use the following steps to create an *EDA* custom resource object.
 . Select the {OperatorPlatformNameShort} installed on your project namespace.
 . Select the *Automation Hub* tab.
 . Click btn:[Create AutomationHub]. You can create the object through the *Form view* or *YAML view*. The following inputs are available through the *Form view*.
-. Enter a name for the new deployment.
-. In *Advanced configurations*:
-.. From the *Admin Password Secret* list, select your xref:create-secret-key-secret_aap-migration[secret key secret].
-.. From the *Database Configuration Secret* list, select the xref:create-postresql-secret_aap-migration[postgres configuration secret].
-. Click btn:[Create].
+.. Enter a name for the new deployment.
+.. In *Advanced configurations*:
+... From the *Admin Password Secret* list, select your xref:create-secret-key-secret_aap-migration[secret key secret].
+... From the *Database Configuration Secret* list, select the xref:create-postresql-secret_aap-migration[postgres configuration secret].
+.. Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-create_hub.adoc
+++ b/downstream/modules/platform/proc-aap-create_hub.adoc
@@ -11,9 +11,10 @@ Use the following steps to create an *AutomationHub* custom resource object.
 . Navigate to menu:Operators[Installed Operators].
 . Select the {OperatorPlatformNameShort} installed on your project namespace.
 . Select the *Automation Hub* tab.
-. Click btn:[Create AutomationHub]. You can create the object through the *Form view* or *YAML view*. The following inputs are available through the *Form view*.
-. Enter a name for the new deployment.
-. In *Advanced configurations*:
-.. From the *Admin Password Secret* list, select your xref:create-secret-key-secret_aap-migration[secret key secret].
-.. From the *Database Configuration Secret* list, select the xref:create-postresql-secret_aap-migration[postgres configuration secret].
-. Click btn:[Create].
+. Click btn:[Create AutomationHub]. You can create the object through the *Form view* or *YAML view*.
+The following inputs are available through the *Form view*.
+.. Enter a name for the new deployment.
+.. In *Advanced configurations*:
+... From the *Admin Password Secret* list, select your xref:create-secret-key-secret_aap-migration[secret key secret].
+... From the *Database Configuration Secret* list, select the xref:create-postresql-secret_aap-migration[postgres configuration secret].
+.. Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-create_hub.adoc
+++ b/downstream/modules/platform/proc-aap-create_hub.adoc
@@ -4,14 +4,16 @@
 
 [role=_abstract]
 
-Use the following steps to create an AutomationHub custom resource object.
+Use the following steps to create an *AutomationHub* custom resource object.
 
 .Procedure
 . Log in to *{OCP}*.
 . Navigate to menu:Operators[Installed Operators].
 . Select the {OperatorPlatformNameShort} installed on your project namespace.
 . Select the *Automation Hub* tab.
-. Click btn:[Create AutomationHub].
+. Click btn:[Create AutomationHub]. You can create the object through the *Form view* or *YAML view*. The following inputs are available through the *Form view*.
 . Enter a name for the new deployment.
-. In *Advanced configurations*, select your xref:create-secret-key-secret_aap-migration[secret key secret] and xref:create-postresql-secret_aap-migration[postgres configuration secret].
+. In *Advanced configurations*:
+.. From the *Admin Password Secret* list, select your xref:create-secret-key-secret_aap-migration[secret key secret].
+.. From the *Database Configuration Secret* list, select the xref:create-postresql-secret_aap-migration[postgres configuration secret].
 . Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-migration-backup.adoc
+++ b/downstream/modules/platform/proc-aap-migration-backup.adoc
@@ -1,7 +1,7 @@
 [id="aap-migration-backup"]
 [role="_abstract"]
 
-= Migrating to Ansible Automation Platform Operator
+= Migrating to {OperatorPlatformNameShort}
 
 .Prerequisites
 
@@ -18,21 +18,9 @@ You can store the secret key information in the inventory file before the initia
 If you are unable to remember your secret key or have trouble locating your inventory file, contact link:https://access.redhat.com/[Ansible support] through the Red Hat Customer portal.
 ====
 
-Before migrating your data from {PlatformNameShort} 2.x or earlier, you must back up your data for loss prevention. To backup your data, do the following:
+Before migrating your data from {PlatformNameShort} 2.4, you must back up your data for loss prevention.
 
 .Procedure
+
 . Log in to your current deployment project.
-. Run `setup.sh` to create a backup of your current data or deployment:
-+
-For on-prem deployments of version 2.x or earlier:
-+
------
-$ ./setup.sh -b
------
-+
-For OpenShift deployments before version 2.0 (non-operator deployments):
-+
------
-./setup_openshift.sh -b
------
-//reminder - add a cross reference statement to new Backup and Restore doc once published. "For Openshift Operator installations for version 2.0 and later, refer to"
+. Run `$ ./setup.sh -b` to create a backup of your current data or deployment.

--- a/downstream/modules/platform/proc-aap-migration.adoc
+++ b/downstream/modules/platform/proc-aap-migration.adoc
@@ -4,4 +4,4 @@
 
 [role=_abstract]
 
-After you have set your secret key, postgresql credentials, verified network connectivity and installed the {OperatorPlatformNameShort}, you must create a custom resource controller object before you can migrate your data.
+After you have set your secret key, postgresql credentials, verified network connectivity, and installed the {OperatorPlatformNameShort}, you must create a custom resource controller object before you can migrate your data.

--- a/downstream/modules/platform/proc-create-postresql-secret.adoc
+++ b/downstream/modules/platform/proc-create-postresql-secret.adoc
@@ -8,7 +8,7 @@ For migration to be successful, you must provide access to the database for your
 
 .Procedure
 
-. Create a yaml file for your postgresql configuration secret:
+. Create a YAML file for your postgresql configuration secret:
 +
 -----
 apiVersion: v1

--- a/downstream/modules/platform/proc-create-secret-key-secret.adoc
+++ b/downstream/modules/platform/proc-create-secret-key-secret.adoc
@@ -4,23 +4,31 @@
 
 [role=_abstract]
 
-To migrate your data to {OperatorPlatformNameShort} on {OCPShort}, you must create a secret key that matches the secret key defined in the inventory file during your initial installation. Otherwise, the migrated data will remain encrypted and unusable after migration.
+To migrate your data to {OperatorPlatformNameShort} on {OCPShort}, you must create a secret key that matches the secret key defined in the inventory file during your initial installation.
+Otherwise, the migrated data remains encrypted and unusable after migration.
 
 .Procedure
 
 . Locate the old secret key in the inventory file you used to deploy {PlatformNameShort} in your previous installation.
-. Create a yaml file for your secret key:
+. Create a YAML file for your secret key:
 +
 -----
 apiVersion: v1
 kind: Secret
 metadata:
-  name: <resourcename>-secret-key
+  name: <resourcename>-admin-password
   namespace: <target-namespace>
 stringData:
-  secret_key: <old-secret-key>
+  password: mysuperlongpassword
 type: Opaque
 -----
++
+[NOTE]
+====
+If `admin_password_secret` is not provided, the operator looks for a secret named `<resourcename>-admin-password` for the admin password.
+If it is not present, the operator generates a password and create a secret from it named `<resourcename>-admin-password`.
+====
++
 . Apply the secret key yaml to the cluster:
 +
 -----

--- a/downstream/modules/platform/proc-post-migration-cleanup.adoc
+++ b/downstream/modules/platform/proc-post-migration-cleanup.adoc
@@ -11,7 +11,9 @@ After your data migration is complete, you must delete any Instance Groups that 
 +
 [NOTE]
 ====
-Note: If you did not create an administrator password during migration, one was automatically created for you. To locate this password, go to your project, select menu:Workloads[Secrets] and open controller-admin-password. From there you can copy the password and paste it into the {PlatformName} password field.
+If you did not create an administrator password during migration, one was automatically created for you.
+To locate this password, go to your project, select menu:Workloads[Secrets] and open controller-admin-password.
+From there you can copy the password and paste it into the {PlatformName} password field.
 ====
 +
 . Select {MenuInfrastructureInstanceGroups}.

--- a/downstream/modules/platform/proc-verify-network-connectivity.adoc
+++ b/downstream/modules/platform/proc-verify-network-connectivity.adoc
@@ -11,7 +11,7 @@ Take note of the host and port information from your existing deployment. This i
 
 .Procedure
 
-. Create a yaml file to verify the connection between your new deployment and your old deployment database:
+. Create a YAML file to verify the connection between your new deployment and your old deployment database:
 +
 -----
 apiVersion: v1

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -40,12 +40,12 @@ include::platform/platform/proc-operator-deploy-redis.adoc[leveloffset=+1]
 
 include::platform/assembly-using-rhsso-operator-with-automation-hub.adoc[leveloffset=+1]
 
-// [gmurray] Commenting out this module as  migration is not supported for  2.5 EA. 
-// include::platform/assembly-aap-migration.adoc[leveloffset=+1]
-
+include::platform/assembly-aap-migration.adoc[leveloffset=+1]
 
 include::platform/assembly-operator-upgrade.adoc[leveloffset=+1]
 
 include::platform/assembly-operator-add-execution-nodes.adoc[leveloffset=+1]
+
 include::platform/assembly-controller-resource-operator.adoc[leveloffset=+1]
+
 include::platform/assembly-appendix-operator-crs.adoc[leveloffset=+1]


### PR DESCRIPTION
[AAP-33159](https://issues.redhat.com/browse/AAP-33159)

Updating the migration section of the [Installing on OCP doc](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/installing_on_openshift_container_platform/index) for 2.5 Event 2.