### PR TITLE
Elaborated on deployment name for backing up to clarify expected format.

### DIFF
--- a/downstream/modules/platform/proc-aap-controller-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-backup.adoc
@@ -18,7 +18,7 @@ Use this procedure to back up a deployment of the controller, including jobs, in
 . Select the *Automation Controller Backup* tab.
 . Click btn:[Create AutomationControllerBackup].
 . Enter a *Name* for the backup.
-. Enter the *Deployment name* of the deployed {PlatformNameShort} instance being backed up. The deployment name displays in the following format, `<deployment_name>-[web|task]`. For example, if your {ControllerName} must be backed up and the deployment name is 'automationcontroller-2b5a30e4-web` or `automationcontroller-2b5a30e4-task', enter `automationcontroller` in the *Deployment name* field to filter the list down to applicable deployments.
+. In the *Deployment name* field, enter the name of the AutomationController custom resource object of the deployed {PlatformNameShort} instance being backed up. This name was created when you xref:aap-create_controller[created your AutomationController object].
 . If you want to use a custom, pre-created pvc:
 .. [Optional]: enter the name of the *Backup persistent volume claim*.
 .. [Optional]: enter the *Backup PVC storage requirements*, and *Backup PVC storage class*.

--- a/downstream/modules/platform/proc-aap-controller-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-backup.adoc
@@ -18,8 +18,7 @@ Use this procedure to back up a deployment of the controller, including jobs, in
 . Select the *Automation Controller Backup* tab.
 . Click btn:[Create AutomationControllerBackup].
 . Enter a *Name* for the backup.
-. Enter the *Deployment name* of the deployed {PlatformNameShort} instance being backed up.
-For example, if your {ControllerName} must be backed up and the deployment name is `aap-controller`, enter 'aap-controller' in the *Deployment name* field.
+. Enter the *Deployment name* of the deployed {PlatformNameShort} instance being backed up. The deployment name displays in the following format, `<deployment_name>-[web|task]`. For example, if your {ControllerName} must be backed up and the deployment name is 'automationcontroller-2b5a30e4-web` or `automationcontroller-2b5a30e4-task', enter `automationcontroller` in the *Deployment name* field to filter the list down to applicable deployments.
 . If you want to use a custom, pre-created pvc:
 .. [Optional]: enter the name of the *Backup persistent volume claim*.
 .. [Optional]: enter the *Backup PVC storage requirements*, and *Backup PVC storage class*.


### PR DESCRIPTION
Addresses [AAP-32993](https://issues.redhat.com/browse/AAP-32993) by clarifying the format of the deployment name. I am unable to add Chris Meyers (chrismeyersfsu) as a reviewer but he needs to sign off in this.

The output will read as follows:

> In the **Deployment name** field, enter the name of the AutomationController custom resource object of the deployed Ansible Automation Platform instance being backed up. This name was created when you [created your AutomationController object](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index#aap-create_controller).