### PR TITLE
AAP-12198-2.4 Docs to support the throttling risk for EDA for 2.4

### DIFF
--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -42,9 +42,9 @@ The content would be equivalent to the file passed through the `--vars` flag of 
 
 [IMPORTANT]
 ====
- Each rulebook activation might potentially send numerous requests to the {ControllerName} and trigger multiple jobs, depending on how rules in your rulebook are defined and the volume of incoming events. To avoid potential saturation on {ControllerName}, each rulebook activation (ansible-rulebook process) has a default throttling mechanism set at 30 connections when connecting to the {ControllerName}. 
- 
- You can adjust this value in the inventory file using the environment variable `EDA_CONTROLLER_CONNECTION_LIMIT` if you anticipate that your rulebook might trigger more jobs on the {ControllerName} than it can process. However, {EDAcontroller} that is installed with {PlatformNameShort} {PlatformVers} does not support the customization of environment variables per activation. As a workaround, you can define `EDA_CONTROLLER_CONNECTION_LIMIT` during the image build step. 
+Each rulebook activation might potentially send numerous requests to the the {ControllerName} and trigger multiple jobs, depending on how rules in your rulebook are defined and the volume of incoming events. To avoid potential saturation on {ControllerName}, each rulebook activation (ansible-rulebook process) has a default throttling mechanism set at 30 connections when connecting to the {ControllerName}.
+
+You can adjust this value in the inventory file using the environment variable `EDA_CONTROLLER_CONNECTION_LIMIT` if you anticipate that your rulebook might trigger more jobs on the {ControllerName} than it can process. However, {EDAcontroller} that is installed with {PlatformNameShort} {PlatformVers} does not support the customization of environment variables per activation. As a workaround, you can define `EDA_CONTROLLER_CONNECTION_LIMIT` during the image build step.
 ====
 
 Your rulebook activation is now created and can be managed on the *Rulebook Activations* page.

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -40,6 +40,13 @@ The content would be equivalent to the file passed through the `--vars` flag of 
 
 . Click btn:[Create rulebook activation].
 
+[IMPORTANT]
+====
+ Each rulebook activation might potentially send numerous requests to the {ControllerName} and trigger multiple jobs, depending on how rules in your rulebook are defined and the volume of incoming events. To avoid potential saturation on {ControllerName}, each rulebook activation (ansible-rulebook process) has a default throttling mechanism set at 30 connections when connecting to the {ControllerName}. 
+ 
+ You can adjust this value in the inventory file using the environment variable `EDA_CONTROLLER_CONNECTION_LIMIT` if you anticipate that your rulebook might trigger more jobs on the {ControllerName} than it can process. However, {EDAcontroller} that is installed with {PlatformNameShort} {PlatformVers} does not support the customization of environment variables per activation. As a workaround, you can define `EDA_CONTROLLER_CONNECTION_LIMIT` during the image build step. 
+====
+
 Your rulebook activation is now created and can be managed on the *Rulebook Activations* page.
 
 After saving the new rulebook activation, the rulebook activation's details page is displayed.


### PR DESCRIPTION
Tasks for this PR include: 

- Added an important admonition to the "Setting a rulebook activation" sub-chapter. 

- Also planning to add a warning to an installation topic (not clear which doc yet). Work is TBD.