### PR TITLE
Add patch 2 release notes

### DIFF
--- a/downstream/titles/release-notes/async/aap-25-1-7-oct.adoc
+++ b/downstream/titles/release-notes/async/aap-25-1-7-oct.adoc
@@ -1,15 +1,16 @@
 //This is the working version of the patch release notes document.
 
-[[aap-25-2-patch-release-7-oct-2024]]
+[[aap-25-1-7-oct]]
 
 
-= {PlatformName} 2.5-2 - October 7, 2024
+= {PlatformNameShort} patch release October 7, 2024
 
-This release includes a few enhancements and fixes that have been implemented in the Red Hat {PlatformNameShort} 2.5-2.
+The following enhancements and fixes have been implemented in this release of {PlatformName}.
 
 == Enhancements
 
 * {EDAName} workers and scheduler add timeout and retry resilience when communicating with a Redis cluster. (AAP-32139) 
+
 * Removed the *MTLS* credential type that was incorrectly added. (AAP-31848)
 
 == Fixed issues
@@ -33,27 +34,15 @@ This release includes a few enhancements and fixes that have been implemented in
 
 * Configured the setting *EVENT_STREAM_MTLS_BASE_URL* to the correct default to ensure MTLS is disallowed in the containerized installer. (AAP-31851)
 
-* Fixed a bug where the Event-Driven Ansible workers and scheduler are unable to reconnect to the Redis cluster if a primary Redis node enters a *failed* state and a new primary node is promoted. See the KCS article link:https://access.redhat.com/articles/7088545[Redis failover causes {EDAName} activation failures] that include the steps that were necessary before this bug was fixed. (AAP-30722)
+* Fixed a bug where the {EDAName} workers and scheduler are unable to reconnect to the Redis cluster if a primary Redis node enters a *failed* state and a new primary node is promoted. See the KCS article link:https://access.redhat.com/articles/7088545[Redis failover causes {EDAName} activation failures] that include the steps that were necessary before this bug was fixed. (AAP-30722)
 
 == Advisories
-This section lists the various errata advisories contained in this release.
+The following errata advisories are included in this release:
 
-.Errata advisories
-//cols="a,a" formats the columns as AsciiDoc allowing for AsciiDoc syntax
-[cols="2a,3a", options="header"]
-|===
-| Patch release version | Errata advisory 
+* link:https://access.redhat.com/errata/RHBA-2024:7756[RHBA-2024:7756]
 
-| {PlatformNameShort} 2.5-2 - October 7, 2024
+* link:https://access.redhat.com/errata/RHBA-2024:7760[RHBA-2024:7760]
 
-|
+* link:https://access.redhat.com/errata/RHBA-2024:7766[RHBA-2024:7766]
 
-link:https://access.redhat.com/errata/RHBA-2024:7756[RHBA-2024:7756]
-
-link:https://access.redhat.com/errata/RHBA-2024:7760[>RHBA-2024:7760]
-
-link:https://access.redhat.com/errata/RHBA-2024:7766[RHBA-2024:7766]
-
-link:https://access.redhat.com/errata/RHBA-2024:7810[RHBA-2024:7810]
-
-|===
+* link:https://access.redhat.com/errata/RHBA-2024:7810[RHBA-2024:7810]

--- a/downstream/titles/release-notes/async/aap-25-2-14-oct.adoc
+++ b/downstream/titles/release-notes/async/aap-25-2-14-oct.adoc
@@ -1,0 +1,41 @@
+[[aap-25-1-14-oct]]
+
+= {PlatformNameShort} patch release October 14, 2024
+
+The following fixes have been implemented in this release of {PlatformName}.
+
+== Fixed issues
+
+=== {PlatformNameShort}
+
+* Fixed an issue in {Gateway} where examining output logs for UWSGI shows a message that can be viewed as insensitive. (AAP-33213)
+
+* Fixed external Redis port configuration issue, which resulted in a `cluster_host` error when trying to connect to Redis. (AAP-32691)
+
+* Fixed a faulty conditional which was causing managed Redis to be deployed even if an external Redis was being configured. (AAP-31607)
+
+* After the initial deployment of {PlatformNameShort}, if you make changes to the {ControllerName}, {HubName}, or {EDAName} sections of the {PlatformNameShort} CR specification, those changes are now propagated to the component custom resources. (AAP-32350)
+
+* Fixed addressing issues when the filter `keep_keys` is used, all keys are removed from the dictionary. The `keepkey` fix is available in the updated `ansible.utils` collection. (AAP-32960)
+
+* Fixed an issue in `cisco.ios.ios_static_routes` where the metric distance is to be populated in the `forward_router_address` attribute. (AAP-32960)
+
+* Fixed an issue where {OperatorPlatformNameShort} is not transferring metric settings to the controller. (AAP-32073)
+
+* Fixed an issue where you have a schedule on a resource, such as a job template, that prompts for credentials, and you update the credential to be different from what is on the resource by default, the new credential is not submitted to the API and it does not get updated. (AAP-31957)
+
+* Fixed an issue where setting `*pg_host=` without any other context no longer results in an empty HOST section of `settings.py` in controller. (AAP-32440)
+
+// Commenting this out for now as the advisories are not yet published to the Errata tab on the downloads page: https://access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.5/x86_64/product-errata
+
+// == Advisories
+// The following errata advisories are included in this release:
+
+// * link:https://access.redhat.com/errata/[]
+
+// * link:https://access.redhat.com/errata/[]
+
+// * link:https://access.redhat.com/errata/[]
+
+// * link:https://access.redhat.com/errata/[]
+

--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -27,4 +27,6 @@ include::topics/aap-25-fixed-issues.adoc[leveloffset=+1]
 
 include::topics/docs-25.adoc[leveloffset=+1]
 
-include::topics/aap-25-2-patch-release-7-oct-2024.adoc[leveloffset=+1]
+include::async/aap-25-2-14-oct.adoc[leveloffset=+1]
+
+include::async/aap-25-1-7-oct.adoc[leveloffset=+1]


### PR DESCRIPTION
Add release notes for patch 2 for AAP 2.5 scheduled for release 14th Oct.

Draft doc: https://docs.google.com/document/d/1R795y4V8p_UzNCaBmKpaG1lmJQDH4JTFZ_axh05fCI0/edit#heading=h.jn2xcct2bgfe