### PR TITLE
AAP-21556 - org/team/user migration and superuser identification for AAP-24050

### DIFF
--- a/downstream/modules/platform/proc-controller-add-organization-user.adoc
+++ b/downstream/modules/platform/proc-controller-add-organization-user.adoc
@@ -5,11 +5,20 @@
 You can provide a user with access to an organization by adding them to the organization and managing the roles associated with the user. To add a user to an organization, the user must already exist. For more information, see xref:proc-controller-creating-a-user[Creating a user]. 
 To add roles for a user, the role must already exist. See xref:proc-gw-create-roles[Creating a role] for more information.
 
+The following tab selections are available when adding users to an organization. When user accounts from the {ControllerName} organization have been migrated to {PlatformNameShort} 2.5 during the upgrade process, the *Automation Execution* tab shows content based on whether the users were added to the organization prior to migration.  
+
+{PlatformNameShort}:: Reflects all users added to the organization at the platform level. From this tab, you can add users as organization members and, optionally provide specific organization level roles.
+
+Automation Execution:: Reflects users that were added directly to the {ControllerName} organization prior to an upgrade and migration. From this tab, you can only view existing memberships in {ControllerName} and remove those memberships but not you can not add new memberships. 
+
+New user memberships to an organization must be added at the platform level.
+
 .Procedure
 . From the navigation panel, select {MenuAMOrganizations}.
 . From the *Organizations* list view, select the organization to which you want to add a user. 
 . Click the *Users* tab to add users.
-. Click btn:[Add users] and select one or more users from the list by clicking the checkbox next to the name to add them as members.
+. Select the *{PlatformNameShort}* tab and click btn:[Add users] to add user access to the team, or select the *Automation Execution* tab to view or remove user access from the team.
+. Select one or more users from the list by clicking the checkbox next to the name to add them as members.
 . Click btn:[Next].
 . Select the roles you want the selected user to have. Scroll down for a complete list of roles.
 +

--- a/downstream/modules/platform/proc-gw-editing-a-user.adoc
+++ b/downstream/modules/platform/proc-gw-editing-a-user.adoc
@@ -6,6 +6,15 @@
 
 You can modify the properties of a user account after it is created.
 
+In upgrade scenarios, there might be pre-existing user accounts from {ControllerName}, {EDAName} or {HubName} services. When editing these user accounts, the *User type* checkboxes indicate whether the account had service level administrator privileges. You can revoke or assign administrator permissions for the individual services and designate the user as either an {PlatformNameShort} Administrator, {PlatformNameShort} Auditor or Normal User. Assigning administrator privileges to all of the individual services automatically designates the user as an {PlatformNameShort} Administrator. See xref:proc-controller-creating-a-user[Creating a user] for more information about user types.
+
+To see whether a user had service level auditor privileges, you must refer to the API.
+
+[NOTE]
+====
+Users previously designated as automation controller or automation hub administrators are labeled as *Normal* in the *User type* column in the xref:proc-gw-users-list-view[Users list view]. You can see whether these users have administrator privileges, from the *Edit Users* page.
+====
+
 .Procedure
 
 . From the navigation panel, select {MenuAMUsers}.
@@ -15,5 +24,10 @@ You can modify the properties of a user account after it is created.
 . Click the *Pencil* icon and select *Edit user*.
 
 . The *Edit* user page is displayed where you can modify user details such as, *Password*, *Email*, *User type*, and *Organization*.
-
++
+[NOTE]
+====
+If the user account was migrated to {PlatformNameShort} 2.5 during the upgrade process and had administrator privileges for an individual service, additional User type checkboxes will be available. You can use these checkboxes to revoke or add individual privileges or designate the user as a platform administrator, system auditor or normal user.
+====
++
 . After your changes are complete, click *Save user*.

--- a/downstream/modules/platform/proc-gw-editing-a-user.adoc
+++ b/downstream/modules/platform/proc-gw-editing-a-user.adoc
@@ -12,7 +12,7 @@ To see whether a user had service level auditor privileges, you must refer to th
 
 [NOTE]
 ====
-Users previously designated as automation controller or automation hub administrators are labeled as *Normal* in the *User type* column in the xref:proc-gw-users-list-view[Users list view]. You can see whether these users have administrator privileges, from the *Edit Users* page.
+Users previously designated as {ControllerName} or {HubName} administrators are labeled as *Normal* in the *User type* column in the xref:proc-gw-users-list-view[Users list view]. You can see whether these users have administrator privileges, from the *Edit Users* page.
 ====
 
 .Procedure

--- a/downstream/modules/platform/proc-gw-team-add-user.adoc
+++ b/downstream/modules/platform/proc-gw-team-add-user.adoc
@@ -5,11 +5,23 @@
 = Adding users to a team
 To add a user to a team, the user must already have been created. For more information, see xref:proc-controller-creating-a-user[Creating a user]. Adding a user to a team adds them as a member only. Use the *Roles* tab to assign a role for different resources to the selected team.
 
+The following tab selections are available when adding users to a team. When user accounts from {ControllerName} or {HubName} organizations have been migrated to {PlatformNameShort} 2.5 during the upgrade process, the *Automation Execution* and *Automation Content* tabs show content based on whether the users were added to those organizations prior to migration.  
+
+{PlatformNameShort}:: Reflects all users added to the organization at the platform level. From this tab, you can add users as organization members and, optionally provide specific organization level roles.
+
+Automation Execution:: Reflects users that were added directly to the {ControllerName} organization prior to an upgrade and migration. From this tab, you can only view existing memberships in {ControllerName} and remove those memberships but you can not add new memberships. New organization memberships must be added through the platform.
+
+Automation Content:: Reflects users that were added directly to the {HubName} organization prior to an upgrade and migration. From this tab, you can only view existing memberships in {HubName} and remove those memberships but you can not add new memberships. 
+
+New user memberships to a team must be added at the platform level.
+
+
 .Procedure
 
 . From the navigation panel, select {MenuAMTeams}.
 . Select the team to which you want to add users.
-. Select the *Users* tab and click btn:[Add users].
+. Select the *Users* tab.
+. Select the *{PlatformNameShort}* tab and click btn:[Add users] to add user access to the team, or select the *Automation Execution* or *Automation Content* tab to view or remove user access from the team.
 . Select one or more users from the list by clicking the checkbox next to the name to add them as members of this team.
 . Click btn:[Add users].
  

--- a/downstream/modules/platform/proc-gw-users-list-view.adoc
+++ b/downstream/modules/platform/proc-gw-users-list-view.adoc
@@ -6,6 +6,8 @@
 
 The *Users* page displays the existing users for your installation. From here, you can search for a specific user, filter the list of users, or change the sort order for the list.
 
+When user accounts have been migrated to {PlatformNameShort} 2.5 during the upgrade process, these accounts are also displayed in the *Users* list view. Users previously designated as {ControllerName} or {HubName} administrators are labeled as *Normal* in the *User type* column. You can see whether these users have administrator privileges, by editing the account. See xref:gw-editing-a-user[Editing a user] for instructions.
+
 .Procedure
 
 . From the navigation panel, select {MenuAMUsers}.


### PR DESCRIPTION
This PR addresses the content updates needed for org/team/user migration and superuser for 2.5 Event 2 to address the changes requested in https://issues.redhat.com/browse/AAP-21556 and https://issues.redhat.com/browse/AAP-24050. 