### PR TITLE
Added RHEL 8.8 to 2.5 system requirements (#2350)

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -17,7 +17,7 @@ See, link:{LinkTopologies} for more information on topology options.
 
 h| Subscription | Valid {PlatformName} |
 
-h| OS | {RHEL} 9.2 or later x86_64 aarch64 |{PlatformName} is also supported on OpenShift, see link:{LinkOperatorInstallation} for more information.
+h| OS | {RHEL} 8.8 or later (x86_64, aarch64), or {RHEL} 9.2 or later (x86_64, aarch64) |{PlatformName} are also supported on OpenShift, see link:{LinkOperatorInstallation} for more information.
 
 h| Ansible-core | Ansible-core version {CoreInstVers} or later | {PlatformNameShort} uses the system-wide ansible-core package to install the platform, but uses ansible-core {CoreUseVers} for both its control plane and built-in execution environments.
 


### PR DESCRIPTION
* Added RHEL 8.8 to 2.5 system requirements

[Doc]AAP 2.5 system requirements should include RHEL 8.8

https://issues.redhat.com/browse/AAP-32708

* Added RHEL 8.8 to 2.5 system requirements

Correction

https://issues.redhat.com/browse/AAP-32708