### PR TITLE
AAP-32980 Corrected broken links and incorrect titles in the Operating AAP guide

### DIFF
--- a/downstream/modules/platform/con-why-automation-mesh.adoc
+++ b/downstream/modules/platform/con-why-automation-mesh.adoc
@@ -16,6 +16,6 @@ The {AutomationMesh} component of the {PlatformName} simplifies the process of d
 
 * For information about automation mesh and the various ways to design your automation mesh for your environment:
 
-** For a VM-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_guide_for_vm-based_installations/index[{PlatformName} {AutomationMesh} guide for VM-based installations].
+** For a VM-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_vm_environments/index[{PlatformName} {AutomationMesh} guide for VM-based installations].  
 
-** For an operator-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_for_operator-based_installations/index[{PlatformName} {AutomationMesh} for operator-based installations].
+** For an operator-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_managed_cloud_or_operator_environments/index[{PlatformName} {AutomationMesh} for operator-based installations].

--- a/downstream/modules/platform/con-why-automation-mesh.adoc
+++ b/downstream/modules/platform/con-why-automation-mesh.adoc
@@ -16,6 +16,6 @@ The {AutomationMesh} component of the {PlatformName} simplifies the process of d
 
 * For information about automation mesh and the various ways to design your automation mesh for your environment:
 
-** For a VM-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_vm_environments/index[{AutomationMesh} guide for VM-based installations].  
+** For a VM-based installation, see the link:{LinkAutomationMesh}.  
 
-** For an operator-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_managed_cloud_or_operator_environments/index[{AutomationMesh} for operator-based installations].
+** For an operator-based installation, see the link:{LinkOperatorMesh}

--- a/downstream/modules/platform/con-why-automation-mesh.adoc
+++ b/downstream/modules/platform/con-why-automation-mesh.adoc
@@ -16,6 +16,6 @@ The {AutomationMesh} component of the {PlatformName} simplifies the process of d
 
 * For information about automation mesh and the various ways to design your automation mesh for your environment:
 
-** For a VM-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_vm_environments/index[{PlatformName} {AutomationMesh} guide for VM-based installations].  
+** For a VM-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_vm_environments/index[{AutomationMesh} guide for VM-based installations].  
 
-** For an operator-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_managed_cloud_or_operator_environments/index[{PlatformName} {AutomationMesh} for operator-based installations].
+** For an operator-based installation, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_managed_cloud_or_operator_environments/index[{AutomationMesh} for operator-based installations].

--- a/downstream/modules/platform/proc-change-ssl-installer.adoc
+++ b/downstream/modules/platform/proc-change-ssl-installer.adoc
@@ -9,8 +9,7 @@ The following procedure describes how to change the SSL certificate and key in t
 
 . Copy the new SSL certificates and keys to a path relative to the {PlatformNameShort} installer.
 . Add the absolute paths of the SSL certificates and keys to the inventory file. 
-Refer to the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables] 
-link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the 
+Refer to the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables], link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the 
 {LinkInstallationGuide}.
 for guidance on setting these variables.
 +

--- a/downstream/modules/platform/proc-change-ssl-installer.adoc
+++ b/downstream/modules/platform/proc-change-ssl-installer.adoc
@@ -9,9 +9,7 @@ The following procedure describes how to change the SSL certificate and key in t
 
 . Copy the new SSL certificates and keys to a path relative to the {PlatformNameShort} installer.
 . Add the absolute paths of the SSL certificates and keys to the inventory file. 
-Refer to the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables], link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the 
-{LinkInstallationGuide}.
-for guidance on setting these variables.
+Refer to the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables], link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the {LinkInstallationGuide} for guidance on setting these variables.
 +
 --
 ** {ControllerNameStart}: `web_server_ssl_cert`, `web_server_ssl_key`, `custom_ca_cert`

--- a/downstream/modules/platform/proc-change-ssl-installer.adoc
+++ b/downstream/modules/platform/proc-change-ssl-installer.adoc
@@ -9,7 +9,7 @@ The following procedure describes how to change the SSL certificate and key in t
 
 . Copy the new SSL certificates and keys to a path relative to the {PlatformNameShort} installer.
 . Add the absolute paths of the SSL certificates and keys to the inventory file. 
-Refer to the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables], link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the {LinkInstallationGuide} for guidance on setting these variables.
+Refer to the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables], link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the {LinkInstallationGuide} document for guidance on setting these variables.
 +
 --
 ** {ControllerNameStart}: `web_server_ssl_cert`, `web_server_ssl_key`, `custom_ca_cert`

--- a/downstream/modules/platform/proc-change-ssl-installer.adoc
+++ b/downstream/modules/platform/proc-change-ssl-installer.adoc
@@ -9,9 +9,9 @@ The following procedure describes how to change the SSL certificate and key in t
 
 . Copy the new SSL certificates and keys to a path relative to the {PlatformNameShort} installer.
 . Add the absolute paths of the SSL certificates and keys to the inventory file. 
-Refer to the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index#ref-hub-variables[{ControllerNameStart} variables], 
-link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index#ref-controller-variables[{HubNameStart} variables], and link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the 
-link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[{PlatformName} Installation Guide]
+Refer to the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables] 
+link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the 
+{LinkInstallationGuide}.
 for guidance on setting these variables.
 +
 --

--- a/downstream/modules/platform/proc-change-ssl-installer.adoc
+++ b/downstream/modules/platform/proc-change-ssl-installer.adoc
@@ -9,7 +9,7 @@ The following procedure describes how to change the SSL certificate and key in t
 
 . Copy the new SSL certificates and keys to a path relative to the {PlatformNameShort} installer.
 . Add the absolute paths of the SSL certificates and keys to the inventory file. 
-Refer to the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables], link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of the {LinkInstallationGuide} document for guidance on setting these variables.
+Refer to the link:{URLInstallationGuide}/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables], link:{URLInstallationGuide}/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of link:{LinkInstallationGuide} for guidance on setting these variables.
 +
 --
 ** {ControllerNameStart}: `web_server_ssl_cert`, `web_server_ssl_key`, `custom_ca_cert`


### PR DESCRIPTION
Corrections to links in two modules in the 2.5 [Operating AAP guide](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/operating_ansible_automation_platform/index)

