### PR TITLE
removing base url info from warning

### DIFF
--- a/stories/assembly-saas-post-install-config.adoc
+++ b/stories/assembly-saas-post-install-config.adoc
@@ -10,7 +10,7 @@ link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_a
 
 [WARNING]
 ====
-Do not change the "Base URL of the service" or "Gateway proxy URL" settings. Changing the base URL breaks notification links, and altering the gateway proxy might cause false outages on the status page.
+Do not change the "Gateway proxy URL" settings. Altering the gateway proxy might cause false outages on the status page.
 ====
 
 ifdef::parent-context[:context: {parent-context}]


### PR DESCRIPTION
[AAP-33170](https://issues.redhat.com/browse/AAP-33170) 

Undoing changes as no longer needed for Base URL settings. 