### PR TITLE
2.5 Update must-gather version in troubleshooting guide (#2363)

### DIFF
--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
@@ -27,7 +27,7 @@ oc login _<openshift_url>_
 +
 [subs="+quotes"]
 ----
-oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-24/aap-must-gather-rhel8 --dest-dir _<dest_dir>_
+oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-25/aap-must-gather-rhel8 --dest-dir _<dest_dir>_
 ----
 +
 ** `--image` specifies the image that gathers data
@@ -37,7 +37,7 @@ oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-24/aap
 +
 [subs="+quotes"]
 ----
-oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-24/aap-must-gather-rhel8 --dest-dir _<dest_dir>_ – /usr/bin/ns-gather _<namespace>_
+oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-25/aap-must-gather-rhel8 --dest-dir _<dest_dir>_ – /usr/bin/ns-gather _<namespace>_
 ----
 +
 ** `– /usr/bin/ns-gather` limits the `must-gather` data collection to a specified namespace


### PR DESCRIPTION
Update the must-gather image location version to match up with 2.5

[Docs] Update AAP must gather image name in documentation

https://issues.redhat.com/browse/AAP-33519