### PR TITLE
AAP-31305: Added info. about disabling SSL cert validation in Lightspeed operator

### DIFF
--- a/lightspeed/modules/proc_troubleshooting-lightspeed-onpremise-config.adoc
+++ b/lightspeed/modules/proc_troubleshooting-lightspeed-onpremise-config.adoc
@@ -104,3 +104,48 @@ or:
 `{ibmwatsonxcodeassistant} Model ID is invalid. Please contact your administrator.`
 +
 This error indicates that the model secret contains incorrect values. To resolve this error, ensure that you have not accidentally added any whitespace characters (extra line, space, and so on) to the `username`, `model_url`, and `model_api_key` parameters in the model connection secret. For more information, see xref:create-connection-secrets_configuring-lightspeed-onpremise[Creating connection secrets]. 
+
+== Cannot connect to the Ansible Lightspeed service due to SSL connection error
+
+If you are using self-signed certificates on the model server, you might encounter SSL certification verification errors, causing the connection between Ansible Lightspeed service and the model server to fail. The following error message is displayed:
+----
+Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] 
+certificate verify failed: self signed certificate in certificate chain (_ssl.c:1006)'))
+----
+
+To resolve this error, you can disable the SSL protection between the model server and the Ansible Lightspeed service. For example, you can disable the SSL protection when you are on a testing environment. To disable the SSL protection, you must add the following extra setting in the {LightspeedShortName} Custom Resource Definition (CRD) YAML file under the `spec:` section:
+----
+extra_settings:
+    - setting: ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL
+      value: false
+----
+
+[IMPORTANT]
+.Reenabling the SSL protection
+====
+You must re-enable the SSL protection when deploying on a production environment. To re-enable the SSL protection, simply remove the extra setting from the YAML file.
+====
+
+.Procedure
+. Go to the {OCP}. 
+. Select menu:Operators[Installed Operators].
+. From the *Projects* list, select the namespace that you created when you installed the {PlatformName} operator.
+. Locate and select the *Ansible Automation Platform (provided by Red Hat)* operator that you installed earlier.
+. Select the *Ansible Lightspeed* tab.
+. Find and select the instance you want to update.
+. Select the *YAML* tab. The editor switches to a YAML editor view.
+. Scroll and find the spec: section, and add the following parameter under the `spec:` section:
++
+----
+extra_settings:
+    - setting: ANSIBLE_AI_MODEL_MESH_API_VERIFY_SSL
+      value: false
+----
+. Click *Save*. 
+. Restart the automation controller pods to apply the revised YAML. +
+Perform the following steps: 
+.. From the {OCP}, select menu:Workloads[Pods].
+.. Locate and select the Ansible Lightspeed pod that you updated.
+.. Click the *Edit* icon beside the pod and select *Delete Pod*. +
+The select pod gets deleted and a new pod gets created. 
+


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-31305.

Changes made:

- Added a troubleshooting section on disabling SSL certificate validation in Lightspeed operator. 