### PR TITLE
2.5 Update Containerized installation inventory variable references (#2370)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -29,7 +29,7 @@ include::snippets/container-upgrades.adoc[]
 * A {RHEL} (RHEL) 9.2 based host. Use a minimal operating system base install.
 * A non-root user for the {RHEL} host, with sudo or other Ansible supported privilege escalation (sudo recommended). This user is responsible for the installation of containerized {PlatformNameShort}.
 * SSH public key authentication for the non-root user. For guidelines on setting up SSH public key authentication for the non-root user, see link:https://access.redhat.com/solutions/4110681[How to configure SSH public key authentication for passwordless login].
-** SSH keys are only required when installing on remote hosts. If doing a self contained local VM based installation, you can use `ansible_connection: local`.
+** SSH keys are only required when installing on remote hosts. If doing a self contained local VM based installation, you can use `ansible_connection=local`.
 * Internet access from the {RHEL} host if you are using the default online installation method.
 * The appropriate network ports are open if a firewall is in place. For more information about the ports to open, see link:{URLTopologies}/container-topologies[Container topologies] in _{TitleTopologies}_.
 

--- a/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
+++ b/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
@@ -12,14 +12,14 @@ After the installation completes, the default protocol and ports used for {Platf
 You can customize the ports with the following variables:
 
 ----
-gateway_nginx_http_port: 8500
-gateway_nginx_https_port: 8501
+gateway_nginx_http_port=8500
+gateway_nginx_https_port=8501
 ----
 
 If you want to disable HTTPS, set `gateway_nginx_disable_https` to `true`:
 
 ----
-gateway_nginx_disable_https: true
+gateway_nginx_disable_https=true
 ----
 
 .Accessing the platform UI

--- a/downstream/modules/platform/ref-containerized-troubleshoot-install.adoc
+++ b/downstream/modules/platform/ref-containerized-troubleshoot-install.adoc
@@ -34,11 +34,11 @@ callbacks_enabled = ansible.posix.profile_tasks
 This error is due to `manifest.zip` license files that are larger than the `nginx_client_max_body_size` setting. If this error occurs, you will need to change the installation inventory file to include the following variables:
 
 ----
-nginx_disable_hsts: false
-nginx_http_port: 8081
-nginx_https_port: 8444
-nginx_client_max_body_size: 20m
-nginx_user_headers: []
+nginx_disable_hsts=false
+nginx_http_port=8081
+nginx_https_port=8444
+nginx_client_max_body_size=20m
+nginx_user_headers=[]
 ----
 
 The current default setting of `20m` should be enough to avoid this issue.


### PR DESCRIPTION
Update inventory variable references to match INI formatting For example, change from: `gateway_nginx_http_port: 8500` to `gateway_nginx_http_port=8500`

Containerized installer has mix of json and ini

https://issues.redhat.com/browse/AAP-33697