### PR TITLE
AAP-32998: Adds links about OAuth application migration to the Upgrade/Migration guide

### DIFF
--- a/downstream/modules/platform/proc-account-linking.adoc
+++ b/downstream/modules/platform/proc-account-linking.adoc
@@ -13,7 +13,7 @@ To address this problem, use the account linking procedure to authenticate from 
 
 [IMPORTANT]
 ====
-{ControllerNameStart} OAuth applications on the platform UI are not supported for 2.4 to 2.5 migration.
+{ControllerNameStart} OAuth applications on the platform UI are not supported for 2.4 to 2.5 migration. See this link:https://access.redhat.com/solutions/7091987[Knowledgebase article] for more information. To learn how to recreate your OAuth applications, see link:{URLCentralAuth}/gw-token-based-authentication#assembly-controller-applications[Applications] in the link:{TitleCentralAuth} guide.
 ====
 
 .Prerequisites

--- a/downstream/modules/platform/proc-account-linking.adoc
+++ b/downstream/modules/platform/proc-account-linking.adoc
@@ -13,7 +13,7 @@ To address this problem, use the account linking procedure to authenticate from 
 
 [IMPORTANT]
 ====
-{ControllerNameStart} OAuth applications on the platform UI are not supported for 2.4 to 2.5 migration. See this link:https://access.redhat.com/solutions/7091987[Knowledgebase article] for more information. To learn how to recreate your OAuth applications, see link:{URLCentralAuth}/gw-token-based-authentication#assembly-controller-applications[Applications] in the link:{TitleCentralAuth} guide.
+{ControllerNameStart} OAuth applications on the platform UI are not supported for 2.4 to 2.5 migration. See this link:https://access.redhat.com/solutions/7091987[Knowledgebase article] for more information. To learn how to recreate your OAuth applications, see link:{URLCentralAuth}/gw-token-based-authentication#assembly-controller-applications[Applications] in the {TitleCentralAuth} guide.
 ====
 
 .Prerequisites


### PR DESCRIPTION
See [AAP-32998](https://issues.redhat.com/browse/AAP-32998) for more info. 