### PR TITLE
AAP-32794 updates

### DIFF
--- a/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
+++ b/downstream/modules/platform/proc-cli-get-controller-pwd.adoc
@@ -34,14 +34,14 @@ The address for the platform gateway instance is `example-ansible-automation-pla
 
 == Fetching the platform gateway password
 
-The YAML block for the platform gateway instance in [filename]`sub.yaml` assigns values to the _name_ and _admin_user_ keys.
+The YAML block for the platform gateway instance in the `AnsibleAutomationPlatform` object assigns values to the _name_ and _admin_user_ keys.
 Use these values in the following command to fetch the password for the platform gateway instance.
 
 -----
 oc get secret/<your instance name>-<admin_user>-password -o yaml
 -----
 
-The default value for _admin_user_ is `_admin_`. Modify the command if you changed the admin username in [filename]`sub.yaml`.
+The default value for _admin_user_ is `_admin_`. Modify the command if you changed the admin username in the `AnsibleAutomationPlatform` object.
 
 The following example retrieves the password for a platform gateway object called `_example_`: 
 
@@ -49,7 +49,7 @@ The following example retrieves the password for a platform gateway object calle
 oc get secret/example-admin-password -o yaml
 -----
 
-The password for the platform gateway instance is listed in the `metadata` field in the output:
+The base64 encoded password for the platform gateway instance is listed in the `metadata` field in the output:
 
 -----
 $ oc get secret/example-admin-password -o yaml

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -55,40 +55,63 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
-apiVersion: automationcontroller.ansible.com/v1beta1
-kind: AutomationController
-metadata:
-  name: example
-  namespace: ansible-automation-platform
-spec:
-  replicas: 1
-
 -----
 +
 This file creates a `Subscription` object called `_ansible-automation-platform_` that subscribes the `ansible-automation-platform` namespace to the `ansible-automation-platform-operator` operator.
 +
-It then creates an `AutomationController` object called `_example_` in the `ansible-automation-platform` namespace.
-+
-To change the {ControllerName} name from `_example_`, edit the _name_ field in the `kind: AutomationController` section of [filename]`sub.yaml` and replace `_<automation_controller_name>_` with the name you want to use:
-+
-[subs="+quotes"]
------
-apiVersion: automationcontroller.ansible.com/v1beta1
-kind: AutomationController
-metadata:
-  name: __<automation_controller_name>__
-  namespace: ansible-automation-platform
------
 . Run the [command]`*oc apply*` command to create the objects specified in the [filename]`sub.yaml` file:
 +
 -----
 oc apply -f sub.yaml
 -----
-
-To verify that the namespace has been successfully subscribed to the `ansible-automation-platform-operator` operator, run the [command]`*oc get subs*` command:
-
++
+. Verify the CSV PHASE reports Succeeded before proceeding using the [command]`oc get csv -n ansible-automation-platform` command:
++
 -----
-$ oc get subs -n ansible-automation-platform
+oc get csv -n ansible-automation-platform
+
+NAME                               DISPLAY                       VERSION              REPLACES                           PHASE
+aap-operator.v2.5.0-0.1728520175   Ansible Automation Platform   2.5.0+0.1728520175   aap-operator.v2.5.0-0.1727875185   Succeeded
+-----
++
+. Create an `AnsibleAutomationPlatform` object called `_example_` in the `ansible-automation-platform` namespace.
++
+To change the {PlatformNameShort} and its components from  from `_example_`, edit the _name_ field in the `metadata:` section and replace example with the name you want to use:
+
++
+[subs="+quotes"]
+-----
+oc apply -f - <<EOF
+apiVersion: aap.ansible.com/v1alpha1
+kind: AnsibleAutomationPlatform
+metadata:
+  name: example
+  namespace: ansible-automation-platform
+spec:
+  # Platform
+  image_pull_policy: IfNotPresent
+  # Components
+  controller:
+    disabled: false
+  eda:
+    disabled: false
+  hub:
+    disabled: false
+    ## Modify to contain your RWM storage class name
+    storage_type: file
+    file_storage_storage_class: <your-read-write-many-storage-class>
+    file_storage_size: 10Gi
+
+    ## uncomment if using S3 storage for Content pod
+    # storage_type: S3
+    # object_storage_s3_secret: example-galaxy-object-storage
+
+    ## uncomment if using Azure storage for Content pod
+    # storage_type: azure
+    # object_storage_azure_secret: azure-secret-name
+  lightspeed:
+    disabled: true
+EOF
 -----
 
 For further information about subscribing namespaces to operators, see link:{BaseURL}/openshift_container_platform/{OCPLatest}/html/operators/user-tasks#olm-installing-operator-from-operatorhub-using-cli_olm-installing-operators-in-namespace[Installing from OperatorHub using the CLI] in the {OCP} _Operators_ guide.

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -65,7 +65,7 @@ This file creates a `Subscription` object called `_ansible-automation-platform_`
 oc apply -f sub.yaml
 -----
 +
-. Verify the CSV PHASE reports Succeeded before proceeding using the [command]`oc get csv -n ansible-automation-platform` command:
+. Verify the CSV PHASE reports "Succeeded" before proceeding using the [command]`oc get csv -n ansible-automation-platform` command:
 +
 -----
 oc get csv -n ansible-automation-platform


### PR DESCRIPTION
[AAP-32794](https://issues.redhat.com/browse/AAP-32794) 

Chapter 3. Installing Ansible Automation Platform Operator from the OpenShift Container Platform CLI in the new Ansible Automation Platform 2.5 documentation does not configure the AnsibleAutomationPlatform object as required for the new deployment. 