### PR TITLE
Adding note about duplicate credentials

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-credentials.adoc
+++ b/downstream/assemblies/platform/assembly-controller-credentials.adoc
@@ -31,6 +31,21 @@ To pass the key from {ControllerName} to SSH, the key must be decrypted before i
 {ControllerNameStart} uses that pipe to send the key to SSH, so that the key is never written to disk.
 If passwords are used, {ControllerName} handles them by responding directly to the password prompt and decrypting the password before writing it to the prompt.
 
+[NOTE]
+====
+It is possible to create duplicate credentials with the same name and without an organization. 
+However, it is not possible to create two duplicate credentials in the same organization.
+
+.Example
+
+. Create two machine credentials with the same name but without an organization.
+. Use the module `ansible.controller.export` to export the credentials.
+. Use the module `ansible.controller.import` in a different automation execution node.
+. Check the imported credentials.
+
+When you export two duplicate credentials and then import them in a different node, only one credential is imported.
+====
+
 //Removed as part of editorial review - include::platform/ref-controller-credentials-getting-started.adoc[leveloffset=+1]
 include::platform/proc-controller-create-credential.adoc[leveloffset=+1]
 include::platform/proc-controller-add-users-job-templates.adoc[leveloffset=+1]


### PR DESCRIPTION
Controller UI allows to create duplicate credentials without organization

https://issues.redhat.com/browse/AAP-25150

Affects `titles/controller-user-guide`