### PR TITLE
2.5 Update port variables in Containerized installation (#2383)

### DIFF
--- a/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
+++ b/downstream/modules/platform/ref-accessing-control-auto-hub-eda-control.adoc
@@ -12,14 +12,14 @@ After the installation completes, the default protocol and ports used for {Platf
 You can customize the ports with the following variables:
 
 ----
-gateway_nginx_http_port=8500
-gateway_nginx_https_port=8501
+envoy_http_port=80
+envoy_https_port=443
 ----
 
-If you want to disable HTTPS, set `gateway_nginx_disable_https` to `true`:
+If you want to disable HTTPS, set `envoy_disable_https` to `true`:
 
 ----
-gateway_nginx_disable_https=true
+envoy_disable_https=true
 ----
 
 .Accessing the platform UI


### PR DESCRIPTION
Update the port variables referenced in "Accessing Ansible Automation Platform"

containerized installer ports are wrong in the documentation

https://issues.redhat.com/browse/AAP-33760