### PR TITLE
Add required vars to cont-b inventory files

### DIFF
--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -155,6 +155,8 @@ eda2.example.org
 # Common variables
 # {URLContainerizedInstall}/appendix-inventory-files-vars#ref-general-inventory-variables
 # -----------------------------------------------------
+postgresql_admin_username=<set your own>
+postgresql_admin_password=<set your own>
 registry_username=<your RHN username>
 registry_password=<your RHN password>
 

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -126,6 +126,8 @@ eda2.example.org
 # Common variables
 # https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-general-inventory-variables
 # -----------------------------------------------------
+postgresql_admin_username=<set your own>
+postgresql_admin_password=<set your own>
 registry_username=<your RHN username>
 registry_password=<your RHN password>
 


### PR DESCRIPTION
Add the following variables to the inventory file examples for the enterprise container topology
- postgresql_admin_username
- postgresql_admin_password

This affects Supported deployment models and Containerized installation docs.

Documentation for enterprise containerized 2.5 installation has misleading inventory example

https://issues.redhat.com/browse/AAP-33520