### PR TITLE
Add note to Operator topologies section of Tested deployment models

### DIFF
--- a/downstream/assemblies/topologies/assembly-ocp-topologies.adoc
+++ b/downstream/assemblies/topologies/assembly-ocp-topologies.adoc
@@ -2,7 +2,13 @@
 
 = Operator topologies
 
-The {OperatorPlatformNameShort} uses Red Hat OpenShift operators to deploy {PlatformNameShort} within Red Hat OpenShift. Customers manage the product and infrastructure lifecycle.
+The {OperatorPlatformNameShort} uses Red Hat OpenShift Operators to deploy {PlatformNameShort} within Red Hat OpenShift. Customers manage the product and infrastructure lifecycle.
+
+[IMPORTANT]
+====
+You can only install a single instance of the {OperatorPlatformNameShort} into a single namespace. 
+Installing multiple instances in the same namespace can lead to improper operation for both Operator instances. 
+====
 
 //OCP growth topology
 include::topologies/ref-ocp-a-env-a.adoc[leveloffset=+1]


### PR DESCRIPTION
Add a note to the Operator topologies section of Tested deployment models to denote the single namespace limitation.

Add install-related note to Tested deployment models for OCP

https://issues.redhat.com/browse/AAP-33878