### PR TITLE
Updated the note for a backup failure status. (#2329)

### DIFF
--- a/downstream/modules/platform/proc-aap-controller-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-backup.adoc
@@ -52,5 +52,5 @@ A backup tarball of the specified deployment is created and available for data r
 +
 [NOTE]
 ====
-If *Successful* is `False`, the backup has failed. Check the {ControllerName} operator logs for the error to fix the issue.
+If the status is `Failure`, the backup has failed. Check the {ControllerName} operator logs for the error to fix the issue.
 ====


### PR DESCRIPTION
This resolves [AAP-32994](https://issues.redhat.com/browse/AAP-32994), which corrects the error message in the event of a backup failure. I am unable to add Chris Meyers (chrismeyersfsu) as a reviewer but he needs to sign off in this.