### PR TITLE
Added a short note denoting the Python 3.5 removal as a supported

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25-removed-features.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-removed-features.adoc
@@ -43,10 +43,11 @@ The following table provides information about features that are removed in {Pla
 |`inventory_cache` - Removed deprecated `default.fact_caching_prefix ini` configuration option. Use `defaults.fact_caching_prefix` instead.
 
 |Ansible-core
-|
-- `module_utils/basic.py` - Removed Python 3.5 as a supported remote version. Python version 2.7 or Python version 3.6 or later is now required.
+|`module_utils/basic.py` - Removed Python 3.5 as a supported remote version. Python version 2.7 or Python version 3.6 or later is now required.
 
-- With the removal of Python 2 support, the `yum` module and `yum action` plug-in are removed and redirected to `dnf`.
+*NOTE:* This applies to Ansible version 2.17 only.
+
+With the removal of Python 2 support, the `yum` module and `yum action` plug-in are removed and redirected to `dnf`.
 
 |Ansible-core
 |`stat` - Removed the unused `get_md5` parameter.


### PR DESCRIPTION
remote version only applies to Ansible version 2.17.

Resolves: AAP-33894