### PR TITLE
AAP-30120 Added extra bullet to the admonition in Setting up a rulebook activation section

### DIFF
--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -24,7 +24,8 @@ Credential:: Select 0 or more credentials for this rulebook activation. This fie
 +
 [NOTE]
 ====
-The credentials that display in this field are customized based on your rulebook activation and only include the following credential types: Vault, {PlatformName}, or any custom credential types that you have created. For more information about credentials, see xref:eda-credentials[Credentials].
+* If you plan to use a {PlatformName} credential, you can _only_ select 1 of this credential type for your rulebook activation.
+* The credentials that display in this field are customized based on your rulebook activation and only include the following credential types: Vault, {PlatformName}, or any custom credential types that you have created. For more information about credentials, see xref:eda-credentials[Credentials].
 ====
 //[J. Self] Might need to update the link above for the updated Credentials section.
 Decision environment:: Decision environments are a container image to run Ansible rulebooks.

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -27,7 +27,7 @@ Credential:: Select 0 or more credentials for this rulebook activation. This fie
 * If you plan to use a {PlatformName} credential, you can _only_ select 1 of this credential type for your rulebook activation.
 * The credentials that display in this field are customized based on your rulebook activation and only include the following credential types: Vault, {PlatformName}, or any custom credential types that you have created. For more information about credentials, see xref:eda-credentials[Credentials].
 ====
-//[J. Self] Might need to update the link above for the updated Credentials section.
+
 Decision environment:: Decision environments are a container image to run Ansible rulebooks.
 +
 [NOTE]


### PR DESCRIPTION
Added an extra point to the admonition in the proc-eda-set-up-rulebook-activation.adoc module. Alerts users/customers to only select 1 RH AAP credential when setting up a rulebook activation using the RH AAP credential.