### PR TITLE
Backport to 2.5: AAP-15176 Fixes broken links and typos in managing automation content guide (#2…

### DIFF
--- a/downstream/assemblies/hub/assembly-delete-container.adoc
+++ b/downstream/assemblies/hub/assembly-delete-container.adoc
@@ -19,7 +19,7 @@ You can delete repositories from the {PlatformName} interface in the *Execution 
 . When the confirmation message is displayed, click the checkbox and click btn:[Delete {ExecEnvShort}].
 
 .Verification
-* Return to the *{ExecEnvName}s* list view.
+* Return to the *{ExecEnvName}* list view.
 If the {ExecEnvName} has been successfully deleted, it will no longer be in the list.
 
 

--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -10,12 +10,12 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-By default, {PrivateHubName} does not include {ExecEnvShort}s.
-To populate your container registry, you must push a {ExecEnvShort} to it.
+By default, {PrivateHubName} does not include {ExecEnvName}.
+To populate your container registry, you must push an {ExecEnvShort} to it.
 
 You must follow a specific workflow to populate your {PrivateHubName} remote registry:
 
-* Pull {ExecEnvShort}s from the Red Hat Ecosystem Catalog (registry.redhat.io)
+* Pull {ExecEnvName} from the Red Hat Ecosystem Catalog (registry.redhat.io)
 * Tag them
 * Push them to your {PrivateHubName} remote registry
 
@@ -32,7 +32,7 @@ Use the hostnames instead of IP addresses when configuring firewall rules.
 
 After making this change you can continue to pull {ExecEnvShort}s from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
 
-However, manifests, sometimes called “subscription allocations”, on the web-based Red Hat Subscription Management are no longer supported as of early 2024 with one exception: If a system is part of a closed network or “air gapped” system that does not receive its updates from Red Hat’s servers directly, manifests are supported until the release of Red Hat Satellite 6.16. Keep up to date with link:access.redhat.com/articles/1365633[Red Hat Satellite Release Dates] for the announcement for Red Hat Satellite 6.16's release date announcement.
+However, manifests, sometimes called “subscription allocations”, on the web-based Red Hat Subscription Management are no longer supported as of early 2024 with one exception: If a system is part of a closed network or “air gapped” system that does not receive its updates from Red Hat's servers directly, manifests are supported until the release of Red Hat Satellite 6.16. Keep up to date with link:https://access.redhat.com/articles/1365633[Red Hat Satellite Release Dates] for Red Hat Satellite 6.16's release date announcement.
 ====
 
 include::hub/proc-obtain-images.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-pull-image.adoc
+++ b/downstream/assemblies/hub/assembly-pull-image.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 :context: pulling-images-container-repository
 
 [role="_abstract"]
-Pull {ExecEnvName}s from the {HubName} remote registry to make a copy to your local machine. 
+Pull {ExecEnvName} from the {HubName} remote registry to make a copy to your local machine. 
 {HubNameStart} provides the `podman pull` command for each `latest` {ExecEnvName} in the container repository. 
 You can copy and paste this command into your terminal, or use `podman pull` to copy an {ExecEnvName} based on an {ExecEnvName} tag.
 

--- a/downstream/assemblies/hub/assembly-setup-container-repository.adoc
+++ b/downstream/assemblies/hub/assembly-setup-container-repository.adoc
@@ -11,7 +11,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-When you set up your container repository, you must add a description, include a README, add teams that can access the repository, and tag {ExecEnvName}s.
+When you set up your container repository, you must add a description, include a README, add teams that can access the repository, and tag {ExecEnvName}.
 
 == Prerequisites to setting up your remote registry
 

--- a/downstream/modules/hub/proc-add-group-to-container-repo.adoc
+++ b/downstream/modules/hub/proc-add-group-to-container-repo.adoc
@@ -1,9 +1,9 @@
 [id="providing-access-to-containers"]
 
-= Providing access to your {ExecEnvName}s
+= Providing access to your {ExecEnvName}
 
 [role="_abstract"]
-Provide access to your {ExecEnvName}s for users who need to work with the images.
+Provide access to your {ExecEnvName} for users who need to work with the images.
 Adding a team allows you to modify the permissions the team can have to the container repository.
 You can use this option to extend or restrict permissions based on what the team is assigned.
 
@@ -15,7 +15,7 @@ You can use this option to extend or restrict permissions based on what the team
 
 . Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuACExecEnvironments}.
-. Select your {ExecEnvName}.
+. Select your {ExecEnvNameSing}.
 . From the *Team Access* tab, click btn:[Add roles].
 . Select the team or teams to which you want to grant access and click btn:[Next].
 . Select the roles that you want to add to this {ExecEnvShort} and click btn:[Next].

--- a/downstream/modules/hub/proc-obtain-images.adoc
+++ b/downstream/modules/hub/proc-obtain-images.adoc
@@ -18,15 +18,15 @@ New Red Hat accounts automatically use Simple Content Access for their subscript
 
 .Prerequisites
 
-* You have permissions to pull {ExecEnvShort}s from registry.redhat.io.
+* You have permissions to pull {ExecEnvName} from registry.redhat.io.
 
 * A Red Hat account with Simple Content Access enabled.
 
 .Procedure
 
-. If you need to access your manifest for your container images log in to link:console.redhat.com/subscriptions/manifests[Red Hat Console].
+. If you need to access your manifest for your container images log in to link:https://console.redhat.com/subscriptions/manifests[Red Hat Console].
 
-. Click the three-dot menu for the manifest you need for your {ExecEnvShort}s, and click btn:[Export manifest].
+. Click the three-dot menu for the manifest you need for your {ExecEnvName}, and click btn:[Export manifest].
 
 . Log in to Podman by using your registry.redhat.io credentials:
 +
@@ -58,6 +58,6 @@ $ podman images
 [role="_additional-resources"]
 .Additional resources
 
-* See link:redhat-connect.gitbook.io/catalog-help/[Red Hat Ecosystem Catalog Help] for information on registering and getting {ExecEnvShort}s.
+* See link:https://redhat-connect.gitbook.io/catalog-help/[Red Hat Ecosystem Catalog Help] for information on registering and getting {ExecEnvShort}s.
 
 * See link:{BaseURL}/subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] to learn more about the changes coming to Red Hat subscription tooling.

--- a/downstream/modules/hub/proc-pull-image.adoc
+++ b/downstream/modules/hub/proc-pull-image.adoc
@@ -4,7 +4,7 @@
 
 
 [role="_abstract"]
-You can pull {ExecEnvName}s from the {HubName} remote registry to make a copy to your local machine.
+You can pull {ExecEnvName} from the {HubName} remote registry to make a copy to your local machine.
 
 .Prerequisites
 
@@ -12,7 +12,7 @@ You can pull {ExecEnvName}s from the {HubName} remote registry to make a copy to
 
 .Procedure
 
-. If you are pulling {ExecEnvName}s from a password or token-protected registry, xref:proc-create-credential[create a credential] before pulling the {ExecEnvName}.
+. If you are pulling {ExecEnvName} from a password or token-protected registry, xref:proc-create-credential[create a credential] before pulling the {ExecEnvName}.
 . From the navigation panel, select {MenuACExecEnvironments}.
 . Select your {ExecEnvName}.
 . In the *Pull this image* entry, click btn:[Copy to clipboard].

--- a/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
+++ b/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
@@ -3,7 +3,7 @@
 
 = Pushing container images from your local environment
 
-Use the following procedure to sign {ExecEnvName}s on a local system and push those signed {ExecEnvName}s to the {HubName} registry.
+Use the following procedure to sign {ExecEnvName} on a local system and push those signed {ExecEnvName} to the {HubName} registry.
 
 .Procedure
 . From a terminal, log in to Podman, or any container client currently in use:

--- a/downstream/modules/hub/proc-reject-collections.adoc
+++ b/downstream/modules/hub/proc-reject-collections.adoc
@@ -14,6 +14,6 @@ Collections requiring approval have the status *Needs review*.
 
 . From the navigation panel, select {MenuACAdminCollectionApproval}.
 . Find the collection you want to review in the list. You can also filter collections by Namespace, Repository, and Status using the search bar.
-. Click the thumbs down icon to approve and sign the collection. Confirm your choice in the modal that appears.
+. Click the thumbs down icon to reject the collection. Confirm your choice in the modal that appears.
 
 Collections you decline for publication are moved to the *Rejected* repository.

--- a/downstream/modules/hub/proc-sync-image.adoc
+++ b/downstream/modules/hub/proc-sync-image.adoc
@@ -3,8 +3,8 @@
 [id="proc-sync-image-adoc_{context}"]
 = Syncing images from a container repository
 
-You can pull {ExecEnvName}s from the {HubName} remote registry to sync an image to your local machine.
-To sync an {ExecEnvName} from a remote registry, you must first configure a remote registry.
+You can pull {ExecEnvName} from the {HubName} remote registry to sync an image to your local machine.
+To sync an {ExecEnvNameSing} from a remote registry, you must first configure a remote registry.
 
 .Prerequisites
 
@@ -38,7 +38,7 @@ For example, if the upstream name is set to "alpine" and the *Name* field is "lo
 ====
 +
 . Set a list of tags to include or exclude.
-Syncing {ExecEnvName}s with a large number of tags is time consuming and uses a lot of disk space.
+Syncing {ExecEnvName} with a large number of tags is time consuming and uses a lot of disk space.
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/hub/proc-tag-image.adoc
+++ b/downstream/modules/hub/proc-tag-image.adoc
@@ -5,11 +5,11 @@
 = Tagging container images
 
 [role="_abstract"]
-Tag {ExecEnvName}s to add an additional name to {ExecEnvName}s stored in your {HubName} container repository. If no tag is added to an {ExecEnvName}, {HubName} defaults to `latest` for the name.
+Tag {ExecEnvName} to add an additional name to {ExecEnvName} stored in your {HubName} container repository. If no tag is added to an {ExecEnvNameSing}, {HubName} defaults to `latest` for the name.
 
 .Prerequisites
 
-* You have *change {ExecEnvName} tags* permissions.
+* You have *change {ExecEnvNameSing} tags* permissions.
 
 .Procedure
 

--- a/downstream/modules/platform/con-gs-execution-env.adoc
+++ b/downstream/modules/platform/con-gs-execution-env.adoc
@@ -2,7 +2,7 @@
 
 = Build and use an {ExecEnvShort}
 
-All automation in Red Hat Ansible Automation Platform runs on container images called {ExecEnvName}s.
+All automation in Red Hat Ansible Automation Platform runs on container images called {ExecEnvName}.
 
 {ExecEnvNameStart} are consistent and shareable container images that serve as Ansible control nodes. 
 {ExecEnvNameStart} reduce the challenge of sharing Ansible content that has external dependencies. 


### PR DESCRIPTION
This PR ports the changes from [PR 2416](https://github.com/ansible/aap-docs/pull/2416) to the 2.5 branch. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more.