### PR TITLE
Backport to 2.5: AAP 34122 moves assembly from upgrading 2.5 to 2.5x to Installing on OCP guide …

### DIFF
--- a/downstream/assemblies/platform/assembly-update-ocp.adoc
+++ b/downstream/assemblies/platform/assembly-update-ocp.adoc
@@ -1,6 +1,6 @@
 [id="update-ocp"]
 
-= {PlatformNameShort} on {OCPShort}
+= Updating {PlatformNameShort} on {OCPShort}
 
 You can use an upgrade patch to update your operator-based {PlatformNameShort}.
 

--- a/downstream/modules/platform/proc-update-aap-on-ocp.adoc
+++ b/downstream/modules/platform/proc-update-aap-on-ocp.adoc
@@ -1,5 +1,5 @@
 [id="update-aap-on-ocp"]
-= Updating {PlatformNameShort} on {OCPShort}
+= Patch updating {PlatformNameShort} on {OCPShort}
 
 When you perform a patch update for an installation of {PlatformNameShort} on {OCPShort}, most updates happen within a channel:
 

--- a/downstream/titles/aap-operator-installation/master.adoc
+++ b/downstream/titles/aap-operator-installation/master.adoc
@@ -21,6 +21,8 @@ include::platform/assembly-operator-install-planning.adoc[leveloffset=+1]
 
 include::platform/assembly-install-aap-operator.adoc[leveloffset=+1]
 
+include::platform/assembly-update-ocp.adoc[leveloffset=+1]
+
 include::platform/assembly-installing-aap-operator-cli.adoc[leveloffset=+1]
 
 include::platform/assembly-configure-aap-operator.adoc[leveloffset=+1]

--- a/downstream/titles/updating-aap/master.adoc
+++ b/downstream/titles/updating-aap/master.adoc
@@ -21,4 +21,4 @@ Upgrades from 2.4 to 2.5 are unsupported at this time. For more information, see
 
 include::platform/assembly-update-rpm.adoc[leveloffset=+1]
 include::platform/assembly-update-container.adoc[leveloffset=+1]
-include::platform/assembly-update-ocp.adoc[leveloffset=+1]
+// [hherbly]: moved to Installing on OCP guide per AAP-34122 include::platform/assembly-update-ocp.adoc[leveloffset=+1]


### PR DESCRIPTION
This backport ports the changes from[ PR 2417](https://github.com/ansible/aap-docs/pull/2417) to the 2.5 branch. See [AAP-34122](https://issues.redhat.com/browse/AAP-34122) for more info. 