### PR TITLE
Add update content to Containerized installation

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -68,6 +68,8 @@ include::platform/ref-using-custom-receptor-signing-keys.adoc[leveloffset=+1]
 include::platform/ref-enabling-automation-hub-collection-and-container-signing.adoc[leveloffset=+1]
 include::platform/ref-adding-execution-nodes.adoc[leveloffset=+1]
 include::platform/proc-add-eda-safe-plugin-var.adoc[leveloffset=+1]
+include::platform/proc-update-aap-container.adoc[leveloffset=+1]
+include::platform/proc-backup-aap-container.adoc[leveloffset=+1]
 include::platform/proc-uninstalling-containerized-aap.adoc[leveloffset=+1]
 
 

--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -2,7 +2,7 @@
 
 = Backing up container-based {PlatformNameShort}
 
-Perform a back up of your container-based {PlatformNameShort} installer.
+Perform a back up of your {ContainerBase} of {PlatformNameShort}.
 
 .Procedure
 
@@ -22,4 +22,4 @@ This will backup the important data deployed by the containerized installer such
 
 * Data files
 
-By default, the backup directory is set to `~/backups` but this can be changed by using the `backup_dir` variable in your `inventory` file.
+By default, the backup directory is set to `~/backups`. You can change this by using the `backup_dir` variable in your `inventory` file.

--- a/downstream/modules/platform/proc-update-aap-container.adoc
+++ b/downstream/modules/platform/proc-update-aap-container.adoc
@@ -2,13 +2,13 @@
 
 = Updating container-based {PlatformNameShort}
 
-Perform a patch update for a container-based installation of {PlatformNameShort}.
+Perform a patch update for a {ContainerBase} of {PlatformNameShort} from 2.5 to 2.5.x.
 
 .Prerequisites
 
 You have done the following:
 
-* Reviewed the release notes for the associated patch release.
+* Reviewed the release notes for the associated patch release. For more information, see the link:{URLReleaseNotes}[{PlatformNameShort} {TitleReleaseNotes}].
 
 * Created a backup of your {PlatformNameShort} deployment. For more information, see xref:proc-backup-aap-container[Backing up controller-based {PlatformNameShort}].
 
@@ -38,7 +38,7 @@ $ tar xfvz ansible-automation-platform-containerized-setup-<version>.tar.gz
 $ tar xfvz ansible-automation-platform-containerized-setup-bundle-<version>-<arch name>.tar.gz
 ----
 +
-. Edit the `inventory` file so that it matches your desired configuration. You can keep the same parameters from your existing {PlatformNameShort} deployment or you can modify the parameters to match any changes to your environment.
+. Edit the `inventory` file so that it matches your required configuration. You can keep the same parameters from your existing {PlatformNameShort} deployment or you can change the parameters to match any modifications to your environment.
 
 . Run the `install` command:
 +


### PR DESCRIPTION
With event 2, the update content from Updating from Ansible Automation Platform 2.5 to 2.5.x should be migrated into the associated install guides. This PR addresses the Containerized installation guide.

Move upgrade content into the Containerized installation guide

https://issues.redhat.com/browse/AAP-34068