### PR TITLE
Backport-2.5-2429 (AAP-30120-B) Tweaked admonition bullets for rulebook activation

### DIFF
--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -24,8 +24,8 @@ Credential:: Select 0 or more credentials for this rulebook activation. This fie
 +
 [NOTE]
 ====
-* If you plan to use a {PlatformName} credential, you can _only_ select 1 of this credential type for your rulebook activation.
 * The credentials that display in this field are customized based on your rulebook activation and only include the following credential types: Vault, {PlatformName}, or any custom credential types that you have created. For more information about credentials, see xref:eda-credentials[Credentials].
+* If you plan to use a {PlatformName} credential, you can _only_ select 1 {PlatformName} credential type for a rulebook activation.
 ====
 
 Decision environment:: Decision environments are a container image to run Ansible rulebooks.


### PR DESCRIPTION
Tweaked previous statement originally proposed in PR https://github.com/ansible/aap-docs/pull/2418 and rearranged the order of the bullet list to ensure clarity.