### PR TITLE
[Backport] Minor fixes to correct broken link and doc formatting (#2432)

### DIFF
--- a/downstream/modules/platform/proc-gs-auto-dev-create-template.adoc
+++ b/downstream/modules/platform/proc-gs-auto-dev-create-template.adoc
@@ -113,7 +113,7 @@ For more information about job slices, see link:{URLControllerUserGuide}/control
 | Show Changes | Enables you to see the changes made by Ansible tasks. | Yes
 | Instance Groups | Choose link:{URLControllerUserGuide}/controller-instance-and-container-groups#controller-instance-group-policies[Instance and Container Groups] to associate with this job template.
 If the list is extensive, use the image:examine.png[examine,15,15] icon to narrow the options.
-Job template instance groups contribute to the job scheduling criteria, see link:{URLControllerUserGuide}/assembly-controller-topology-viewer#controller-job-runtime-behavior[Job Runtime Behavior] and link:{URLControllerAdminGuide}controller-clustering#controller-cluster-job-runtime[Control where a job runs] for rules.
+Job template instance groups contribute to the job scheduling criteria, see link:{URLControllerUserGuide}/assembly-controller-topology-viewer#controller-job-runtime-behavior[Job Runtime Behavior] and link:{URLControllerAdminGuide}/controller-clustering#controller-cluster-job-runtime[Control where a job runs] for rules.
 A System Administrator must grant you or your team permissions to be able to use an instance group in a job template.
 Use of a container group requires admin rights. a| - Yes.
 
@@ -161,7 +161,7 @@ See link:{URLControllerUserGuide}/controller-credentials#ref-controller-credenti
 * *Concurrent jobs*: If checked, you are allowing jobs in the queue to run simultaneously if not dependent on one another. Check this box if you want to run job slices simultaneously. For more information, see link:{URLControllerUserGuide}/controller-jobs#controller-capacity-determination[{ControllerNameStart} capacity determination and job impact].
 * *Enable fact storage*: If checked, {ControllerName} stores gathered facts for all hosts in an inventory related to the job running.
 * *Prevent instance group fallback*: Check this option to allow only the instance groups listed in the *Instance Groups* field to run the job.
-If clear, all available instances in the execution pool are used based on the hierarchy described in link:{URLControllerAdminGuide}controller-clustering#controller-cluster-job-runtime[Control where a job runs].
+If clear, all available instances in the execution pool are used based on the hierarchy described in link:{URLControllerAdminGuide}/controller-clustering#controller-cluster-job-runtime[Control where a job runs].
 . Click btn:[Create job template], when you have completed configuring the details of the job template.
 
 Creating the template does not exit the job template page but advances to the Job Template *Details* tab.

--- a/downstream/titles/builder/master.adoc
+++ b/downstream/titles/builder/master.adoc
@@ -21,6 +21,7 @@ include::builder/assembly-publishing-exec-env.adoc[leveloffset=+1]
 include::hub/assembly-populate-container-registry.adoc[leveloffset=+1]
 include::hub/assembly-setup-container-repository.adoc[leveloffset=+1]
 include::hub/assembly-pull-image.adoc[leveloffset=+1]
-include::builder/assembly-open-source-license.adoc[levloffset=+1]
+include::builder/assembly-open-source-license.adoc[leveloffset=+1]
 [appendix]
 include::builder/builder/con-ee-precedence.adoc[leveloffset=+1]
+ 


### PR DESCRIPTION
This PR backports the changes from #2432 to the 2.5 branch.