### PR TITLE
AAP-33892 Moved install scenarios to appropriate sub-heading

### DIFF
--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -43,6 +43,16 @@ include::platform/proc-editing-inventory-file.adoc[leveloffset=+1]
 include::platform/con-install-scenario-examples.adoc[leveloffset=+1]
 include::platform/con-install-scenario-recommendations.adoc[leveloffset=+2]
 //Added for AAP-29120
+include::platform/ref-gateway-controller-ext-db.adoc[leveloffset=+3]
+include::platform/ref-gateway-controller-hub-ext-db.adoc[leveloffset=+3]
+include::platform/ref-gateway-controller-hub-eda-ext-db.adoc[leveloffset=+3]
+include::platform/con-ha-hub-installation.adoc[leveloffset=+3]
+include::platform/proc-install-ha-hub-selinux.adoc[leveloffset=+3]
+include::platform/proc-configure-pulpcore-service.adoc[leveloffset=+4]
+include::platform/proc-apply-selinux-context.adoc[leveloffset=+4]
+include::hub/hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+3]
+include::platform/proc-add-eda-safe-plugin-var.adoc[leveloffset=+3]
+
 include::platform/proc-set-registry-username-password.adoc[leveloffset=+2]
 //[emcwhinn] Removing for AAP-29246 as content is being moved to one guide in 2.4 customer portal 
 //include::platform/con-eda-2-5-with-controller-2-4.adoc[leveloffset=+3]
@@ -56,8 +66,7 @@ include::platform/proc-set-registry-username-password.adoc[leveloffset=+2]
 // include::platform/ref-standalone-controller-hub-ext-database-inventory.adoc[leveloffset=+3]
 //[rjgrange] Removed for AAP-22613 Removing all references to SSO and LDAP installation
 //include::platform/ref-connect-hub-to-rhsso.adoc[leveloffset=+4]
-include::platform/ref-gateway-controller-ext-db.adoc[leveloffset=+3]
-include::platform/ref-gateway-controller-hub-ext-db.adoc[leveloffset=+3]
+
 
 //[rjgrange] Removed for AAP-22613 Removing all references to SSO and LDAP installation
 //include::platform/ref-ldap-config-on-pah.adoc[leveloffset=+3]
@@ -66,14 +75,8 @@ include::platform/ref-gateway-controller-hub-ext-db.adoc[leveloffset=+3]
 //[ifowler] Removed for AAP-18700 Install Guide Scenario Consolidation  
 //include::platform/ref-standalone-hub-ext-database-customer-provided.adoc[leveloffset=+3]
 // dcdacosta - removed this assembly because the modules are included above. include::assembly-installing-high-availability-hub.adoc[leveloffset=+3]
-include::platform/ref-gateway-controller-hub-eda-ext-db.adoc[leveloffset=+3]
 
-include::platform/con-ha-hub-installation.adoc[leveloffset=+3]
-include::platform/proc-install-ha-hub-selinux.adoc[leveloffset=+3]
-include::platform/proc-configure-pulpcore-service.adoc[leveloffset=+4]
-include::platform/proc-apply-selinux-context.adoc[leveloffset=+4]
-include::hub/hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+3]
-include::platform/proc-add-eda-safe-plugin-var.adoc[leveloffset=+3]
+
 include::platform/ref-redis-config-enterprise-topology.adoc[leveloffset=+3]
 include::platform/proc-running-setup-script.adoc[leveloffset=+1]
 include::platform/proc-verify-aap-installation.adoc[leveloffset=+1]


### PR DESCRIPTION
Installation scenarios in the [RPM Installation guide](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/index) were under a different sub-heading than the previous version of the [RH Installation Guide (2.4)](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/red_hat_ansible_automation_platform_installation_guide/index). 

Moved topics numbered as 3.2.2.1 - 3.2.2.7 in the guide under sub-heading [3.2.2. Setting registry_username and registry_password](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/assembly-platform-install-scenario#proc-set-registry-username-password) to the most appropriate sub-heading [3.2.1 Inventory file recommendations based on installation scenarios](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/assembly-platform-install-scenario#con-install-scenario-recommendations). These topics will become 3.2.1.1 - 3.2.1.7 as they were in the original installation guide.