### PR TITLE
Backport to 2.5: Adds SME feedback to RPM upgrade guide (#2437)

### DIFF
--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -19,12 +19,15 @@ Before you begin the upgrade process, review the following considerations to pla
 When upgrading from {PlatformNameShort} 2.4 to 2.5, the API endpoints for the {ControllerName}, {HubName}, and {EDAcontroller} are all available for use. These APIs are being deprecated and will be disabled in an upcoming release. This grace period is to allow for migration to the new APIs put in place with the {Gateway}.
 ====
 +
-* Ensure you have a valid subscription from a previous version. You must provide your credentials or a link:https://access.redhat.com/articles/5807761[subscriptions manifest] upon upgrading to the latest version of {PlatformNameShort}.
+* Verify that you have a valid subscription before upgrading from a previous version of {PlatformNameShort}. Existing subscriptions are carried over during the upgrade process. 
 * Ensure you have a backup of an {PlatformNameShort} 2.4 environment before upgrading in case any issues occur. See link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] and link:{LinkOperatorBackup} for the specific topology of the environment.
-* Clustered upgrades require special attention to instance and instance groups before upgrading. Ensure you capture your inventory or instance group details before upgrading.
-* Upgrades of {EDAName} version 2.4 to 2.5 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.5 are not compatible.
+* Ensure you capture your inventory or instance group details before upgrading.
+* Upgrades of {EDAName} version 2.4 to 2.5 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.5 are not compatible. For more information, see xref:platform/proc-upgrade-controller-hub-eda-unified-ui.adoc[{ControllerName} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades].
 +
-If you are currently running {EDAcontroller} 2.5, it is recommended that you disable all {EDAName} activations before upgrading to ensure that only new activations run after the upgrade process is complete. 
+If you are currently running {EDAcontroller} 2.5, it is recommended that you disable all {EDAName} activations before upgrading to ensure that only new activations run after the upgrade process is complete.
+* {ControllerNameStart} OAuth applications on the platform UI are not supported for 2.4 to 2.5 migration. See this link:https://access.redhat.com/solutions/7091987[Knowledgebase article] for more information. To learn how to recreate your OAuth applications, see link:{URLCentralAuth}/gw-token-based-authentication#assembly-controller-applications[Applications] in the {TitleCentralAuth} guide.
+* During the upgrade process, user accounts from the individual services are migrated. If there are accounts from multiple services, they must be linked to access the unified platform. See xref:platform/proc-account-linking.adoc[Account linking] for details.
+* {PlatformNameShort} 2.5 offers a centralized Redis instance in both link:{URLPlanningGuide}/ha-redis_planning#gw-single-node-redis_planning[standalone] and link:{URLPlanningGuide}/ha-redis_planning#gw-clustered-redis_planning[clustered] topologies. For information on how to configure Redis, see link:{URLInstallationGuide}/assembly-platform-install-scenario#redis-config-enterprise-topology_platform-install-scenario[Configuring Redis] in the {TitleInstallationGuide} guide.
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/platform/proc-account-linking.adoc
+++ b/downstream/modules/platform/proc-account-linking.adoc
@@ -7,14 +7,9 @@
 
 {PlatformNameShort} 2.5 provides a centralized location for users, teams and organizations to access the platform's services and features. When you upgrade from a previous version of {PlatformNameShort}, your existing account is automatically migrated to a single platform account. However, if you have multiple component accounts, your accounts must be linked to use the centralized features of the platform.
 
-The first time you log in to {PlatformNameShort} 2.5, the platform searches through the existing services to locate a user account with the credentials you entered. When there is a match to an existing account, that account is registered and becomes centrally managed by the platform. Any subsequent component accounts in the system are orphaned. This can cause problems accessing the services in {PlatformNameShort}. 
+The first time you log in to {PlatformNameShort} 2.5, the platform searches through the existing services to locate a user account with the credentials you entered. When there is a match to an existing account, that account is registered and becomes centrally managed by the platform. Any subsequent component accounts in the system are orphaned and cannot be used to log into the platform.
 
 To address this problem, use the account linking procedure to authenticate from any of your existing component accounts and still be recognized by the platform. Linking accounts associates existing component accounts with the same user profile. 
-
-[IMPORTANT]
-====
-{ControllerNameStart} OAuth applications on the platform UI are not supported for 2.4 to 2.5 migration. See this link:https://access.redhat.com/solutions/7091987[Knowledgebase article] for more information. To learn how to recreate your OAuth applications, see link:{URLCentralAuth}/gw-token-based-authentication#assembly-controller-applications[Applications] in the {TitleCentralAuth} guide.
-====
 
 .Prerequisites
 
@@ -26,6 +21,12 @@ If you have completed the upgrade process and have a legacy {PlatformNameShort} 
 . Navigate to the login page for {PlatformNameShort}. 
 . In the login modal, select either *I have an {ControllerName} account* or *I have an {HubName} account* based on the credentials you have. 
 . On the next screen, enter the legacy credentials for the component account you selected and click btn:[Log in].
++
+[NOTE]
+====
+If you are logging in using OIDC credentials, see link:LINK TBD
+====
++
 . If you have successfully linked your account, the next screen shows your username with a green checkmark beside it. If you have other legacy accounts that you want to link, enter those account credentials and click btn:[Link] to link them to your centralized {Gateway} account.
 . Click btn:[Submit] to complete linking your legacy accounts. 
 . After your accounts are linked, depending on your authentication method, you might be prompted to create a new username and password. These credentials will replace your legacy credentials for each component account. 
@@ -40,7 +41,7 @@ If you encounter an error message telling your that your account could not be au
 
 [NOTE]
 ====
-If you log into {PlatformNameShort} for the first time and are prompted to change your username, this is an indication that another user has already logged into {PlatformNameShort} with the same username. To proceed with account migration, follow the prompts to change your username. {PlatformNameShort} uses your password to authenticate which account or accounts belong to you. If you have multiple accounts, you will be prompted to merge them before the migration begins.
+If you log into {PlatformNameShort} for the first time and are prompted to change your username, this is an indication that another user has already logged into {PlatformNameShort} with the same username. To proceed with account migration, follow the prompts to change your username. {PlatformNameShort} uses your password to authenticate which account or accounts belong to you.
 ====
 
 .A diagram of the account linking flow

--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -14,14 +14,14 @@ Bundled installer::
 +
 [source,options="nowrap",subs=attributes+]
 -----
-$ cd ansible-automation-platform-setup-bundle-2.5-1-x86_64
+$ cd ansible-automation-platform-setup-bundle-2.5-4-x86_64
 -----
 +
 Online installer::
 +
 [source,options="nowrap",subs=attributes+]
 -----
-$ cd ansible-automation-platform-setup-2.5-1
+$ cd ansible-automation-platform-setup-2.5-4
 -----
 
 . Open the `inventory` file for editing.
@@ -44,7 +44,3 @@ If `localhost` is used, the upgrade will be stopped as part of preflight checks.
 ----
 include::ini/clustered-nodes.ini[]
 ----
-
-.Deprovisioning nodes or groups in a cluster
-
-* Append `node_state=deprovision` to the node or group within the `inventory` file. Note that this is only for automationcontroller nodes or execution_nodes.


### PR DESCRIPTION
This PR ports the changes from [PR 2437](https://github.com/ansible/aap-docs/pull/2437) to the 2.5 branch. 