### PR TITLE
AAP-34003: Import AAP 2.5 attributes to Lightspeed docs

### DIFF
--- a/lightspeed/attributes/attributes.adoc
+++ b/lightspeed/attributes/attributes.adoc
@@ -6,11 +6,20 @@
 :AAPCentralAuth: Ansible Automation Platform Central Authentication
 :CentralAuthStart: Central authentication
 :CentralAuth: central authentication
-:PlatformVers: 2.4
-:AnsibleCoreVers: 2.15
-:AnsibleInstallVers: 2.4-1
-:PlatformDownloadUrl: https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software
-:BaseURL: https://access.redhat.com/documentation/en-us
+:PlatformVers: 2.5
+:PostgresVers: PostgreSQL 15
+//The Ansible-core version required to install AAP
+:CoreInstVers: 2.16
+//The Ansible-core version used by the AAP control plane and EEs
+:CoreUseVers: 2.16
+:PlatformDownloadUrl: https://access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.5/x86_64/product-software
+:BaseURL: https://docs.redhat.com/en/documentation
+:VMBase: VM-based installation
+:OperatorBase: operator-based installation
+:ContainerBase: container-based installation
+:PlatformDashboard: platform dashboard
+:Gateway: platform gateway
+:GatewayStart: Platform gateway
 
 // Ansible Lightspeed
 :LightspeedFullName: Red Hat Ansible Lightspeed with IBM watsonx Code Assistant
@@ -19,6 +28,7 @@
 :AnsibleCodeBot: Ansible code bot
 :AnsibleContentParser: content parser tool
 :ibmwatsonxcodeassistant: IBM watsonx Code Assistant
+:ibmCPD: {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data
 
 // Event-Driven Ansible
 :EDAName: Event-Driven Ansible
@@ -30,17 +40,21 @@
 :AWS: Amazon Web Services
 :GCP: Google Cloud Platform
 :Azure: Microsoft Azure
+:MSEntraID: Microsoft Entra ID
 
 // Automation Mesh
 :AutomationMesh: automation mesh
 :AutomationMeshStart: Automation mesh
+:ReceptorRpm: receptor rpm/container
+:RunnerRpm: Ansible-runner rpm/container
 
 // Operators
-:OperatorPlatform: Ansible Automation Platform Operator
+:OperatorPlatformName: Red Hat Ansible Automation Platform Operator
+:OperatorPlatformNameShort: Ansible Automation Platform Operator
 :OperatorHub: Ansible Automation Platform Hub Operator
 :OperatorController: Ansible Automation Platform Controller Operator
 :OperatorResource: Ansible Automation Platform Resource Operator
-
+:OperatorResourceShort: Resource Operator
 
 // Automation services catalog
 :CatalogName: automation services catalog
@@ -82,11 +96,10 @@
 :MessageQueue: message queue/cache/KV store
 :MeshConnect: automation mesh connector
 :MeshReceptor: automation mesh receptor
-
-// Automation Mesh
-:MeshName: automation mesh
-:ReceptorRpm: receptor rpm/container
-:RunnerRpm: Ansible-runner rpm/container
+:ControllerGS: Getting started with automation controller
+:ControllerUG: Using automation execution
+:ControllerAG: Configuring automation execution
+:Analytics: Automation Analytics
 
 // Execution environments
 :ExecEnvNameStart: Automation execution environments
@@ -99,15 +112,20 @@
 :Runner: Ansible Runner
 :Role: Role ARG Spec
 
-
-// Ansible developer tools
-:ToolsName: Ansible developer tools
-:Test: Ansible-test
+// Ansible development tools
+:ToolsName: Ansible development tools
+:AAPRHDH: Ansible plug-ins for Red Hat Developer Hub
+:AAPRHDHShort: Ansible plug-ins
+:RHDH: Red Hat Developer Hub
+:RHDHVers: 1.2
+:RHDHShort: RHDH
 :Builder: Ansible Builder
-:Navigator: Automation content navigator
+:Navigator: automation content navigator
+:NavigatorStart: Automation content navigator
 :IDEplugin: Ansible IDE plugins
 :IDEcollection: Ansible IDE collection explorer
 :IDElanguage: Ansible IDE language server
+:VSCode: VS Code
 
 // Content Collections
 :CertifiedName: Ansible Certified Content Collections
@@ -134,3 +152,284 @@
 // Icons
 :MoreActionsIcon: &vellip;
 :SettingsIcon: &#9881;
+
+// Feedback module
+:DocumentationFeedback: providing-feedback.adoc
+:Boilerplate: aap-common/boilerplate.adoc
+
+// Linux platforms
+:RHEL: Red Hat Enterprise Linux
+
+// 2.5 Gateway Menu selections
+// These menu selections were based on the UI build environment dated 05/03/24 and should be verified against the final build before GA
+// Top level menu definitions for use only when selections go 3 levels deep.
+:MenuTopAE: Automation Execution
+:MenuAD: Automation Decisions
+// Not yet used but looks to be future scoped and might replace Automation Execution > Infrastructure
+//:MenuAI: Automation Infrastructure
+:MenuTopAC: Automation Content
+:MenuAA: Automation Analytics
+:MenuAL: Ansible Lightspeed with IBM watsonx Code Assistant
+:MenuQS: Quick Starts
+// Not yet used but looks to be future scoped and will include a blend of menu selections that currently exist.
+//:MenuU: Utilities
+:MenuAM: Access Management
+//Might become Global Settings in the future with a few changed/new selections?
+:MenuAEAdminSettings: Settings
+
+// Automation Execution (aka automation controller menu items)
+:MenuAEJobs: menu:{MenuTopAE}[Jobs]
+:MenuAETemplates: menu:{MenuTopAE}[Templates]
+:MenuAESchedules: menu:{MenuTopAE}[Schedules]
+// FYI Automation Execution and Automation Decisions Projects will be under 1 selection in the 2.5-next or later.
+:MenuAEProjects: menu:{MenuTopAE}[Projects]
+
+// Automation Execution > Infrastructure
+:MenuInfrastructureTopology: menu:{MenuTopAE}[Infrastructure > Topology View]
+:MenuInfrastructureInventories: menu:{MenuTopAE}[Infrastructure > Inventories]
+:MenuInfrastructureHosts: menu:{MenuTopAE}[Infrastructure > Hosts]
+:MenuInfrastructureInstanceGroups: menu:{MenuTopAE}[Infrastructure > Instance Groups]
+:MenuInfrastructureInstances: menu:{MenuTopAE}[Infrastructure > Instances]
+:MenuInfrastructureExecEnvironments: menu:{MenuTopAE}[Infrastructure > Execution Environments]
+:MenuAECredentials: menu:{MenuTopAE}[Infrastructure > Credentials]
+:MenuAECredentialType: menu:{MenuTopAE}[Infrastructure > Credential Types]
+
+// Automation Execution > Administration
+:MenuAEAdminActivityStream: menu:{MenuTopAE}[Administration > Activity Stream]
+:MenuAEAdminWorkflowApprovals: menu:{MenuTopAE}[Administration > Workflow Approvals]
+:MenuAEAdminJobNotifications: menu:{MenuTopAE}[Administration > Notifiers]
+:MenuAEAdminManageJobs: menu:{MenuTopAE}[Administration > Management Jobs]
+
+//Each of the services previously had selections for access which will be centralized in 2.5, ultimately these should be changed to use the attributes in Access Management menu selections but I'm leaving these for later cleanup to avoid possible errors:
+:MenuControllerOrganizations: menu:{MenuAM}[Organizations]
+:MenuControllerUsers: menu:{MenuAM}[Users]
+:MenuControllerTeams: menu:{MenuAM}[Teams]
+
+// Automation Decisions (aka event driven automation menu selections)
+:MenuADRuleAudit: menu:{MenuAD}[Rule Audit]
+:MenuADRulebookActivations: menu:{MenuAD}[Rulebook Activations]
+// FYI Automation Execution and Automation Decisions Projects will be under 1 selection in the 2.5-next or later.
+:MenuADProjects: menu:{MenuAD}[Projects]
+:MenuADDecisionEnvironments: menu:{MenuAD}[Decision Environments]
+:MenuADEventStreams: menu:{MenuAD}[Event Streams]
+:MenuADCredentials: menu:{MenuAD}[Infrastructure > Credentials]
+:MenuADCredentialType: menu:{MenuAD}[Infrastructure > Credential Types]
+
+// Automation Content (aka automation hub menu selections)
+// In 2.5EA the Automation Content selection will open a hub ui instance in a new tab/browser so the menu definitions will not change until 2.5-next
+:MenuACNamespaces: menu:{MenuTopAC}[Namespaces]
+:MenuACCollections: menu:{MenuTopAC}[Collections]
+:MenuACExecEnvironments: menu:{MenuTopAC}[Execution Environments]
+
+// Automation Content > Administration
+:MenuACAdminSignatureKeys: menu:{MenuTopAC}[Signature Keys]
+:MenuACAdminRepositories: menu:{MenuTopAC}[Repositories]
+:MenuACAdminRemoteRegistries: menu:{MenuTopAC}[Remote Registries]
+:MenuACAdminTasks: menu:{MenuTopAC}[Task Management]
+:MenuACAdminCollectionApproval: menu:{MenuTopAC}[Collection Approvals]
+:MenuACAdminRemotes: menu:{MenuTopAC}[Remotes]
+:MenuACAPIToken: menu:{MenuTopAC}[API token]
+//Each of the services previously had selections for access which will be centralized, ultimately these should be changed to use the attributes in Access Management menu selections once automation hub is provide in the full ui platform experience in 2.5-next
+:MenuHubUsers: menu:{MenuAM}[Users]
+:MenuHubGroups: menu:User Access[Groups]
+:MenuHubRoles: menu:{MenuAM}[Roles]
+
+// Automation Analytics menu selections - According to mockups, analytics will be included in the Gateway nav only includes Automation Calculator, Host Metrics and Subscription Usage, other settings are also included on the Ansible dashboard on the Hybrid Cloud Console https://console.redhat.com/ansible/ansible-dashboard
+:MenuAAReports: menu:{MenuAA}[Reports]
+:MenuAASavingsPlanner: menu:{MenuAA}[Savings Planner]
+:MenuAAAutomationCalc: menu:{MenuAA}[Automation Calculator]
+:MenuAAHostMetrics: menu:{MenuAA}[Host Metrics]
+:MenuAAOrgStats: menu:{MenuAA}[Organization Statistics]
+:MenuAAJobExplorer: menu:{MenuAA}[Job Explorer]
+:MenuAAClusters: menu:{MenuAA}[Clusters]
+:MenuAANotifications: menu:{MenuAA}[Notification]
+//The following currently don't exist in the console but may be included in the 2.5 platform
+//:MenuAAActivityStream: menu:{MenuAA}[Activity Stream]
+//:MenuAAAnalyticsBuilder: menu:{MenuAA}[Analytics builder]
+//:MenuAAHostSubscriptionUse: menu:{MenuAA}[Subscription Usage]
+
+// Ansible Lightspeed menu selections
+// --- the following is not in the current build but may be added later ---
+//:MenuALSeatManagement: menu:{MenuAL}[Seat Management]
+
+// Access Management menu selections
+:MenuAMAuthentication: menu:{MenuAM}[Authentication Methods]
+:MenuAMOrganizations: menu:{MenuAM}[Organizations]
+:MenuAMTeams: menu:{MenuAM}[Teams]
+:MenuAMUsers: menu:{MenuAM}[Users]
+:MenuAMRoles: menu:{MenuAM}[Roles]
+:MenuAMAdminOauthApps: menu:{MenuAM}[OAuth Applications]
+// [ddacosta Credentials will not be centralized until 2.5-next]
+// :MenuAMCredentials: menu:{MenuAM}[Credentials]
+// :MenuAMCredentialType: menu:{MenuAM}[Credential Types]
+
+
+//Settings menu selections
+// --Previously settings was a single menu selection, in 2.5 it's a top level selection with sub selections see above for the attribute {MenuAEAdminSettings}
+:MenuSetSubscription: menu:{MenuAEAdminSettings}[Subscription]
+:MenuSetGateway: menu:{MenuAEAdminSettings}[Platform gateway]
+:MenuSetUserPref: menu:{MenuAEAdminSettings}[User Preferences]
+:MenuSetSystem: menu:{MenuAEAdminSettings}[System]
+:MenuSetJob: menu:{MenuAEAdminSettings}[Job]
+:MenuSetLogging: menu:{MenuAEAdminSettings}[Logging]
+:MenuSetTroubleshooting: menu:{MenuAEAdminSettings}[Troubleshooting]
+// Not yet implemented but look to be in the future scope 2.5-next plan
+//:MenuSetLogin: {MenuAEAdminSettings}[Log In Settings]
+//:MenuSetUI: {MenuAEAdminSettings}[User Interface Settings]
+
+// Title and link attributes
+//
+// titles/troubleshooting-aap
+:TitleTroubleshootingAAP: Troubleshooting Ansible Automation Platform
+:URLTroubleshootingAAP: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/troubleshooting_ansible_automation_platform
+:LinkTroubleshootingAAP: {URLTroubleshootingAAP}[{TitleTroubleshootingAAP}]
+//
+// titles/aap-plugin-rhdh-install
+:TitlePluginRHDHInstall: Installing Ansible plug-ins for Red Hat Developer Hub
+:URLPluginRHDHInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/installing_ansible_plug-ins_for_red_hat_developer_hub
+:LinkPluginRHDHInstall: {URLPluginRHDHInstall}[{TitlePluginRHDHInstall}]
+//
+// titles/aap-plugin-rhdh-using
+:TitlePluginRHDHUsing: Using Ansible plug-ins for Red Hat Developer Hub
+:URLPluginRHDHUsing: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_ansible_plug-ins_for_red_hat_developer_hub
+:LinkPluginRHDHUsing: {URLPluginRHDHUsing}[{TitlePluginRHDHUsing}]
+//
+// titles/aap-operations-guide
+:TitleAAPOperationsGuide: Operating Ansible Automation Platform
+:URLAAPOperationsGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/operating_ansible_automation_platform
+:LinkAAPOperationsGuide: {URLAAPOperationsGuide}[{TitleAAPOperationsGuide}]
+//
+// titles/eda/eda-user-guide
+:TitleEDAUserGuide: Using automation decisions 
+:URLEDAUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_decisions 
+:LinkEDAUserGuide: {URLEDAUserGuide}[{TitleEDAUserGuide}]
+//
+// titles/upgrade
+:TitleUpgrade: Upgrade and migration
+:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/upgrade_and_migration
+:LinkUpgrade: {URLUpgrade}[{TitleUpgrade}]
+//
+// titles/aap-operator-installation
+:TitleOperatorInstallation: Installing on OpenShift Container Platform
+:URLOperatorInstallation: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/installing_on_openshift_container_platform
+:LinkOperatorInstallation: {URLOperatorInstallation}[{TitleOperatorInstallation}]
+//
+// titles/aap-installation-guide
+:TitleInstallationGuide: RPM installation
+:URLInstallationGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation
+:LinkInstallationGuide: {URLInstallationGuide}[{TitleInstallationGuide}]
+//
+// titles/aap-planning-guide
+:TitlePlanningGuide: Planning your installation
+:URLPlanningGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/planning_your_installation
+:LinkPlanningGuide: {URLPlanningGuide}[{TitlePlanningGuide}]
+//
+// titles/operator-mesh
+:TitleOperatorMesh: Automation mesh for managed cloud or operator environments
+:URLOperatorMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_managed_cloud_or_operator_environments
+:LinkOperatorMesh: {URLOperatorMesh}[{TitleOperatorMesh}]
+//
+// titles/automation-mesh
+:TitleAutomationMesh: Automation mesh for VM environments
+:URLAutomationMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_vm_environments
+:LinkAutomationMesh: {URLAutomationMesh}[{TitleAutomationMesh}]
+//
+// titles/ocp_performance_guide
+:TitleOCPPerformanceGuide: Performance considerations for operator environments
+:URLOCPPerformanceGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/performance_considerations_for_operator_environments
+:LinkOCPPerformanceGuide: {URLOCPPerformanceGuide}[{TitleOCPPerformanceGuide}]
+//
+// titles/security-guide
+:TitleSecurityGuide: Implementing security automation
+:URLSecurityGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/implementing_security_automation
+:LinkSecurityGuide: {URLSecurityGuide}[{TitleSecurityGuide}]
+//
+// titles/playbooks/playbooks-getting-started
+:TitlePlaybooksGettingStarted: Getting started with playbooks
+:URLPlaybooksGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_playbooks
+:LinkPlaybooksGettingStarted: {URLPlaybooksGettingStarted}[{TitlePlaybooksGettingStarted}]
+//
+// titles/playbooks/playbooks-reference
+:TitlePlaybooksReference: Reference guide to Ansible Playbooks
+:URLPlaybooksReference: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/reference_guide_to_ansible_playbooks
+:LinkPlaybooksReference: {URLPlaybooksReference}[{TitlePlaybooksReference}]
+//
+// titles/release-notes
+:TitleReleaseNotes: Release notes
+:URLReleaseNotes: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/release_notes
+:LinkReleaseNotes: {URLReleaseNotes}[{TitleReleaseNotes}]
+//
+// titles/controller/controller-user-guide
+:TitleControllerUserGuide: Using automation execution
+:URLControllerUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution
+:LinkControllerUserGuide: {URLControllerUserGuide}[{TitleControllerUserGuide}]
+//
+// titles/controller/controller-admin-guide
+:TitleControllerAdminGuide: Configuring automation execution
+:URLControllerAdminGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/configuring_automation_execution
+:LinkControllerAdminGuide: {URLControllerAdminGuide}[{TitleControllerAdminGuide}]
+//
+// titles/controller/controller-api-overview
+:TitleControllerAPIOverview: Automation execution API overview
+:URLControllerAPIOverview: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_execution_api_overview
+:LinkControllerAPIOverview: {URLControllerAPIOverview}[{TitleControllerAPIOverview}]
+//
+// titles/aap-operator-backup
+:TitleOperatorBackup: Backup and recovery for operator environments
+:URLOperatorBackup: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/backup_and_recovery_for_operator_environments
+:LinkOperatorBackup: {URLOperatorBackup}[{TitleOperatorBackup}]
+//
+// titles/central-auth
+:TitleCentralAuth: Access management and authentication
+:URLCentralAuth: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/access_management_and_authentication
+:LinkCentralAuth: {URLCentralAuth}[{TitleCentralAuth}]
+//
+// titles/getting-started
+:TitleGettingStarted: Getting started with Ansible Automation Platform
+:URLGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_ansible_automation_platform
+:LinkGettingStarted: {URLGettingStarted}[{TitleGettingStarted}]
+//
+// titles/aap-containerized-install
+:TitleContainerizedInstall: Containerized installation
+:URLContainerizedInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation
+:LinkContainerizedInstall: {URLContainerizedInstall}[{TitleContainerizedInstall}]
+//
+// titles/navigator-guide
+:TitleNavigatorGuide: Using content navigator
+:URLNavigatorGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_content_navigator
+:LinkNavigatorGuide: {URLNavigatorGuide}[{TitleNavigatorGuide}]
+//
+// titles/aap-hardening
+:TitleHardening: Hardening and compliance
+:URLHardening: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/hardening_and_compliance
+:LinkHardening: {URLHardening}[{TitleHardening}]
+//
+// titles/builder
+:TitleBuilder: Creating and using execution environments
+:URLBuilder: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_using_execution_environments
+:LinkBuilder: {URLBuilder}[{TitleBuilder}]
+//
+// titles/hub/managing-content
+:TitleHubManagingContent: Managing automation content
+:URLHubManagingContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_automation_content
+:LinkHubManagingContent: {URLHubManagingContent}[{TitleHubManagingContent}]
+//
+// titles/analytics
+:TitleAnalytics: Using automation analytics
+:URLAnalytics: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_analytics
+:LinkAnalytics: {URLAnalytics}[{TitleAnalytics}]
+//
+// titles/develop-automation-content
+:TitleDevelopAutomationContent: Developing automation content
+:URLDevelopAutomationContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/developing_automation_content
+:LinkDevelopAutomationContent: {URLDevelopAutomationContent}[{TitleDevelopAutomationContent}]
+//
+// titles/topologies
+:TitleTopologies: Tested deployment models
+:URLTopologies: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models
+:LinkTopologies: {URLTopologies}[{TitleTopologies}]
+//
+// Lightspeed branch titles/lightspeed-user-guide
+:TitleLightspeedUserGuide: Red Hat Ansible Lightspeed with IBM watsonx Code Assistant User Guide
+:URLLightspeedUserGuide: {BaseURL}/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide
+:LinkLightspeedUserGuide: {URLLightspeedUserGuide}[{TitleLightspeedUserGuide}]


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-34003. 

Changes made:
Imported AAP 2.5 attributes to Lightspeed docs so that they are consistent throughout the doc sets. 

