### PR TITLE
2.5 Add release notes for async 2.5-3 aka event 2 (#2441)

### DIFF
--- a/downstream/titles/release-notes/async/aap-25-1-7-oct.adoc
+++ b/downstream/titles/release-notes/async/aap-25-1-7-oct.adoc
@@ -39,10 +39,10 @@ The following enhancements and fixes have been implemented in this release of {P
 == Advisories
 The following errata advisories are included in this release:
 
-* link:https://access.redhat.com/errata/RHBA-2024:7756[RHBA-2024:7756]
+* link:https://access.redhat.com/errata/RHBA-2024:7756[RHBA-2024:7756 - Product Release Update]
 
-* link:https://access.redhat.com/errata/RHBA-2024:7760[RHBA-2024:7760]
+* link:https://access.redhat.com/errata/RHBA-2024:7760[RHBA-2024:7760 - Container Release Update]
 
-* link:https://access.redhat.com/errata/RHBA-2024:7766[RHBA-2024:7766]
+* link:https://access.redhat.com/errata/RHBA-2024:7766[RHBA-2024:7766 - Cluster Scoped Container Release Update]
 
-* link:https://access.redhat.com/errata/RHBA-2024:7810[RHBA-2024:7810]
+* link:https://access.redhat.com/errata/RHBA-2024:7810[RHBA-2024:7810 - Setup Bundle Release Update]

--- a/downstream/titles/release-notes/async/aap-25-2-14-oct.adoc
+++ b/downstream/titles/release-notes/async/aap-25-2-14-oct.adoc
@@ -26,16 +26,14 @@ The following fixes have been implemented in this release of {PlatformName}.
 
 * Fixed an issue where setting `*pg_host=` without any other context no longer results in an empty HOST section of `settings.py` in controller. (AAP-32440)
 
-// Commenting this out for now as the advisories are not yet published to the Errata tab on the downloads page: https://access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.5/x86_64/product-errata
+== Advisories
+The following errata advisories are included in this release:
 
-// == Advisories
-// The following errata advisories are included in this release:
+* link:https://access.redhat.com/errata/RHBA-2024:8079[RHBA-2024:8079 - Product Release Update]
 
-// * link:https://access.redhat.com/errata/[]
+* link:https://access.redhat.com/errata/RHBA-2024:8084[RHBA-2024:8084 - Container Release Update]
 
-// * link:https://access.redhat.com/errata/[]
+* link:https://access.redhat.com/errata/RHBA-2024:8096[RHBA-2024:8096 - Cluster Scoped Container Release Update]
 
-// * link:https://access.redhat.com/errata/[]
-
-// * link:https://access.redhat.com/errata/[]
+* link:https://access.redhat.com/errata/RHBA-2024:8141[RHBA-2024:8141 - Setup Bundle Release Update]
 

--- a/downstream/titles/release-notes/async/aap-25-3-28-oct.adoc
+++ b/downstream/titles/release-notes/async/aap-25-3-28-oct.adoc
@@ -1,0 +1,68 @@
+[[aap-25-3-28-oct]]
+
+= {PlatformNameShort} patch release October 28, 2024
+
+The following enhancements and bug fixes have been implemented in this release of {PlatformNameShort}.
+
+== Enhancements
+
+=== {PlatformNameShort}
+
+* With this update, upgrades from {PlatformNameShort} 2.4 to 2.5 are supported for RPM and Operator-based deployments. For more information on how to upgrade, see link:{URLUpgrade}[{TitleUpgrade}]. (ANSTRAT-809)
+** Upgrades from 2.4 Containerized {PlatformNameShort} Tech Preview to 2.5 Containerized {PlatformNameShort} are unsupported at this time. 
+** Upgrades for {EDAName} are unsupported from {PlatformNameShort} 2.4 to {PlatformNameShort} 2.5.
+
+=== {OperatorPlatformNameShort}
+
+* An informative redirect page is now shown when you go to the {HubName} URL root. (AAP-30915)
+
+=== Containerized installer
+
+* The TLS Certificate Authority private key can now use a passphrase. (AAP-33594)
+
+* {HubNameStart} is populated with container images (decision and execution environments) and Ansible collections. (AAP-33759)
+
+* The {ControllerName}, {EDAName}, and {HubName} legacy UIs now display a redirect page to the Platform UI rather than a blank page. (AAP-33794)
+
+=== RPM installer
+
+* Added platform Redis to RPM-based {PlatformNameShort}. This allows a 6 node cluster for a Redis high availability (HA) deployment. Removed the variable `aap_caching_mtls` and replaced it with `redis_disable_tls` and `redis_disable_mtls` which are boolean flags that disable Redis server TLS and Redis client certificate authentication. (AAP-33773)
+
+== Bug fixes
+
+=== {PlatformNameShort}
+
+* Removed the *Legacy external password* option from the *Authentication Type* list. (AAP-31506)
+
+* link:https://access.redhat.com/security/cve/CVE-2024-10033[CVE-2024-10033] - `automation-gateway`: Fixed a Cross-site Scripting (XSS) vulnerability on the `automation-gateway` component that allowed a malicious user to perform actions that impact users.
+
+* link:https://access.redhat.com/security/cve/CVE-2024-22189[CVE-2024-22189] - `receptor`: Resolved an issue in `quic-go` that would allow an attacker to trigger a denial of service by sending a large number of `NEW_CONNECTION_ID` frames that retire old connection IDs.
+
+=== {ControllerNameStart}
+
+* link:https://access.redhat.com/security/cve/CVE-2024-41989[CVE-2024-41989] - `automation-controller`: Before this update, in Django, if `floatformat` received a string representation of a number in scientific notation with a large exponent, it could lead to significant memory consumption. With this update, decimals with more than 200 digits are now returned as is.
+
+* link:https://access.redhat.com/security/cve/CVE-2024-45230[CVE-2024-45230] - `automation-controller`: Resolved an issue in Python's Django `urlize()` and `urlizetrunc()` functions where excessive input with a specific sequence of characters would lead to denial of service.
+
+=== {OperatorPlatformNameShort}
+
+* The port is now correctly set when configuring the {Gateway} cache `redis_host` setting when using an external Redis cache. (AAP-33279)
+
+* Added checksums to the {HubName} deployments so that pods are cycled to pick up changes to the PostgreSQL configuration and galaxy server settings Kubernetes secrets. (AAP-33518)
+
+=== Containerized installer
+
+* Fixed the uninstall playbook execution when the environment was already uninstalled. (AAP-32981)
+
+// Commenting this out for now as the advisories are not yet published to the Errata tab on the downloads page: https://access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.5/x86_64/product-errata
+
+// == Advisories
+// The following errata advisories are included in this release:
+
+// * link:https://access.redhat.com/errata/[]
+
+// * link:https://access.redhat.com/errata/[]
+
+// * link:https://access.redhat.com/errata/[]
+
+// * link:https://access.redhat.com/errata/[]

--- a/downstream/titles/release-notes/async/async-updates.adoc
+++ b/downstream/titles/release-notes/async/async-updates.adoc
@@ -1,28 +1,18 @@
 
-= Asynchronous updates
+= Patch releases
 
-Security, bug fix, and enhancement updates for {PlatformNameShort} {PlatformVers} are released as asynchronous erratas. All {PlatformNameShort} erratas are available on the link:{PlatformDownloadUrl}[Download {PlatformName}] page in the Customer Portal. 
+Security, bug fixes, and enhancements for {PlatformNameShort} {PlatformVers} are released as asynchronous erratas. All {PlatformNameShort} erratas are available on the link:{PlatformDownloadUrl}[Download {PlatformName}] page. 
 
-As a Red Hat Customer Portal user, you can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, you receive notifications through email whenever new erratas relevant to your registered systems are released.
+As a Red{nbsp}Hat Customer Portal user, you can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, you receive notifications through email whenever new erratas relevant to your registered systems are released.
 
 [NOTE]
 ====
-Red Hat Customer Portal user accounts must have systems registered and consuming {PlatformNameShort} entitlements for {PlatformNameShort} errata notification emails to generate.
+Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {PlatformNameShort} entitlements for {PlatformNameShort} errata notification emails to generate.
 ====
 
-The Asynchronous updates section of the release notes will be updated over time to give notes on enhancements and bug fixes for asynchronous errata releases of {PlatformNameShort} {PlatformVers}.
+The patch releases section of the release notes will be updated over time to give notes on enhancements and bug fixes for patch releases of {PlatformNameShort} {PlatformVers}.
 
 [role="_additional-resources"]
 .Additional resources
 * For more information about asynchronous errata support in {PlatformNameShort}, see link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[{PlatformName} Life Cycle].
 * For information about Common Vulnerabilities and Exposures (CVEs), see link:https://www.redhat.com/en/topics/security/what-is-cve[What is a CVE?] and link:https://access.redhat.com/security/security-updates/cve[Red Hat CVE Database].
-
-== RPM releases
-
-//Component version table for RPM releases
-include::../async/rpm-version-table.adoc[leveloffset=+3]
-
-== Installer releases
-
-//Component version table for installer releases
-include::../async/installer-version-table.adoc[leveloffset=+3]

--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -27,6 +27,11 @@ include::topics/aap-25-fixed-issues.adoc[leveloffset=+1]
 
 include::topics/docs-25.adoc[leveloffset=+1]
 
-include::async/aap-25-2-14-oct.adoc[leveloffset=+1]
-
-include::async/aap-25-1-7-oct.adoc[leveloffset=+1]
+// == Asynchronous updates
+include::async/async-updates.adoc[leveloffset=+1]
+// Async release 2.5-3 (AKA event 2) 28th Oct 
+include::async/aap-25-3-28-oct.adoc[leveloffset=+2]
+// Async release 2.5-2 14th Oct
+include::async/aap-25-2-14-oct.adoc[leveloffset=+2]
+//Async release 2.5-1 7th Oct
+include::async/aap-25-1-7-oct.adoc[leveloffset=+2]


### PR DESCRIPTION
- Added release notes for event 2 `aap-25-3-28-oct.adoc`
- Updated `aap-25-2-14-oct.adoc` and `aap-25-1-7-oct.adoc` to include errata advisories
- Updated `async-updates.adoc` and included in the release notes `master.adoc`

AAP 2.5 (3) Async Release - Update Async Release Notes

https://issues.redhat.com/browse/AAP-33685