### PR TITLE
Fixes broken xrefs in RPM upgrade and migration guide

### DIFF
--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -3,7 +3,7 @@
 [id="aap-upgrade-planning_{context}"]
 
 = {PlatformNameShort} upgrade planning
-
+ 
 [role="_abstract"]
 Before you begin the upgrade process, review the following considerations to plan and prepare your {PlatformNameShort} deployment:
 
@@ -22,17 +22,17 @@ When upgrading from {PlatformNameShort} 2.4 to 2.5, the API endpoints for the {C
 * Verify that you have a valid subscription before upgrading from a previous version of {PlatformNameShort}. Existing subscriptions are carried over during the upgrade process. 
 * Ensure you have a backup of an {PlatformNameShort} 2.4 environment before upgrading in case any issues occur. See link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] and link:{LinkOperatorBackup} for the specific topology of the environment.
 * Ensure you capture your inventory or instance group details before upgrading.
-* Upgrades of {EDAName} version 2.4 to 2.5 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.5 are not compatible. For more information, see xref:platform/proc-upgrade-controller-hub-eda-unified-ui.adoc[{ControllerName} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades].
+* Upgrades of {EDAName} version 2.4 to 2.5 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.5 are not compatible. For more information, see xref:upgrade-controller-hub-eda-unified-ui_aap-upgrading-platform[{ControllerName} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades].
 +
 If you are currently running {EDAcontroller} 2.5, it is recommended that you disable all {EDAName} activations before upgrading to ensure that only new activations run after the upgrade process is complete.
 * {ControllerNameStart} OAuth applications on the platform UI are not supported for 2.4 to 2.5 migration. See this link:https://access.redhat.com/solutions/7091987[Knowledgebase article] for more information. To learn how to recreate your OAuth applications, see link:{URLCentralAuth}/gw-token-based-authentication#assembly-controller-applications[Applications] in the {TitleCentralAuth} guide.
-* During the upgrade process, user accounts from the individual services are migrated. If there are accounts from multiple services, they must be linked to access the unified platform. See xref:platform/proc-account-linking.adoc[Account linking] for details.
+* During the upgrade process, user accounts from the individual services are migrated. If there are accounts from multiple services, they must be linked to access the unified platform. See xref:account-linking_aap-upgrading-platform[Account linking] for details.
 * {PlatformNameShort} 2.5 offers a centralized Redis instance in both link:{URLPlanningGuide}/ha-redis_planning#gw-single-node-redis_planning[standalone] and link:{URLPlanningGuide}/ha-redis_planning#gw-clustered-redis_planning[clustered] topologies. For information on how to configure Redis, see link:{URLInstallationGuide}/assembly-platform-install-scenario#redis-config-enterprise-topology_platform-install-scenario[Configuring Redis] in the {TitleInstallationGuide} guide.
 
 [role="_additional-resources"]
 .Additional resources
 * link:{URLCentralAuth}/assembly-gateway-licensing#proc-attaching-subscriptions[Attaching a subscription]
-* xref:platform/con-backup-aap.adoc[Backup and restore]
+* xref:con-backup-aap_aap-upgrading-platform[Backup and restore]
 * link:{URLControllerAdminGuide}/controller-clustering[Clustering]
 * link:{LinkPlanningGuide}
 

--- a/downstream/modules/platform/con-aap-upgrades.adoc
+++ b/downstream/modules/platform/con-aap-upgrades.adoc
@@ -12,4 +12,4 @@ Upgrading {PlatformNameShort} {PlatformVers}  involves downloading the installat
 // [hherbly]: not sure we need the addt'l resources block? the xref goes to the next section of the document.
 [role="_additional-resources"]
 .Additional resources
-* xref:platform/assembly-aap-upgrading-platform[Upgrading to {PlatformName} {PlatformVers}]
+* xref:aap-upgrading-platform[Upgrading to {PlatformName} {PlatformVers}] 


### PR DESCRIPTION
This PR fixes broken xrefs in the RPM upgrade and migration guide preventing the document from building.