### PR TITLE
[Backport] AAP-34122 - Move content from Updating AAP 2.5 to 2.5x to upgrade guide (#2445)

### DIFF
--- a/downstream/modules/platform/con-aap-upgrades.adoc
+++ b/downstream/modules/platform/con-aap-upgrades.adoc
@@ -4,12 +4,44 @@
 
 = {PlatformNameShort} upgrades
 
-Upgrading {PlatformNameShort} {PlatformVers}  involves downloading the installation package and then performing the following steps:
+Currently, it is possible to perform {PlatformNameShort} upgrades using one of the following supported upgrade paths. 
 
-* Set up your inventory to match your installation environment. See link:{LinkTopologies} for a list of example inventory files. 
-* Run the {PlatformVers} installation program over your current {PlatformNameShort} installation.
+[IMPORTANT]
+====
+Upgrading from {EDAName} 2.4 is not supported. If you’re using {EDAName} 2.4 in production, contact Red Hat before you upgrade.
+====
+
+Before beginning your upgrade be sure to review the prerequisites and upgrade planning sections of this guide.
+
+[cols="a,a"]
+|===
+h|Supported upgrade path h| Steps to upgrade
+|{PlatformNameShort} 2.4 to 2.5 | xref:proc-choosing-obtaining-installer_aap-upgrading-platform[Download the installation package].
+
+xref:editing-inventory-file-for-updates_aap-upgrading-platform[Set up your inventory file] to match your installation environment. See link:{LinkTopologies} for a list of example inventory files.
+
+xref:con-backup-aap_aap-upgrading-platform[Back up your {PlatformNameShort} instance].
+
+xref:proc-running-setup-script-for-updates[Run the 2.5 installation program] over your current {PlatformNameShort} instance.
+
+xref:account-linking_aap-upgrading-platform[Link your existing service level accounts] to a single unified platform account. 
+
+|{PlatformNameShort} 2.5 to 2.5.x | xref:proc-choosing-obtaining-installer_aap-upgrading-platform[Download the installation package].
+
+xref:editing-inventory-file-for-updates_aap-upgrading-platform[Set up your inventory file] to match your installation environment. See link:{LinkTopologies} for a list of example inventory files.
+
+xref:con-backup-aap_aap-upgrading-platform[Back up your {PlatformNameShort} instance].
+
+xref:proc-running-setup-script-for-updates[Run the 2.5 installation program] over your current {PlatformNameShort} instance.
+
+|xref:upgrade-controller-hub-eda-unified-ui_aap-upgrading-platform[{ControllerNameStart} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades] | Upgrade the 2.4 services (using inventory file to only specify {ControllerName} and {HubName} VMs) to get them to the initial version of AAP 2.5.
+
+After all the services are at the same version, run a 2.5 upgrade on all the services
+|===
+ 
 
 // [hherbly]: not sure we need the addt'l resources block? the xref goes to the next section of the document.
-[role="_additional-resources"]
-.Additional resources
-* xref:aap-upgrading-platform[Upgrading to {PlatformName} {PlatformVers}] 
+// [ddacosta]: agree, it's not needed.
+//[role="_additional-resources"]
+//.Additional resources
+//* xref:aap-upgrading-platform[Upgrading to {PlatformName} {PlatformVers}] 

--- a/downstream/modules/platform/proc-choosing-obtaining-installer.adoc
+++ b/downstream/modules/platform/proc-choosing-obtaining-installer.adoc
@@ -1,6 +1,6 @@
 
 
-// [id="proc-choosing-obtaining-installer_{context}"]
+[id="proc-choosing-obtaining-installer_{context}"]
 
 
 = Choosing and obtaining a {PlatformName} installer

--- a/downstream/modules/platform/proc-running-setup-script-for-updates.adoc
+++ b/downstream/modules/platform/proc-running-setup-script-for-updates.adoc
@@ -13,4 +13,8 @@ You can run the setup script once you have finished updating the `inventory` fil
 $ ./setup.sh
 -----
 
-The installation will begin.
+The installation will begin. 
+
+[role="_additional-resources"]
+.Next steps
+If you are upgrading from {PlatformNameShort} 2.4 to 2.5, proceed to xref:account-linking_aap-upgrading-platform[Account linking] to link your existing service level accounts to the single unified platform account. 

--- a/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
+++ b/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
@@ -3,7 +3,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="upgrade-controller-hub-eda-unified-ui_{context}"]
-= Automation controller and automation hub 2.4 and EDA 2.5 with unified UI upgrades
+= Automation controller and automation hub 2.4 and Event-Driven Ansible 2.5 with unified UI upgrades
 
 {PlatformNameShort} 2.5 supports upgrades from {PlatformNameShort} 2.4 environments for all components, with the exception of {EDAName}. You can also configure a mixed environment with {EDAName} from 2.5 connected to a legacy 2.4 cluster. Combining install methods (OCP, RPM, Containerized) within such a topology is not supported by {PlatformNameShort}.
 


### PR DESCRIPTION
This PR backports the changes from #2455  to the 2.5 branch.