### PR TITLE
[Backport] Add upgrade prerequisite details (#2457)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
+++ b/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
@@ -10,6 +10,14 @@ ifdef::context[:parent-context: {context}]
 To upgrade your {PlatformName}, start by reviewing link:{LinkPlanningGuide} to ensure a successful upgrade.
 You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
 
+== Prerequisites
+
+Upgrades to {PlatformNameShort} 2.5 include the link:{URLPlanningGuide}/ref-aap-components#con-about-platform-gateway_planning[{Gateway}]. Ensure you review the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[2.5 Network ports and protocols] for architectural changes and link:{LinkTopologies} for information on opinionated deployment models. 
+
+You have reviewed the centralized Redis instance offered by {PlatformNameShort} for both standalone and clustered topologies.
+
+Prior to upgrading your {PlatformName}, ensure you have reviewed link:{LinkPlanningGuide} for a successful upgrade. You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
+
 include::platform/con-aap-upgrade-planning.adoc[leveloffset=+1]
 
 include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]
@@ -21,3 +29,4 @@ include::platform/proc-account-linking.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
+ 


### PR DESCRIPTION
This PR backports the changes from #2457 to the 2.5 branch.