### PR TITLE
Change xref to link in a shared file

### DIFF
--- a/downstream/assemblies/platform/assembly-update-rpm.adoc
+++ b/downstream/assemblies/platform/assembly-update-rpm.adoc
@@ -8,4 +8,6 @@ include::platform/con-update-planning.adoc[leveloffset=+1]
 include::assembly-choosing-obtaining-installer.adoc[leveloffset=+1]
 include::platform/proc-backup-aap-rpm.adoc[leveloffset=+1]
 include::platform/proc-inventory-file-setup-rpm.adoc[leveloffset=+1]
+:updating:
 include::platform/proc-running-setup-script-for-updates.adoc[leveloffset=+1]
+:updating!:

--- a/downstream/modules/platform/proc-running-setup-script-for-updates.adoc
+++ b/downstream/modules/platform/proc-running-setup-script-for-updates.adoc
@@ -17,4 +17,4 @@ The installation will begin.
 
 [role="_additional-resources"]
 .Next steps
-If you are upgrading from {PlatformNameShort} 2.4 to 2.5, proceed to xref:account-linking_aap-upgrading-platform[Account linking] to link your existing service level accounts to the single unified platform account. 
+If you are upgrading from {PlatformNameShort} 2.4 to 2.5, proceed to link:{URLUpgrade}/account-linking_aap-upgrading-platform[Linking your account] to link your existing service level accounts to a single unified platform account. 


### PR DESCRIPTION
This PR fixes a broken xref in a shared file by converting it to a link. 