### PR TITLE
Remove conditional tagging not used

### DIFF
--- a/downstream/assemblies/platform/assembly-update-rpm.adoc
+++ b/downstream/assemblies/platform/assembly-update-rpm.adoc
@@ -8,6 +8,4 @@ include::platform/con-update-planning.adoc[leveloffset=+1]
 include::assembly-choosing-obtaining-installer.adoc[leveloffset=+1]
 include::platform/proc-backup-aap-rpm.adoc[leveloffset=+1]
 include::platform/proc-inventory-file-setup-rpm.adoc[leveloffset=+1]
-:updating:
 include::platform/proc-running-setup-script-for-updates.adoc[leveloffset=+1]
-:updating!:


### PR DESCRIPTION
This PR removes conditional tagging left behind during a previous fix. 