### PR TITLE
[Backport] 2457 - fix formatting issues in upgrade guide (#2463)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
+++ b/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
@@ -14,7 +14,7 @@ You can then download the desired version of the {PlatformNameShort} installer, 
 
 Upgrades to {PlatformNameShort} 2.5 include the link:{URLPlanningGuide}/ref-aap-components#con-about-platform-gateway_planning[{Gateway}]. Ensure you review the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[2.5 Network ports and protocols] for architectural changes and link:{LinkTopologies} for information on opinionated deployment models. 
 
-You have reviewed the centralized Redis instance offered by {PlatformNameShort} for both standalone and clustered topologies.
+You have reviewed the link:{URLPlanningGuide}/ha-redis_planning#gw-centralized-redis_planning[centralized Redis] instance offered by {PlatformNameShort} for both standalone and clustered topologies.
 
 Prior to upgrading your {PlatformName}, ensure you have reviewed link:{LinkPlanningGuide} for a successful upgrade. You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
 

--- a/downstream/modules/platform/proc-account-linking.adoc
+++ b/downstream/modules/platform/proc-account-linking.adoc
@@ -47,4 +47,4 @@ If you log into {PlatformNameShort} for the first time and are prompted to chang
 .A diagram of the account linking flow
 image:account-linking-flow.png[Account linking flow]
 
-After you have migrated your user account, you can manage your account from the menu:Access Management[] menu. See link:{URLCentralAuth}/gw-managing-access[Managing access with role based access control]. 
+After you have migrated your user account, you can manage your account from the *Access Management* menu. See link:{URLCentralAuth}/gw-managing-access[Managing access with role based access control]. 


### PR DESCRIPTION
This PR backports the changes from #2463 to the 2.5 branch.