### PR TITLE
[Backport] Fix error in Editing a user procedure (#2467)

### DIFF
--- a/downstream/modules/platform/proc-gw-editing-a-user.adoc
+++ b/downstream/modules/platform/proc-gw-editing-a-user.adoc
@@ -6,7 +6,7 @@
 
 You can modify the properties of a user account after it is created.
 
-In upgrade scenarios, there might be pre-existing user accounts from {ControllerName}, {EDAName} or {HubName} services. When editing these user accounts, the *User type* checkboxes indicate whether the account had service level administrator privileges. You can revoke or assign administrator permissions for the individual services and designate the user as either an {PlatformNameShort} Administrator, {PlatformNameShort} Auditor or Normal User. Assigning administrator privileges to all of the individual services automatically designates the user as an {PlatformNameShort} Administrator. See xref:proc-controller-creating-a-user[Creating a user] for more information about user types.
+In upgrade scenarios, there might be pre-existing user accounts from {ControllerName} or {HubName} services. When editing these user accounts, the *User type* checkboxes indicate whether the account had service level administrator privileges. You can revoke or assign administrator permissions for the individual services and designate the user as either an *{PlatformNameShort} Administrator*, *{PlatformNameShort} Auditor* or normal user. Assigning administrator privileges to all of the individual services automatically designates the user as an *{PlatformNameShort} Administrator*. See xref:proc-controller-creating-a-user[Creating a user] for more information about user types.
 
 To see whether a user had service level auditor privileges, you must refer to the API.
 


### PR DESCRIPTION
This PR backports the changes from #2467 to the 2.5 branch and includes the following:

* Fix error in Editing a user procedure

* Adding peer review changes