### PR TITLE
Remove upgrades unsupported content from release notes

### DIFF
--- a/downstream/titles/release-notes/topics/platform-intro.adoc
+++ b/downstream/titles/release-notes/topics/platform-intro.adoc
@@ -3,9 +3,6 @@
 
 {PlatformName} simplifies the development and operation of automation workloads for managing enterprise application infrastructure lifecycles. {PlatformNameShort} works across multiple IT domains, including operations, networking, security, and development, as well as across diverse hybrid environments. Simple to adopt, use, and understand, {PlatformNameShort} provides the tools needed to rapidly implement enterprise-wide automation, no matter where you are in your automation journey.
 
-== Upgrades are unsupported at this time
-At the initial release of {PlatformNameShort} 2.5, upgrades from earlier releases are unsupported. Only new installations are supported. Upgrade support will follow shortly after the initial 2.5 release. However, you can deploy {EDAName} 2.5 with an existing 2.4 {ControllerName}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/release_notes/index#eda-2.5-with-automation-controller-2.4[{EDAName} 2.5 with {ControllerName} 2.4].
-
 [[whats-included]]
 == What is included in the {PlatformNameShort}
 


### PR DESCRIPTION
The release notes still include content stating that upgrades are unsupported but they are now that the event 2 async has been released. Removed this content to ensure up to date functionality is reflected in the docs

Remove unsupported upgrade content from release notes

https://issues.redhat.com/browse/AAP-34772