### PR TITLE
AAP-34814 - update application OAuth paths

### DIFF
--- a/downstream/assemblies/platform/assembly-gw-token-based-authentication.adoc
+++ b/downstream/assemblies/platform/assembly-gw-token-based-authentication.adoc
@@ -26,4 +26,3 @@ include::platform/ref-controller-clear-sessions.adoc[leveloffset=+3]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:] 
-  

--- a/downstream/modules/platform/proc-controller-create-application.adoc
+++ b/downstream/modules/platform/proc-controller-create-application.adoc
@@ -2,7 +2,7 @@
 
 = Creating a new application
 
-When integrating an external web application with {ControllerName} the web application might need to create OAuth2 tokens on behalf of users of the web application.
+When integrating an external web application with {PlatformNameShort}, the web application might need to create OAuth2 tokens on behalf of users of the web application.
 
 Creating an application with the Authorization Code grant type is the preferred way to do this for the following reasons:
 

--- a/downstream/modules/platform/ref-controller-app-token-functions.adoc
+++ b/downstream/modules/platform/ref-controller-app-token-functions.adoc
@@ -2,4 +2,4 @@
 
 = Application token functions
 
-The `refresh` and `revoke` functions associated with tokens, for tokens at the `/api/o/` endpoints can currently only be carried out with application tokens.
+The `refresh` and `revoke` functions associated with tokens, for tokens at the `/o/` endpoints can currently only be carried out with application tokens.

--- a/downstream/modules/platform/ref-controller-refresh-existing-token.adoc
+++ b/downstream/modules/platform/ref-controller-refresh-existing-token.adoc
@@ -19,14 +19,14 @@ The following example shows an existing access token with a refresh token provid
 }
 ----
 
-The `/api/o/token/` endpoint is used for refreshing the access token:
+The `/o/token/` endpoint is used for refreshing the access token:
 
 [literal, options="nowrap" subs="+attributes"]
 ----
 curl -X POST \
     -d "grant_type=refresh_token&refresh_token=AL0NK9TTpv0qp54dGbC4VUZtsZ9r8z" \
     -u "gwSPoasWSdNkMDtBN3Hu2WYQpPWCO9SwUEsKK22l:fI6ZpfocHYBGfm1tP92r0yIgCyfRdDQt0Tos9L8a4fNsJjQQMwp9569eIaUBsaVDgt2eiwOGe0bg5m5vCSstClZmtdy359RVx2rQK5YlIWyPlrolpt2LEpVeKXWaiybo" \
-    http://<controller>/api/o/token/ -i
+    http://<gateway>/o/token/ -i
 ----
 
 Where `refresh_token` is provided by `refresh_token` field of the preceding access token. 
@@ -36,7 +36,7 @@ The authentication information is of format `<client_id>:<client_secret>`, where
 [NOTE]
 ====
 The special OAuth 2 endpoints only support using the `x-www-form-urlencoded` *Content-type*, so as a result, none of the
-`api/o/*` endpoints accept `application/json`.
+`/o/*` endpoints accept `application/json`.
 ====
 
 On success, a response displays in JSON format containing the new (refreshed) access token with the same scope information as the previous one:
@@ -60,4 +60,4 @@ Strict-Transport-Security: max-age=15768000
 
 The refresh operation replaces the existing token by deleting the original and then immediately creating a new token with the same scope and related application as the original one. 
 
-Verify that the new token is present and the old one is deleted in the `/api/v2/tokens/` endpoint.
+Verify that the new token is present and the old one is deleted in the `gateway/api/v1/tokens/` endpoint.

--- a/downstream/modules/platform/ref-controller-revoke-access-token.adoc
+++ b/downstream/modules/platform/ref-controller-revoke-access-token.adoc
@@ -2,7 +2,7 @@
 
 = Revoke an access token
 
-You can revoke an access token by deleting the token in the platform UI, or by using the `/api/o/revoke-token/` endpoint.
+You can revoke an access token by deleting the token in the platform UI, or by using the `/o/revoke-token/` endpoint.
 
 Revoking an access token by this method is the same as deleting the token resource object, but it enables you to delete a token by providing its token value, and the associated `client_id` (and `client_secret` if the application is `confidential`). For example:
 
@@ -10,13 +10,13 @@ Revoking an access token by this method is the same as deleting the token resour
 ----
 curl -X POST -d "token=rQONsve372fQwuc2pn76k3IHDCYpi7" \
 -u "gwSPoasWSdNkMDtBN3Hu2WYQpPWCO9SwUEsKK22l:fI6ZpfocHYBGfm1tP92r0yIgCyfRdDQt0Tos9L8a4fNsJjQQMwp9569eIaUBsaVDgt2eiwOGe0bg5m5vCSstClZmtdy359RVx2rQK5YlIWyPlrolpt2LEpVeKXWaiybo" \
-http://<controller>/api/o/revoke_token/ -i
+http://<gateway>/o/revoke_token/ -i
 ----
 
 [NOTE]
 ====
 * The special OAuth 2 endpoints only support using the `x-www-form-urlencoded` *Content-type*, so as a result, none of the
-`api/o/*` endpoints accept `application/json`.
+`/o/*` endpoints accept `application/json`.
 * The *Allow External Users to Create Oauth2 Tokens* (`ALLOW_OAUTH2_FOR_EXTERNAL_USERS` in the API) setting is disabled by default. 
 External users refer to users authenticated externally with a service such as LDAP, or any of the other SSO services. 
 This setting ensures external users cannot create their own tokens. 
@@ -27,4 +27,4 @@ This setting can be configured from the {MenuSetGateway} menu.
 Alternatively, to revoke OAuth2 tokens, you can use the `manage` utility, see xref:ref-controller-revoke-oauth2-token[Revoke oauth2 tokens].
 
 On success, a response of `200 OK` is displayed. 
-Verify the deletion by checking whether the token is present in the `/api/v2/tokens/` endpoint.
+Verify the deletion by checking whether the token is present in the `gateway/api/v1/tokens/` endpoint.

--- a/downstream/modules/platform/ref-controller-token-session-management.adoc
+++ b/downstream/modules/platform/ref-controller-token-session-management.adoc
@@ -2,7 +2,7 @@
 
 = Token and session management
 
-{ControllerNameStart} supports the following commands for OAuth2 token management:
+{PlatformNameShort} supports the following commands for OAuth2 token management:
 
 * xref:ref-controller-create-oauth2-token[`create_oauth2_token`]
 * xref:ref-controller-revoke-oauth2-token[`revoke_oauth2_tokens`]


### PR DESCRIPTION
This PR updates the application OAuth paths to correctly reflect gateway:

`/api/o/token/` changed to `/o/token/`
`/api/o/revoke-token/` changed to `/o/revoke-token/`
`http://<controller>/api/o/revoke_token/ -i` changed to `http://<gateway>/o/revoke_token/ -i`
`/api/v2/tokens/` changed to `/gateway/api/v1/tokens/`