### PR TITLE
Corrected yaml indentation

### DIFF
--- a/downstream/modules/devtools/ref-rhdh-full-aap-configmap-example.adoc
+++ b/downstream/modules/devtools/ref-rhdh-full-aap-configmap-example.adoc
@@ -16,9 +16,9 @@ data:
         baseUrl: 127.0.0.1
         port: '8000'
       rhaap:
-       baseUrl: '<https://MyControllerUrl>'
-       token: '<AAP Personal Access Token>'
-       checkSSL: <true or false>
+        baseUrl: '<https://MyControllerUrl>'
+        token: '<AAP Personal Access Token>'
+        checkSSL: <true or false>
       # Optional integrations 
       devSpaces:
         baseUrl: '<https://MyDevSpacesURL>'


### PR DESCRIPTION
Correction

DOCS - Ansible plugins for RHDH - Indententation error in examples

https://issues.redhat.com/browse/AAP-34042