### PR TITLE
Update redis_tls_cert and key vars in appendix

### DIFF
--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -167,9 +167,17 @@ Default = `false`
 
 | | `eda_redis_password` | Redis {EDAcontroller} password (for many nodes).
 
-| | `eda_redis_tls_cert` | {EDAcontroller} Redis TLS certificate.
+| | `eda_redis_tls_cert` | _Optional_
 
-| | `eda_redis_tls_key` | {EDAcontroller} Redis TLS key.
+`/path/to/edaredis.crt`
+
+Location of the {EDAcontroller} Redis TLS certificate.
+
+| | `eda_redis_tls_key` | _Optional_
+
+`/path/to/edaredis.key`
+
+Location of the {EDAcontroller} Redis TLS key.
 
 | | `eda_redis_username` | Redis {EDAcontroller} username (for many nodes).
 

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -133,9 +133,17 @@ Default = `false`
 
 | | `gateway_redis_password` | Redis {Gateway} password.
 
-| | `gateway_redis_tls_cert` | {GatewayStart} Redis TLS certificate.
+| | `gateway_redis_tls_cert` | _Optional_
 
-| | `gateway_redis_tls_key` | {GatewayStart} Redis TLS key.
+`/path/to/gatewayredis.crt`
+
+Location of the {GatewayStart} Redis TLS certificate.
+
+| | `gateway_redis_tls_key` | _Optional_
+
+`/path/to/gatewayredis.key`
+
+Location of the {GatewayStart} Redis TLS key.
 
 | | `gateway_redis_username` | Redis {Gateway} username.
 

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -137,13 +137,13 @@ Default = `false`
 
 `/path/to/gatewayredis.crt`
 
-Location of the {GatewayStart} Redis TLS certificate.
+Location of the {Gateway} Redis TLS certificate.
 
 | | `gateway_redis_tls_key` | _Optional_
 
 `/path/to/gatewayredis.key`
 
-Location of the {GatewayStart} Redis TLS key.
+Location of the {Gateway} Redis TLS key.
 
 | | `gateway_redis_username` | Redis {Gateway} username.
 

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -14,7 +14,7 @@ Default = `false`
 
 | |`ca_tls_cert` | Define a Certification Authority certificate here along with a matching key in `ca_tls_key` when you want the installer to create leaf certificates for each product for you.
 
-| |`ca_tls_key` | Define the key for a Certication Authority certificate here for the matching certificate in `ca_tls_cert` when you want the installer to create leaf certs for each product for you.
+| |`ca_tls_key` | Define the key for a Certification Authority certificate here for the matching certificate in `ca_tls_cert` when you want the installer to create leaf certificates for each product for you.
 
 | |`ca_tls_remote` |TLS CA remote files.
 
@@ -61,7 +61,7 @@ Default = `ansible-automation-platform-25`
 | |`registry_ns_rhel` |RHEL registry namespace.
 
 Default = `rhel8`
-| `redis_mode` | | Redis can be colocated with automationgateway, automationhub, and automationedacontroller nodes. 
+| `redis_mode` | | Redis can be colocated with {Gateway}, {HubName}, and {EDAcontroller} nodes. 
 
 Default = cluster
 | `registry_password` |`registry_password` | This variable is only required if a non-bundle installer is used.


### PR DESCRIPTION
Update the relevant redis_tls_cert and redis_tls_key vars in the inventory variables appendix for Containerized installation.

DOCS - Redis_tls_cert and redis_tls_key missing from inventory vars appendix

https://issues.redhat.com/browse/AAP-32788