### PR TITLE
Added line to clarify Python version removal. (#2487)

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25-removed-features.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-removed-features.adoc
@@ -45,6 +45,8 @@ The following table provides information about features that are removed in {Pla
 |Ansible-core
 |`module_utils/basic.py` - Removed Python 3.5 as a supported remote version. Python version 2.7 or Python version 3.6 or later is now required.
 
+Removed Python versions 2.7 and 3.6 as supported remote versions. Use Python 3.7 or later for target execution.
+
 *NOTE:* This applies to Ansible version 2.17 only.
 
 With the removal of Python 2 support, the `yum` module and `yum action` plug-in are removed and redirected to `dnf`.


### PR DESCRIPTION
Added the Python versions that have been removed as supported remote versions.

Resolves: #2414
See also: AAP-33894