### PR TITLE
This fixes the naming convention for the attribute URLUpgrade

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -313,7 +313,7 @@
 //
 // titles/upgrade
 :TitleUpgrade: RPM upgrade and migration
-:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/upgrade_and_migration
+:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_upgrade_and_migration
 :LinkUpgrade: {URLUpgrade}[{TitleUpgrade}]
 //
 // titles/aap-operator-installation


### PR DESCRIPTION
Fixes the naming convention for the attribute from upgrade_migration
to
rpm_upgrade_migration

Resolves: AAP-34824