### PR TITLE
 Backport-2.5-2469 (AAP-29905) Added new modules to the RH AAP credentials chapter (#2469)

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
+++ b/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
@@ -2,6 +2,16 @@
 
 = {PlatformName} credential
 
-The {PlatformName} credential type can connect to {ControllerName} through the use of an {ControllerName} URL and a username and password. After you have created this credential type, it can be attached to a rulebook and used to run rulebook activations.  
+When {EDAcontroller} is deployed on {PlatformNameShort} {PlatformVers}, you can create a {PlatformName} credential to connect to {ControllerName} through the use of an {ControllerName} URL and a username and password. After it has been created, you can attach the {PlatformName} credential to a rulebook and use it to run rulebook activations. These credentials provide a simple way to configure communication between {ControllerName} and {EDAcontroller}, enabling your rulebook activations to launch job templates.
 
+[NOTE]
+====
+If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. 
+====
+
+Complete the following procedures to delete controller tokens and their associated rulebook activations before setting up {PlatformName} credentials.
+
+include::eda/con-replacing-controller-tokens.adoc[leveloffset=+1]
+include::eda/proc-eda-delete-rulebook-activations-with-cont-tokens.adoc[leveloffset=+2]
+include::eda/proc-eda-delete-controller-token.adoc[leveloffset=+2]
 include::eda/proc-eda-set-up-rhaap-credential.adoc[leveloffset=+1]

--- a/downstream/modules/eda/con-replacing-controller-tokens.adoc
+++ b/downstream/modules/eda/con-replacing-controller-tokens.adoc
@@ -1,0 +1,6 @@
+[id="replacing-controller-tokens"]
+
+= Replacing controller tokens in {PlatformName} {PlatformVers}
+
+
+To use {EDAcontroller} in {PlatformName} {PlatformVers}, you must replace legacy controller tokens configured in your environment with {PlatformName} credentials because controller tokens have been deprecated.

--- a/downstream/modules/eda/proc-eda-delete-controller-token.adoc
+++ b/downstream/modules/eda/proc-eda-delete-controller-token.adoc
@@ -1,0 +1,18 @@
+[id="eda-delete-controller-token"]
+
+= Deleting controller tokens
+
+Before you can set up {PlatformName} credentials, you must delete any existing controller tokens.
+
+.Prerequisites
+* You have deleted all rulebook activations that use controller tokens.
+
+.Procedure
+
+. Log in to the {PlatformNameShort} Dashboard.
+. From the top navigation panel, select your profile.
+. Click *User details*.
+. Select the *Tokens* tab.
+. Delete all of your previous controller tokens. 
+
+After deleting the controller tokens and rulebook activations, proceed with xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].

--- a/downstream/modules/eda/proc-eda-delete-rulebook-activations-with-cont-tokens.adoc
+++ b/downstream/modules/eda/proc-eda-delete-rulebook-activations-with-cont-tokens.adoc
@@ -1,0 +1,17 @@
+[id="eda-delete-rulebook-activations-with-cont-tokens"]
+
+= Deleting rulebook activations with controller tokens
+
+To replace the controller tokens, you must delete the rulebook activations that were associated with them.
+
+.Procedure
+
+. Log in to the {PlatformNameShort} Dashboard.
+. From the top navigation panel, select {MenuADRulebookActivations}.
+. Select the rulebook activations that have controller tokens.
+. Select the btn:[More Actions] icon *{MoreActionsIcon}* next to the *Rulebook Activation enabled/disabled* toggle.
+. Select btn:[Delete rulebook activation].
+. In the window, select btn:[Yes, I confirm that I want to delete these X rulebook activations].
+. Select btn:[Delete rulebook activations].
+
+

--- a/downstream/modules/eda/proc-eda-set-up-credential.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-credential.adoc
@@ -28,13 +28,6 @@ Credential type:: Click the list to select your Credential type.
 ====
 When you select the credential type, the *Type Details* section is displayed with fields that are applicable for the credential type you chose.   
 ==== 
-+
-//[JMS] Deleting this note for now. Not sure it's still relevant with all of the new credential types added to the list. 
-//[NOTE]
-//====
-//If you are using a container registry, the token field can be a token or a password, depending on the registry provider.
-//If you are using the {PlatformNameShort} hub registry, insert the password for that in the token field.
-//====
 
 . Complete the fields that are applicable to the credential type you selected.
 . Click btn:[Create credential].

--- a/downstream/modules/eda/proc-eda-set-up-rhaap-credential.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rhaap-credential.adoc
@@ -12,7 +12,7 @@ You can create a {PlatformName} credential type to run your rulebook activations
 
 .Procedure
 
-. Log in to the {PlatformNameShort}.
+. Log in to the {PlatformNameShort} Dashboard.
 . From the navigation panel, select {MenuADCredentials}.
 . Click btn:[Create credential].
 . Insert the following:
@@ -34,7 +34,7 @@ For {EDAcontroller} {PlatformVers} with {ControllerName} 2.4, use the following 
 
 For {PlatformNameShort} {PlatformVers}, use the following example: \https://<your_gateway_host>/api/controller/
 ====
-. Enter a valid *Username* and *Password* or *Oauth Token*. 
+. Enter a valid *Username* and *Password*, or *Oauth Token*. 
 . Click btn:[Create credential].
 
 After you create this credential, you can use it for configuring your rulebook activations.


### PR DESCRIPTION
Added new modules to [Chapter 7. Red Hat Ansible Automation Platform credential](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-set-up-rhaap-credential-type):

- downstream/modules/eda/con-replacing-controller-tokens.adoc
- downstream/modules/eda/proc-eda-delete-controller-token.adoc
- downstream/modules/eda/proc-eda-delete-rulebook-activations-with-cont-tokens.adoc