### PR TITLE
Updating path for REST api

### DIFF
--- a/downstream/modules/platform/proc-controller-api-browsing-api.adoc
+++ b/downstream/modules/platform/proc-controller-api-browsing-api.adoc
@@ -4,7 +4,7 @@
 
 . Go to the {ControllerName} REST API in a web browser at: 
 +
-\https://<server name>/api/
+\https://<server name>/api/controller/v2
 +
 . Click the **"v2"** link next to **"current versions"** or **"available versions"**.
 {ControllerNameStart} supports version 2 of the API.


### PR DESCRIPTION
Incorrect path for REST API info

https://issues.redhat.com/browse/AAP-34823

Affects `titles/controller-user-guide`