### PR TITLE
AAP-29905B Correction to note to link user to replacing tokens with RHAAP creds

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
+++ b/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
@@ -6,7 +6,7 @@ When {EDAcontroller} is deployed on {PlatformNameShort} {PlatformVers}, you can 
 
 [NOTE]
 ====
-If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. See xref:replacing-controller-tokens[Replacing controller tokens in Red Hat Ansible Automation Platform 2.5] for more details.
+If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. To delete these deprecated controller tokens and the rulebook activations associated with them, complete the following procedures starting with xref:replacing-controller-tokens[Replacing controller tokens in Red Hat Ansible Automation Platform 2.5] before proceeding with xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
 ====
 
 include::eda/con-replacing-controller-tokens.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
+++ b/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
@@ -6,7 +6,7 @@ When {EDAcontroller} is deployed on {PlatformNameShort} {PlatformVers}, you can 
 
 [NOTE]
 ====
-If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. See xref:replacing-controller-tokens[Replacing controller tokens in Red Hat Ansible Automation Platform 2.5 for more details].
+If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. See xref:replacing-controller-tokens[Replacing controller tokens in Red Hat Ansible Automation Platform 2.5] for more details.
 ====
 
 include::eda/con-replacing-controller-tokens.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
+++ b/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
@@ -6,7 +6,7 @@ When {EDAcontroller} is deployed on {PlatformNameShort} {PlatformVers}, you can 
 
 [NOTE]
 ====
-If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. To delete these deprecated controller tokens and the rulebook activations associated with them, complete the following procedures starting with xref:replacing-controller-tokens[Replacing controller tokens in Red Hat Ansible Automation Platform 2.5] before proceeding with xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
+If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. To delete deprecated controller tokens and the rulebook activations associated with them, complete the following procedures starting with xref:replacing-controller-tokens[Replacing controller tokens in Red Hat Ansible Automation Platform 2.5] before proceeding with xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
 ====
 
 include::eda/con-replacing-controller-tokens.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
+++ b/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
@@ -6,10 +6,8 @@ When {EDAcontroller} is deployed on {PlatformNameShort} {PlatformVers}, you can 
 
 [NOTE]
 ====
-If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. 
+If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. See xref:replacing-controller-tokens[Replacing controller tokens in Red Hat Ansible Automation Platform 2.5 for more details].
 ====
-
-Complete the following procedures to delete controller tokens and their associated rulebook activations before setting up {PlatformName} credentials.
 
 include::eda/con-replacing-controller-tokens.adoc[leveloffset=+1]
 include::eda/proc-eda-delete-rulebook-activations-with-cont-tokens.adoc[leveloffset=+2]

--- a/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
+++ b/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
@@ -6,7 +6,7 @@ When {EDAcontroller} is deployed on {PlatformNameShort} {PlatformVers}, you can 
 
 [NOTE]
 ====
-If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. To delete deprecated controller tokens and the rulebook activations associated with them, complete the following procedures starting with xref:replacing-controller-tokens[Replacing controller tokens in Red Hat Ansible Automation Platform 2.5] before proceeding with xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
+If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. To delete deprecated controller tokens and the rulebook activations associated with them, complete the following procedures starting with xref:replacing-controller-tokens[Replacing controller tokens in {PlatformNameShort} {PlatformVers}] before proceeding with xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
 ====
 
 include::eda/con-replacing-controller-tokens.adoc[leveloffset=+1]


### PR DESCRIPTION
Updated the note in downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc (follows Google draft). 