### PR TITLE
Backport to 2.4: AAP-33331: clarifies instructions on keeping offline hub token active

### DIFF
--- a/downstream/modules/hub/con-offline-token-active.adoc
+++ b/downstream/modules/hub/con-offline-token-active.adoc
@@ -3,13 +3,13 @@
 
 = Keeping your offline token active
 
-Offline tokens expire after 30 days of inactivity. You can keep your offline token from expiring by periodically refreshing your offline token.
+Offline tokens expire after 30 days of inactivity. You can keep your offline token from expiring by keeping it active. 
 
-Keeping an online token active is useful when an application performs an action on behalf of the user; for example, this allows the application to perform a routine data backup when the user is offline.
+Keeping an offline token active is useful when an application performs an action on behalf of the user; for example, this allows the application to perform a routine data backup when the user is offline.
 
 [NOTE]
 ====
-If your offline token expires, you must request a new one.
+If your offline token expires, you must xref:proc-create-api-token[obtain a new one].
 ====
 
 .Procedure

--- a/downstream/modules/hub/proc-create-api-token-pah.adoc
+++ b/downstream/modules/hub/proc-create-api-token-pah.adoc
@@ -10,7 +10,7 @@ In {PrivateHubName}, you can create an API token using API token management. The
 * Valid subscription credentials for {PlatformName}.
 
 .Procedure
-//[ddacosta] For 2.5 this will be Log in to Ansible Automation Platform and select Automation Content. Automation hub opens in a new tab. From the navigation ...
+
 . Log in to your {PrivateHubName}.
 . From the navigation panel, select {MenuACAPIToken}.
 . Click btn:[Load Token].

--- a/downstream/modules/hub/proc-create-api-token.adoc
+++ b/downstream/modules/hub/proc-create-api-token.adoc
@@ -1,26 +1,26 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
 [id="proc-create-api-token"]
-= Creating the API token in {HubName}
+= Creating the offline token in {HubName}
 
-In {HubName}, you can create an API token by using *Token management*. The API token is a secret token used to protect your content.
+In {HubName}, you can create an offline token using *Token management*. The offline token is a secret token used to protect your content.
 
 .Procedure
 
 . Navigate to link:https://console.redhat.com/ansible/automation-hub/token/[{PlatformNameShort} on the Red Hat Hybrid Cloud Console].
 . From the navigation panel, select menu:Automation Hub[Connect to Hub].
 . Under *Offline token*, click btn:[Load Token].
-. Click the btn:[Copy to clipboard] icon to copy the API token.
-. Paste the API token into a file and store in a secure location.
+. Click the btn:[Copy to clipboard] icon to copy the offline token.
+. Paste the token into a file and store in a secure location.
 
 [IMPORTANT]
 ====
-The API token is a secret token used to protect your content. Store your API token in a secure location.
+The offline token is a secret token used to protect your content. Store your token in a secure location.
 ====
 
-The API token is now available for configuring {HubName} as your default collections server or for uploading collections by using the `ansible-galaxy` command line tool.
+The offline token is now available for configuring {HubName} as your default collections server or for uploading collections by using the `ansible-galaxy` command line tool.
 
 [NOTE]
 ====
-The API token does not expire. 
+Your offline token expires after 30 days of inactivity. For more on obtaining a new offline token, see xref:con-offline-token-active[Keeping your offline token active].
 ====


### PR DESCRIPTION
This PR backports the changes from [PR 2492](https://github.com/ansible/aap-docs/pull/2492) to the 2.4 branch. See [AAP-33331](https://issues.redhat.com/browse/AAP-33331) for more info. 