### PR TITLE
Backport-2.5-2502 (AAP-29905B) Correction to note to link user to replacing tokens with R…

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
+++ b/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
@@ -6,10 +6,8 @@ When {EDAcontroller} is deployed on {PlatformNameShort} {PlatformVers}, you can 
 
 [NOTE]
 ====
-If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. 
+If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. To delete deprecated controller tokens and the rulebook activations associated with them, complete the following procedures starting with xref:replacing-controller-tokens[Replacing controller tokens in {PlatformNameShort} {PlatformVers}] before proceeding with xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
 ====
-
-Complete the following procedures to delete controller tokens and their associated rulebook activations before setting up {PlatformName} credentials.
 
 include::eda/con-replacing-controller-tokens.adoc[leveloffset=+1]
 include::eda/proc-eda-delete-rulebook-activations-with-cont-tokens.adoc[leveloffset=+2]


### PR DESCRIPTION
Updated the note in downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc (follows Google draft).