### PR TITLE
Added deprecation note for receptor.

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25-deprecated-features.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-deprecated-features.adoc
@@ -58,6 +58,9 @@ Import the helpers from the source definition.
 |Installer
 |The Ansible team is exploring ways to improve the installation of the {PlatformNameShort} on {RHEL}, which may include changes to how components are deployed using RPM directly on the host OS. RPMs will be replaced by packages deployed into containers that are run via Podman; this is similar to how automation currently executes on Podman in containers (execution environments) on the host OS. Changes will be communicated through release notes, but removal will occur in major release versions of the {PlatformNameShort}.
 
+|Automation mesh
+|The Work Python option has been deprecated and will be removed from automation mesh in a future release.
+
 |===
 
 


### PR DESCRIPTION
Addresses [AAP-28125](https://issues.redhat.com/browse/AAP-28125) to deprecate the receptor option for worker python. Based on the changes made in [PR #1101](https://github.com/ansible/receptor/pull/1101).

***This needs to be backported to 2.4***