### PR TITLE
AAP-35120 updated architecture introduction (#2510)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-architecture.adoc
+++ b/downstream/assemblies/platform/assembly-aap-architecture.adoc
@@ -2,7 +2,11 @@
 [id='aap_architecture']
 = {PlatformName} Architecture
 
-As a modular platform, {PlatformNameShort} provides the flexibility to easily integrate components and customize your deployment to best meet your automation requirements. The following section provides a comprehensive architectural example of an {PlatformNameShort} deployment.
+Deploy all components of {PlatformNameShort} so that all features and capabilities are available for use without the need to take further action.
+
+Red Hat tests the installation of {PlatformNameShort} {PlatformVers} based on a defined set of infrastructure topologies or reference architectures. Enterprise organizations can use one of the enterprise topologies for production deployments to ensure the highest level of uptime, performance, and continued scalability. Organizations or deployments that are resource constrained can use a "growth" topology.
+
+The following section provides a comprehensive architectural example of an {PlatformNameShort} deployment.
 
 include::platform/con-aap-example-architecture.adoc[leveloffset=+1]
 include::platform/ref-example-CONT-architecture.adoc[leveloffset=+1]


### PR DESCRIPTION
2.5 backport of [PR 2510](https://github.com/ansible/aap-docs/pull/2510)

[AAP-35120](https://issues.redhat.com/browse/AAP-35120)

Updated introductory paragraph to [Ch 2 Red Hat Ansible Automation Platform Architecture](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/planning_your_installation/aap_architecture)

Files modified:

assembly-aap-architecture.adoc