### PR TITLE
Clouds - Add attributes for current AAP version on Azure

### DIFF
--- a/attributes/attributes.adoc
+++ b/attributes/attributes.adoc
@@ -7,6 +7,7 @@
 :CentralAuthStart: Central authentication
 :CentralAuth: central authentication
 :PlatformVers: 2.5
+:AzurePlatformVers: 2.4
 :AnsibleCoreVers: 2.13
 :BaseURL: https://docs.redhat.com/en/documentation
 
@@ -134,3 +135,160 @@
 
 // Feedback module
 :DocumentationFeedback: aap-common/providing-feedback.adoc
+
+// Title and link attributes
+//
+// titles/troubleshooting-aap
+:TitleTroubleshootingAAP: Troubleshooting Ansible Automation Platform
+:URLTroubleshootingAAP: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/troubleshooting_ansible_automation_platform
+:LinkTroubleshootingAAP: {URLTroubleshootingAAP}[{TitleTroubleshootingAAP}]
+//
+// titles/aap-plugin-rhdh-install
+:TitlePluginRHDHInstall: Installing Ansible plug-ins for Red Hat Developer Hub
+:URLPluginRHDHInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/installing_ansible_plug-ins_for_red_hat_developer_hub
+:LinkPluginRHDHInstall: {URLPluginRHDHInstall}[{TitlePluginRHDHInstall}]
+//
+// titles/aap-plugin-rhdh-using
+:TitlePluginRHDHUsing: Using Ansible plug-ins for Red Hat Developer Hub
+:URLPluginRHDHUsing: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_ansible_plug-ins_for_red_hat_developer_hub
+:LinkPluginRHDHUsing: {URLPluginRHDHUsing}[{TitlePluginRHDHUsing}]
+//
+// titles/aap-operations-guide
+:TitleAAPOperationsGuide: Operating Ansible Automation Platform
+:URLAAPOperationsGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/operating_ansible_automation_platform
+:LinkAAPOperationsGuide: {URLAAPOperationsGuide}[{TitleAAPOperationsGuide}]
+//
+// titles/eda/eda-user-guide
+:TitleEDAUserGuide: Using automation decisions 
+:URLEDAUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_decisions 
+:LinkEDAUserGuide: {URLEDAUserGuide}[{TitleEDAUserGuide}]
+//
+// titles/upgrade
+:TitleUpgrade: RPM upgrade and migration
+:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_upgrade_and_migration
+:LinkUpgrade: {URLUpgrade}[{TitleUpgrade}]
+//
+// titles/aap-operator-installation
+:TitleOperatorInstallation: Installing on OpenShift Container Platform
+:URLOperatorInstallation: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/installing_on_openshift_container_platform
+:LinkOperatorInstallation: {URLOperatorInstallation}[{TitleOperatorInstallation}]
+//
+// titles/aap-installation-guide
+:TitleInstallationGuide: RPM installation
+:URLInstallationGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_installation
+:LinkInstallationGuide: {URLInstallationGuide}[{TitleInstallationGuide}]
+//
+// titles/aap-planning-guide
+:TitlePlanningGuide: Planning your installation
+:URLPlanningGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/planning_your_installation
+:LinkPlanningGuide: {URLPlanningGuide}[{TitlePlanningGuide}]
+//
+// titles/operator-mesh
+:TitleOperatorMesh: Automation mesh for managed cloud or operator environments
+:URLOperatorMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_managed_cloud_or_operator_environments
+:LinkOperatorMesh: {URLOperatorMesh}[{TitleOperatorMesh}]
+//
+// titles/automation-mesh
+:TitleAutomationMesh: Automation mesh for VM environments
+:URLAutomationMesh: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_vm_environments
+:LinkAutomationMesh: {URLAutomationMesh}[{TitleAutomationMesh}]
+//
+// titles/ocp_performance_guide
+:TitleOCPPerformanceGuide: Performance considerations for operator environments
+:URLOCPPerformanceGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/performance_considerations_for_operator_environments
+:LinkOCPPerformanceGuide: {URLOCPPerformanceGuide}[{TitleOCPPerformanceGuide}]
+//
+// titles/security-guide
+:TitleSecurityGuide: Implementing security automation
+:URLSecurityGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/implementing_security_automation
+:LinkSecurityGuide: {URLSecurityGuide}[{TitleSecurityGuide}]
+//
+// titles/playbooks/playbooks-getting-started
+:TitlePlaybooksGettingStarted: Getting started with playbooks
+:URLPlaybooksGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_playbooks
+:LinkPlaybooksGettingStarted: {URLPlaybooksGettingStarted}[{TitlePlaybooksGettingStarted}]
+//
+// titles/playbooks/playbooks-reference
+:TitlePlaybooksReference: Reference guide to Ansible Playbooks
+:URLPlaybooksReference: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/reference_guide_to_ansible_playbooks
+:LinkPlaybooksReference: {URLPlaybooksReference}[{TitlePlaybooksReference}]
+//
+// titles/release-notes
+:TitleReleaseNotes: Release notes
+:URLReleaseNotes: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/release_notes
+:LinkReleaseNotes: {URLReleaseNotes}[{TitleReleaseNotes}]
+//
+// titles/controller/controller-user-guide
+:TitleControllerUserGuide: Using automation execution
+:URLControllerUserGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution
+:LinkControllerUserGuide: {URLControllerUserGuide}[{TitleControllerUserGuide}]
+//
+// titles/controller/controller-admin-guide
+:TitleControllerAdminGuide: Configuring automation execution
+:URLControllerAdminGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/configuring_automation_execution
+:LinkControllerAdminGuide: {URLControllerAdminGuide}[{TitleControllerAdminGuide}]
+//
+// titles/controller/controller-api-overview
+:TitleControllerAPIOverview: Automation execution API overview
+:URLControllerAPIOverview: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_execution_api_overview
+:LinkControllerAPIOverview: {URLControllerAPIOverview}[{TitleControllerAPIOverview}]
+//
+// titles/aap-operator-backup
+:TitleOperatorBackup: Backup and recovery for operator environments
+:URLOperatorBackup: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/backup_and_recovery_for_operator_environments
+:LinkOperatorBackup: {URLOperatorBackup}[{TitleOperatorBackup}]
+//
+// titles/central-auth
+:TitleCentralAuth: Access management and authentication
+:URLCentralAuth: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/access_management_and_authentication
+:LinkCentralAuth: {URLCentralAuth}[{TitleCentralAuth}]
+//
+// titles/getting-started
+:TitleGettingStarted: Getting started with Ansible Automation Platform
+:URLGettingStarted: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_ansible_automation_platform
+:LinkGettingStarted: {URLGettingStarted}[{TitleGettingStarted}]
+//
+// titles/aap-containerized-install
+:TitleContainerizedInstall: Containerized installation
+:URLContainerizedInstall: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation
+:LinkContainerizedInstall: {URLContainerizedInstall}[{TitleContainerizedInstall}]
+//
+// titles/navigator-guide
+:TitleNavigatorGuide: Using content navigator
+:URLNavigatorGuide: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_content_navigator
+:LinkNavigatorGuide: {URLNavigatorGuide}[{TitleNavigatorGuide}]
+//
+// titles/aap-hardening
+:TitleHardening: Hardening and compliance
+:URLHardening: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/hardening_and_compliance
+:LinkHardening: {URLHardening}[{TitleHardening}]
+//
+// titles/builder
+:TitleBuilder: Creating and using execution environments
+:URLBuilder: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/creating_and_using_execution_environments
+:LinkBuilder: {URLBuilder}[{TitleBuilder}]
+//
+// titles/hub/managing-content
+:TitleHubManagingContent: Managing automation content
+:URLHubManagingContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/managing_automation_content
+:LinkHubManagingContent: {URLHubManagingContent}[{TitleHubManagingContent}]
+//
+// titles/analytics
+:TitleAnalytics: Using automation analytics
+:URLAnalytics: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_analytics
+:LinkAnalytics: {URLAnalytics}[{TitleAnalytics}]
+//
+// titles/develop-automation-content
+:TitleDevelopAutomationContent: Developing automation content
+:URLDevelopAutomationContent: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/developing_automation_content
+:LinkDevelopAutomationContent: {URLDevelopAutomationContent}[{TitleDevelopAutomationContent}]
+//
+// titles/topologies
+:TitleTopologies: Tested deployment models
+:URLTopologies: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/tested_deployment_models
+:LinkTopologies: {URLTopologies}[{TitleTopologies}]
+//
+// Lightspeed branch titles/lightspeed-user-guide
+:TitleLightspeedUserGuide: Red Hat Ansible Lightspeed with IBM watsonx Code Assistant User Guide
+:URLLightspeedUserGuide: {BaseURL}/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide
+:LinkLightspeedUserGuide: {URLLightspeedUserGuide}[{TitleLightspeedUserGuide}]

--- a/stories/topics/con-azure-about.adoc
+++ b/stories/topics/con-azure-about.adoc
@@ -15,5 +15,5 @@ The following Red Hat Automation Platform components are available on {AAPonAzur
 * Ansible Content Collections, including the Microsoft collection for Azure
 * Automation Execution Environment
 * Ansible content tools, including access to {InsightsName}
-* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_automation_mesh_for_operator-based_installations/index[Automation mesh]
+* link:{LinkOperatorMesh}
 


### PR DESCRIPTION
Self-managed Azure is not upgrading to the new AAP release for a while, so we need an attribute to track the current Azure version.