### PR TITLE
AAP-35359 Clouds - update sync script for AWS / GCP deprecation

### DIFF
--- a/bin/sync_cloud_docs.sh
+++ b/bin/sync_cloud_docs.sh
@@ -26,53 +26,20 @@ rm -rf $target/saas-aws/images
 rm -rf $target/saas-aws/stories
 rm -rf $target/saas-aws/stories.adoc
 
-rm -rf $target/aap-on-aws/aap-common
-rm -rf $target/aap-on-aws/attributes
-rm -rf $target/aap-on-aws/images
-rm -rf $target/aap-on-aws/stories
-rm -rf $target/aap-on-aws/stories.adoc
-
-rm -rf $target/aap-on-gcp/aap-common
-rm -rf $target/aap-on-gcp/attributes
-rm -rf $target/aap-on-gcp/images
-rm -rf $target/aap-on-gcp/stories
-rm -rf $target/aap-on-gcp/stories.adoc
-
-rm -rf $target/release-notes-gcp/aap-common
-rm -rf $target/release-notes-gcp/attributes
-rm -rf $target/release-notes-gcp/images
-rm -rf $target/release-notes-gcp/stories
-rm -rf $target/release-notes-gcp/stories.adoc
-
 # Copy aap-common to the target directories.
 cp -r $source/aap-common/ $target/aap-on-azure/
 cp -r $source/aap-common/ $target/saas-aws/
-cp -r $source/aap-common/ $target/aap-on-aws/
-cp -r $source/aap-common/ $target/aap-on-gcp/
-cp -r $source/aap-common/ $target/release-notes-gcp/
 
 # Copy attributes to the target directories.
 cp -r $source/attributes/ $target/aap-on-azure/
 cp -r $source/attributes/ $target/saas-aws/
-cp -r $source/attributes/ $target/aap-on-aws/
-cp -r $source/attributes/ $target/aap-on-gcp/
-cp -r $source/attributes/ $target/release-notes-gcp/
 
 # Copy images to the target directories.
 cp -r $source/images/ $target/aap-on-azure/
 cp -r $source/images/ $target/saas-aws/
-cp -r $source/images/ $target/aap-on-aws/
-cp -r $source/images/ $target/aap-on-gcp/
-cp -r $source/images/ $target/release-notes-gcp/
 
 # Copy user stories to the target directories.
 cp -r $source/stories/ $target/saas-aws/
 cp -r $source/titles/saas-aws/stories.adoc $target/saas-aws/
 cp -r $source/stories/ $target/aap-on-azure/
 cp -r $source/titles/aap-on-azure/stories.adoc $target/aap-on-azure/
-cp -r $source/stories/ $target/aap-on-aws/
-cp -r $source/titles/aap-on-aws/stories.adoc $target/aap-on-aws/
-cp -r $source/stories/ $target/aap-on-gcp/
-cp -r $source/titles/aap-on-gcp/stories.adoc $target/aap-on-gcp/
-cp -r $source/stories/ $target/release-notes-gcp/
-cp -r $source/titles/release-notes-gcp/stories.adoc $target/release-notes-gcp/


### PR DESCRIPTION
AAP-35359 Clouds - update sync script for AWS / GCP deprecation

The AWS and GCP docs have been deprecated. Update the sync script so that Jenkins does not attempt to sync these to the production repo.