### PR TITLE
[Backport] AAP-33062 - add more details for LDAP Group types (#2537)

### DIFF
--- a/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
@@ -17,32 +17,49 @@ Users created through an LDAP login should not change their username, first name
 . Select *LDAP* from the *Authentication type* list and click btn:[Next].
 . Enter a *Name* for this LDAP configuration. The configuration name is required, must be unique across all authenticators, and must not be longer than 512 characters.
 . In the *LDAP Server URI* field, enter or modify the list of LDAP servers to which you want to connect. This field supports multiple addresses.
-. In the *LDAP Bind DN text* field, enter the Distinguished Name (DN) to specify the user that the Ansible Automation Platform uses to connect to the LDAP server. For example:
+. In the *LDAP Bind DN text* field, enter the Distinguished Name (DN) to specify the user that the {PlatformNameShort} uses to connect to the LDAP server. For example:
 +
 ----
 CN=josie,CN=users,DC=website,DC=com
 ----
 +
 . In the *LDAP Bind Password* text field, enter the password to use for the binding user.
-. Select a group type from the *LDAP Group Type* list.
+. Select a group type from the *LDAP Group Type* list. The *LDAP Group Type* list includes the following groups:
++
+* `PosixGroupType`
+* `GroupOfNamesType`
+* `GroupOfUniqueNamesType`
+* `ActiveDirectoryGroupType`
+* `OrganizationalRoleGroupType`
+* `MemberDNGroupType`
+* `NISGroupType`
+* `NestedGroupOfNamesType`
+* `NestedGroupOfUniqueNamesType`
+* `NestedActiveDirectoryGroupType`
+* `NestedOrganizationalRoleGroupType`
+* `NestedMemberDNGroupType`
+* `PosixUIDGroupType`
 +
 [NOTE]
 ====
-The LDAP group types that are supported by the Ansible Automation Platform use the underlying link:https://django-auth-ldap.readthedocs.io/en/latest/reference.html#django_auth_ldap.config.LDAPGroupType[django-auth-ldap library]. 
+The group types that are supported by {PlatformNameShort} use the underlying link:https://django-auth-ldap.readthedocs.io/en/latest/reference.html#django_auth_ldap.config.LDAPGroupType[django-auth-ldap library]. To specify the parameters for the selected group type, see Step 13 of this procedure.
 ====
-+
 . To use *LDAP User DN Template* as an alternative to user search, enter the name of the template. This approach is more efficient for user lookups than searching if it is usable in your organizational environment. If this setting has a value it will be used instead of the *LDAP User Search* setting.
 . *LDAP Start TLS* is disabled by default. To enable TLS when the LDAP connection is not using SSL, set the switch to *On*.
 +
 include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
 +
 . Enter any *LDAP Connection Options* to set for the LDAP connection. 
-. In the *LDAP Group Type Parameters* field, enter the parameters required for the LDAP Group Type you previously selected to identify LDAP groups and the members that belong to those groups.
+. Depending on the selected *LDAP Group Type*, different parameters are available in the *LDAP Group Type Parameters* field to account for this. `LDAP_GROUP_TYPE_PARAMS` is a dictionary, which is converted to `kwargs` and passed to the *LDAP Group Type* class selected. There are two common parameters used by group types: `name_attr` and `member_attr`. Where `name_attr` defaults to `cn` and `member_attr` defaults to `member`: 
++
+----
+{"name_attr": "cn", "member_attr": "member"}
+----
 +
 To determine the parameters that a specific *LDAP Group Type* requires, refer to the link:https://django-auth-ldap.readthedocs.io/en/latest/reference.html#django_auth_ldap.config.LDAPGroupType[django_auth_ldap documentation] on the classes `init` parameters.
 +
 . In the *LDAP Group Search* field, specify which groups should be searched and how to search them. 
-. In the *LDAP User Attribute Map* field, enter user attributes to map LDAP fields to your Ansible Automation Platform users for example, email or first_name. 
+. In the *LDAP User Attribute Map* field, enter user attributes to map LDAP fields to your {PlatformNameShort} users, for example, `email` or `first_name`. 
 . In the *LDAP User Search* field, enter where to search for users during authentication. 
 +
 include::snippets/snip-gw-authentication-common-checkboxes.adoc[]


### PR DESCRIPTION
This PR backports the changes from #2537 to the 2.5 branch and includes the following:

* AAP-33062 - add more details for LDAP Group types

* AAP-33062 - added peer review suggestions