### PR TITLE
Fix link in RPM upgrade guide (#2545)

### DIFF
--- a/downstream/modules/platform/proc-running-setup-script-for-updates.adoc
+++ b/downstream/modules/platform/proc-running-setup-script-for-updates.adoc
@@ -17,4 +17,5 @@ The installation will begin.
 
 [role="_additional-resources"]
 .Next steps
-If you are upgrading from {PlatformNameShort} 2.4 to 2.5, proceed to link:{URLUpgrade}/account-linking_aap-upgrading-platform[Linking your account] to link your existing service level accounts to a single unified platform account. 
+If you are upgrading from {PlatformNameShort} 2.4 to 2.5, proceed to
+xref:account-linking_aap-upgrading-platform[Linking your account] to link your existing service level accounts to a single unified platform account. 


### PR DESCRIPTION
Fix link in RPM upgrade guide

Affects `titles/upgrade/`