### PR TITLE
Add port 27199 to CONT-A-ENV-A in Supported deployment models

### DIFF
--- a/downstream/modules/topologies/ref-cont-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-a-env-a.adoc
@@ -60,8 +60,9 @@ a|
 | 5432 | TCP | PostgreSQL | {GatewayStart} | External database 
 | 5432 | TCP | PostgreSQL | {HubNameStart} | External database
 | 5432 | TCP | PostgreSQL | {ControllerNameStart} | External database
-| 6379 | TCP | Redis | {EDAName} | Redis node
-| 6379 | TCP | Redis | {GatewayStart} | Redis node
+| 27199 | TCP | Receptor | {ControllerNameStart} | Execution container
+| 6379 | TCP | Redis | {EDAName} | Redis container
+| 6379 | TCP | Redis | {GatewayStart} | Redis container
 | 8433 | TCP | HTTPS | {GatewayStart} | {GatewayStart}
 | 50051 | TCP | gRPC | {GatewayStart} | {GatewayStart}
 |====


### PR DESCRIPTION
Add the missing port number 27199 in the Network Ports table to the CONT-A-ENV-A (Growth Container) tested topology.

Affects: `titles/topologies`

Tested deployment models - Update CONT-A-ENV-A port table to include 27199

https://issues.redhat.com/browse/AAP-35150