### PR TITLE
Updating "pods/log" resource (#2523)

### DIFF
--- a/downstream/modules/platform/proc-controller-create-container-group.adoc
+++ b/downstream/modules/platform/proc-controller-create-container-group.adoc
@@ -43,10 +43,10 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: [""]
   resources: ["pods/log"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  verbs: ["get"]
 - apiGroups: [""]
   resources: ["pods/attach"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  verbs: ["get", "list", "watch", "create"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Revamp the permissions for "pods/log" resource of an AAP container group

https://issues.redhat.com/browse/AAP-14596

Affects `titles/controller-user-guide`