### PR TITLE
AAP-32543 Clarify options in mesh node types definition

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -40,6 +40,8 @@
 :GCP: Google Cloud Platform
 :Azure: Microsoft Azure
 :MSEntraID: Microsoft Entra ID
+:SaaSonAWS: Red Hat Ansible Automation Platform Service on AWS
+:SaaSonAWSShort: Ansible Automation Platform Service on AWS
 
 // Automation Mesh
 :AutomationMesh: automation mesh

--- a/downstream/modules/platform/proc-define-mesh-node-types.adoc
+++ b/downstream/modules/platform/proc-define-mesh-node-types.adoc
@@ -19,6 +19,13 @@ These hop nodes are not part of the Kubernetes cluster and are registered in {Co
 
 The following procedure demonstrates how to set the node type for the hosts.
 
+ifdef::operator-mesh[]
+[NOTE]
+====
+By default, {SaaSonAWS} includes two hop nodes that you can peer execution nodes to.
+====
+endif::operator-mesh[]
+
 .Procedure
 //[ddacosta]Removed specified panel to simplify changes in the future.
 . From the navigation panel, select {MenuInfrastructureInstances}.
@@ -50,28 +57,27 @@ Options:
 
 ** *Enable instance*: Check this box to make it available for jobs to run on an execution node.
 ** Check the *Managed by policy* box to enable policy to dictate how the instance is assigned.
-** Check the *Peers from control nodes* box to enable control nodes to peer to this instance automatically.
-For nodes connected to {ControllerName}, check the *Peers from Control* nodes box to create a direct communication link between that node and {ControllerName}.
-For all other nodes:
-
-*** If you are not adding a hop node, make sure *Peers from Control* is checked.
-*** If you are adding a hop node, make sure *Peers from Control* is not checked.
-*** For execution nodes that communicate with hop nodes, do not check this box.
-** To peer an execution node with a hop node, select the execution node, then select *Peers* tab.
-+
-The Select Peers window is displayed.
-+
-** Select the execution node to peer to the hop node.
-
-** Click btn:[Associate peers].
+** *Peers from control nodes*:
+*** If you are configuring a hop node:
+**** If the hop node needs to have requests pushed directly from {ControllerName}, then check the *Peers from Control* box.
+// This creates a direct communication link between the hop node and {ControllerName}.
+**** If the hop node is peered to another hop node, then make sure *Peers from Control* is not checked.
+*** If you are configuring an execution node:
+**** If the execution node needs to have requests pushed directly from {ControllerName}, then check the *Peers from Control* box.
+// This creates a direct communication link between the execution node and {ControllerName}.
+**** If the execution node is peered to a hop node, then make sure that *Peers from Control* is not checked.
+. Click btn:[Associate peers].
 //+
 //image::instances_create_details.png[Create Instance details]
-
 ifdef::operator-mesh[]
-. To view a graphical representation of your updated topology, see link:{URLControllerUserGuide}/assembly-controller-topology-viewer[Topology view].
+. To verify peering configuration and the direction of traffic, you can use the topology view
+to view a graphical representation of your updated topology.
+This can help to determine where your firewall rules might need to be updated.
+For more information, see link:{URLControllerUserGuide}/assembly-controller-topology-viewer[Topology view].
 endif::operator-mesh[]
 ifdef::controller-UG[]
-. To view a graphical representation of your updated topology, see xref:assembly-controller-topology-viewer[Topology view].
+. To view a graphical representation of your updated topology, see
+xref:assembly-controller-topology-viewer[Topology view].
 endif::controller-UG[]
 +
 [NOTE]


### PR DESCRIPTION
Affects `/titles/operator-mesh/`

Part of AAP-32543
DO NOT PUBLISH THIS UNTIL SaaS IS RELEASED, because one of the updated files mentions SaaS!
Might be best to delay the backport to 2.5 for this reason.