### PR TITLE
Add missing receptor vars to inventory appendix

### DIFF
--- a/downstream/modules/platform/ref-ansible-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-ansible-inventory-variables.adoc
@@ -28,7 +28,6 @@ Never store this variable in plain text.
 
 Always use a vault.
 | `ansible_ssh_private_key_file` | Private key file used by SSH. Useful if using multiple keys and you do not want to use an SSH agent.
-Useful if using multiple keys and you do not want to use an SSH agent.
 | `ansible_ssh_common_args` | This setting is always appended to the default command line for `sftp`, `scp`, and `ssh`.
 Useful to configure a ProxyCommand for a certain host or group.
 | `ansible_sftp_extra_args` | This setting is always appended to the default `sftp` command line.
@@ -41,9 +40,7 @@ If using SSH key-based authentication, the key must be managed by an SSH agent.
 
 This setting overrides the default behavior to use the system SSH.
 This can override the `ssh_executable` setting in `ansible.cfg`.
-| `ansible_ssh_executable` | Added in version 2.2.
 
-This setting overrides the default behavior to use the system SSH. This can override the `ssh_executable` setting in 'ansible.cfg'.
 | `ansible_shell_type` | The shell type of the target system.
 Do not use this setting unless you have set the `ansible_shell_executable` to a non-Bourne (sh) compatible shell.
 By default commands are formatted using sh-style syntax.

--- a/downstream/modules/platform/ref-ansible-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-ansible-inventory-variables.adoc
@@ -11,47 +11,47 @@ For a list of global configuration options, see link:https://docs.ansible.com/an
 [cols="50%,50%",options="header"]
 |====
 | *Variable* | *Description*
-| *`ansible_connection`* | The connection plugin used for the task on the target host.
+| `ansible_connection` | The connection plugin used for the task on the target host.
 
 This can be the name of any of Ansible connection plugins.
 SSH protocol types are `smart`, `ssh` or `paramiko`.
 
 Default = `smart`
-| *`ansible_host`* | The IP or name of the target host to use instead of *`inventory_hostname`*.
-| *`ansible_port`* | The connection port number.
+| `ansible_host` | The IP or name of the target host to use instead of `inventory_hostname`.
+| `ansible_port` | The connection port number.
 
-Default: 22 for ssh
-| *`ansible_user`* | The user name to use when connecting to the host.
-| *`ansible_password`* | The password to authenticate to the host.
+Default: 22 for SSH
+| `ansible_user` | The user name to use when connecting to the host.
+| `ansible_password` | The password to authenticate to the host.
 
 Never store this variable in plain text.
 
 Always use a vault.
-| *`ansible_ssh_private_key_file`* | Private key file used by SSH. Useful if using multiple keys and you do not want to use an SSH agent.
+| `ansible_ssh_private_key_file` | Private key file used by SSH. Useful if using multiple keys and you do not want to use an SSH agent.
 Useful if using multiple keys and you do not want to use an SSH agent.
-| *`ansible_ssh_common_args`* | This setting is always appended to the default command line for `sftp`, `scp`, and `ssh`.
+| `ansible_ssh_common_args` | This setting is always appended to the default command line for `sftp`, `scp`, and `ssh`.
 Useful to configure a ProxyCommand for a certain host or group.
-| *`ansible_sftp_extra_args`* | This setting is always appended to the default `sftp` command line.
-| *`ansible_scp_extra_args`* | This setting is always appended to the default `scp` command line.
-| *`ansible_ssh_extra_args`* | This setting is always appended to the default `ssh` command line.
-| *`ansible_ssh_pipelining`* | Determines if SSH pipelining is used.
-This can override the pipelining setting in `ansible.cfg`.
+| `ansible_sftp_extra_args` | This setting is always appended to the default `sftp` command line.
+| `ansible_scp_extra_args` | This setting is always appended to the default `scp` command line.
+| `ansible_ssh_extra_args` | This setting is always appended to the default `ssh` command line.
+| `ansible_ssh_pipelining` | Determines if SSH `pipelining` is used.
+This can override the `pipelining` setting in `ansible.cfg`.
 If using SSH key-based authentication, the key must be managed by an SSH agent.
-| *`ansible_ssh_executable`* | Added in version 2.2.
+| `ansible_ssh_executable` | Added in version 2.2.
 
 This setting overrides the default behavior to use the system SSH.
-This can override the ssh_executable setting in `ansible.cfg`.
-| *`ansible_ssh_executable`* | Added in version 2.2.
+This can override the `ssh_executable` setting in `ansible.cfg`.
+| `ansible_ssh_executable` | Added in version 2.2.
 
-This setting overrides the default behavior to use the system SSH. This can override the ssh_executable setting in 'ansible.cfg'.
-| *`ansible_shell_type`* | The shell type of the target system.
+This setting overrides the default behavior to use the system SSH. This can override the `ssh_executable` setting in 'ansible.cfg'.
+| `ansible_shell_type` | The shell type of the target system.
 Do not use this setting unless you have set the `ansible_shell_executable` to a non-Bourne (sh) compatible shell.
 By default commands are formatted using sh-style syntax.
 Setting this to `csh` or `fish` causes commands executed on target systems to follow the syntax of those shells instead.
-| *`ansible_shell_executable`* | This sets the shell that the Ansible controller uses on the target machine and overrides the executable in `ansible.cfg` which defaults to `/bin/sh`.
+| `ansible_shell_executable` | This sets the shell that the Ansible controller uses on the target machine and overrides the executable in `ansible.cfg` which defaults to `/bin/sh`.
 
 Do not change this variable unless `/bin/sh` is not installed on the target machine or cannot be run from sudo.
-| *`inventory_hostname`* | This variable takes the hostname of the machine from the inventory script or the Ansible configuration file.
+| `inventory_hostname` | This variable takes the hostname of the machine from the inventory script or the Ansible configuration file.
 
 You cannot set the value of this variable.
 

--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -5,9 +5,9 @@
 [cols="50%,50%,50%",options="header"]
 |====
 | *RPM variable name* | *Container variable name* | *Description*
-| *`admin_email`* | | The email address used for the admin user for {ControllerName}.
+| `admin_email` | | The email address used for the admin user for {ControllerName}.
 
-| *`admin_password`* | `controller_admin_password`| _Required_
+| `admin_password` | `controller_admin_password`| _Required_
 
 {ControllerNameStart} admin password.
 
@@ -15,54 +15,54 @@ Passwords must be enclosed in quotes when they are provided in plain text in the
 
 Use of special characters for this variable is limited. The password can include any printable ASCII character except `/`, `”`, or `@`.
 
-| *`admin_username`* | `controller_admin_user` | {ControllerNameStart} admin user.
+| `admin_username` | `controller_admin_user` | {ControllerNameStart} admin user.
 
 Default = `admin`
 
-| *`automation_controller_main_url`* | |  {ControllerNameStart} main URL.
+| `automation_controller_main_url` | |  {ControllerNameStart} main URL.
 
-| *`controller_tls_files_remote`* | `controller_tls_remote` | {ControllerNameStart} TLS remote files.
-
-Default = `false`
-
-| *`nginx_disable_hsts`* | `controller_nginx_disable_hsts` | Disable NGINX HTTP Strict Transport Security (HSTS).
+| `controller_tls_files_remote` | `controller_tls_remote` | {ControllerNameStart} TLS remote files.
 
 Default = `false`
 
-| *`nginx_disable_https`* | `controller_nginx_disable_https` | Disable NGINX HTTPS.
+| `nginx_disable_hsts` | `controller_nginx_disable_hsts` | Disable NGINX HTTP Strict Transport Security (HSTS).
 
 Default = `false`
 
-| *`nginx_hsts_max_age`* | `controller_nginx_hsts_max_age` | This variable specifies how long, in seconds, the system must be considered as an _HTTP Strict Transport Security_ (HSTS) host. That is, how long HTTPS is used only for communication.
+| `nginx_disable_https` | `controller_nginx_disable_https` | Disable NGINX HTTPS.
+
+Default = `false`
+
+| `nginx_hsts_max_age` | `controller_nginx_hsts_max_age` | This variable specifies how long, in seconds, the system must be considered as an _HTTP Strict Transport Security_ (HSTS) host. That is, how long HTTPS is used only for communication.
 
 Default = `63072000` seconds, or two years.
 
-| *`nginx_http_port`* | `controller_nginx_http_port` | The NGINX HTTP server listens for inbound connections.
+| `nginx_http_port` | `controller_nginx_http_port` | The NGINX HTTP server listens for inbound connections.
 
 RPM default = `80`
 
 Container default = `8080`
 
-| *`nginx_https_port`* | `controller_nginx_https_port` | The NGINX HTTPS server listens for secure connections.
+| `nginx_https_port` | `controller_nginx_https_port` | The NGINX HTTPS server listens for secure connections.
 
 RPM Default = `443`
 
 Container default = `8443`
 
-| *`nginx_user_headers`* | `controller_nginx_user_headers` | List of NGINX headers for the {ControllerName} web server.
+| `nginx_user_headers` | `controller_nginx_user_headers` | List of NGINX headers for the {ControllerName} web server.
 
 Each element in the list is provided to the web server's NGINX configuration as a separate line. 
 
 Default = empty list
 
-| *`node_state`* | | _Optional_
+| `node_state` | | _Optional_
 
 The status of a node or group of nodes.
 Valid options are `active`, `deprovision` to remove a node from a cluster, or `iso_migrate` to migrate a legacy isolated node to an execution node.
 
 Default = `active`
 
-| *`node_type`* | | For `[automationcontroller]` group.
+| `node_type` | | For `[automationcontroller]` group.
 
 Two valid `node_types` can be assigned for this group.
 
@@ -81,7 +81,7 @@ A `node_type=hop` implies that the node forwards jobs to an execution node.
 A `node_type=execution` implies that the node can run jobs.
 
 Default for this group = `execution`.
-| *`peers`* | | _Optional_
+| `peers` | | _Optional_
 
 The `peers` variable is used to indicate which nodes a specific host or group connects to. Wherever this variable is defined, an outbound connection to the specific host or group is established.
 
@@ -90,15 +90,15 @@ This variable is used to add `tcp-peer` entries in the `receptor.conf` file used
 The peers variable can be a comma-separated list of hosts and groups from the inventory.
 This is resolved into a set of hosts that is used to construct the `receptor.conf` file.
 
-| *`pg_database`* | `controller_pg_database` | The name of the PostgreSQL database.
+| `pg_database` | `controller_pg_database` | The name of the PostgreSQL database.
 
 Default = `awx`
 
-| *`pg_host`* | `controller_pg_host` | _Required_
+| `pg_host` | `controller_pg_host` | _Required_
 
 The PostgreSQL host, which can be an externally managed database.
 
-| *`pg_password`* | `controller_pg_password` | _Required_
+| `pg_password` | `controller_pg_password` | _Required_
 
 The password for the PostgreSQL database.
 
@@ -111,27 +111,27 @@ NOTE
 You no longer have to provide a `pg_hashed_password` in your inventory file at the time of installation, because PostgreSQL 13 can now store user passwords more securely.
 
 When you supply `pg_password` in the inventory file for the installer, PostgreSQL uses the SCRAM-SHA-256 hash to secure that password as part of the installation process.
-| *`pg_port`* | `controller_pg_port` | The PostgreSQL port to use.
+| `pg_port` | `controller_pg_port` | The PostgreSQL port to use.
 
 Default = `5432`
 
-| *`pg_username`* | `controller_pg_username` | Your PostgreSQL database username.
+| `pg_username` | `controller_pg_username` | Your PostgreSQL database username.
 
 Default = `awx`.
 
-| *`supervisor_start_retry_count`* | | When specified, it adds `startretries = <value specified>` to the supervisor config file (/`etc/supervisord.d/tower.ini`).
+| `supervisor_start_retry_count` | | When specified, it adds `startretries = <value specified>` to the supervisor config file (/`etc/supervisord.d/tower.ini`).
 
 See link:http://supervisord.org/configuration.html#program-x-section-values[program:x Section Values] for more information about `startretries`.
 
 No default value exists.
 
-| *`web_server_ssl_cert`* | `controller_tls_cert` | _Optional_
+| `web_server_ssl_cert` | `controller_tls_cert` | _Optional_
 
 `/path/to/webserver.cert`
 
 Same as `automationhub_ssl_cert` but for web server UI and API.
 
-| *`web_server_ssl_key`* | `controller_tls_key` | _Optional_
+| `web_server_ssl_key` | `controller_tls_key` | _Optional_
 
 `/path/to/webserver.key`
 
@@ -141,7 +141,7 @@ Same as `automationhub_server_ssl_key` but for web server UI and API.
 
 Default = `4`
 
-| | `controller_license_file` | The location of your automation controller license file.
+| | `controller_license_file` | The location of your {ControllerName} license file.
 
 For example:
 

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -5,28 +5,28 @@
 [cols="50%,50%,50%",options="header"]
 |====
 | *RPM variable name* | *Container variable name* | *Description*
-| *`pg_ssl_mode`* | | Choose one of the two available modes: `prefer` and `verify-full`. 
+| `pg_ssl_mode` | | Choose one of the two available modes: `prefer` and `verify-full`. 
 
-Set to `verify-full` for client-side enforced SSL. 
+Set to `verify-full` for client-side enforced SSL/TLS. 
 
 Default = `prefer`
-| *`postgres_ssl_cert`* | `postgresql_tls_cert` | Location of the PostgreSQL SSL/TLS certificate.
+| `postgres_ssl_cert` | `postgresql_tls_cert` | Location of the PostgreSQL SSL/TLS certificate.
 
 `/path/to/pgsql_ssl.cert`
 
-| *`postgres_ssl_key`* | `postgresql_tls_key` | Location of the PostgreSQL SSL/TLS key.
+| `postgres_ssl_key` | `postgresql_tls_key` | Location of the PostgreSQL SSL/TLS key.
 
 `/path/to/pgsql_ssl.key`
 
-| *`postgres_use_cert`* | | Location of the PostgreSQL user certificate.
+| `postgres_use_cert` | | Location of the PostgreSQL user certificate.
 
 `/path/to/pgsql.crt`
 
-| *`postgres_use_ssl`* | `postgresql_disable_tls` | Determines if the connection between {PlatformNameShort} and the PostgreSQL database should use SSL/TLS. The default for this variable is `false` which means SSL/TLS is not used for PostgreSQL connections. When set to `true`, the platform connects to PostgreSQL by using SSL/TLS.
+| `postgres_use_ssl` | `postgresql_disable_tls` | Determines if the connection between {PlatformNameShort} and the PostgreSQL database should use SSL/TLS. The default for this variable is `false` which means SSL/TLS is not used for PostgreSQL connections. When set to `true`, the platform connects to PostgreSQL by using SSL/TLS.
 
-| *`postgres_max_connections`* | `postgresql_max_connections` | Maximum database connections setting to apply if you are using installer-managed PostgreSQL.
+| `postgres_max_connections` | `postgresql_max_connections` | Maximum database connections setting to apply if you are using installer-managed PostgreSQL.
 
-See link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref-controller-database-settings[PostgreSQL database configuration and maintenance for automation controller] for help selecting a value.
+See link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref-controller-database-settings[PostgreSQL database configuration and maintenance for {ControllerName}] for help selecting a value.
 
 Default = `1024`
 

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -24,11 +24,11 @@ Default = `info`
 Default = `false`
 
 | | `receptor_peers` | Receptor peers list. 
-| | `receptor_port` | Receptor port. 
+| `receptor_listener_port` | `receptor_port` | Receptor port number.
 
 Default = `27199`
 
-| | `receptor_protocol` | Receptor protocol.
+| `receptor_listener_protocol` | `receptor_protocol` | Receptor protocol.
 
 Default = `tcp`
 


### PR DESCRIPTION
Add missing receptor vars (receptor_listener_port, receptor_listener_protocol) to the Inventory file variables appendix

Affects: `titles/aap-containerized-install` and `titles/aap-installation-guide`

Containerized installation - Update receptor inventory file vars in Inventory file variables

https://issues.redhat.com/browse/AAP-35192