### PR TITLE
2.4 AAP-34041 plug-ins: view container logs on OCP UI (#2561)

### DIFF
--- a/downstream/modules/devtools/proc-rhdh-add-plugin-config.adoc
+++ b/downstream/modules/devtools/proc-rhdh-add-plugin-config.adoc
@@ -52,10 +52,25 @@ The developer hub pods restart and the plug-ins are installed.
 
 .Verification
 
-Verify that the plug-ins have been installed:
+To verify that the plug-ins have been installed, open the `install-dynamic-plugin` container logs and check that the Ansible plug-ins are visible in {RHDH}:
 
 . Open the Developer perspective for the {RHDH} application in the OpenShift Web console.
-. Check the `install-dynamic-plugin` container logs: the Ansible plug-ins are visible in {RHDH}.
+. Select the *Topology* view.
+. Select the {RHDH} deployment pod to open an information pane.
+. Select the *Resources* tab of the information pane.
+. In the *Pods* section, click *View logs* to open the *Pod details* page.
+. In the *Pod details* page, select the *Logs* tab.
+. Select `install-dynamic-plugins` from the drop-down list of containers to view the container log.
+. In the `install-dynamic-plugin` container logs, search for the Ansible plug-ins.
++
+The following example from the log indicates a successful installation for one of the plug-ins:
++
+-----
+=> Successfully installed dynamic plugin http://plugin-registry-1:8080/ansible-plugin-backstage-rhaap-1.1.0.tgz
+-----
++
+The following image shows the container log in the *Pod details* page.
+The version numbers and file names can differ.
 +
 image::rhdh-check-plugin-config.png[container logs for install-dynamic-plugin]
 

--- a/downstream/modules/devtools/proc-rhdh-create-plugin-registry.adoc
+++ b/downstream/modules/devtools/proc-rhdh-create-plugin-registry.adoc
@@ -36,9 +36,9 @@ image::rhdh-plugin-registry.png[Developer perspective]
 . In the terminal, run `ls` to confirm that the .tar files are in the plugin registry.
 +
 ----
-ansible-plugin-backstagc-rhaap-x.y.z.tgz
+ansible-plugin-backstage-rhaap-x.y.z.tgz
 ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
-ansible-plugin-scaffolder-backend-modulc-backstagc-rhaap-x.y.z.tgz
+ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
 ----
 +
 The version numbers and file names can differ.


### PR DESCRIPTION
Describe how to view container logs for a pod from the OpenShift UI so that the user can verify that the plug-ins have been installed.
Affects `titles/aap-plugin-rhdh-install/`