### PR TITLE
AAP-15176: fixes broken link in Configuring automation execution guide

### DIFF
--- a/downstream/modules/platform/proc-controller-cluster-deprovision-instances.adoc
+++ b/downstream/modules/platform/proc-controller-cluster-deprovision-instances.adoc
@@ -22,4 +22,4 @@ $ awx-manage deprovision_instance --hostname=hostB
 ----
 
 Deprovisioning instance groups in {ControllerName} does not automatically deprovision or remove instance groups.
-For more information, see the link:{URLControllerUserGuide/}/controller-instance-and-container-groups#controller-deprovision-instance-group[Deprovisioning instance groups] section in _{ControllerUG}_.
+For more information, see the link:{URLControllerUserGuide}/controller-instance-and-container-groups#controller-deprovision-instance-group[Deprovisioning instance groups] section in _{ControllerUG}_.


### PR DESCRIPTION
Part of an ongoing project to fix broken links in the AAP doc set. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more info. 