### PR TITLE
backport to 2.5: AAP-15176 fixes broken link in Configuring automation execution guide (#2566)

### DIFF
--- a/downstream/modules/platform/proc-controller-cluster-deprovision-instances.adoc
+++ b/downstream/modules/platform/proc-controller-cluster-deprovision-instances.adoc
@@ -22,4 +22,4 @@ $ awx-manage deprovision_instance --hostname=hostB
 ----
 
 Deprovisioning instance groups in {ControllerName} does not automatically deprovision or remove instance groups.
-For more information, see the link:{URLControllerUserGuide/}/controller-instance-and-container-groups#controller-deprovision-instance-group[Deprovisioning instance groups] section in _{ControllerUG}_.
+For more information, see the link:{URLControllerUserGuide}/controller-instance-and-container-groups#controller-deprovision-instance-group[Deprovisioning instance groups] section in _{ControllerUG}_.


### PR DESCRIPTION
This PR ports the changes from [PR 2566](https://github.com/ansible/aap-docs/pull/2566) to the 2.5 branch. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more info. 