### PR TITLE
Add shared storage info to Containerized installation

### DIFF
--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -233,6 +233,19 @@ gateway_main_url=<https://load_balancer_url>
 HAProxy SSL passthrough mode is not supported with {Gateway}.
 ====
 
+.Configuring shared storage for {HubName}
+
+Shared storage is required when installing more than one instance of {HubName} with a `file` storage backend. When installing a single instance of the {HubName}, shared storage is optional.
+
+* To configure shared storage for {HubName}, set the following variable in the inventory file, ensuring your network file system (NFS) share has read, write, and execute permissions:
+
+----
+hub_shared_data_path=<path_to_nfs_share>
+----
+
+* To change the mount options for your NFS share, use the `hub_shared_data_mount_opts` variable. This variable is optional and the default value is `rw,sync,hard`.
+
+
 .Loading an {ControllerName} license file
 
 * To define the location of your {ControllerName} license file, set the following variable in the inventory file:

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -263,5 +263,15 @@ Default = `30`
 
 Default = `main`
 
-|  | `hub_postinstall_repo_url` | {HubNameStart} repository URL. 
+|  | `hub_postinstall_repo_url` | {HubNameStart} repository URL.
+| | `hub_shared_data_path` | Required when installing more than one instance of {HubName} with a file storage backend. When installing a single instance of {HubName}, it is optional.
+
+Path to a Network File System (NFS) share with read, write, and execute (RWX) access.
+
+| | `hub_shared_data_mount_opts` | _Optional_
+
+Mount options for NFS share.
+
+Default = `rw,sync,hard`
+
 |====


### PR DESCRIPTION
Add shared storage info to the installation section and include the relevant variables in the appendix

Affects: `titles/aap-containerized-install` and `titles/aap-installation-guide`

[doc] hub_shared_data_path missing in doc

https://issues.redhat.com/browse/AAP-30613