### PR TITLE
Backport to 2.5: AAP-35099: adds info for token management with PAH and keycloak (#2574)

### DIFF
--- a/downstream/assemblies/hub/assembly-hub-create-api-token.adoc
+++ b/downstream/assemblies/hub/assembly-hub-create-api-token.adoc
@@ -10,9 +10,11 @@ Before you can interact with {HubName} by uploading or downloading collections, 
 
 Your method for creating the API token differs according to the type of {HubName} that you are using:
 
-* {HubNameStart} uses Offline token management. See xref:proc-create-api-token[Creating the API token in {HubName}].
+* {HubNameStart} uses offline token management. See xref:proc-create-api-token[Creating the offline token in {HubName}].
 
 * {PrivateHubNameStart} uses API token management. See xref:proc-create-api-token-pah[Creating the API token in {PrivateHubName}].
+
+* If you are using Keycloak to authenticate your {PrivateHubName}, follow the procedure for xref:proc-create-api-token[Creating the offline token in {HubName}].
 
 
 include::hub/proc-create-api-token.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR ports the changes from [PR 2574](https://github.com/ansible/aap-docs/pull/2574) to the 2.5 branch. See [AAP-35099](https://issues.redhat.com/browse/AAP-35099) for more.