### PR TITLE
AAP-33304: Document case-sensitivity of authenticator map group triggers (#2579)

### DIFF
--- a/downstream/modules/platform/con-gw-authenticator-map-triggers.adoc
+++ b/downstream/modules/platform/con-gw-authenticator-map-triggers.adoc
@@ -18,7 +18,12 @@ If you are only keying off one group it doesn’t matter if you select *"and"* o
 ====
 +
 * *Groups:* This is a list of one or more groups coming from the authentication system that the user must be a member of. See the *Operation* field to determine the behavior of the trigger if more than one group is specified in the trigger.
-
++
+[NOTE]
+====
+Group identifiers are case-sensitive and must match the authenticator backend. For example, `cn=johnsmith,dc=example,dc=com` instead of `CN=johnsmith,DC=example,DC=com`.
+====
++
 Attribute:: The map is true or false based on a users attributes coming from the source system. When defining an attribute trigger, the authentication mapping expands to include the following selections:
 +
 * *Operation:* This field includes conditional settings that trigger the handling of the rule based on the specified *Attribute* criteria. In version {PlatformVers} this field indicates what will happen if the source system returns a list of  attributes instead of a single value. For example, if the source system returns multiple emails for a user and *Operation* was set to *and*, all of the given emails must match the *Comparison* for the trigger to be _True_. If *Operation* was set to *or*, any of the returned emails will set the trigger to _True_ if they match the *Comparison* in the trigger. 


### PR DESCRIPTION
This PR backports the changes made in #2579 to the 2.5 branch. 