### PR TITLE
AAP 2.5 (4) Async Release-Updated Release Notes (#2588)

### DIFF
--- a/downstream/titles/release-notes/async/aap-25-4-20-nov.adoc
+++ b/downstream/titles/release-notes/async/aap-25-4-20-nov.adoc
@@ -1,0 +1,72 @@
+[[aap-25-4-20-nov]]
+
+= {PlatformNameShort} patch release November 20, 2024
+
+The following enhancements and bug fixes have been implemented in this release of {PlatformNameShort}.
+
+== Enhancements
+
+* With this release, a redirect page has now been implemented that will be exhibited when you navigate to the root `/` for each component's stand-alone URL. The API endpoint remains functional. This affects {EDAName}, {ControllerName}, {OperatorPlatformNameShort}, and {OCPShort}.
+
+
+== Bug fixes
+
+=== General
+
+With this update, the following CVEs have been addressed:
+
+link:https://access.redhat.com/security/cve/cve-2024-9902[CVE-2024-9902] ansible-core: Ansible-core user may read/write unauthorized content.
+
+link:https://access.redhat.com/security/cve/cve-2024-8775[CVE-2024-8775] ansible-core: Exposure of sensitive information in Ansible vault files due to improper logging.
+
+
+=== {PlatformNameShort}
+
+* Fixed an issue where the user was unable to filter out hosts on inventory groups where it returned a *Failed to load* options on {PlatformNameShort} UI.
+
+=== Execution Environment
+
+* Update *pywinrm* to 0.4.3 in *ee-minimal* and *ee-supported* container images to fix Python 3.11 compatibility.
+
+=== {OperatorPlatformNameShort}
+
+* Fixed a syntax error when `bundle_cacert_secret` was defined due to incorrect indentation.
+
+* Fixed an issue where the default operator catalog for {PlatformNameShort} aligned to cluster-scoped versus namespace-scoped.
+
+* Added the ability to set tolerations and `node_selector` for the Redis *statefulset* and the gateway deployment.
+
+* Ensure the platform URL status is set when *Ingress* is used to resolve an issue with {Azure} on Cloud managed deployments. This is due to the {PlatformNameShort} operator failing to finish because it is looking for {OCPShort} routes that are not available on Azure Kubernetes Service.
+
+* Fixed an issue where the {PlatformNameShort} Operator description did not render code block correctly.
+
+* It is necessary to specify the `CONTROLLER_SSO_URL` and `AUTOMATION_HUB_SSO_URL` settings in Gateway to fix the OIDC auth redirect flow.
+
+* It is necessary to set the `SERVICE_BACKED_SSO_AUTH_CODE_REDIRECT_URL` setting to fix the OIDC auth redirect flow.
+
+=== {ContainerBase} {PlatformNameShort}
+
+* Fixed an issue when the port value was not defined in the `gateway_main_url` variable, the containerized installer failed with incorrect {ExecEnvShort} image reference error.
+
+* Fixed an issue where the containerized installer used port number when specifying the `image_url` for a decision environment. The user should not add a port to image URLs when using the default value.
+
+=== RPM-based {PlatformNameShort}
+
+* Fixed an issue where not setting up the *gpg* agent socket properly when multiple hub nodes are configured resulted in not creating a *gpg* socket file in `/var/run/pulp`.
+
+=== {ToolsName}
+
+* Fixed an issue where missing data files were not included in the molecule RPM package.
+
+// Commenting this out for now as the advisories are not yet published to the Errata tab on the downloads page: https://access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.5/x86_64/product-errata
+
+// == Advisories
+// The following errata advisories are included in this release:
+
+// * link:https://access.redhat.com/errata/[]
+
+// * link:https://access.redhat.com/errata/[]
+
+// * link:https://access.redhat.com/errata/[]
+
+// * link:https://access.redhat.com/errata/[]


### PR DESCRIPTION
* AAP 2.5 (4) Async Release-Updated Release Notes

These release notes cover the current enhancements and bug fixes for the AAP 2.5 (4) release on November 20, 2024.

Resolves: AAP-35387

* Update aap-25-4-20-nov.adoc

* Update aap-25-4-20-nov.adoc

* Update aap-25-4-20-nov.adoc

* Update aap-25-4-20-nov.adoc

* Update aap-25-4-20-nov.adoc

* Update aap-25-4-20-nov.adoc

* Update aap-25-4-20-nov.adoc

* Update aap-25-4-20-nov.adoc