### PR TITLE
2.5 Add container troubleshooting info (#2590)

### DIFF
--- a/downstream/assemblies/platform/assembly-appendix-troubleshoot-containerized-aap.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-troubleshoot-containerized-aap.adoc
@@ -3,6 +3,7 @@
 
 Use this information to troubleshoot your containerized {PlatformNameShort} installation.
 
+include::platform/ref-containerized-troubleshoot-diagnosing.adoc[leveloffset=+1]
 include::platform/ref-containerized-troubleshoot-install.adoc[leveloffset=+1]
 include::platform/ref-containerized-troubleshoot-config.adoc[leveloffset=+1]
 include::platform/ref-containerized-troubleshoot-ref.adoc[leveloffset=+1]

--- a/downstream/modules/platform/ref-containerized-troubleshoot-diagnosing.adoc
+++ b/downstream/modules/platform/ref-containerized-troubleshoot-diagnosing.adoc
@@ -1,0 +1,123 @@
+[id="ref-containerized-troubleshoot-diagnosing"]
+
+= Diagnosing the problem
+
+For general container-based troubleshooting, you can inspect the container logs for any running service to help troubleshoot underlying issues.
+
+.Identifying the running containers
+
+To get a list of the running container names run the following command:
+
+----
+$ podman ps --all --format "{{.Names}}"
+----
+
+Example output:
+
+----
+postgresql
+redis-unix
+redis-tcp
+receptor
+automation-controller-rsyslog
+automation-controller-task
+automation-controller-web
+automation-eda-api
+automation-eda-daphne
+automation-eda-web
+automation-eda-worker-1
+automation-eda-worker-2
+automation-eda-activation-worker-1
+automation-eda-activation-worker-2
+automation-eda-scheduler
+automation-gateway-proxy
+automation-gateway
+automation-hub-api
+automation-hub-content
+automation-hub-web
+automation-hub-worker-1
+automation-hub-worker-2
+----
+
+.Inspecting the logs
+
+To inspect any running container logs run the `journalctl` command:
+
+----
+$ journalctl CONTAINER_NAME=<container_name>
+----
+
+Example command with output:
+
+----
+$ journalctl CONTAINER_NAME=automation-gateway-proxy
+
+Oct 08 01:40:12 aap.example.org automation-gateway-proxy[1919]: [2024-10-08 00:40:12.885][2][info][upstream] [external/envoy/source/common/upstream/cds_ap>
+Oct 08 01:40:12 aap.example.org automation-gateway-proxy[1919]: [2024-10-08 00:40:12.885][2][info][upstream] [external/envoy/source/common/upstream/cds_ap>
+Oct 08 01:40:19 aap.example.org automation-gateway-proxy[1919]: [2024-10-08T00:40:16.753Z] "GET /up HTTP/1.1" 200 - 0 1138 10 0 "192.0.2.1" "python->
+----
+
+To view the logs of a running container in real-time, run the `podman logs -f` command:
+
+----
+$ podman logs -f <container_name>
+----
+
+.Controlling container operations
+
+You can control operations for a container by running the `systemctl` command:
+
+----
+$ systemctl --user status <container_name>
+----
+
+Example command with output:
+
+----
+$ systemctl --user status automation-gateway-proxy
+● automation-gateway-proxy.service - Podman automation-gateway-proxy.service
+    Loaded: loaded (/home/user/.config/systemd/user/automation-gateway-proxy.service; enabled; preset: disabled)
+    Active: active (running) since Mon 2024-10-07 12:39:23 BST; 23h ago
+       Docs: man:podman-generate-systemd(1)
+    Process: 780 ExecStart=/usr/bin/podman start automation-gateway-proxy (code=exited, status=0/SUCCESS)
+   Main PID: 1919 (conmon)
+      Tasks: 1 (limit: 48430)
+     Memory: 852.0K
+        CPU: 2.996s
+     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/automation-gateway-proxy.service
+             └─1919 /usr/bin/conmon --api-version 1 -c 2dc3c7b2cecd73010bad1e0aaa806015065f92556ed3591c9d2084d7ee209c7a -u 2dc3c7b2cecd73010bad1e0aaa80>
+Oct 08 11:44:10 aap.example.org automation-gateway-proxy[1919]: [2024-10-08T10:44:02.926Z] "GET /api/galaxy/_ui/v1/settings/ HTTP/1.1" 200 - 0 654 58 47 ">
+Oct 08 11:44:10 aap.example.org automation-gateway-proxy[1919]: [2024-10-08T10:44:03.387Z] "GET /api/controller/v2/config/ HTTP/1.1" 200 - 0 4018 58 44 "1>
+Oct 08 11:44:10 aap.example.org automation-gateway-proxy[1919]: [2024-10-08T10:44:03.370Z] "GET /api/galaxy/v3/plugin/ansible/search/collection-versions/?>
+Oct 08 11:44:10 aap.example.org automation-gateway-proxy[1919]: [2024-10-08T10:44:03.405Z] "GET /api/controller/v2/organizations/?role_level=notification_>
+Oct 08 11:44:10 aap.example.org automation-gateway-proxy[1919]: [2024-10-08T10:44:04.366Z] "GET /api/galaxy/_ui/v1/me/ HTTP/1.1" 200 - 0 1368 79 40 "192.1>
+Oct 08 11:44:10 aap.example.org automation-gateway-proxy[1919]: [2024-10-08T10:44:04.360Z] "GET /api/controller/v2/workflow_approvals/?page_size=200&statu>
+Oct 08 11:44:10 aap.example.org automation-gateway-proxy[1919]: [2024-10-08T10:44:04.379Z] "GET /api/controller/v2/job_templates/7/ HTTP/1.1" 200 - 0 1356>
+Oct 08 11:44:10 aap.example.org automation-gateway-proxy[1919]: [2024-10-08T10:44:04.378Z] "GET /api/galaxy/_ui/v1/feature-flags/ HTTP/1.1" 200 - 0 207 81>
+Oct 08 11:44:13 aap.example.org automation-gateway-proxy[1919]: [2024-10-08 10:44:13.856][2][info][upstream] [external/envoy/source/common/upstream/cds_ap>
+Oct 08 11:44:13 aap.example.org automation-gateway-proxy[1919]: [2024-10-08 10:44:13.856][2][info][upstream] [external/envoy/source/common/upstream/cds_ap
+----
+
+.Getting container information about the execution plane
+
+To get container information about {ControllerName}, {EDAName}, and `execution_nodes` nodes, prefix any Podman commands with either:
+
+----
+CONTAINER_HOST=unix://run/user/<user_id>/podman/podman.sock
+----
+
+or
+
+----
+CONTAINERS_STORAGE_CONF=<user_home_directory>/aap/containers/storage.conf
+----
+
+Example with output:
+
+----
+$ CONTAINER_HOST=unix://run/user/1000/podman/podman.sock podman images
+
+REPOSITORY                                                            TAG         IMAGE ID      CREATED     SIZE
+registry.redhat.io/ansible-automation-platform-25/ee-supported-rhel8  latest      59d1bc680a7c  6 days ago  2.24 GB
+registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8    latest      a64b9fc48094  6 days ago  338 MB
+----


### PR DESCRIPTION
Add information for troubleshooting the logs and containers in Containerized installation

Affects: `titles/aap-containerized-install`

Small additions to AAP Containerized Install Guide Troubleshooting section

https://issues.redhat.com/browse/AAP-33026