### PR TITLE
2.5 Add mTLS configuration for external databases (#2592)

### DIFF
--- a/downstream/modules/platform/proc-setup-postgresql-ext-database.adoc
+++ b/downstream/modules/platform/proc-setup-postgresql-ext-database.adoc
@@ -8,7 +8,7 @@ Red Hat does not support the use of external (customer supported) databases, how
 The following guidance on inital configuration, from a product installation perspective only, is provided to avoid related support requests.
 ====  
 
-To create a database, user and password on an external PostgreSQL compliant database for use with {ControllerName}, use the following procedure.
+Use the following procedure to configure an external PostgreSQL compliant database for use with an {PlatformNameShort} component, for example {ControllerName}, {EDAName}, {HubName}, and {Gateway}.
 
 .Procedure
 . Install and then connect to a PostgreSQL compliant database server with superuser privileges.
@@ -46,23 +46,109 @@ If so, connection string parameters override any conflicting command line option
 
 . Create the user, database, and password with the `createDB` or administrator role assigned to the user. 
 For further information, see link:https://www.postgresql.org/docs/13/user-manag.html[Database Roles].
-. Add the database credentials and host details to the automation controller inventory file as an external database.
-The default values are used in the following example:
+. Add the database credentials and host details to the installation program's inventory file under the `[all:vars]` group.
 +
+.Without mutual TLS (mTLS) authentication to the database
+Use the following inventory file snippet to configure each component's database without mTLS authentication. Uncomment the configuration you need.
 
++
+[source,yaml,subs="+attributes"]
 ----
-[database]
-  pg_host='db.example.com'
-  pg_port=5432
-  pg_database='awx'
-  pg_username='awx'
-  pg_password='redhat'
+[all:vars]
+# {ControllerNameStart} database variables
+
+# awx_install_pg_host=data.example.com 
+# awx_install_pg_port=<port_number> 
+# awx_install_pg_database=<database_name> 
+# awx_install_pg_username=<username>
+# awx_install_pg_password=<password> # This is not required if you enable mTLS authentication to the database
+# pg_sslmode=prefer # Set to verify-ca or verify-full to enable mTLS authentication to the database
+
+
+# {EDAName} database variables
+
+# automationedacontroller_install_pg_host=data.example.com 
+# automationedacontroller_install_pg_port=<port_number> 
+# automationedacontroller_install_pg_database=<database_name> 
+# automationedacontroller_install_pg_username=<username>
+# automationedacontroller_install_pg_password=<password> # This is not required if you enable mTLS authentication to the database
+# automationedacontroller_pg_sslmode=prefer # Set to verify-full to enable mTLS authentication to the database
+
+
+# {HubNameStart} database variables
+
+# automationhub_pg_host=data.example.com 
+# automationhub_pg_port=<port_number> 
+# automationhub_pg_database=<database_name> 
+# automationhub_pg_username=<username>
+# automationhub_pg_password=<password> # This is not required if you enable mTLS authentication to the database
+# automationhub_pg_sslmode=prefer # Set to verify-ca or verify-full to enable mTLS authentication to the database
+
+
+# {GatewayStart} database variables
+
+# automationgateway_install_pg_host=data.example.com 
+# automationgateway_install_pg_port=<port_number> 
+# automationgateway_install_pg_database=<database_name> 
+# automationgateway_install_pg_username=<username>
+# automationgateway_install_pg_password=<password> # This is not required if you enable mTLS authentication to the database
+# automationgateway_pg_sslmode=prefer # Set to verify-ca or verify-full to enable mTLS authentication to the database
 ----
 +
+.With mTLS authentication to the database
 
+Use the following inventory file snippet to configure each component's database with mTLS authentication. Uncomment the configuration you need.
++
+[source,yaml,subs="+attributes"]
+----
+[all:vars]
+# {ControllerNameStart} database variables
+
+# awx_install_pg_host=data.example.com 
+# awx_install_pg_port=<port_number> 
+# awx_install_pg_database=<database_name> 
+# awx_install_pg_username=<username>
+# pg_sslmode=verify-full # This can be either verify-ca or verify-full
+# pgclient_sslcert=/path/to/cert # Path to the certificate file 
+# pgclient_sslkey=/path/to/key # Path to the key file
+
+
+# {EDAName} database variables
+
+# automationedacontroller_install_pg_host=data.example.com 
+# automationedacontroller_install_pg_port=<port_number> 
+# automationedacontroller_install_pg_database=<database_name> 
+# automationedacontroller_install_pg_username=<username>
+# automationedacontroller_pg_sslmode=verify-full # EDA does not support verify-ca
+# automationedacontroller_pgclient_sslcert=/path/to/cert # Path to the certificate file 
+# automationedacontroller_pgclient_sslkey=/path/to/key # Path to the key file
+
+
+# {HubNameStart} database variables
+
+# automationhub_pg_host=data.example.com 
+# automationhub_pg_port=<port_number> 
+# automationhub_pg_database=<database_name> 
+# automationhub_pg_username=<username>
+# automationhub_pg_sslmode=verify-full # This can be either verify-ca or verify-full
+# automationhub_pgclient_sslcert=/path/to/cert # Path to the certificate file 
+# automationhub_pgclient_sslkey=/path/to/key # Path to the key file
+
+
+# {GatewayStart} database variables
+
+# automationgateway_install_pg_host=data.example.com 
+# automationgateway_install_pg_port=<port_number> 
+# automationgateway_install_pg_database=<database_name> 
+# automationgateway_install_pg_username=<username>
+# automationgateway_pg_sslmode=verify-full # This can be either verify-ca or verify-full
+# automationgateway_pgclient_sslcert=/path/to/cert # Path to the certificate file 
+# automationgateway_pgclient_sslkey=/path/to/key # Path to the key file
+----
++
 . Run the installer.
-If you are using a PostgreSQL database with automation controller, the database is owned by the connecting user and must have a `createDB` or administrator role assigned to it.
-. Check that you are able to connect to the created database with the user, password and database name.
+If you are using a PostgreSQL database, the database is owned by the connecting user and must have a `createDB` or administrator role assigned to it.
+. Check that you can connect to the created database with the credentials provided in the inventory file.
 . Check the permission of the user. The user should have the `createDB` or administrator role.
 
 [NOTE]


### PR DESCRIPTION
Re-adding this content as the backport wasn't merged.

[Docs] Certificate auth support (mTLS) for ProgreSQL external DB instructions no longer present (overwritten)

https://issues.redhat.com/browse/AAP-36108