### PR TITLE
Elaborated on deployment name for backing up to clarify expected format (#2330)

### DIFF
--- a/downstream/modules/platform/proc-aap-controller-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-backup.adoc
@@ -18,8 +18,7 @@ Use this procedure to back up a deployment of the controller, including jobs, in
 . Select the *Automation Controller Backup* tab.
 . Click btn:[Create AutomationControllerBackup].
 . Enter a *Name* for the backup.
-. Enter the *Deployment name* of the deployed {PlatformNameShort} instance being backed up.
-For example, if your {ControllerName} must be backed up and the deployment name is `aap-controller`, enter 'aap-controller' in the *Deployment name* field.
+. In the *Deployment name* field, enter the name of the AutomationController custom resource object of the deployed {PlatformNameShort} instance being backed up. This name was created when you xref:aap-create_controller[created your AutomationController object].
 . If you want to use a custom, pre-created pvc:
 .. Optionally enter the name of the *Backup persistant volume claim*.
 .. Optionally enter the *Backup PVC storage requirements*, and *Backup PVC storage class*.


### PR DESCRIPTION
This PR backports the changes from #2330 to the 2.4 branch and includes the following:

* Elaborated on deployment name for backing up to clarify expected format.

* Updated step to describe the field better and how the user can find the name.