### PR TITLE
Fixed broken link caused by PR 2330

### DIFF
--- a/downstream/modules/platform/proc-aap-controller-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-backup.adoc
@@ -18,7 +18,7 @@ Use this procedure to back up a deployment of the controller, including jobs, in
 . Select the *Automation Controller Backup* tab.
 . Click btn:[Create AutomationControllerBackup].
 . Enter a *Name* for the backup.
-. In the *Deployment name* field, enter the name of the AutomationController custom resource object of the deployed {PlatformNameShort} instance being backed up. This name was created when you xref:aap-create_controller[created your AutomationController object].
+. In the *Deployment name* field, enter the name of the AutomationController custom resource object of the deployed {PlatformNameShort} instance being backed up. This name was created when you link:{URLOperatorInstallation}/aap-migration#aap-create_controller[created your AutomationController object].
 . If you want to use a custom, pre-created pvc:
 .. [Optional]: enter the name of the *Backup persistent volume claim*.
 .. [Optional]: enter the *Backup PVC storage requirements*, and *Backup PVC storage class*.


### PR DESCRIPTION
This PR fixes a broken xref created by the changes from #2330. xrefs can't be used to link to another document, a link must be used.