### PR TITLE
AAP-35215: Updated Lightspeed docs for playbook generation support on Lightspeed onpremise deployments

### DIFF
--- a/lightspeed/assemblies/assembly_configuring-lightspeed-onpremise.adoc
+++ b/lightspeed/assemblies/assembly_configuring-lightspeed-onpremise.adoc
@@ -12,9 +12,8 @@ ifdef::context[:parent-context: {context}]
 
 As an {PlatformName} administrator, you can set up a {LightspeedShortName} on-premise deployment and connect it to an {ibmwatsonxcodeassistant} instance. After the on-premise deployment is successful, you can start using the Ansible Lightspeed service with the Ansible Visual Studio (VS) Code extension. 
 
-The following capabilities are not yet supported on {LightspeedShortName} on-premise deployment:
+The following capability is not yet supported on {LightspeedShortName} on-premise deployments:
 
-* Generating playbooks and viewing playbook explanations
 * Viewing telemetry data on the Admin dashboard 
 
 [NOTE]

--- a/lightspeed/assemblies/assembly_generating-playbooks.adoc
+++ b/lightspeed/assemblies/assembly_generating-playbooks.adoc
@@ -16,7 +16,7 @@ These capabilities enable Ansible developers to use natural language prompts to 
 
 [NOTE]
 ====
-You can generate playbooks and view playbook explanations when connecting to the {LightspeedShortName} cloud service. These features are not yet available with {LightspeedShortName} on-premise deployments.
+You can generate playbooks and view playbook explanations when connecting to the {LightspeedShortName} cloud service and on-premise deployments.
 ====
 
 include::modules/con_playbook-generation-best-practices.adoc[leveloffset=+1]

--- a/lightspeed/titles/lightspeed-release-notes/master.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/master.adoc
@@ -12,6 +12,7 @@ include::attributes/attributes.adoc[]
  
 include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
 include::modules/lightspeed-intro.adoc[leveloffset=+1]
+include::modules/lightspeed-rn-11dec2024.adoc[leveloffset=+1]
 include::modules/lightspeed-rn-august2024.adoc[leveloffset=+1]
 include::modules/lightspeed-rn-june2024.adoc[leveloffset=+1]
 include::modules/lightspeed-rn-7march2024.adoc[leveloffset=+1]

--- a/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-11dec2024.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-11dec2024.adoc
@@ -1,0 +1,11 @@
+:_content-type: CONCEPT
+
+[id="lightspeed-key-features-june2024_{context}"]
+= 11 December 2024
+
+This release {LightspeedShortName} features the following enhancement: 
+
+* Playbook generation and viewing playbook explanations are now supported on {LightspeedShortName} on-premise deployments. 
++
+Using the Ansible VS Code extension, you can create Ansible playbooks using a natural language interface in English. You can also view the explanations for new or existing playbooks. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html-single/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/index#generating-playbooks_lightspeed-user-guide[Generating playbooks and viewing playbook explanations].
+


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-35215.

Changes made:

- Updated references in the Lightspeed User guide for playbook generation support on onprem deployments. 
- Added a release notes announcement. 