### PR TITLE
Backport to 2.5: fixes module ascii formatting (#2614)

### DIFF
--- a/downstream/modules/hub/con-token-management-hub.adoc
+++ b/downstream/modules/hub/con-token-management-hub.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: CONCEPT
 
-[id="token-management-hub_{context}"]
+[id="token-management-hub"]
 = Token management in {HubName}
 
 Before you can interact with {HubName} by uploading or downloading collections, you must create an API token. The {HubName} API token authenticates your `ansible-galaxy` client to the Red Hat {HubName} server.


### PR DESCRIPTION
This PR ports the changes from [PR 2614](https://github.com/ansible/aap-docs/pull/2614) to the 2.5 branch. 