### PR TITLE
Add note regarding unsupported backups for earlier releases

### DIFF
--- a/downstream/modules/platform/proc-upgrading-between-minor-aap-releases.adoc
+++ b/downstream/modules/platform/proc-upgrading-between-minor-aap-releases.adoc
@@ -11,6 +11,16 @@
 
 To upgrade between minor releases of {PlatformNameShort} 2, use this general workflow.
 
+[IMPORTANT]
+====
+Ensure that you make a backup before and after the upgrade:
+
+* Make a backup before the upgrade in case the upgrade fails. 
+You can then roll back to the earlier install and apply the backup compatible with that {PlatformNameShort} version. 
+
+* Make a postinstall backup that is compatible with the most recent change.
+====
+
 .Procedure
 
 . Download and unarchive the latest {PlatformNameShort} 2 setup bundle.

--- a/downstream/modules/platform/proc-upgrading-between-minor-aap-releases.adoc
+++ b/downstream/modules/platform/proc-upgrading-between-minor-aap-releases.adoc
@@ -13,7 +13,10 @@ To upgrade between minor releases of {PlatformNameShort} 2, use this general wor
 
 [IMPORTANT]
 ====
-Ensure that you make a backup before and after the upgrade:
+With the 2.4-8 installer you can restore a backup created with 2.4-8 or later.
+However, you cannot restore backups with the 2.4-1 to 2.4-7 installer.
+
+Ensure that you make a backup before and after the upgrade to 2.4-8 or later:
 
 * Make a backup before the upgrade in case the upgrade fails. 
 You can then roll back to the earlier install and apply the backup compatible with that {PlatformNameShort} version. 


### PR DESCRIPTION
update 2.4 docs to reflect breaking change around backups/restores

https://issues.redhat.com/browse/AAP-36246

Affects `titles/aap-installation-guide`