### PR TITLE
Backport-backport-2.5-2602 Enhance docs re: the management of maximum running activations

### DIFF
--- a/downstream/assemblies/platform/assembly-install-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-install-aap-operator.adoc
@@ -18,5 +18,6 @@ ifdef::context[:parent-context: {context}]
 include::platform/proc-install-aap-operator.adoc[leveloffset=+2]
 
 
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
+++ b/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
@@ -3,18 +3,21 @@
 = Modifying the number of simultaneous rulebook activations 
 
 [role="_abstract"]
-By default, {EDAcontroller} allows 12 rulebook activations to run simultaneously.
-If more than 12 rulebook activations are created, the expected behavior is that subsequent rulebook activations wait until there is an available rulebook activation worker.
+By default, {EDAcontroller} allows 12 rulebook activations per node. For example, with two worker or hybrid nodes, it results in a limit of 24 activations in total to run simultaneously.
+If more than 24 rulebook activations are created, the expected behavior is that subsequent rulebook activations wait until there is an available rulebook activation worker.
 In this case, the rulebook activation status is displayed as *Pending* even if there is enough free memory and CPU on your {EDAcontroller} instance.
 To change this behavior, you must change the default maximum number of running rulebook activations.
 
 [NOTE]
 ====
-The value for `MAX_RUNNING_ACTIVATIONS` does not change when you modify the instance size, so it needs to be adjusted manually.
+* The value for `MAX_RUNNING_ACTIVATIONS` does not change when you modify the instance size, so it needs to be adjusted manually.
+* If you are installing {EDAName} on {OCPShort}, the 12 rulebook activations per node is a global value since there is no concept of worker nodes when installing {EDAName} on {OCPShort}. For more information, see link:{URLOperatorInstallation}/operator-install-planning#modifying_the_number_of_simultaneous_rulebook_activations_during_or_after_event_driven_ansible_controller_installation[Modifying the number of simultaneous rulebook activations during or after {EDAcontroller} installation] in link:{LinkOperatorInstallation}.
 ====
 
 include::proc-modifying-activations-during-install.adoc[leveloffset=+1]
 include::proc-modifying-activations-after-install.adoc[leveloffset=+1]
 
-.Resources 
-For more information about rulebook activations, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/event-driven_ansible_controller_user_guide/index#eda-rulebook-activations[Rulebook activations].
+.Additional Resources 
+* For more information about rulebook activations, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/event-driven_ansible_controller_user_guide/index#eda-rulebook-activations[Rulebook activations].
+* For more information about modifying simultaneous rulebook activations during or after {EDAName} on {OCPShort}, see link:{URLOperatorInstallation}/appendix-operator-crs_performance-considerations#eda_max_running_activations[EDA_MAX_RUNNING_ACTIVATIONS].
+

--- a/downstream/modules/eda/proc-modifying-activations-during-install.adoc
+++ b/downstream/modules/eda/proc-modifying-activations-during-install.adoc
@@ -3,8 +3,7 @@
 = Modifying the number of simultaneous rulebook activations during {EDAcontroller} installation 
 
 [role="_abstract"]
-By default, {EDAcontroller} allows 12 activations to run simultaneously.
-You can modify this default value during installation by using the following procedure:
+By default, {EDAcontroller} allows 12 rulebook activations per node. For example, with two worker or hybrid nodes, it results in a limit of 24 activations in total to run simultaneously. You can modify this default value during installation by using the following procedure:
 
 .Procedure
 Provide a variable to the VM installer:

--- a/downstream/modules/platform/con-ocp-supported-install.adoc
+++ b/downstream/modules/platform/con-ocp-supported-install.adoc
@@ -32,6 +32,7 @@ If existing components have already been deployed, you must specify these compon
 * Same with {ControllerName} and {EDAName}
 |===
 
+
 //Commenting out as upgrade is not included in EA [gmurray]
 //[NOTE]
 //====

--- a/downstream/modules/platform/con-operator-custom-resources.adoc
+++ b/downstream/modules/platform/con-operator-custom-resources.adoc
@@ -3,3 +3,13 @@
 = Custom resources
 
 You can define custom resources for each primary installation workflows.
+
+//[Jameria] Moved this topic from supported installation section to custom resources since that's what the cross-referenced topic links to in the appendix (Custom resources appendix)
+== Modifying the number of simultaneous rulebook activations during or after {EDAcontroller} installation
+
+* If you plan to install {EDAName} on {OCPShort} and modify the number of simultaneous rulebook activations, add the required `EDA_MAX_RUNNING_ACTIVATIONS` parameter to your custom resources. By default, {EDAcontroller} allows 12 activations per node to run simultaneously. See the example in appendix link:{URLOperatorInstallation}#eda_max_running_activations[EDA_MAX_RUNNING_ACTIVATIONS]. 
+
+[NOTE]
+====
+`EDA_MAX_RUNNING_ACTIVATIONS` for {OCPShort} is a global value since there is no concept of worker nodes when installing {EDAName} on {OCPShort}.
+====

--- a/downstream/modules/platform/ref-operator-crs.adoc
+++ b/downstream/modules/platform/ref-operator-crs.adoc
@@ -649,3 +649,19 @@ spec:
 # * {LightspeedShortName} is not deployed
 ----
 
+== EDA_MAX_RUNNING_ACTIVATIONS
+
+[subs="+attributes"]
+----
+---
+apiVersion: aap.ansible.com/v1alpha1
+kind: AnsibleAutomationPlatform
+metadata:
+  name: myaap
+spec:
+  eda:
+    extra_settings:
+      - setting: EDA_MAX_RUNNING_ACTIVATIONS
+        value: "15" # Setting this value to "-1" means there will be no limit
+
+----


### PR DESCRIPTION
Enhancement to content about management of maximum running activations:

- Using automation decisions modules

     - downstream/modules/eda/con-modifying-simultaneous-activations.adoc

     - downstream/modules/eda/proc-modifying-activations-during-install.adoc

- Installing on OpenShift Container Platform

     - downstream/modules/platform/con-operator-custom-resources.adoc

     - downstream/modules/platform/ref-operator-crs.adoc