### PR TITLE
Backport to 2.5: Adds context attribute to assembly in Managing automation content 

### DIFF
--- a/downstream/assemblies/hub/assembly-hub-create-api-token.adoc
+++ b/downstream/assemblies/hub/assembly-hub-create-api-token.adoc
@@ -10,11 +10,11 @@ Before you can interact with {HubName} by uploading or downloading collections, 
 
 Your method for creating the API token differs according to the type of {HubName} that you are using:
 
-* {HubNameStart} uses offline token management. See xref:proc-create-api-token[Creating the offline token in {HubName}].
+* {HubNameStart} uses offline token management. See xref:proc-create-api-token_api-token[Creating the offline token in {HubName}].
 
-* {PrivateHubNameStart} uses API token management. See xref:proc-create-api-token-pah[Creating the API token in {PrivateHubName}].
+* {PrivateHubNameStart} uses API token management. See xref:proc-create-api-token-pah_api-token[Creating the API token in {PrivateHubName}].
 
-* If you are using Keycloak to authenticate your {PrivateHubName}, follow the procedure for xref:proc-create-api-token[Creating the offline token in {HubName}].
+* If you are using Keycloak to authenticate your {PrivateHubName}, follow the procedure for xref:proc-create-api-token_api-token[Creating the offline token in {HubName}].
 
 
 include::hub/proc-create-api-token.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
+++ b/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 [id="managing-cert-valid-content"]
 = Red Hat Certified, validated, and Ansible Galaxy content in automation hub
 
-:context: managing-cert-validated-content
+:context: cloud-sync
 
 [role="_abstract"]
 {CertifiedName} are included in your subscription to {PlatformName}. Using {HubNameMain}, you can access and curate a unique set of collections from all forms of Ansible content.
@@ -63,9 +63,9 @@ You can use {HubNameMain} to distribute the relevant {CertifiedColl}s to your us
 
 Before you can use a requirements file to install content, you must: 
 
-. xref:retrieve-api-token_managing-cert-validated-content[Obtain an automation hub API token]
-. xref:proc-set-rhcertified-remote[Use the API token to configure a remote repository in your local hub]
-. Then, xref:create-requirements-file_managing-cert-validated-content[Create a requirements file].
+. xref:token-management-hub_cloud-sync[Obtain an automation hub API token]
+. xref:proc-set-rhcertified-remote_cloud-sync[Use the API token to configure a remote repository in your local hub]
+. Then, xref:create-requirements-file_cloud-sync[Create a requirements file].
 
 
 

--- a/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
+++ b/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
@@ -1,6 +1,8 @@
 [id="assembly-creating-tokens-in-automation-hub"]
 = Configuring {HubNameMain} remote repositories to synchronize content
 
+:context: cloud-sync
+
 Use remote configurations to configure your {PrivateHubName} to synchronize with {CertifiedName} hosted on `{Console}` or with your collections in {Galaxy}.
 
 [IMPORTANT]
@@ -42,7 +44,7 @@ Collection namespaces must follow Python module name convention.
 This means collections should have short, all lowercase names. 
 You can use underscores in the collection name if it improves readability.
 
-// [hherbly: there's only a couple of sentences in this concept module, and they make more sense at the beginning of this assembly. Moving this content to line 13] include::hub/con-remote-repos.adoc[leveloffset=+1]
+// [hherbly: there's only a couple of sentences in this concept module, and they make more sense at the beginning of this assembly. Moving this content to line 15] include::hub/con-remote-repos.adoc[leveloffset=+1]
 
 // [hherbly: replacing this with the 4 modules below from the Getting started with hub guide include::hub/proc-obtaining-org-collection-url.adoc[leveloffset=+1]
 

--- a/downstream/modules/hub/con-offline-token-active.adoc
+++ b/downstream/modules/hub/con-offline-token-active.adoc
@@ -1,5 +1,5 @@
 
-[id="con-offline-token-active"]
+[id="con-offline-token-active_{context}"]
 
 == Keeping your offline token active
 
@@ -9,7 +9,7 @@ Keeping an online token active is useful when an application performs an action 
 
 [NOTE]
 ====
-If your offline token expires, you must request a new one.
+If your offline token expires, you must xref:proc-create-api-token_cloud-sync[obtain a new one].
 ====
 
 .Procedure

--- a/downstream/modules/hub/con-token-management-hub.adoc
+++ b/downstream/modules/hub/con-token-management-hub.adoc
@@ -3,17 +3,17 @@
 
 :_mod-docs-content-type: CONCEPT
 
-[id="token-management-hub"]
+[id="token-management-hub_{context}"]
 = Token management in {HubName}
 
 Before you can interact with {HubName} by uploading or downloading collections, you must create an API token. The {HubName} API token authenticates your `ansible-galaxy` client to the Red Hat {HubName} server.
 
 Your method for creating the API token differs according to the type of {HubName} that you are using:
 
-* {HubNameStart} uses offline token management. See xref:proc-create-api-token[Creating the offline token in {HubName}].
+* {HubNameStart} uses offline token management. See xref:proc-create-api-token_cloud-sync[Creating the offline token in {HubName}].
 
-* {PrivateHubNameStart} uses API token management. See xref:proc-create-api-token-pah[Creating the API token in {PrivateHubName}].
+* {PrivateHubNameStart} uses API token management. See xref:proc-create-api-token-pah_cloud-sync[Creating the API token in {PrivateHubName}].
 
-* If you are using Keycloak to authenticate your {PrivateHubName}, follow the procedure for xref:proc-create-api-token[Creating the offline token in {HubName}].
+* If you are using Keycloak to authenticate your {PrivateHubName}, follow the procedure for xref:proc-create-api-token_cloud-sync[Creating the offline token in {HubName}].
 
 

--- a/downstream/modules/hub/proc-create-api-token-pah.adoc
+++ b/downstream/modules/hub/proc-create-api-token-pah.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
-[id="proc-create-api-token-pah"]
+[id="proc-create-api-token-pah_{context}"]
 == Creating the API token in {PrivateHubName}
 
 In {PrivateHubName}, you can create an API token using API token management. The API token is a secret token used to protect your content.

--- a/downstream/modules/hub/proc-create-api-token.adoc
+++ b/downstream/modules/hub/proc-create-api-token.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
-[id="proc-create-api-token"]
+[id="proc-create-api-token_{context}"]
 == Creating the offline token in {HubName}
 
 In {HubName}, you can create an API token by using *Token management*. The API token is a secret token used to protect your content.
@@ -22,5 +22,9 @@ The API token is now available for configuring {HubName} as your default collect
 
 [NOTE]
 ====
+<<<<<<< HEAD
 The API token does not expire. 
+=======
+Your offline token expires after 30 days of inactivity. For more on obtaining a new offline token, see xref:con-offline-token-active_cloud-sync[Keeping your offline token active].
+>>>>>>> d9443620... Adds context attribute to assembly in Managing automation content (#2616)
 ====

--- a/downstream/modules/hub/proc-create-requirements-file.adoc
+++ b/downstream/modules/hub/proc-create-requirements-file.adoc
@@ -5,7 +5,7 @@
 [id="create-requirements-file_{context}"]
 = Creating a requirements file
 
-We recommend using a requirements file to add collections to your {HubName}. Requirements files are in YAML format and list the collections that you want to install in your {HubName}. After you create your requirements.yml file listing the collections you want to install, you will then run the install command to add the collections to your hub instance. 
+Use a requirements file to add collections to your {HubName}. Requirements files are in YAML format and list the collections that you want to install in your {HubName}. After you create your requirements.yml file listing the collections you want to install, you will then run the install command to add the collections to your hub instance. 
 
 A standard `requirements.yml` file contains the following parameters:
 

--- a/downstream/modules/hub/proc-set-community-remote.adoc
+++ b/downstream/modules/hub/proc-set-community-remote.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
-[id="proc-set-community-remote"]
+[id="proc-set-community-remote_{context}"]
 = Configuring the community remote repository and syncing {Galaxy} collections
 
 You can edit the *community* remote repository to synchronize chosen collections from {Galaxy} to your {PrivateHubName}.

--- a/downstream/modules/hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/hub/proc-set-rhcertified-remote.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
-[id="proc-set-rhcertified-remote"]
+[id="proc-set-rhcertified-remote_{context}"]
 = Configuring the rh-certified remote repository and synchronizing {CertifiedColl}
 
 You can edit the *rh-certified* remote repository to synchronize collections from {HubName} hosted on {Console} to your {PrivateHubName}.


### PR DESCRIPTION
This PR ports the changes from [PR 2616](https://github.com/ansible/aap-docs/pull/2616/files) to the 2.5 branch. See [AAP 35928](https://issues.redhat.com/browse/AAP-35928) for context.