### PR TITLE
Updates subscription info for Satellite users in managing automation content guide

### DIFF
--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -32,7 +32,7 @@ Use the hostnames instead of IP addresses when configuring firewall rules.
 
 After making this change you can continue to pull {ExecEnvShort}s from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
 
-If you are using Red Hat Satellite Server, follow the link:https://docs.redhat.com/en/documentation/red_hat_satellite/6.15/html/managing_content/managing_red_hat_subscriptions_content-management#Importing_a_Red_Hat_Subscription_Manifest_into_Server_content-management[procedure in the Red Hat Satellite documentation to import a subscription manifest into Satellite Server].
+If you are using Red Hat Satellite Server, follow the link:https://docs.redhat.com/en/documentation/red_hat_satellite/{SatelliteVers}/html/managing_content/managing_red_hat_subscriptions_content-management#Importing_a_Red_Hat_Subscription_Manifest_into_Server_content-management[procedure in the Red Hat Satellite documentation to import a subscription manifest into Satellite Server].
 ====
 
 include::hub/proc-obtain-images.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -24,7 +24,7 @@ You must follow a specific workflow to populate your {PrivateHubName} remote reg
 Image manifests and filesystem blobs were both originally served directly from `registry.redhat.io` and `registry.access.redhat.com`.
 As of 1 May 2023, filesystem blobs are served from `quay.io` instead.
 
-* Ensure that the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[Network ports and protocols] listed in _Table 5.4. Execution Environments (EE)_ are available to avoid problems pulling container images.
+* Ensure that the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[Network ports and protocols] listed in _Table 6.4. Execution Environments (EE)_ are available to avoid problems pulling container images.
 
 Make this change to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
 
@@ -32,7 +32,7 @@ Use the hostnames instead of IP addresses when configuring firewall rules.
 
 After making this change you can continue to pull {ExecEnvShort}s from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
 
-However, manifests, sometimes called “subscription allocations”, on the web-based Red Hat Subscription Management are no longer supported as of early 2024 with one exception: If a system is part of a closed network or “air gapped” system that does not receive its updates from Red Hat's servers directly, manifests are supported until the release of Red Hat Satellite 6.16. Keep up to date with link:https://access.redhat.com/articles/1365633[Red Hat Satellite Release Dates] for Red Hat Satellite 6.16's release date announcement.
+However, manifests, sometimes called “subscription allocations”, on the web-based Red Hat Subscription Management are no longer supported as of early 2024 with one exception: If a system is part of a closed network or “air gapped” system that does not receive its updates from Red Hat's servers directly, such as Red Hat Satellite Server, manifests are supported. Keep up to date with link:https://access.redhat.com/articles/1365633[Red Hat Satellite Release Dates] for potential changes to this policy.
 ====
 
 include::hub/proc-obtain-images.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -32,7 +32,7 @@ Use the hostnames instead of IP addresses when configuring firewall rules.
 
 After making this change you can continue to pull {ExecEnvShort}s from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
 
-However, manifests, sometimes called “subscription allocations”, on the web-based Red Hat Subscription Management are no longer supported as of early 2024 with one exception: If a system is part of a closed network or “air gapped” system that does not receive its updates from Red Hat's servers directly, such as Red Hat Satellite Server, manifests are supported. Keep up to date with link:https://access.redhat.com/articles/1365633[Red Hat Satellite Release Dates] for potential changes to this policy.
+If you are using Red Hat Satellite Server, follow the link:https://docs.redhat.com/en/documentation/red_hat_satellite/6.15/html/managing_content/managing_red_hat_subscriptions_content-management#Importing_a_Red_Hat_Subscription_Manifest_into_Server_content-management[procedure in the Red Hat Satellite documentation to import a subscription manifest into Satellite Server].
 ====
 
 include::hub/proc-obtain-images.adoc[leveloffset=+1]


### PR DESCRIPTION
Satellite 6.16 has been released and still supports subscription allocations. This PR updates the language to reflect this. 

The update will appear in the "Important" admonition [here](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/managing_automation_content/managing-containers-hub#populate-container-registry). 

This work is being tracked in [AAP-36858](https://issues.redhat.com/browse/AAP-36858)