### PR TITLE
Fixes ascii error in Note in Managing automation content guide

### DIFF
--- a/downstream/modules/hub/proc-create-api-token.adoc
+++ b/downstream/modules/hub/proc-create-api-token.adoc
@@ -3,28 +3,24 @@
 [id="proc-create-api-token_{context}"]
 == Creating the offline token in {HubName}
 
-In {HubName}, you can create an API token by using *Token management*. The API token is a secret token used to protect your content.
+In {HubName}, you can create an offline token by using *Token management*. The offline token is a secret token used to protect your content.
 
 .Procedure
 
 . Navigate to link:https://console.redhat.com/ansible/automation-hub/token/[{PlatformNameShort} on the Red Hat Hybrid Cloud Console].
 . From the navigation panel, select menu:Automation Hub[Connect to Hub].
 . Under *Offline token*, click btn:[Load Token].
-. Click the btn:[Copy to clipboard] icon to copy the API token.
+. Click the btn:[Copy to clipboard] icon to copy the offline token.
 . Paste the API token into a file and store in a secure location.
 
 [IMPORTANT]
 ====
-The API token is a secret token used to protect your content. Store your API token in a secure location.
+The offline token is a secret token used to protect your content. Store your token in a secure location.
 ====
 
-The API token is now available for configuring {HubName} as your default collections server or for uploading collections by using the `ansible-galaxy` command line tool.
+The offline token is now available for configuring {HubName} as your default collections server or for uploading collections by using the `ansible-galaxy` command line tool.
 
 [NOTE]
 ====
-<<<<<<< HEAD
-The API token does not expire. 
-=======
 Your offline token expires after 30 days of inactivity. For more on obtaining a new offline token, see xref:con-offline-token-active_cloud-sync[Keeping your offline token active].
->>>>>>> d9443620... Adds context attribute to assembly in Managing automation content (#2616)
 ====


### PR DESCRIPTION
It looks like this error originated from a missed backport. The "main" version is as it should be. 