### PR TITLE
AAP-30287 [Cee.neXT] [Docs] EDA can't be installed as HA/Cluster.

### DIFF
--- a/downstream/modules/platform/ref-single-controller-hub-eda-with-managed-db.adoc
+++ b/downstream/modules/platform/ref-single-controller-hub-eda-with-managed-db.adoc
@@ -11,7 +11,7 @@ Use this example to populate the inventory file to deploy single instances of {C
 
 * {EDAController} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
 
-* {EDAController} cannot be installed in a high availability or clustered configuration. Ensure there is only one host entry in the [automationedacontroller] section of the inventory.
+* {EDAController} cannot be installed in a high availability or clustered configuration. Ensure there is only one host entry in the `automationedacontroller` section of the inventory.
 
 * When you activate an {EDAName} rulebook under standard conditions, it uses approximately 250 MB of memory. However, the actual memory consumption can vary significantly based on the complexity of your rules and the volume and size of the events processed. In scenarios where a large number of events are anticipated or the rulebook complexity is high, conduct a preliminary assessment of resource usage in a staging environment. This ensures that your maximum number of activations is based on the capacity of your resources. In the following example, the default `automationedacontroller_max_running_activations` setting is 12, but you can adjust according to your capacity. 
 

--- a/downstream/modules/platform/ref-single-controller-hub-eda-with-managed-db.adoc
+++ b/downstream/modules/platform/ref-single-controller-hub-eda-with-managed-db.adoc
@@ -11,6 +11,8 @@ Use this example to populate the inventory file to deploy single instances of {C
 
 * {EDAController} must be installed on a separate server and cannot be installed on the same host as {HubName} and {ControllerName}.
 
+* {EDAController} cannot be installed in a high availability or clustered configuration. Ensure there is only one host entry in the [automationedacontroller] section of the inventory.
+
 * When you activate an {EDAName} rulebook under standard conditions, it uses approximately 250 MB of memory. However, the actual memory consumption can vary significantly based on the complexity of your rules and the volume and size of the events processed. In scenarios where a large number of events are anticipated or the rulebook complexity is high, conduct a preliminary assessment of resource usage in a staging environment. This ensures that your maximum number of activations is based on the capacity of your resources. In the following example, the default `automationedacontroller_max_running_activations` setting is 12, but you can adjust according to your capacity. 
 
 ====


### PR DESCRIPTION
Updated the 2.4 AAP Installation guide, specifically in [3.2.1.7. Single automation controller, single automation hub, and single Event-Driven Ansible controller node with external (installer managed) database](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_installation_guide/index#ref-single-controller-hub-eda-with-managed-db) in the Important admonition section (3rd bullet point) to let users know they cannot install EDA in a high availability or clustered environment. 