### PR TITLE
AAP-36005 Removed instances of de-supported options

### DIFF
--- a/downstream/modules/eda/proc-eda-build-a-custom-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-build-a-custom-decision-environment.adoc
@@ -17,15 +17,15 @@ You can create a custom decision environment for {EDAName} that provides a custo
 .Procedure
 
 * Use `de-minimal` as the base image with {Builder} to build your custom decision environments. 
-This image is built from a base image provided by Red Hat at link:https://catalog.redhat.com/software/containers/ansible-automation-platform-25/de-minimal-rhel8/650a5671acdb2bef1d5d3a3b[{PlatformNameShort} minimal decision environment].  
+This image is built from a base image provided by Red Hat at link:https://catalog.redhat.com/software/containers/ansible-automation-platform-25/de-minimal-rhel9/650a5672a370728c710acaab[{PlatformNameShort} minimal decision environment].  
 
 +
 [IMPORTANT]
 ====
 * Use the correct {EDAcontroller} decision environment in {PlatformNameShort} to prevent rulebook activation failure.
 
-** If you want to connect {EDAcontroller} to {PlatformNameShort} 2.4, you must use `registry.redhat.io/ansible-automation-platform-24/de-minimal-rhel8:latest`
-** If you want to connect {EDAcontroller} to {PlatformNameShort} {PlatformVers}, you must use `registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel8:latest`
+** If you want to connect {EDAcontroller} to {PlatformNameShort} 2.4, you must use `registry.redhat.io/ansible-automation-platform-24/de-minimal-rhel9:latest`
+** If you want to connect {EDAcontroller} to {PlatformNameShort} {PlatformVers}, you must use `registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel9:latest`
 ====
 
 The following is an example of the {Builder} definition file that uses `de-minimal` as a base image to build a custom decision environment with the ansible.eda collection:
@@ -34,7 +34,7 @@ version: 3
 
 images:
   base_image:
-    name: 'registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel8:latest'
+    name: 'registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel9:latest'
 
 dependencies:
   galaxy:
@@ -53,7 +53,7 @@ version: 3
 
 images:
   base_image:
-    name: 'registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel8:latest'
+    name: 'registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel9:latest'
 
 dependencies:
   galaxy:

--- a/downstream/modules/eda/proc-eda-build-a-custom-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-build-a-custom-decision-environment.adoc
@@ -17,15 +17,15 @@ You can create a custom decision environment for {EDAName} that provides a custo
 .Procedure
 
 * Use `de-minimal` as the base image with {Builder} to build your custom decision environments. 
-This image is built from a base image provided by Red Hat at link:https://catalog.redhat.com/software/containers/ansible-automation-platform-25/de-supported-rhel9/650a5674ad524b664b693729[{PlatformNameShort} supported decision environment].
+This image is built from a base image provided by Red Hat at link:https://catalog.redhat.com/software/containers/ansible-automation-platform-25/de-minimal-rhel8/650a5671acdb2bef1d5d3a3b[{PlatformNameShort} minimal decision environment].  
 
 +
 [IMPORTANT]
 ====
 * Use the correct {EDAcontroller} decision environment in {PlatformNameShort} to prevent rulebook activation failure.
 
-** If you want to connect {EDAcontroller} to {PlatformNameShort} 2.4, you must use `registry.redhat.io/ansible-automation-platform-24/de-supported-rhel8:latest`
-** If you want to connect {EDAcontroller} to {PlatformNameShort} {PlatformVers}, you must use `registry.redhat.io/ansible-automation-platform-25/de-supported-rhel8:latest`
+** If you want to connect {EDAcontroller} to {PlatformNameShort} 2.4, you must use `registry.redhat.io/ansible-automation-platform-24/de-minimal-rhel8:latest`
+** If you want to connect {EDAcontroller} to {PlatformNameShort} {PlatformVers}, you must use `registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel8:latest`
 ====
 
 The following is an example of the {Builder} definition file that uses `de-minimal` as a base image to build a custom decision environment with the ansible.eda collection:

--- a/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
@@ -8,7 +8,7 @@ You can import a decision environment into your {EDAcontroller} using a default 
 
 * You have set up a credential, if necessary.
 For more information, see the xref:eda-set-up-credential[Setting up credentials] section.
-* You have pushed a decision environment image to an image repository or you chose to use the `de-minimal` image that is provided by `de-supported` options located in link:http://registry.redhat.io/[registry.redhat.io].
+* You have pushed a decision environment image to an image repository or you chose to use the `de-minimal` image located in link:http://registry.redhat.io/[registry.redhat.io].
 
 .Procedure
 


### PR DESCRIPTION
Per instructions from meeting with SMEs, `de-supported` will be replaced with `de-minimal` images for decision environments, until further notice. 

Will refer to `de-minimal` only for now to prevent confusion for users. EDA collections have been added by @jamesmarshall24 to `de-minimal` images for now. 