### PR TITLE
Remove controller variable (#2633)

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -119,12 +119,6 @@ Default = `5432`
 
 Default = `awx`.
 
-| `supervisor_start_retry_count` | | When specified, it adds `startretries = <value specified>` to the supervisor config file (/`etc/supervisord.d/tower.ini`).
-
-See link:http://supervisord.org/configuration.html#program-x-section-values[program:x Section Values] for more information about `startretries`.
-
-No default value exists.
-
 | `web_server_ssl_cert` | `controller_tls_cert` | _Optional_
 
 `/path/to/webserver.cert`


### PR DESCRIPTION
Remove supervisor_start_retry_count from AAP 2.4 and 2.5 docs

https://issues.redhat.com/browse/AAP-36524