### PR TITLE
Removed 2.4 controller variable

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -127,11 +127,6 @@ and 1024 for a cluster.
 | *`receptor_listener_port`* | Port to use for receptor connection.
 
 Default = 27199
-| *`supervisor_start_retry_count`* | When specified, it adds `startretries = <value specified>` to the supervisor config file (/etc/supervisord.d/tower.ini).
-
-See link:http://supervisord.org/configuration.html#program-x-section-values[program:x Section Values] for more information about `startretries`.
-
-No default value exists.
 
 | *`web_server_ssl_cert`* | _Optional_
 


### PR DESCRIPTION
Remove supervisor_start_retry_count from AAP 2.4 and 2.5 docs

https://issues.redhat.com/browse/AAP-36524