### PR TITLE
2.5 Add IBM-Z to CONT topologies (#2642)

### DIFF
--- a/downstream/modules/topologies/ref-cont-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-a-env-a.adoc
@@ -36,7 +36,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 a| 
 * Valid {PlatformName} subscription
 * Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -42,7 +42,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 a| 
 * Valid {PlatformName} subscription
 * Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome.
 | Database | {PostgresVers}


### PR DESCRIPTION
Affects: `titles/topologies`

Update product docs to include IBM Z arch test support for CONT topologies

https://issues.redhat.com/browse/AAP-35969