### PR TITLE
AAP-36921-update: Added info. about receptor_datadir variable

### DIFF
--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -25,7 +25,7 @@ Default = `false`
 
 | | `receptor_peers` | Receptor peers list. 
 
-| | `receptor_datadir` | This variable configures the receptor data directory. By default, it is set to `/tmp/receptor`. To change the default location, run the installation script with `"-e receptor_datadir="` and specify the target directory that you want. 
+| `receptor_datadir` | | This variable configures the receptor data directory. By default, it is set to `/tmp/receptor`. To change the default location, run the installation script with `"-e receptor_datadir="` and specify the target directory that you want. 
 
 *NOTES*
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-36921.

Changes made:
After updating the docs in PR https://github.com/ansible/aap-docs/pull/2655, I realized that I entered the detail in the wrong column (container variable name). This ticket rectifies the error, and adds the new variable in the correct 'RPM variable name' column. 
