### PR TITLE
Backport PR #2656 from main to 2.5.

### DIFF
--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -24,6 +24,15 @@ Default = `info`
 Default = `false`
 
 | | `receptor_peers` | Receptor peers list. 
+
+| `receptor_datadir` | | This variable configures the receptor data directory. By default, it is set to `/tmp/receptor`. To change the default location, run the installation script with `"-e receptor_datadir="` and specify the target directory that you want. 
+
+*NOTES*
+
+* The target directory must be accessible to *awx* users. 
+
+* If the target directory is a temporary file system *tmpfs*, ensure it is remounted correctly after a reboot. Failure to do so results in the receptor no longer having a working directory.
+
 | `receptor_listener_port` | `receptor_port` | Receptor port number.
 
 Default = `27199`


### PR DESCRIPTION
This PR backports PR https://github.com/ansible/aap-docs/pull/2656 from main to 2.5.
