### PR TITLE
AAP-36614 Apply updates for EDA max activations and correct link to OCP appendix

### DIFF
--- a/downstream/modules/eda/proc-modifying-activations-after-install.adoc
+++ b/downstream/modules/eda/proc-modifying-activations-after-install.adoc
@@ -3,7 +3,7 @@
 = Modifying the number of simultaneous rulebook activations after {EDAcontroller} installation
 
 [role="_abstract"]
-By default, {EDAcontroller} allows 12 activations to run simultaneously.
+By default, {EDAcontroller} allows 12 rulebook activations per node. For example, with two worker or hybrid nodes, it results in a limit of 24 activations in total to run simultaneously. 
 You can modify this default value after installation by using the following procedure:
 
 .Procedure

--- a/downstream/modules/platform/con-operator-custom-resources.adoc
+++ b/downstream/modules/platform/con-operator-custom-resources.adoc
@@ -7,7 +7,7 @@ You can define custom resources for each primary installation workflows.
 //[Jameria] Moved this topic from supported installation section to custom resources since that's what the cross-referenced topic links to in the appendix (Custom resources appendix)
 == Modifying the number of simultaneous rulebook activations during or after {EDAcontroller} installation
 
-* If you plan to install {EDAName} on {OCPShort} and modify the number of simultaneous rulebook activations, add the required `EDA_MAX_RUNNING_ACTIVATIONS` parameter to your custom resources. By default, {EDAcontroller} allows 12 activations per node to run simultaneously. See the example in appendix link:{URLOperatorInstallation}#eda_max_running_activations[EDA_MAX_RUNNING_ACTIVATIONS]. 
+* If you plan to install {EDAName} on {OCPShort} and modify the number of simultaneous rulebook activations, add the required `EDA_MAX_RUNNING_ACTIVATIONS` parameter to your custom resources. By default, {EDAcontroller} allows 12 activations per node to run simultaneously. See the example in appendix link:{URLOperatorInstallation}/appendix-operator-crs_performance-considerations#eda_max_running_activations[EDA_MAX_RUNNING_ACTIVATIONS]. 
 
 [NOTE]
 ====


### PR DESCRIPTION
Issue [AAP-36614](https://issues.redhat.com/browse/AAP-36614) picks up on the problem described in [AAP-32980](https://issues.redhat.com/browse/AAP-32980). Discovered two minor necessary updates:

- Using automation decisions guide - update section [10.1.1.2. Modifying the number of simultaneous rulebook activations after Event-Driven Ansible controller installation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-performance-tuning#modifying-activations-after-install) in the same manner as we did for section [10.1.1.1. Modifying the number of simultaneous rulebook activations during Event-Driven Ansible controller installation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-performance-tuning#modifying-activations-during-install) .

- Installing on OpenShift Container Platform - correct the link from the new section, [1.4.1. Modifying the number of simultaneous rulebook activations during or after Event-Driven Ansible controller installation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_on_openshift_container_platform/operator-install-planning#modifying_the_number_of_simultaneous_rulebook_activations_during_or_after_event_driven_ansible_controller_installation) that should take the end user to the new appendix [14.1.16. EDA_MAX_RUNNING_ACTIVATIONS](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_on_openshift_container_platform/appendix-operator-crs_performance-considerations#eda_max_running_activations).