### PR TITLE
Editing curl command (#2661)

### DIFF
--- a/downstream/modules/platform/proc-controller-enable-provision-callbacks.adoc
+++ b/downstream/modules/platform/proc-controller-enable-provision-callbacks.adoc
@@ -29,8 +29,9 @@ To callback manually using REST:
 . Ensure that the request from the host is a POST. 
 The following is an example using `curl` (all on a single line):
 +
+[literal, options="nowrap" subs="+attributes"]
 ----
-curl -k -f -i -H 'Content-Type:application/json' -XPOST -d '{"host_config_key": "redhat"}' \
+curl -k -i -H 'Content-Type:application/json' -XPOST -d '{"host_config_key": "redhat"}' \
                   https://<CONTROLLER_SERVER_NAME>/api/v2/job_templates/7/callback/
 ----
 +


### PR DESCRIPTION
Documentation for provisioning callbacks provides the wrong curl options

https://issues.redhat.com/browse/AAP-37039

Affects `titles/controller-user-guide`