### PR TITLE
Adding edits from AAP-35971

### DIFF
--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -40,7 +40,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Red Hat OpenShift  
 a| 
 * Version: 4.14

--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -45,6 +45,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Red Hat OpenShift  
 a| 
 * Red Hat OpenShift on AWS Hosted Control Planes 4.15.16


### PR DESCRIPTION
[AAP-35971](https://issues.redhat.com/browse/AAP-35971)

- In Tested deployment models, move tested architectures (x86_64, AArch64) into a new row "CPU architecture".
- Update OCP topologies in Tested deployment models to include "s390x (IBM Z)" in the new CPU architecture row.