### PR TITLE
Backport to 2.5: fixes broken links from nov broken links report (#2671)

### DIFF
--- a/downstream/modules/aap-hardening/con-logging-log-capture.adoc
+++ b/downstream/modules/aap-hardening/con-logging-log-capture.adoc
@@ -11,7 +11,7 @@ Visibility and analytics is an important pillar of Enterprise Security and Zero 
 Logging is key to capturing actions and auditing. 
 You can manage logging and auditing by using the built-in audit support described in the link:{BaseURL}/red_hat_enterprise_linux/9/html/security_hardening/auditing-the-system_security-hardening[Auditing the system] section of the Security hardening for {RHEL} guide. 
 {PlatformNameShort}'s built-in logging and activity stream support {PlatformName} logs all changes within {PlatformName} and automation logs for auditing purposes. 
-More detailed information is available in the link:{URLControllerAdminGuid}/assembly-controller-logging-aggregation[Logging and Aggregation] section of {TitleControllerAdminGuide}.
+More detailed information is available in the link:{URLControllerAdminGuide}/assembly-controller-logging-aggregation[Logging and Aggregation] section of {TitleControllerAdminGuide}.
 
 This guide recommends that you configure {PlatformNameShort} and the underlying {RHEL} systems to collect logging and auditing centrally, rather than reviewing it on the local system. 
 {PlatformNameShort} must be configured to use external logging to compile log records from multiple components within the {PlatformNameShort} server. 

--- a/downstream/modules/platform/proc-gs-use-base-execution-env.adoc
+++ b/downstream/modules/platform/proc-gs-use-base-execution-env.adoc
@@ -12,7 +12,7 @@ Base images included with {PlatformNameShort} are hosted on the Red Hat Ecosyste
 
 .Procedure 
 
-. Log in to link:registry.redhat.io[registry.redhat.io].
+. Log in to registry.redhat.io.
 +
 [source,bash]
 ----


### PR DESCRIPTION
This PR ports the changes from [PR 2671](https://github.com/ansible/aap-docs/pull/2671) to the 2.5 branch. See [AAP-15176](https://issues.redhat.com/browse/AAP-15176) for more. 