### PR TITLE
AAP-37105: fixes incorrect link in the RPM Install guide

### DIFF
--- a/downstream/modules/platform/con-adding-subscription-manifest.adoc
+++ b/downstream/modules/platform/con-adding-subscription-manifest.adoc
@@ -4,4 +4,4 @@
 
 [role="_abstract"]
 
-Before you first log in, you must add your subscription information to the platform. To add a subscription to {PlatformNameShort}, see link:{URLAAPOperationsGuide}/index#assembly-aap-obtain-manifest-files[Obtaining a manifest file] in the link:{LinkCentralAuth}. 
+Before you first log in, you must add your subscription information to the platform. To add a subscription to {PlatformNameShort}, see link:{URLCentralAuth}/assembly-gateway-licensing#assembly-aap-obtain-manifest-files[Obtaining a manifest file] in the link:{LinkCentralAuth} guide. 


### PR DESCRIPTION
See [AAP-37105 ](https://issues.redhat.com/browse/AAP-37105)for more info. 