### PR TITLE
Backport to 2.5: AAP-37105: fixes incorrect link (#2673)

### DIFF
--- a/downstream/modules/platform/con-adding-subscription-manifest.adoc
+++ b/downstream/modules/platform/con-adding-subscription-manifest.adoc
@@ -4,4 +4,4 @@
 
 [role="_abstract"]
 
-Before you first log in, you must add your subscription information to the platform. To add a subscription to {PlatformNameShort}, see link:{URLAAPOperationsGuide}/index#assembly-aap-obtain-manifest-files[Obtaining a manifest file] in the link:{LinkCentralAuth}. 
+Before you first log in, you must add your subscription information to the platform. To add a subscription to {PlatformNameShort}, see link:{URLCentralAuth}/assembly-gateway-licensing#assembly-aap-obtain-manifest-files[Obtaining a manifest file] in the link:{LinkCentralAuth} guide. 


### PR DESCRIPTION
This PR ports the changes from [PR 2673](https://github.com/ansible/aap-docs/pull/2673) to the 2.5 branch. See [AAP-37105](https://issues.redhat.com/browse/AAP-37105) for more. 