### PR TITLE
AAP-36632: Restructure the Lightspeed User Guide

### DIFF
--- a/lightspeed/assemblies/assembly_developing_ansible_content.adoc
+++ b/lightspeed/assemblies/assembly_developing_ansible_content.adoc
@@ -1,0 +1,26 @@
+ifdef::context[:parent-context: {context}]
+
+:_content-type: ASSEMBLY
+
+[id="developing-ansible-content_{context}"]
+
+= Developing Ansible content
+
+:context: developing-ansible-content
+
+[role="_abstract"]
+
+As an automation developer, you can use {LightspeedShortName} to implement your organization’s automation strategy. {LightspeedShortName} can help you create and use custom automation content. This chapter provides information about how to get set up as an automation developer on {LightspeedShortName}, with details on how to:
+
+* Access the Ansible Lightspeed portal as an automation developer
+* Install and configure the {AnsibleVSCode}
+* Create task recommendations
+* Create playbooks and view playbook explanations
+* Create roles (TBD)
+* Provide feedback on the Ansible Lightspeed service
+
+include::modules/proc_log-into-portal-auto-dev.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]
+

--- a/lightspeed/attributes/attributes.adoc
+++ b/lightspeed/attributes/attributes.adoc
@@ -26,6 +26,7 @@
 :LightspeedShortName: Red Hat Ansible Lightspeed
 :LightspeedTechPreview: Ansible Lightspeed Technical Preview
 :AnsibleCodeBot: Ansible code bot
+:AnsibleVSCode: Ansible VS Code extension
 :AnsibleContentParser: content parser tool
 :ibmwatsonxcodeassistant: IBM watsonx Code Assistant
 :ibmCPD: {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data

--- a/lightspeed/modules/proc_log-into-portal-auto-dev.adoc
+++ b/lightspeed/modules/proc_log-into-portal-auto-dev.adoc
@@ -1,0 +1,39 @@
+:_content-type: PROCEDURE
+
+[id="log-into-portal-auto-dev_{context}"]
+
+= Accessing the Ansible Lightspeed portal as an automation developer
+You can access {LightspeedShortName} through the link:https://c.ai.ansible.redhat.com/[Ansible Lightspeed portal]. After you enter your {RHSSO} ({RHSSOshort}) account credentials, your account is authenticated and you are granted access. Your assigned user role is displayed on the login screen of the Ansible Lightspeed portal. 
+
+.User login scenarios
+[cols="50%,50%",options="header"]
+|====
+| *Scenario* | *Result*
+|You are a {RHSSOshort} user. +
+NOTE: This is the typical scenario for accessing {LightspeedShortName} as an Ansible user.| You are routed to the {LightspeedShortName} paid commercial offering.
+|You are a {RHSSOshort} user, but your organization administrator has not configured {LightspeedShortName} to connect with {ibmwatsonxcodeassistant}.| You are routed to the {LightspeedShortName} paid commercial offering with a message that your organization administrator has not configured a model for your organization.
+|====
+
+== Logging in to the Ansible Lightspeed portal
+
+.Procedure
+
+. Go to the link:https://c.ai.ansible.redhat.com/[Ansible Lightspeed portal login page].
+. Click menu:Log in[Log in with Red Hat].
+. Enter your Red Hat account username and password.
+
+On successful authentication, the login screen is displayed along with your username and your assigned user role.
+
+= Logging out of the Ansible Lightspeed Service
+
+[role="_abstract"]
+To log out of the Ansible Lightspeed Service, you must log out of both the Ansible Lightspeed VS Code extension and the Ansible Lightspeed portal.
+
+.Procedure
+
+* Log out of the Ansible Lightspeed VS Code extension:
+** Click the *Person* icon image:person-icon-vs-code.png[Person icon]. You will see a list of accounts that VS Code is logged into.
+** Select menu:Ansible Lightspeed[Sign Out].
+* Log out of the Ansible Lightspeed portal:
+** Navigate to the link:https://c.ai.ansible.redhat.com/[Ansible Lightspeed portal login page].
+** Click *Log out*.

--- a/lightspeed/titles/lightspeed-user-guide/master.adoc
+++ b/lightspeed/titles/lightspeed-user-guide/master.adoc
@@ -22,3 +22,11 @@ include::assemblies/assembly_generating-playbooks.adoc[leveloffset=+1]
 include::assemblies/assembly_using-code-bot-for-suggestions.adoc[leveloffset=+1]
 include::assemblies/assembly_managing-admin-dashboard-telemetry.adoc[leveloffset=+1]
 include::assemblies/assembly_troubleshooting-lightspeed.adoc[leveloffset=+1]
+
+
+THIS IS NEW TOC:
+include::aap-common/making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::assemblies/assembly-lightspeed-intro.adoc[leveloffset=+1]
+include::assemblies/assembly_starting-lightspeed-trial.adoc[leveloffset=+1]
+include::assemblies/assembly_setting-up-lightspeed.adoc[leveloffset=+1]
+include::assemblies/assembly_developing_ansible_content.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-36632.

Changes made:

- Updates to the Lightspeed User Guide TOC as per the restructuring plan. Updates are made in incremental commits. 