### PR TITLE
Removing 20 node limit from 2.4 doc

### DIFF
--- a/downstream/modules/platform/ref-controller-setup-considerations.adoc
+++ b/downstream/modules/platform/ref-controller-setup-considerations.adoc
@@ -12,7 +12,6 @@ Note the following important considerations in the new clustering environment:
 * When you start a cluster, the database node must be a standalone server, and PostgreSQL must not be installed on one of the {ControllerName} nodes.
 * PgBouncer is not recommended for connection pooling with {ControllerName}. 
 {ControllerNameStart} relies on `pg_notify` for sending messages across various components, and therefore, PgBouncer cannot readily be used in transaction pooling mode.
-* The maximum supported instances in a cluster is 20.
 * All instances must be reachable from all other instances and they must be able to reach the database. 
 It is also important for the hosts to have a stable address or hostname (depending on how the {ControllerName} host is configured).
 * All instances must be geographically collocated, with reliable low-latency connections between instances.


### PR DESCRIPTION
[Docs] 20 node limit in docs is obselete

https://issues.redhat.com/browse/AAP-23909

Affects `titles/controller-admin-guide`