### PR TITLE
2.5 Update inventory file examples (#2683)

### DIFF
--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -26,10 +26,14 @@ Use the example inventory file to perform an online installation for the contain
 
 [source,yaml,subs="+attributes"]
 ----
-# This is the {PlatformNameShort} growth installer inventory file
-# Please consult the docs if you are unsure what to add
-# For all optional variables please consult the included README.md
-# or the Red Hat documentation:
+# This is the {PlatformNameShort} installer inventory file intended for the container growth deployment topology.
+# This inventory file expects to be run from the host where {PlatformNameShort} will be installed.
+# Consult the {PlatformNameShort} product documentation about this topology's tested hardware configuration.
+# {URLTopologies}/container-topologies
+#
+# Consult the docs if you are unsure what to add
+# For all optional variables consult the included README.md
+# or the {PlatformNameShort} documentation:
 # {URLContainerizedInstall}
 
 # This section is for your {Gateway} hosts
@@ -72,7 +76,7 @@ registry_password=<your RHN password>
 
 redis_mode=standalone
 
-# Platform gateway
+# {GatewayStart}
 # {URLContainerizedInstall}/appendix-inventory-files-vars#ref-gateway-variables
 # -----------------------------------------------------
 gateway_admin_password=<set your own>
@@ -108,8 +112,8 @@ Use the example inventory file to perform an online installation for the contain
 [source,yaml,subs="+attributes"]
 ----
 # This is the {PlatformNameShort} enterprise installer inventory file
-# Please consult the docs if you are unsure what to add
-# For all optional variables please consult the included README.md
+# Consult the docs if you are unsure what to add
+# For all optional variables consult the included README.md
 # or the Red Hat documentation:
 # {URLContainerizedInstall}
 
@@ -162,7 +166,7 @@ postgresql_admin_password=<set your own>
 registry_username=<your RHN username>
 registry_password=<your RHN password>
 
-# Platform gateway
+# {GatewayStart}
 # {URLContainerizedInstall}/appendix-inventory-files-vars#ref-gateway-variables
 # -----------------------------------------------------
 gateway_admin_password=<set your own>

--- a/downstream/modules/topologies/ref-cont-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-a-env-a.adoc
@@ -73,11 +73,15 @@ Use the example inventory file to perform an installation for this topology:
 
 [source,yaml,subs="+attributes"]
 ----
-# This is the growth installer inventory file
-# Please consult the docs if you are unsure what to add
-# For all optional variables please consult the included README.md
-# or the Red Hat documentation:
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation
+# This is the {PlatformNameShort} installer inventory file intended for the container growth deployment topology.
+# This inventory file expects to be run from the host where {PlatformNameShort} will be installed.
+# Consult the {PlatformNameShort} product documentation about this topology's tested hardware configuration.
+# {URLTopologies}/container-topologies
+#
+# Consult the docs if you are unsure what to add
+# For all optional variables consult the included README.md
+# or the {PlatformNameShort} documentation:
+# {URLContainerizedInstall}
 
 # This section is for your {Gateway} hosts
 # -----------------------------------------------------
@@ -109,7 +113,7 @@ aap.example.org
 ansible_connection=local
 
 # Common variables
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-general-inventory-variables
 # -----------------------------------------------------
 postgresql_admin_username=postgres
 postgresql_admin_password=<set your own>
@@ -120,28 +124,28 @@ registry_password=<your RHN password>
 redis_mode=standalone
 
 # {GatewayStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-gateway-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-gateway-variables
 # -----------------------------------------------------
 gateway_admin_password=<set your own>
 gateway_pg_host=aap.example.org
 gateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-controller-variables
 # -----------------------------------------------------
 controller_admin_password=<set your own>
 controller_pg_host=aap.example.org
 controller_pg_password=<set your own>
 
 # {HubNameStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-hub-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-hub-variables
 # -----------------------------------------------------
 hub_admin_password=<set your own>
 hub_pg_host=aap.example.org
 hub_pg_password=<set your own>
 
 # {EDAcontroller}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLContainerizedInstall}/appendix-inventory-files-vars#event-driven-ansible-controller
 # -----------------------------------------------------
 eda_admin_password=<set your own>
 eda_pg_host=aap.example.org

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -82,11 +82,11 @@ Use the example inventory file to perform an installation for this topology:
 
 [source,yaml,subs="+attributes"]
 ----
-# This is the enterprise installer inventory file
-# Please consult the docs if you are unsure what to add
-# For all optional variables please consult the included README.md
+# This is the {PlatformNameShort} enterprise installer inventory file
+# Consult the docs if you are unsure what to add
+# For all optional variables consult the included README.md
 # or the Red Hat documentation:
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation
+# {URLContainerizedInstall}
 
 # This section is for your {Gateway} hosts
 # -----------------------------------------------------
@@ -130,7 +130,7 @@ eda2.example.org
 [all:vars]
 
 # Common variables
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-general-inventory-variables
 # -----------------------------------------------------
 postgresql_admin_username=<set your own>
 postgresql_admin_password=<set your own>
@@ -138,7 +138,7 @@ registry_username=<your RHN username>
 registry_password=<your RHN password>
 
 # {GatewayStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-gateway-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-gateway-variables
 # -----------------------------------------------------
 gateway_admin_password=<set your own>
 gateway_pg_host=externaldb.example.org
@@ -147,7 +147,7 @@ gateway_pg_username=<set your own>
 gateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-controller-variables
 # -----------------------------------------------------
 controller_admin_password=<set your own>
 controller_pg_host=externaldb.example.org
@@ -156,7 +156,7 @@ controller_pg_username=<set your own>
 controller_pg_password=<set your own>
 
 # {HubNameStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#ref-hub-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-hub-variables
 # -----------------------------------------------------
 hub_admin_password=<set your own>
 hub_pg_host=externaldb.example.org
@@ -165,7 +165,7 @@ hub_pg_username=<set your own>
 hub_pg_password=<set your own>
 
 # {EDAcontroller}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/containerized_installation/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLContainerizedInstall}/appendix-inventory-files-vars#event-driven-ansible-controller
 # -----------------------------------------------------
 eda_admin_password=<set your own>
 eda_pg_host=externaldb.example.org

--- a/downstream/modules/topologies/ref-rpm-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-a.adoc
@@ -68,10 +68,14 @@ Use the example inventory file to perform an installation for this topology:
 
 [source,yaml,subs="+attributes"]
 ----
-# This is the growth installer inventory file
-# Please consult the docs if you are unsure what to add
-# For all optional variables please consult the Red Hat documentation:
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation
+# This is the {PlatformNameShort} installer inventory file intended for the RPM growth deployment topology.
+# Consult the {PlatformNameShort} product documentation about this topology's tested hardware configuration.
+# {URLTopologies}/rpm-topologies
+#
+# Consult the docs if you are unsure what to add
+# For all optional variables consult the {PlatformNameShort} documentation:
+# {URLInstallationGuide}
+
 
 # This section is for your {Gateway} hosts
 # -----------------------------------------------------
@@ -109,7 +113,7 @@ db.example.org
 [all:vars]
 
 # Common variables
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-general-inventory-variables
 # -----------------------------------------------------
 registry_username=<your RHN username>
 registry_password=<your RHN password>
@@ -117,28 +121,28 @@ registry_password=<your RHN password>
 redis_mode=standalone
 
 # {GatewayStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-gateway-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-gateway-variables
 # -----------------------------------------------------
 automationgateway_admin_password=<set your own>
 automationgateway_pg_host=db.example.org
 automationgateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-controller-variables
 # -----------------------------------------------------
 admin_password=<set your own>
 pg_host=db.example.org
 pg_password=<set your own>
 
 # {HubNameStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-hub-variables
 # -----------------------------------------------------
 automationhub_admin_password=<set your own>
 automationhub_pg_host=db.example.org
 automationhub_pg_password=<set your own>
 
 # {EDAcontroller}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller
 # -----------------------------------------------------
 automationedacontroller_admin_password=<set your own>
 automationedacontroller_pg_host=db.example.org

--- a/downstream/modules/topologies/ref-rpm-a-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-b.adoc
@@ -69,10 +69,13 @@ Use the example inventory file to perform an installation for this topology:
 
 [source,yaml,subs="+attributes"]
 ----
-# This is the mixed growth installer inventory file
-# Please consult the docs if you are unsure what to add
-# For all optional variables please consult the Red Hat documentation:
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation
+# This is the {PlatformNameShort} installer inventory file intended for the mixed RPM growth deployment topology.
+# Consult the {PlatformNameShort} product documentation about this topology's tested hardware configuration.
+# {URLTopologies}/rpm-topologies
+#
+# Consult the docs if you are unsure what to add
+# For all optional variables consult the Red Hat documentation:
+# {URLInstallationGuide}
 
 # This section is for your {Gateway} hosts
 # -----------------------------------------------------
@@ -87,7 +90,7 @@ eda.example.org
 [all:vars]
 
 # Common variables
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-general-inventory-variables
 # -----------------------------------------------------
 registry_username=<your RHN username>
 registry_password=<your RHN password>
@@ -95,14 +98,14 @@ registry_password=<your RHN password>
 redis_mode=standalone
 
 # {GatewayStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-gateway-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-gateway-variables
 # -----------------------------------------------------
 automationgateway_admin_password=<set your own>
 automationgateway_pg_host=db.example.org
 automationgateway_pg_password=<set your own>
 
 # {EDAcontroller}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller
 # -----------------------------------------------------
 automationedacontroller_admin_password=<set your own>
 automationedacontroller_pg_host=db.example.org

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -78,10 +78,10 @@ Use the example inventory file to perform an installation for this topology:
 
 [source,yaml,subs="+attributes"]
 ----
-# This is the enterprise installer inventory file
-# Please consult the docs if you are unsure what to add
-# For all optional variables please consult the Red Hat documentation:
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation
+# This is the {PlatformNameShort} enterprise installer inventory file
+# Consult the docs if you are unsure what to add
+# For all optional variables consult the Red Hat documentation:
+# {URLInstallationGuide}
 
 # This section is for your {Gateway} hosts
 # -----------------------------------------------------
@@ -127,13 +127,13 @@ eda2.example.org
 
 [all:vars]
 # Common variables
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-general-inventory-variables
 # -----------------------------------------------------
 registry_username=<your RHN username>
 registry_password=<your RHN password>
 
 # {GatewayStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-gateway-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-gateway-variables
 # -----------------------------------------------------
 automationgateway_admin_password=<set your own>
 automationgateway_pg_host=<set your own>
@@ -142,7 +142,7 @@ automationgateway_pg_username=<set your own>
 automationgateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-controller-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-controller-variables
 # -----------------------------------------------------
 admin_password=<set your own>
 pg_host=<set your own>
@@ -151,7 +151,7 @@ pg_username=<set your own>
 pg_password=<set your own>
 
 # {HubNameStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-hub-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-hub-variables
 # -----------------------------------------------------
 automationhub_admin_password=<set your own>
 automationhub_pg_host=<set your own>
@@ -160,7 +160,7 @@ automationhub_pg_username=<set your own>
 automationhub_pg_password=<set your own>
 
 # {EDAcontroller}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller
 # -----------------------------------------------------
 automationedacontroller_admin_password=<set your own>
 automationedacontroller_pg_host=<set your own>

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -78,10 +78,10 @@ Use the example inventory file to perform an installation for this topology:
 
 [source,yaml,subs="+attributes"]
 ----
-# This is the mixed enterprise installer inventory file
-# Please consult the docs if you are unsure what to add
-# For all optional variables please consult the Red Hat documentation:
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation
+# This is the {PlatformNameShort} mixed enterprise installer inventory file
+# Consult the docs if you are unsure what to add
+# For all optional variables consult the Red Hat documentation:
+# {URLInstallationGuide}
 
 # This section is for your {Gateway} hosts
 # -----------------------------------------------------
@@ -107,13 +107,13 @@ eda3.example.org
 
 [all:vars]
 # Common variables
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-general-inventory-variables
 # -----------------------------------------------------
 registry_username=<your RHN username>
 registry_password=<your RHN password>
 
 # {GatewayStart}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#ref-gateway-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#ref-gateway-variables
 # -----------------------------------------------------
 automationgateway_admin_password=<set your own>
 automationgateway_pg_host=<set your own>
@@ -122,7 +122,7 @@ automationgateway_pg_username=<set your own>
 automationgateway_pg_password=<set your own>
 
 # {EDAcontroller}
-# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller
 # -----------------------------------------------------
 automationedacontroller_admin_password=<set your own>
 automationedacontroller_pg_host=<set your own>


### PR DESCRIPTION
Update the inventory file examples to match what's included when downloading the installers

Affects titles:
- `aap-containerized-install`
- `topologies`

Update the installer inventory files to match the ones supplied to the user

https://issues.redhat.com/browse/AAP-37239