### PR TITLE
Fix error in Lightspeed RN

### DIFF
--- a/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-11dec2024.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-11dec2024.adoc
@@ -1,6 +1,6 @@
 :_content-type: CONCEPT
 
-[id="lightspeed-key-features-june2024_{context}"]
+[id="lightspeed-key-features-11Dec2024_{context}"]
 = 11 December 2024
 
 This release {LightspeedShortName} features the following enhancement: 


### PR DESCRIPTION
This PR fixes and error caused by a duplicated file ID in the Lightspeed Release Notes. 