### PR TITLE
Fixing errors in inventory plugin sections

### DIFF
--- a/downstream/modules/platform/proc-controller-inv-source-aap.adoc
+++ b/downstream/modules/platform/proc-controller-inv-source-aap.adoc
@@ -7,11 +7,11 @@ Use the following procedure to configure an {ControllerName}-sourced inventory.
 .Procedure
 . In the *Create new source* page, select *{PlatformName} from the *Source* list.
 . The *Create Source* window expands with the required *Credential* field.
-Choose from an existing GCE Credential.
-For more information, refer to xref:controller-credentials[Credentials].
+Choose from an existing {PlatformName}.
+For more information, see xref:controller-credentials[Credentials].
 . Optional: You can specify the verbosity, host filter, enabled variables or values, and update options as described in xref:proc-controller-add-source[Adding a source].
-. Use the *Source Variables* field to override variables used by the `gcp_compute` inventory plugin.
-Enter variables using either JSON or YAML syntax.
+. Use the *Source Variables* field to override variables used by the `controller` inventory plugin.
+Enter variables by using either JSON or YAML syntax.
 Use the radio button to toggle between the two.
-For more information on these variables, see link:https://console.redhat.com/ansible/automation-hub/repo/published/ansible/controller/content/inventory/controller[Controller inventory plugin].
+For more information about these variables, see link:https://console.redhat.com/ansible/automation-hub/repo/published/ansible/controller/content/inventory/controller[Controller inventory plugin].
 This requires your Red Hat Customer login.

--- a/downstream/modules/platform/proc-controller-inv-source-insights.adoc
+++ b/downstream/modules/platform/proc-controller-inv-source-insights.adoc
@@ -7,12 +7,12 @@ Use the following procedure to configure a Red Hat Insights-sourced inventory.
 .Procedure
 . In the *Create new source* page, select *Red Hat Insights* from the *Source* list.
 . The *Create Source* window expands with the required *Credential* field.
-Choose from an existing GCE Credential.
-For more information, refer to xref:controller-credentials[Credentials].
+Choose from an existing Red Hat Insights Credential.
+For more information, see xref:controller-credentials[Credentials].
 . Optional: You can specify the verbosity, host filter, enabled variables or values, and update options as described in xref:proc-controller-add-source[Adding a source].
-. Use the *Source Variables* field to override variables used by the `gcp_compute` inventory plugin.
-Enter variables using either JSON or YAML syntax.
+. Use the *Source Variables* field to override variables used by the `insights` inventory plugin.
+Enter variables by using either JSON or YAML syntax.
 Use the radio button to toggle between the two.
-For more information on these variables, see link:https://console.redhat.com/ansible/automation-hub/repo/published/redhat/insights/content/inventory/insights[insights inventory plugin].
+For more information about these variables, see link:https://console.redhat.com/ansible/automation-hub/repo/published/redhat/insights/content/inventory/insights[insights inventory plugin].
 //+
 //image:inventories-create-source-insights-example.png[Inventories - create source - RH Insights example]

--- a/downstream/modules/platform/proc-controller-inv-source-openstack.adoc
+++ b/downstream/modules/platform/proc-controller-inv-source-openstack.adoc
@@ -7,12 +7,12 @@ Use the following procedure to configure an OpenStack-sourced inventory.
 .Procedure
 . In the *Create new source* page, select *Openstack* from the *Source* list.
 . The *Create Source* window expands with the required *Credential* field.
-Choose from an existing GCE Credential.
-For more information, refer to xref:controller-credentials[Credentials].
+Choose from an existing OpenStack Credential.
+For more information, see xref:controller-credentials[Credentials].
 . Optional: You can specify the verbosity, host filter, enabled variables or values, and update options as described in xref:proc-controller-add-source[Adding a source].
-. Use the *Source Variables* field to override variables used by the `gcp_compute` inventory plugin.
-Enter variables using either JSON or YAML syntax.
+. Use the *Source Variables* field to override variables used by the `openstack` inventory plugin.
+Enter variables by using either JSON or YAML syntax.
 Use the radio button to toggle between the two.
-For more information on these variables, see link:https://docs.ansible.com/ansible/latest/collections/openstack/cloud/openstack_inventory.html[openstack inventory plugin].
+For more information about these variables, see link:https://docs.ansible.com/ansible/latest/collections/openstack/cloud/openstack_inventory.html[openstack inventory plugin].
 //+
 //image:inventories-create-source-openstack-example.png[Inventories - create source - OpenStack example]

--- a/downstream/modules/platform/proc-controller-inv-source-rh-virt.adoc
+++ b/downstream/modules/platform/proc-controller-inv-source-rh-virt.adoc
@@ -7,13 +7,13 @@ Use the following procedure to configure a Red Hat virtualization-sourced invent
 .Procedure
 . In the *Create new source* page, select *Red Hat Virtualization* from the *Source* list.
 . The *Create Source* window expands with the required *Credential* field.
-Choose from an existing GCE Credential.
+Choose from an existing Red Hat Virtualization Credential.
 For more information, see xref:controller-credentials[Credentials].
 . Optional: You can specify the verbosity, host filter, enabled variables or values, and update options as described in xref:proc-controller-add-source[Adding a source].
-. Use the *Source Variables* field to override variables used by the `gcp_compute` inventory plugin.
-Enter variables using either JSON or YAML syntax.
+. Use the *Source Variables* field to override variables used by the `ovirt` inventory plugin.
+Enter variables by using either JSON or YAML syntax.
 Use the radio button to toggle between the two.
-For more information on these variables, see link:https://console.redhat.com/ansible/automation-hub/repo/published/redhat/rhv/content/inventory/ovirt[ovirt inventory plugin]
+For more information about these variables, see link:https://console.redhat.com/ansible/automation-hub/repo/published/redhat/rhv/content/inventory/ovirt[ovirt inventory plugin]
 //+
 //image:inventories-create-source-rhv-example.png[Inventories- create source - RHV example]
 


### PR DESCRIPTION
Fix incorrect mention of gcp_compute / gce in Insights inventory plugin sections

https://issues.redhat.com/browse/AAP-37363

Affects `titles/controller-user-guide`