### PR TITLE
backport to 2.5: AAP-36858: updates subscription info in managing automation content guide

### DIFF
--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -31,8 +31,6 @@ Make this change to any firewall configuration that specifically enables outboun
 Use the hostnames instead of IP addresses when configuring firewall rules.
 
 After making this change you can continue to pull {ExecEnvShort}s from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
-
-If you are using Red Hat Satellite Server, follow the link:https://docs.redhat.com/en/documentation/red_hat_satellite/{SatelliteVers}/html/managing_content/managing_red_hat_subscriptions_content-management#Importing_a_Red_Hat_Subscription_Manifest_into_Server_content-management[procedure in the Red Hat Satellite documentation to import a subscription manifest into Satellite Server].
 ====
 
 include::hub/proc-obtain-images.adoc[leveloffset=+1]

--- a/downstream/modules/hub/proc-obtain-images.adoc
+++ b/downstream/modules/hub/proc-obtain-images.adoc
@@ -8,25 +8,11 @@
 [role="_abstract"]
 Before you can push {ExecEnvShort}s to your {PrivateHubName}, you must first pull them from an existing registry and tag them for use. The following example details how to pull an {ExecEnvShort} from the Red Hat Ecosystem Catalog (registry.redhat.io).
 
-[IMPORTANT]
-====
-As of early 2024, Red Hat no longer supports manifests or manifest lists on the Red Hat Subscription Management web platform, which has also been used interchangeably with “subscription allocations.” Red Hat also no longer supports most manifest functionality in Red Hat Satellite with one exception:
-* Red Hat Satellite users in closed network or “air gapped” networks that do not receive their updates directly from Red Hat servers can currently still use `access.redhat.com` until the release of Red Hat Satellite 6.16.
-
-New Red Hat accounts automatically use Simple Content Access for their subscription tooling. New Red Hat accounts and existing Satellite customers who can connect to Red Hat's servers can find their manifests at `console.redhat.com`.
-====
-
 .Prerequisites
 
 * You have permissions to pull {ExecEnvName} from registry.redhat.io.
 
-* A Red Hat account with Simple Content Access enabled.
-
 .Procedure
-
-. If you need to access your manifest for your container images log in to link:https://console.redhat.com/subscriptions/manifests[Red Hat Console].
-
-. Click the three-dot menu for the manifest you need for your {ExecEnvName}, and click btn:[Export manifest].
 
 . Log in to Podman by using your registry.redhat.io credentials:
 +
@@ -41,7 +27,6 @@ $ podman login registry.redhat.io
 -----
 $ podman pull registry.redhat.io/__<ee_name>__:__<tag>__
 -----
-
 
 .Verification
 


### PR DESCRIPTION
This PR backports the changes from [PR 2682](https://github.com/ansible/aap-docs/pull/2682) to the 2.5 branch. See [AAP-36858](https://issues.redhat.com/browse/AAP-36858) for more detail.