### PR TITLE
backport to 2.5: AAP-36858 removes satellite link from section on pulling EEs (#2698)

### DIFF
--- a/downstream/modules/hub/proc-obtain-images.adoc
+++ b/downstream/modules/hub/proc-obtain-images.adoc
@@ -45,4 +45,3 @@ $ podman images
 
 * See link:https://redhat-connect.gitbook.io/catalog-help/[Red Hat Ecosystem Catalog Help] for information on registering and getting {ExecEnvShort}s.
 
-* See link:{BaseURL}/subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] to learn more about the changes coming to Red Hat subscription tooling.


### PR DESCRIPTION
This PR ports the changes from [PR 2698](https://github.com/ansible/aap-docs/pull/2698) to the 2.5 branch. See [AAP-36858](https://issues.redhat.com/browse/AAP-36858) for more detail.