### PR TITLE
Add IBM support link to Tested deployment models

### DIFF
--- a/downstream/assemblies/topologies/assembly-appendix-topology-resources.adoc
+++ b/downstream/assemblies/topologies/assembly-appendix-topology-resources.adoc
@@ -1,0 +1,9 @@
+[id="appendix-topology-resources"]
+= Additional resources for tested deployment models
+
+This appendix provides a reference for the additional resources relevant to the tested deployment models outlined in {TitleTopologies}.
+
+* For additional information about each of the tested topologies described in this document, see the link:https://github.com/ansible/test-topologies/[test-topologies GitHub repo].
+
+* For questions around IBM cloud specific configurations or issues, see link:https://www.ibm.com/mysupport[IBM support].
+

--- a/downstream/titles/topologies/master.adoc
+++ b/downstream/titles/topologies/master.adoc
@@ -23,7 +23,6 @@ include::topologies/assembly-ocp-topologies.adoc[leveloffset=+1]
 //Automation mesh nodes 
 include::topologies/topologies/ref-mesh-nodes.adoc[leveloffset=+1]
 
-[NOTE]
-====
-For additional information about each of the tested topologies described in this document, see the link:https://github.com/ansible/test-topologies/[test-topologies GitHub repo].
-====
+//Additional resources appendix
+[appendix]
+include::topologies/assembly-appendix-topology-resources.adoc[leveloffset=+1]


### PR DESCRIPTION
Adds this content to an appendix at the end of the document as it's relevant for all current topologies

Docs: Add link to IBM configuration documentation in Tested deployment models

https://issues.redhat.com/browse/AAP-37192