### PR TITLE
[Backport] Replaced satellite version number with the defined attribute (#2719)

### DIFF
--- a/downstream/modules/platform/proc-aap-create-subscription-allocation.adoc
+++ b/downstream/modules/platform/proc-aap-create-subscription-allocation.adoc
@@ -8,7 +8,7 @@ Creating a new subscription allocation allows you to set aside subscriptions and
 .Procedure
 . From the link:https://access.redhat.com/management/subscription_allocations/[Subscription Allocations] page, click btn:[New Subscription Allocation].
 . Enter a name for the allocation so that you can find it later.
-. Select *Type: Satellite 6.16* as the management application.
+. Select *Type: Satellite {SatelliteVers}* as the management application.
 . Click btn:[Create].
 
 [role="_additional-resources"]


### PR DESCRIPTION
This PR backports the changes from #2719 to the 2.5 branch. 