### PR TITLE
2.5 Correct typo in link Backing up container-based Ansible Automation Pl…

### DIFF
--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -8,7 +8,7 @@ Perform a back up of your {ContainerBase} of {PlatformNameShort}.
 
 . Go to the {PlatformName} installation directory on your {RHEL} host.
 
-. Run the `backup.yml` playbook:
+. Run the `backup` playbook command:
 +
 ----
 $ ansible-playbook -i inventory ansible.containerized_installer.backup

--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -10,7 +10,7 @@ You can control the installation of {PlatformNameShort} with inventory files. In
 
 Example inventory files are provided in this document that you can copy and change to quickly get started. 
 
-Inventory files for the growth and enterprise topology are also found in the downloaded installer package:
+Inventory files for the growth and enterprise topologies are also found in the downloaded installer package:
 
 * The default one named `inventory` is for the enterprise topology pattern. 
 
@@ -266,9 +266,14 @@ controller_license_file=<full_path_to_your_manifest_zip_file>
 Use the following command to install containerized {PlatformNameShort}:
 
 ----
+ansible-playbook -i <inventory_file_name> ansible.containerized_installer.install
+----
+
+For example:
+----
 ansible-playbook -i inventory ansible.containerized_installer.install
 ----
 
-* If your privilege escalation requires you to enter a password, append `-K` to the command line. You are then prompted for the `BECOME` password. 
-* You can use increasing verbosity, up to 4 v's (`-vvvv`) to see the details of the installation process. However, it is important to note that this can significantly increase installation time, so it is recommended that you use it only as needed or requested by Red Hat support.
+* If your privilege escalation requires you to enter a password, append `-K` to the command. You are then prompted for the `BECOME` password. 
+* You can use increasing verbosity, up to 4 v's (`-vvvv`) to see the details of the installation process. However, it is important to note that this can significantly increase installation time, so it is recommended that you use it only as needed or requested by Red{nbsp}Hat support.
 

--- a/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
@@ -23,7 +23,7 @@ sudo subscription-manager register
 ----
 +
 
-. Run `sudo dnf repolist` to validate that only the BaseOS and AppStream repositories are setup and enabled on the host:
+. Run `sudo dnf repolist` to validate that only the BaseOS and AppStream repositories are set up and enabled on the host:
 +
 ----
 $ sudo dnf repolist
@@ -33,8 +33,7 @@ rhel-9-for-x86_64-appstream-rpms                           Red Hat Enterprise Li
 rhel-9-for-x86_64-baseos-rpms                              Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)
 ----
 +
-. Ensure that only these repositories are available to the {RHEL} host. For more information about managing custom repositories, see:
-link:{BaseURL}/red_hat_enterprise_linux/9/html/managing_software_with_the_dnf_tool/assembly_managing-custom-software-repositories_managing-software-with-the-dnf-tool[Managing custom software repositories].
+. Ensure that only these repositories are available to the {RHEL} host. For more information about managing custom repositories, see link:{BaseURL}/red_hat_enterprise_linux/9/html/managing_software_with_the_dnf_tool/assembly_managing-custom-software-repositories_managing-software-with-the-dnf-tool[Managing custom software repositories].
 
 . Ensure that the host has DNS configured and can resolve host names and IP addresses by using a fully qualified domain name (FQDN). This is essential to ensure services can talk to one another.
 
@@ -57,4 +56,5 @@ sudo dnf install -y wget git-core rsync vim
 * For more information about registering your RHEL system, see link:{BaseURL}/subscription_central/1-latest/html-single/getting_started_with_rhel_system_registration/index[Getting Started with RHEL System Registration].
 * For information about configuring unbound DNS, see link:{BaseURL}/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/assembly_setting-up-an-unbound-dns-server_networking-infrastructure-services[Setting up an unbound DNS server].
 * For information about configuring DNS using BIND, see link:{BaseURL}/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/assembly_setting-up-and-configuring-a-bind-dns-server_networking-infrastructure-services[Setting up and configuring a BIND DNS server].
+* For more information about `ansible-core`, see link:https://docs.ansible.com/ansible/latest/[Ansible Core Documentation].
 

--- a/downstream/modules/platform/proc-reinstalling-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-reinstalling-containerized-aap.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 
-To reinstall a containerized deployment after uninstalling and preserving the database, run the `install.yml` playbook and include the existing secret key value:
+To reinstall a containerized deployment after uninstalling and preserving the database, run the `install` playbook command and include the existing secret key value:
 ----
 $ ansible-playbook -i inventory ansible.containerized_installer.install -e controller_secret_key=<secret_key_value>
 ----

--- a/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
@@ -18,7 +18,7 @@ $ podman secret inspect --showsecret controller_secret_key | jq -r .[].SecretDat
 
 For more information about the `*_secret_key` variables, see link:{URLContainerizedInstall}/appendix-inventory-files-vars[Inventory file variables].
 
-To uninstall a containerized deployment, run the `uninstall.yml` playbook:
+To uninstall a containerized deployment, run the `uninstall` playbook command:
 ----
 $ ansible-playbook -i inventory ansible.containerized_installer.uninstall
 ----
@@ -30,12 +30,12 @@ This stops all systemd units and containers and then deletes all resources used 
 * Podman containers and images
 * RPM packages
 
-To keep container images, set the `container_keep_images` variable to `true`.
+To keep container images, set the `container_keep_images` parameter to `true`.
 ----
 $ ansible-playbook -i inventory ansible.containerized_installer.uninstall -e container_keep_images=true
 ----
 
-To keep PostgreSQL databases, set the `postgresql_keep_databases` variable to `true`.
+To keep PostgreSQL databases, set the `postgresql_keep_databases` parameter to `true`.
 ----
 $ ansible-playbook -i inventory ansible.containerized_installer.uninstall -e postgresql_keep_databases=true
 ----

--- a/downstream/modules/platform/proc-update-aap-container.adoc
+++ b/downstream/modules/platform/proc-update-aap-container.adoc
@@ -10,7 +10,7 @@ You have done the following:
 
 * Reviewed the release notes for the associated patch release. For more information, see the link:{URLReleaseNotes}[{PlatformNameShort} {TitleReleaseNotes}].
 
-* Created a backup of your {PlatformNameShort} deployment. For more information, see xref:proc-backup-aap-container[Backing up controller-based {PlatformNameShort}].
+* Created a backup of your {PlatformNameShort} deployment. For more information, see xref:proc-backup-aap-container[Backing up container-based {PlatformNameShort}].
 
 .Procedure
 
@@ -38,7 +38,7 @@ $ tar xfvz ansible-automation-platform-containerized-setup-<version>.tar.gz
 $ tar xfvz ansible-automation-platform-containerized-setup-bundle-<version>-<arch name>.tar.gz
 ----
 +
-. Edit the `inventory` file so that it matches your required configuration. You can keep the same parameters from your existing {PlatformNameShort} deployment or you can change the parameters to match any modifications to your environment.
+. Edit the `inventory` file to match your required configuration. You can keep the same parameters from your existing {PlatformNameShort} deployment or you can change the parameters to match any modifications to your environment.
 
 . Run the `install` command:
 +
@@ -49,4 +49,4 @@ $ ansible-playbook -i inventory ansible.containerized_installer.install
 * If your privilege escalation requires a password to be entered, append `-K` to the command. You will then be prompted for the `BECOME` password.
 * You can use increasing verbosity, up to 4 v’s (`-vvvv`) to see the details of the installation process. However it is important to note that this can significantly increase installation time, so it is recommended that you use it only as needed or requested by Red Hat support.
 
-The installation will begin.
+The update begins.


### PR DESCRIPTION
…… (#2721)

* Correct typo in link Backing up container-based Ansible Automation Platform

Correcting some typos and wording to ensure clarity in Containerized installation

Containerized installation - correct typo in link Backing up container-based Ansible Automation Platform

https://issues.redhat.com/browse/AAP-37615

* update based on peer review feedback