### PR TITLE
Correcting credentials link in user guide

### DIFF
--- a/downstream/modules/platform/proc-controller-azure-resource-manager.adoc
+++ b/downstream/modules/platform/proc-controller-azure-resource-manager.adoc
@@ -12,7 +12,7 @@ Use the following procedure to configure an {Azure} Resource Manager-sourced inv
 . In the *Create source* page, select *Microsoft Azure Resource Manager* from the *Source* list.
 . Enter the following details in the additional fields:
 . Optional: *Credential*: Choose from an existing Azure Credential.
-For more information, see xref:controller-credentials[Managing user credentials]..
+For more information, see xref:controller-credentials[Managing user credentials].
 
 . Optional: You can specify the verbosity, host filter, enabled variables or values, and update options as described in xref:proc-controller-add-source[Adding a source].
 . Use the *Source variables* field to override variables used by the `azure_rm` inventory plugin.

--- a/downstream/modules/platform/proc-controller-inv-source-gce.adoc
+++ b/downstream/modules/platform/proc-controller-inv-source-gce.adoc
@@ -11,7 +11,7 @@ Use the following procedure to configure a Google-sourced inventory:
 . In the *Add new source* page, select *Google Compute Engine* from the *Source* list.
 . The *Create source* window expands with the required *Credential* field.
 Choose from an existing GCE Credential.
-For more information, see [Credentials].
+For more information, see xref:controller-credentials[Managing user credentials].
 //+
 //image:inventories-create-source-GCE-example.png[Inventories- create source - GCE example]
 


### PR DESCRIPTION
Add correct credentials link to GCE section

https://issues.redhat.com/browse/AAP-37382

Affects 'titles/controller-user-guide'