### PR TITLE
AAP-35970: AAP-35970: Added IBM Z arch test support in RPM topologies

### DIFF
--- a/downstream/modules/topologies/ref-rpm-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-a.adoc
@@ -32,7 +32,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-rpm-a-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-b.adoc
@@ -32,7 +32,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-rpm-a-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-b.adoc
@@ -33,7 +33,7 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
 | Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z)
+| CPU architecture | x86_64, AArch64
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -39,7 +39,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -40,7 +40,7 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
 | Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z)
+| CPU architecture | x86_64, AArch64
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -39,7 +39,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-35970. 

Changes made: 
In Tested deployment models for RPM installation:
-  Moved tested architectures (x86_64, AArch64) into a new row "CPU architecture".
- Updated RPM topologies to include "s390x (IBM Z)" in the new CPU architecture row.
The above updates are made in the ' Tested system configurations' table for RPM growth topology, RPM mixed growth topology, RPM enterprise topology, and RPM mixed enterprise topology. 