### PR TITLE
Removing cleanup string from controller docs

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-management-jobs.adoc
+++ b/downstream/assemblies/platform/assembly-controller-management-jobs.adoc
@@ -12,7 +12,8 @@ image:management-jobs.png[Management jobs]
 The following job types are available for you to schedule and launch:
 
 * *Cleanup Activity Stream*: Remove activity stream history older than a specified number of days
-* *Cleanup Expired OAuth 2 Tokens*: Remove expired OAuth 2 access tokens and refresh tokens
+// [emcwhinn] Removing as part of AAP-37805
+// * *Cleanup Expired OAuth 2 Tokens*: Remove expired OAuth 2 access tokens and refresh tokens
 * *Cleanup Expired Sessions*: Remove expired browser sessions from the database
 * *Cleanup Job Details*: Remove job history older than a specified number of days
 


### PR DESCRIPTION
Remove docs on "Cleanup Expired OAuth 2 Tokens"

https://issues.redhat.com/browse/AAP-37805

Affects `controller-admin-guide`