### PR TITLE
Update RHEL requirements for containerized installation

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -25,8 +25,7 @@ include::snippets/container-upgrades.adoc[]
 ====
 
 .Prerequisites
-
-* A {RHEL} (RHEL) 9.2 based host. Use a minimal operating system base install.
+* A host running {RHEL} (RHEL) 9.2 or later. Use a minimal operating system base install.
 * A non-root user for the {RHEL} host, with sudo or other Ansible supported privilege escalation (sudo recommended). This user is responsible for the installation of containerized {PlatformNameShort}.
 * SSH public key authentication for the non-root user. For guidelines on setting up SSH public key authentication for the non-root user, see link:https://access.redhat.com/solutions/4110681[How to configure SSH public key authentication for passwordless login].
 ** SSH keys are only required when installing on remote hosts. If doing a self contained local VM based installation, you can use `ansible_connection=local`.


### PR DESCRIPTION
Update the prereqs in Containerized installation to denote RHEL 9.2 or later as opposed to just RHEL 9.2

[Docs] update Red Hat Enterprise Linux (RHEL) version in Containerized installer documentation

https://issues.redhat.com/browse/AAP-38119