### PR TITLE
Adding Transparent SAML Login proc in AAP 2.5

### DIFF
--- a/downstream/assemblies/platform/assembly-gw-config-authentication-type.adoc
+++ b/downstream/assemblies/platform/assembly-gw-config-authentication-type.adoc
@@ -30,6 +30,8 @@ include::platform/proc-controller-set-up-LDAP.adoc[leveloffset=+1]
 
 include::platform/proc-controller-set-up-SAML.adoc[leveloffset=+1]
 
+include::platform/proc-controller-configure-transparent-SAML.adoc[leveloffset=+2]
+
 include::platform/proc-controller-set-up-tacacs+.adoc[leveloffset=+1]
 
 include::platform/proc-controller-set-up-azure.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-controller-configure-transparent-SAML.adoc
+++ b/downstream/modules/platform/proc-controller-configure-transparent-SAML.adoc
@@ -6,17 +6,4 @@ For transparent logins to work, you must first get IdP-initiated logins to work.
 
 .Procedure
 
-. Set the `RelayState` on the IdP to the key of the IdP definition in the *SAML Enabled Identity Providers* field.
-. When this is working, specify the redirect URL for non-logged-in users to somewhere other than the default {ControllerName} login page by using the *Login redirect override URL* field in the *Miscellaneous Authentication* settings window of the {MenuAEAdminSettings} menu.
-You must set this to `/sso/login/saml/?idp=<name-of-your-idp>` for transparent SAML login, as shown in the following example:
-+
-image::ag-configure-system-login-redirect-url.png[Configure SAML login]
-+
-[NOTE]
-====
-This example shows a typical IdP format, but might not be the correct format for your particular case.
-You might need to reach out to your IdP for the correct transparent redirect URL as that URL is not the same for all IdPs.
-====
-+
-. After you configure transparent SAML login, to log in using local credentials or a different SSO, go directly to `https://<your-tower-server>/login`.
-This provides the standard {ControllerName} login page, including SSO authentication options, enabling you to log in with any configured method.
+* Set the `RelayState` on the IdP to "IdP".

--- a/downstream/modules/platform/proc-controller-set-up-SAML.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-SAML.adoc
@@ -2,8 +2,9 @@
 
 = Configuring SAML authentication
 
-SAML allows the exchange of authentication and authorization data between an Identity Provider (IdP) and a Service Provider (SP). {PlatformNameShort} is a SAML SP that can be configured to talk with one or more SAML IdPs in order to authenticate users. Based on groups and attributes optionally provided by the IdP users can be placed into teams and organizations in {PlatformNameShort} based on authenticator maps tied to this authenticator.
-
+SAML allows the exchange of authentication and authorization data between an Identity Provider (IdP) and a Service Provider (SP). 
+{PlatformNameShort} is a SAML SP that you can configure to talk with one or more SAML IdPs to authenticate users. 
+Based on groups and attributes optionally provided by the IdP, users can be placed into teams and organizations in {PlatformNameShort} based on authenticator maps tied to this authenticator.
 
 .Procedure
 
@@ -34,7 +35,7 @@ include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
 }
 ----
 +
-. In the *SAML Service Provider Technical Contact* field, provide the name and email address of the technical contact for your service provider. 
+. In the *SAML Service Provider Technical Contact* field, give the name and email address of the technical contact for your service provider. 
 +
 ----
 {
@@ -43,7 +44,7 @@ include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
 }
 ----
 +
-. In the *SAML Service Provider Support Contact* field, provide the name and email address of the support contact for your service provider. 
+. In the *SAML Service Provider Support Contact* field, give the name and email address of the support contact for your service provider. 
 +
 ----	
 {
@@ -65,7 +66,7 @@ include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
 // Indicates a requirement for the <saml:Assertion> elements received by // this SP to be signed. [Metadata of the SP will offer this info] 
 "wantAssertionsSigned": false,
 ----
-For more information and additional options, see link:https://github.com/SAML-Toolkits/python-saml#settings[OneLogin’s SAML Python Toolkit].
+For more information and additional options, see link:https://github.com/SAML-Toolkits/python-saml#settings[OneLogin's SAML Python Toolkit].
 +
 . Optional: In the *SAML IDP to extra_data attribute mapping* field, enter values to map  IDP attributes to extra_data attributes. For more information, see link:https://python-social-auth.readthedocs.io/en/latest/backends/saml.html#advanced-settings[advanced SAML settings].
 +
@@ -73,13 +74,13 @@ For more information and additional options, see link:https://github.com/SAML-To
 ====
 By default only the attributes in the SAML assertion identified in the fields: *User Email*, *Username*, *User Last Name*, *User First Name*, and *User Permanent ID* are available for {PlatformNameShort} authenticator maps.
 
-If you would like to make other attributes from the SAML assertion available for {PlatformNameShort} authenticator maps, you must include them in the *SAML IDP to extra_data attribute mapping* field. For example:
+If you want to make other attributes from the SAML assertion available for {PlatformNameShort} authenticator maps, you must include them in the *SAML IDP to extra_data attribute mapping* field. For example:
 -----
 - Department
 - UserType
 - Organization
 -----
-Alternatively, if you want all attributes returned by the SAML Assertion to be avialable for {PlatformNameShort} authenticator maps you can add the following setting to *Additional Authenticator Fields*:
+Alternatively, if you want all attributes returned by the SAML Assertion to be available for {PlatformNameShort} authenticator maps you can add the following setting to *Additional Authenticator Fields*:
 -----
 GET_ALL_EXTRA_DATA: true
 -----

--- a/downstream/modules/platform/proc-controller-set-up-SAML.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-SAML.adoc
@@ -72,9 +72,9 @@ For more information and additional options, see link:https://github.com/SAML-To
 +
 [NOTE]
 ====
-By default only the attributes in the SAML assertion identified in the fields: *User Email*, *Username*, *User Last Name*, *User First Name*, and *User Permanent ID* are available for {PlatformNameShort} authenticator maps.
+By default only the attributes in the SAML Assertion identified in the fields: *User Email*, *Username*, *User Last Name*, *User First Name*, and *User Permanent ID* are available for {PlatformNameShort} authenticator maps.
 
-If you want to make other attributes from the SAML assertion available for {PlatformNameShort} authenticator maps, you must include them in the *SAML IDP to extra_data attribute mapping* field. For example:
+If you want to make other attributes from the SAML Assertion available for {PlatformNameShort} authenticator maps, you must include them in the *SAML IDP to extra_data attribute mapping* field. For example:
 -----
 - Department
 - UserType


### PR DESCRIPTION
No Documentation Exists for Transparent SAML Logins in AAP 2.5

https://issues.redhat.com/browse/AAP-38120

Affects `titles/central-auth`