### PR TITLE
2.5 AAP-35970: AAP-35970: Added IBM Z arch test support in RPM topologies…

### DIFF
--- a/downstream/modules/topologies/ref-rpm-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-a.adoc
@@ -32,7 +32,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-rpm-a-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-b.adoc
@@ -32,7 +32,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -39,7 +39,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64, s390x (IBM Z)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -39,7 +39,8 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later x86_64 and AArch64
+| Operating system | {RHEL} 9.2 or later
+| CPU architecture | x86_64, AArch64
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}


### PR DESCRIPTION
… (#2726)

* AAP-35970: AAP-35970: Added IBM Z arch test support in RPM topologies

* AAP-35970: Corrected the IBM arch. test support