### PR TITLE
Add IBM P to Tested deployment models

### DIFF
--- a/downstream/modules/topologies/ref-cont-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-a-env-a.adoc
@@ -37,7 +37,7 @@ a|
 * Valid {PlatformName} subscription
 * Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
 | Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z)
+| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -43,7 +43,7 @@ a|
 * Valid {PlatformName} subscription
 * Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
 | Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z)
+| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome.
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -41,7 +41,7 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
 | Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z)
+| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Red Hat OpenShift  
 a| 
 * Version: 4.14

--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -46,7 +46,7 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
 | Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z)
+| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Red Hat OpenShift  
 a| 
 * Red Hat OpenShift on AWS Hosted Control Planes 4.15.16

--- a/downstream/modules/topologies/ref-rpm-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-a.adoc
@@ -33,7 +33,7 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
 | Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z)
+| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -40,7 +40,7 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
 | Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z)
+| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}


### PR DESCRIPTION
Add IBM Power to the Tested system configurations for each topology in Tested deployment models

Update product docs to include IBM P arch test support for all current topologies

https://issues.redhat.com/browse/AAP-37187