### PR TITLE
[Backport] Added notice that OAuth and LDAP data migration is not supported in the platform ui (#2730)

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-applications.adoc
+++ b/downstream/assemblies/platform/assembly-controller-applications.adoc
@@ -5,6 +5,11 @@
 Create and configure token-based authentication for external applications such as ServiceNow and Jenkins.
 With token-based authentication, external applications can easily integrate with {PlatformNameShort}.
 
+[IMPORTANT]
+====
+{ControllerNameStart} OAuth applications on the platform UI are not supported for 2.4 to 2.5 migration. See link:https://access.redhat.com/solutions/7091987[this Knowledgebase article] for more information. 
+====
+
 With OAuth 2 you can use tokens to share data with an application without disclosing login information. 
 You can configure these tokens as read-only.
 

--- a/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
@@ -15,6 +15,11 @@ When LDAP is configured, an account is created for any user who logs in with an 
 
 Users created through an LDAP login should not change their username, first name, last name, or set a local password for themselves. Any changes made to this information is overwritten the next time the user logs in to the platform. 
 
+[IMPORTANT]
+====
+Migration of LDAP authentication settings are not supported for 2.4 to 2.5 in the platform UI. If you are upgrading from {PlatformNameShort} 2.4 to 2.5, be sure to save your authentication provider data before upgrading. 
+====
+
 .Procedure
 
 . From the navigation panel, select {MenuAMAuthentication}.


### PR DESCRIPTION
This PR backports the changes from #2370 to the 2.5 branch. 