### PR TITLE
Update eda config procedures in Containerized installation

### DIFF
--- a/downstream/modules/platform/con-hs-eda-controller.adoc
+++ b/downstream/modules/platform/con-hs-eda-controller.adoc
@@ -27,15 +27,15 @@ endif::aap-install[]
 
 // This content is used in Containerized installation
 ifdef::container-install[]
-The following example shows how you can set up an inventory file for horizontal scaling of {EDAcontroller} on {RHEL} VMs using the host group name `[automationeda]` and the node type variable `eda_node_type`:
+The following example shows how you can set up an inventory file for horizontal scaling of {EDAcontroller} on {RHEL} VMs using the host group name `[automationeda]` and the node type variable `eda_type`:
 
 -----
 [automationeda]
 
 3.88.116.111
-routable_hostname=automationeda-api.example.com eda_node_type=api
+routable_hostname=automationeda-api.example.com eda_type=api
 
 # worker node
-3.88.116.112 routable_hostname=automationeda-api.example.com eda_node_type=worker
+3.88.116.112 routable_hostname=automationeda-api.example.com eda_type=worker
 -----
 endif::container-install[]

--- a/downstream/modules/platform/proc-add-eda-safe-plugin-var.adoc
+++ b/downstream/modules/platform/proc-add-eda-safe-plugin-var.adoc
@@ -3,13 +3,15 @@
 
 = Adding a safe plugin variable to {EDAcontroller}
 
-When using redhat.insights_eda or similar plugins to run rulebook activations in {EDAcontroller}, you must add a safe plugin variable to a directory in {PlatformNameShort}. This ensures connection between {EDAcontroller} and the source plugin, and displays port mappings correctly. 
+When using `redhat.insights_eda` or similar plugins to run rulebook activations in {EDAcontroller}, you must add a safe plugin variable to a directory in {PlatformNameShort}. This ensures connection between {EDAcontroller} and the source plugin, and displays port mappings correctly. 
 
+// Procedure for RPM installer
+ifdef::aap-install[]
 .Procedure
 
 . Create a directory for the safe plugin variable: `mkdir -p ./group_vars/automationedacontroller`
 . Create a file within that directory for your new setting (for example, `touch ./group_vars/automationedacontroller/custom.yml`)
-. Add the variable `automationedacontroller_additional_settings` to extend the default `settings.yaml` template for {EDAcontroller} and add the *SAFE_PLUGINS* field with a list of plugins to enable. For example: 
+. Add the variable `automationedacontroller_additional_settings` to extend the default `settings.yaml` template for {EDAcontroller} and add the `SAFE_PLUGINS` field with a list of plugins to enable. For example: 
 +
 ----
 automationedacontroller_additional_settings:
@@ -20,6 +22,25 @@ automationedacontroller_additional_settings:
 +
 [NOTE]
 ====
-You can also extend the `automationedacontroller_additional_settings` variable beyond SAFE_PLUGINS in the Django configuration file, /etc/ansible-automation-platform/eda/settings.yaml 
+You can also extend the `automationedacontroller_additional_settings` variable beyond `SAFE_PLUGINS` in the Django configuration file `/etc/ansible-automation-platform/eda/settings.yaml`. 
 ====
+endif::aap-install[]
 
+
+// Procedure for Containerized installer
+ifdef::container-install[]
+.Procedure
+
+. Create a directory for the safe plugin variable: 
++
+----
+mkdir -p ./group_vars/automationeda
+----
++
+. Create a file within that directory for your new setting (for example, `touch ./group_vars/automationeda/custom.yml`)
+. Add the variable `eda_safe_plugins` with a list of plugins to enable. For example: 
++
+----
+eda_safe_plugins: ['ansible.eda.webhook', 'ansible.eda.alertmanager']
+----
+endif::container-install[]

--- a/downstream/modules/platform/proc-hs-eda-setup.adoc
+++ b/downstream/modules/platform/proc-hs-eda-setup.adoc
@@ -6,9 +6,11 @@
 
 To scale up (add more nodes) or scale down (remove nodes), you must update the content of the inventory to add or remove nodes and rerun the installer.
 
+
+// Procedure for RPM installer
+ifdef::aap-install[]
 .Procedure
 . Update the inventory to add two more worker nodes:
-
 +
 -----
 [automationedacontroller]
@@ -22,5 +24,28 @@ To scale up (add more nodes) or scale down (remove nodes), you must update the c
 
 3.88.116.114 routable_hostname=automationedacontroller-api.example.com eda_node_type=worker
 -----
-
++
 . Re-run the installer.
+endif::aap-install[]
+
+
+// Procedure for Containerized installer
+ifdef::container-install[]
+.Procedure
+. Update the inventory to add two more worker nodes:
++
+-----
+[automationeda]
+
+3.88.116.111 routable_hostname=automationeda-api.example.com eda_type=api
+
+3.88.116.112 routable_hostname=automationeda-api.example.com eda_type=worker
+
+# two more worker nodes
+3.88.116.113 routable_hostname=automationeda-api.example.com eda_type=worker
+
+3.88.116.114 routable_hostname=automationeda-api.example.com eda_type=worker
+-----
++
+. Re-run the installer.
+endif::container-install[]  


### PR DESCRIPTION
The following files are specific to RPM installations and needed to be updated to account for container installations also:
- proc-add-eda-safe-plugin-var.adoc
- proc-hs-eda-setup.adoc

Add conditional statements to account for both RPM and CONT based procedures.

Affects titles:
- aap-containerized-install
- aap-installation-guide

Containerized installation - Ensure inventory file code snippets contain correct samples for RPM and CONT AAP

https://issues.redhat.com/browse/AAP-36654