### PR TITLE
[Backport] AAP-38268 - corrected typo (#2752)

### DIFF
--- a/downstream/modules/platform/proc-settings-gw-security-options.adoc
+++ b/downstream/modules/platform/proc-settings-gw-security-options.adoc
@@ -19,7 +19,7 @@ Turning this off prevents all basic authentication (local users), so customers n
 +
 Turning it off with only local authentication configured also prevents all access to the UI.
 +
-*Social auth username in full email*: Enabling this setting alerts social authentication to use the full email as username instead of the full name.
+*Social auth username is full email*: Enabling this setting alerts social authentication to use the full email as username instead of the full name.
 +
 *Gateway token name*: The header name to push from the proxy to the backend service. 
 +


### PR DESCRIPTION
This PR backports the changes from #2752 to the 2.5 branch. 