### PR TITLE
[Backport] AAP-28561 - Corrected superuser mapping content (#2759)

### DIFF
--- a/downstream/modules/platform/proc-gw-role-mapping.adoc
+++ b/downstream/modules/platform/proc-gw-role-mapping.adoc
@@ -12,7 +12,7 @@ Role mapping can be specified separately for each account authentication.
 
 .Procedure
 
-. After configuring the authentication details for your authentication type, select *Team* from the *Add authentication mapping* list. 
+. After configuring the authentication details for your authentication type, select *Role* from the *Add authentication mapping* list. 
 . Enter a unique rule *Name* to identify the rule.
 . Select a *Trigger* from the list. See xref:gw-authenticator-map-triggers[Authenticator map triggers] for more information about map triggers.
 . Select *Revoke* to remove the role for the user when none of the trigger conditions are matched. 

--- a/downstream/modules/platform/proc-gw-superuser-mapping.adoc
+++ b/downstream/modules/platform/proc-gw-superuser-mapping.adoc
@@ -4,7 +4,7 @@
 
 = Superuser mapping
 
-Role mapping is the mapping of a user either to a global role, such as Platform Auditor, or team or organization role.
+Superuser mapping is the mapping of a user to the superuser role, such as System Administrator.
 
 When a Team and/or Organization is specified together with the appropriate Role, the behavior is identical with Organization mapping or Team mapping. 
 
@@ -12,7 +12,7 @@ Role mapping can be specified separately for each account authentication.
 
 .Procedure
 
-. After configuring the authentication details for your authentication type, select *Team* from the *Add authentication mapping* list. 
+. After configuring the authentication details for your authentication type, select *Superuser* from the *Add authentication mapping* list. 
 . Enter a unique rule *Name* to identify the rule.
 . Select a *Trigger* from the list. See xref:gw-authenticator-map-triggers[Authenticator map triggers] for more information about map triggers.
 . Select *Revoke* to remove the superuser role from the user when none of the trigger conditions are matched. 


### PR DESCRIPTION
This PR backports the changes from #2759 to the 2.5 branch.