### PR TITLE
2.5 Update redis colocation info for Containerized enterprise topology (#…

### DIFF
--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -38,8 +38,7 @@ Use the example inventory file to perform an online installation for the contain
 include::snippets/inventory-cont-b-env-a.adoc[]
 
 .Redis configuration for an enterprise topology
-* Redis can be colocated with any other node in a clustered installation.
-
+include::snippets/redis-colocation-containerized.adoc[]
 * By default the `redis_mode` is set to `cluster`.
 ** `redis_mode=cluster`
 

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -61,11 +61,13 @@ Default = `ansible-automation-platform-25`
 | |`registry_ns_rhel` |RHEL registry namespace.
 
 Default = `rhel8`
-| `redis_mode` | | Redis can be colocated with {Gateway}, {HubName}, and {EDAcontroller} nodes. 
+| `redis_mode` | `redis_mode` | The Redis mode to use for your {PlatformNameShort} installation.
 
-Possible values are: `standalone` and `cluster`
+Possible values are: `standalone` and `cluster`.
 
-Default = cluster
+For more information about Redis, see link:{URLPlanningGuide}/ha-redis_planning[Caching and queueing system] in _{TitlePlanningGuide}_.
+
+Default = `cluster`
 | `registry_password` |`registry_password` | This variable is only required if a non-bundle installer is used.
 
 Password credential for access to `registry_url`.

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -27,7 +27,7 @@ Each VM has been tested with the following component requirements: 16 GB RAM, 4 
 
 [NOTE]
 ====
-6 VMs are required for a Redis high availability (HA) compatible deployment. Redis can be colocated on each {PlatformNameShort} component VM except for {ControllerName}, execution nodes, or the PostgreSQL database.
+include::snippets/redis-colocation-containerized.adoc[]
 ====
 
 == Tested system configurations

--- a/downstream/snippets/redis-colocation-containerized.adoc
+++ b/downstream/snippets/redis-colocation-containerized.adoc
@@ -1,0 +1,2 @@
+//This snippet details the colocation configuration for a containerized install of AAP - note that it can be colocated with controller.
+* 6 VMs are required for a Redis high availability (HA) compatible deployment. When installing {PlatformNameShort} with the containerized installer, Redis can be colocated on any {PlatformNameShort} component VMs of your choice except for execution nodes or the PostgreSQL database. They might also be assigned VMs specifically for Redis use.


### PR DESCRIPTION
…2764)

Update the Redis colocation note for the containerized enterprise topology. Redis can be colocated on controller but not on execution nodes or the PostgreSQL database. This is specific to the containerized install.

Clearly spell out colocation capabilities of Redis, RPM and Containerized

https://issues.redhat.com/browse/AAP-36021