### PR TITLE
AAP-30609 updated script for installing with internet access

### DIFF
--- a/downstream/modules/platform/proc-installing-with-internet.adoc
+++ b/downstream/modules/platform/proc-installing-with-internet.adoc
@@ -12,7 +12,7 @@ Choose the {PlatformName} installer if your {RHEL} environment is connected to t
 
 . Navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page.
 . Click btn:[Download Now] for the *Ansible Automation Platform <latest-version> Setup*.
-. Extract the files:
+. Use `scp -i private_key.pem aap-bundled-installer.tar.gz user@server_ip:` or curl command to extract the files:
 +
 -----
 $ tar xvzf ansible-automation-platform-setup-<latest-version>.tar.gz

--- a/downstream/modules/platform/proc-installing-with-internet.adoc
+++ b/downstream/modules/platform/proc-installing-with-internet.adoc
@@ -12,11 +12,25 @@ Choose the {PlatformName} installer if your {RHEL} environment is connected to t
 
 . Navigate to the link:{PlatformDownloadUrl}[{PlatformName} download] page.
 . Click btn:[Download Now] for the *Ansible Automation Platform <latest-version> Setup*.
-. Use `scp -i private_key.pem aap-bundled-installer.tar.gz user@server_ip:` or curl command to extract the files:
-+
+. Transfer the file to the target server using `scp` or `curl`:
+.. Using `scp`: 
+... Run the following command, replacing `private_key.pem`, `user`, and `server_ip` with your appropriate values:
 -----
-$ tar xvzf ansible-automation-platform-setup-<latest-version>.tar.gz
+$ scp -i private_key.pem aap-bundled-installer.tar.gz user@server_ip: 
 -----
+.. Using `curl`: 
+... If the setup file URL is available, you can download it directly to the target server using `curl`. Replace `<download_url>` with the file URL:
+-----
+$ curl -0 <download_url>
+-----
+
+[NOTE]
+====
+If the file needs to be extracted after downloading, run the following command:
+-----
+$ tar xvzf aap-bundled-installer.tar.gz
+-----
+====
 
 .RPM install
 


### PR DESCRIPTION
[AAP-30609](https://issues.redhat.com/browse/AAP-30609)

Clarified commands for [installing with internet access](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/planning_your_installation/index#proc-installing-with-internet_planning). See [google doc](https://docs.google.com/document/d/1eYyOfZnNT30ZyZWpb8Di29wZ_Nf1xSqGkxGpXKptLk4/edit?tab=t.0#heading=h.v9wks5gmaxlp) for SME guidance.

Files modified:
- proc-installing-with-internet.adoc