### PR TITLE
[Backport] AAP-36580 added a note that explicitly states 6 VMs are required (#2781)

### DIFF
--- a/downstream/modules/platform/con-gw-clustered-redis.adoc
+++ b/downstream/modules/platform/con-gw-clustered-redis.adoc
@@ -4,7 +4,12 @@
 
 = Clustered Redis
 
-With clustered Redis, data is automatically partitioned over multiple nodes to provide performance stability and nodes are assigned as replicas to provide reliability. Clustered Redis shared between the platform gateway and {EDAName} is provided by default when installing {PlatformNameShort} in containerized and operator-based deployments.
+With clustered Redis, data is automatically partitioned over multiple nodes to provide performance stability and nodes are assigned as replicas to provide reliability. Clustered Redis, shared between the platform gateway and {EDAName}, is provided by default when installing {PlatformNameShort} in containerized and operator-based deployments.
+
+[NOTE]
+====
+6 VMs are required for a Redis high availability (HA) compatible deployment. Redis can be colocated on each {PlatformNameShort} component VM except for {ControllerName}, execution nodes, or the PostgreSQL database. See link:{LinkTopologies} for the opinionated deployment options available. 
+====
 
 A cluster contains three primary nodes and each primary node contains a replica node.
 


### PR DESCRIPTION
This PR backports the changes from #2781 to the 2.5 branch. 