### PR TITLE
AAP-38563: Corrected the broken AAP guide URLs

### DIFF
--- a/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
+++ b/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
@@ -24,7 +24,7 @@ Your system must meet the following minimum system requirements to install and r
 |40 GB
 |===
 
-To see the rest of the {PlatformName} system requirements, see the topic link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_planning_guide/index#red_hat_ansible_automation_platform_system_requirements[System requirements] in the _{PlatformName} Planning Guide_.
+To see the rest of the {PlatformName} system requirements, see the topic link:{URLPlanningGuide}/platform-system-requirements[System requirements] section of _{TitlePlanningGuide}_.
 
 [NOTE]
 ====

--- a/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
+++ b/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
@@ -24,7 +24,7 @@ Your system must meet the following minimum system requirements to install and r
 |40 GB
 |===
 
-To see the rest of the {PlatformName} system requirements, see the topic link:{URLPlanningGuide}/platform-system-requirements[System requirements] section of _{TitlePlanningGuide}_.
+To see the rest of the {PlatformName} system requirements, see the link:{URLPlanningGuide}/platform-system-requirements[System requirements] section of _{TitlePlanningGuide}_.
 
 [NOTE]
 ====

--- a/lightspeed/modules/proc_monitor-onpremise-deployment.adoc
+++ b/lightspeed/modules/proc_monitor-onpremise-deployment.adoc
@@ -9,7 +9,7 @@ After the {LightspeedShortName} on-premise deployment is successful, use the fol
 .Procedure
 
 . Create a *system auditor* user:
-.. Create a user with a *system auditor* role in the the {PlatformName}. For the procedure, see the see the link:{URLGettingStarted}/assembly-gs-platform-admin#proc-gs-platform-admin-create-user[Creating a user] section of _{TitleGettingStarted}_.
+.. Create a user with a *system auditor* role in the the {PlatformName}. For the procedure, see the link:{URLGettingStarted}/assembly-gs-platform-admin#proc-gs-platform-admin-create-user[Creating a user] section of _{TitleGettingStarted}_.
 
 .. Verify that you can log in to the Ansible Lightspeed portal for on-premise deployment (`\https://<lightspeed_route>/`) as the newly-created system auditor user, and then log out.
 

--- a/lightspeed/modules/proc_monitor-onpremise-deployment.adoc
+++ b/lightspeed/modules/proc_monitor-onpremise-deployment.adoc
@@ -9,7 +9,7 @@ After the {LightspeedShortName} on-premise deployment is successful, use the fol
 .Procedure
 
 . Create a *system auditor* user:
-.. Create a user with a *system auditor* role in the the {PlatformName}. Refer to the procedure in the topic link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_user_guide/index#proc-controller-creating-a-user[Creating a user] in the _Automation Controller User Guide_.
+.. Create a user with a *system auditor* role in the the {PlatformName}. For the procedure, see the see the link:{URLGettingStarted}/assembly-gs-platform-admin#proc-gs-platform-admin-create-user[Creating a user] section of _{TitleGettingStarted}_.
 
 .. Verify that you can log in to the Ansible Lightspeed portal for on-premise deployment (`\https://<lightspeed_route>/`) as the newly-created system auditor user, and then log out.
 

--- a/lightspeed/modules/proc_multi-task-recs.adoc
+++ b/lightspeed/modules/proc_multi-task-recs.adoc
@@ -61,7 +61,7 @@ image::lightspeed-multitask-vs-code.png[Settings show Lightspeed as selected lan
 
 . Create a playbook or use an existing playbook. 
 +
-For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_creator_guide/index#creating-playbooks[Creating playbooks] in the {PlatformNameShort} Creator Guide.
+For more information, see the link:{URLPlaybooksGettingStarted}[{TitlePlaybooksGettingStarted}] guide.
 
 . In the playbook, provide the following information to request multitask code recommendations:
 ... Start a new YAML file comment by entering a pound symbol (#) at the correct indentation.

--- a/lightspeed/modules/proc_single-task-recs.adoc
+++ b/lightspeed/modules/proc_single-task-recs.adoc
@@ -46,7 +46,8 @@ image::lightspeed-vs-code.png[Settings show Ansible and Lightspeed as selected l
 
 . Create a playbook or use an existing playbook. 
 +
-For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/red_hat_ansible_automation_platform_creator_guide/index#creating-playbooks[Creating playbooks] in the {PlatformNameShort} Creator Guide.
+For more information, see the link:{URLPlaybooksGettingStarted}[{TitlePlaybooksGettingStarted}] guide.
+
 +
 . In the playbook, provide the following information to request code recommendations for a single task:
 ... Add a new Ansible task by starting a new line with `- name:` at the correct indentation.


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-38563. 

Changes made:

- Corrected the broken links that pointed to AAP docs. 