### PR TITLE
AAP-38369: Updated a crossreference to point to downstream docs (#2793)

### DIFF
--- a/downstream/modules/platform/ref-postgresql-requirements.adoc
+++ b/downstream/modules/platform/ref-postgresql-requirements.adoc
@@ -23,14 +23,14 @@ To determine if your {ControllerName} instance has access to the database, you c
 Database storage increases with the number of hosts managed, number of jobs run, number of facts stored in the fact cache, and number of tasks in any individual job. 
 For example, a playbook runs every hour (24 times a day) across 250 hosts, with 20 tasks, stores over 800000 events in the database every week.
 
-* If not enough space is reserved in the database, the old job runs and facts must be cleaned on a regular basis. For more information, see link:{URLControllerAdminGuide}/assembly-controller-management-jobs[Management Jobs] in the _{TitleControllerAdminGuide}_.
+* If not enough space is reserved in the database, the old job runs and facts must be cleaned on a regular basis. For more information, see link:{URLControllerAdminGuide}/assembly-controller-management-jobs[Management Jobs] in the _{TitleControllerAdminGuide}_ guide.
 ====
 
 .PostgreSQL Configurations
 
 Optionally, you can configure the PostgreSQL database as separate nodes that are not managed by the {PlatformName} installer.
 When the {PlatformNameShort} installer manages the database server, it configures the server with defaults that are generally recommended for most workloads.
-For more information about the settings you can use to improve database performance, see link:https://docs.ansible.com/automation-controller/latest/html/administration/performance.html#database-settings[Database Settings].
+For more information about the settings you can use to improve database performance, see link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref-controller-database-settings[PostgreSQL database configuration and maintenance for automation controller ] in the _{TitleControllerAdminGuide}_ guide.
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
This PR backports PR https://github.com/ansible/aap-docs/pull/2793 from main to AAP 2.5 repo. 