### PR TITLE
2.5 Add registry_username and registry_password proc to Containerized ins…

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -64,6 +64,7 @@ include::platform/proc-installing-containerized-aap.adoc[leveloffset=+1]
 include::platform/ref-accessing-control-auto-hub-eda-control.adoc[leveloffset=+1]
 // Commenting this out until the feature has been released
 // include::platform/proc-setup-postgresql-ext-database.adoc[leveloffset=+1]
+include::platform/proc-set-registry-username-password.adoc[leveloffset=+1]
 include::platform/ref-using-custom-tls-certificates.adoc[leveloffset=+1]
 include::platform/ref-using-custom-receptor-signing-keys.adoc[leveloffset=+1]
 include::platform/ref-enabling-automation-hub-collection-and-container-signing.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-set-registry-username-password.adoc
+++ b/downstream/modules/platform/proc-set-registry-username-password.adoc
@@ -2,23 +2,26 @@
 
 = Setting registry_username and registry_password
 
-If you intend to use the `registry_username` and `registry_password` variables in an inventory file you are recommended to use the following method to create a Registry Service Account to set a token with an expiration in the plaintext `inventory/vars.yml` file instead of using a plaintext username and password, for reasons of security.
+When using the `registry_username` and `registry_password` variables for an online non-bundled installation, you need to create a new registry service account.
 
-Registry service accounts provide named tokens that can be used in environments where credentials are shared, such as deployment systems.
+Registry service accounts are named tokens that can be used in environments where credentials will be shared, such as deployment systems.
 
 .Procedure
-. Navigate to https://access.redhat.com/terms-based-registry/accounts
+. Go to https://access.redhat.com/terms-based-registry/accounts.
 . On the *Registry Service Accounts* page click btn:[New Service Account].
-. Enter a name for the account using only the accepted characters.
+. Enter a name for the account using only the allowed characters.
 . Optionally enter a description for the account.
-. Click btn:[Create account].
-. Find the created account in the list. 
-The list of accounts is long so you might have to click btn:[Next] multiple times before finding the account you created. 
-Alternatively, if you know the name of your token, you can go directly to the page by entering the URL \https://access.redhat.com/terms-based-registry/token/<name-of-your-token>
+. Click btn:[Create].
+. Find the created account in the list by searching for your name in the search field.
 . Click the name of the account that you created. 
-. A *token* page opens, displaying a generated Username (different to the account name) and a token. 
+. Alternatively, if you know the name of your token, you can go directly to the page by entering the URL: 
 +
-If no Username and token are displayed, click btn:[Regenerate token]. You can also click this to generate a new Username and token.
-. Copy the service account name and use it to set `registry_username`.
-. Copy the token and use it to set `registry_password`.
-
+----
+https://access.redhat.com/terms-based-registry/token/<name-of-your-token>
+----
++
+. A *token* page opens, displaying a generated username (different from the account name) and a token. 
++
+If no token is displayed, click btn:[Regenerate Token]. You can also click this to generate a new username and token.
+. Copy the username (for example "1234567|testuser") and use it to set the variable `registry_username`.
+. Copy the token and use it to set the variable `registry_password`.

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -75,29 +75,40 @@ Default = `ansible-automation-platform-25`
 
 Default = `rhel8`
 
-| `registry_password` |`registry_password` | This variable is only required if a non-bundle installer is used.
+| `registry_password` |`registry_password` | Required if performing an online non-bundled installation.
 
-Password credential for access to `registry_url`.
+The password credential for access to the registry source defined in `registry_url`.
 
-Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
-
-When `registry_url` is `registry.redhat.io`, username and password are required if not using a bundle installer.
-
+// This content is used in RPM installation
+ifdef::aap-install[]
 For more information, see link:{URLInstallationGuide}/assembly-platform-install-scenario#proc-set-registry-username-password[Setting registry_username and registry_password].
-| |`registry_tls_verify` |Verify registry TLS.
+endif::aap-install[] 
+// This content is used in Containerized installation
+ifdef::container-install[]
+For more information, see link:{URLContainerizedInstall}/assembly-aap-containerized-installation#proc-set-registry-username-password[Setting registry_username and registry_password].
+endif::container-install[]
+
+| `registry_verify_ssl` |`registry_tls_verify` |Verify registry TLS.
 
 Default = `true`
 
-| `registry_url` |`registry_url` | URL for the registry source. 
+| `registry_url` | `registry_url` | URL for the registry source. 
 
 Default = `registry.redhat.io`
-| `registry_username` |`registry_username` | This variable is only required if a non-bundle installer is used.
 
-User credential for access to `registry_url`.
+| `registry_username` |`registry_username` | Required if performing an online non-bundled installation.
 
-Enter your Red Hat Registry Service Account credentials in `registry_username` and `registry_password` to link to the Red Hat container registry.
+The username credential for access to the registry source defined in `registry_url`.
 
+// This content is used in RPM installation
+ifdef::aap-install[]
 For more information, see link:{URLInstallationGuide}/assembly-platform-install-scenario#proc-set-registry-username-password[Setting registry_username and registry_password].
+endif::aap-install[] 
+// This content is used in Containerized installation
+ifdef::container-install[]
+For more information, see link:{URLContainerizedInstall}/assembly-aap-containerized-installation#proc-set-registry-username-password[Setting registry_username and registry_password].
+endif::container-install[]
+
 | `routable_hostname` |`routable_hostname` | This variable is used if the machine running the installer can only route to the target host through a specific URL. For example, if you use short names in your inventory, but the node running the installer can only resolve that host by using a FQDN.
 
 If `routable_hostname` is not set, it should default to `ansible_host`. If you do not set `ansible_host`, `inventory_hostname` is used as a last resort.


### PR DESCRIPTION
…tallation (#2796)

- Add proc-set-registry-username-password.adoc to Containerized installation
- Update the content to ensure it's accurate
- Update the associated vars in the appendix

Add Setting registry_username and registry_password content to Containerized installation

https://issues.redhat.com/browse/AAP-37656