### PR TITLE
Backport-2.5-2785 (AAP-35762) Added newly supported file and env injectors (#2785)

### DIFF
--- a/downstream/modules/eda/con-custom-credential-types.adoc
+++ b/downstream/modules/eda/con-custom-credential-types.adoc
@@ -52,6 +52,20 @@ h| help_text | The help text associated with this field | No
 [discrete]
 == Injector Configuration
 
-You can use the Injector configuration field to take the fields from input configuration field and map them into `extra_vars` that can be sent to ansible-rulebook when running the activation. The Injector currently only supports `extra_vars`. 
+You can use Injector configuration to extract information from Input configuration fields and map them into injector types that can be sent to ansible-rulebook when running a rulebook activation. {EDAName} supports the following types of injectors: 
 
-Injectors enable you to tailor the fields so that they can be injected into a rulebook as `extra_vars`, which cannot have duplicate keys at the top level. If you have two sources in a rulebook that both require a parameter called username and password, the injectors, along with the rulebook, help you tailor the arguments for each source.
+* Environment variables (`env`) - Used in source plugins for the underlying package or shared library.
+* Ansible extra variables (`extra_vars`) - Used for substitution in the rulebook conditions, actions or source plugin parameters.
+* File-based templating (`file`) - Used to create file contents from the credential inputs such as certificates and keys, which might be required by source plugins. File injectors provide a way to deliver these certificates and keys to ansible-rulebook at runtime without having to store them in decision environments. As a result, ansible-rulebook creates temporary files and the file names can be accessed using `eda.filename` variables, which are automatically created for you after the files have been created (for instance,  "{{eda.filename.my_cert}}”).
+
+[IMPORTANT]
+====
+When creating `extra_vars` in rulebook activations and credential type injectors, avoid using `eda` or `ansible` as key names since that conflicts with internal usage and might cause failure in both rulebook activations and credential type creation.
+====
+
+Injectors enable you to adjust the fields so that they can be injected into a rulebook as one of the above-mentioned injector types, which cannot have duplicate keys at the top level. If you have two sources in a rulebook that both require parameters such as username and password, the injectors, along with the rulebook, help you adapt the arguments for each source.
+
+To view a sample injector and input, see the following GitHub gists, respectively:
+
+* link:https://gist.github.com/mkanoor/f080648917377da870bb002d4563294d[credential injectors]
+* link:https://gist.github.com/mkanoor/04c32b20addb7898af299a9254a46e61#file-gssapi-input-credential-type[gssapi input credential type]


### PR DESCRIPTION
Per request in [AAP-35762](https://issues.redhat.com/browse/AAP-35762), added newly supported injectors file and env along with descriptions to the Injector configuration section of the Custom credential types sub-chapter in the Using automation decisions guide. Updates to downstream/modules/eda/con-custom-credential-types.adoc.