### PR TITLE
AAP-38856 updated note to specify that colocation limitation is specific to RPM (#2807)

### DIFF
--- a/downstream/modules/platform/con-gw-clustered-redis.adoc
+++ b/downstream/modules/platform/con-gw-clustered-redis.adoc
@@ -8,7 +8,7 @@ With clustered Redis, data is automatically partitioned over multiple nodes to p
 
 [NOTE]
 ====
-6 VMs are required for a Redis high availability (HA) compatible deployment. Redis can be colocated on each {PlatformNameShort} component VM except for {ControllerName}, execution nodes, or the PostgreSQL database. See link:{LinkTopologies} for the opinionated deployment options available. 
+6 VMs are required for a Redis high availability (HA) compatible deployment. In RPM deployments, Redis can be colocated on each {PlatformNameShort} component VM except for {ControllerName}, execution nodes, or the PostgreSQL database. In containerized deployments, Redis can be colocated on any {PlatformNameShort} component VMs of your choice except for execution nodes or the PostgreSQL database. See link:{LinkTopologies} for the opinionated deployment options available. 
 ====
 
 A cluster contains three primary nodes and each primary node contains a replica node.


### PR DESCRIPTION
This PR backports the changes from #2807 to the 2.5 branch and includes the following:

* AAP-38856 updated note to specify that colocation limitation is specific to RPM

* Added contianerized colocation details