### PR TITLE
AAP-36381 - add required statement to User Permanent ID field

### DIFF
--- a/downstream/modules/platform/proc-controller-set-up-SAML.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-SAML.adoc
@@ -42,7 +42,7 @@ The IdP in the IdP Public Cert field should contain the entire certificate, incl
 +
 . Enter the entity ID returned in the assertion in the *Entity ID*. This is the identifier from your IdP SAML application. You can find this value in the SAML metadata provided by your IdP.
 . Enter user details in the *Groups*, *User Email*, *Username*, *User Last Name* and *User First Name*.
-. Enter a permanent id for the user in the *User Permanent ID* field. This field is required.
+. Enter a permanent ID for the user in the *User Permanent ID* field. This field is required.
 +
 [NOTE]
 ====

--- a/downstream/modules/platform/proc-controller-set-up-SAML.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-SAML.adoc
@@ -41,7 +41,8 @@ The IdP in the IdP Public Cert field should contain the entire certificate, incl
 ====
 +
 . Enter the entity ID returned in the assertion in the *Entity ID*. This is the identifier from your IdP SAML application. You can find this value in the SAML metadata provided by your IdP.
-. Enter user details in the *Groups*, *User Email*, *Username*, *User Last Name*, *User First Name* and *User Permanent ID* fields.
+. Enter user details in the *Groups*, *User Email*, *Username*, *User Last Name* and *User First Name*.
+. Enter a permanent id for the user in the *User Permanent ID* field. This field is required.
 +
 [NOTE]
 ====


### PR DESCRIPTION
The User Permanent ID is a required field in the SAML configuration process. The UI currently does not label the field as required, so I've added that information to the step in the procedure to eliminate confusion. 