### PR TITLE
AAP-38758 Removed the unsupported Mutual TLS entry

### DIFF
--- a/downstream/modules/eda/con-event-streams.adoc
+++ b/downstream/modules/eda/con-event-streams.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 Event streams can send events from remote systems to {EDAcontroller}. In a typical set-up, a server sends data to an event stream over the internet to an {EDAName} event stream receiver. When the data comes over the internet, the request must be authenticated. Depending on the webhook vendor or remote system, the authentication method could differ.
 
-{EDAcontroller} supports 7 different event stream types.
+{EDAcontroller} supports six different event stream types.
  
 .Event Stream Types
 [cols="a,a,a"]

--- a/downstream/modules/eda/con-event-streams.adoc
+++ b/downstream/modules/eda/con-event-streams.adoc
@@ -25,11 +25,11 @@ h| OAuth2 with JWT | Uses M2M mode with a grant type called *client credentials*
 
 h| ECDSA | Elliptic Curve Digital Signature Algorithm | SendGrid, Twilio
 
-h| Mutual TLS | Needs the vendor's CA certificate to be present in our servers at startup. This supports non-repudiation. 
-| PagerDuty
+//[Jameria] Not currently supported; will leave commented out for now in the event that it is supported in the near future.  h| Mutual TLS | Needs the vendor's CA certificate to be present in our servers at startup. This supports non-repudiation. 
+// | PagerDuty
 |===
 
-{EDAcontroller} also supports 4 other specialized event streams that are based on the 7 basic event stream types: 
+{EDAcontroller} also supports four other specialized event streams that are based on the seven basic event stream types: 
 
 * GitLab Event Stream
 * GitHub Event Stream

--- a/downstream/modules/eda/con-event-streams.adoc
+++ b/downstream/modules/eda/con-event-streams.adoc
@@ -29,7 +29,7 @@ h| ECDSA | Elliptic Curve Digital Signature Algorithm | SendGrid, Twilio
 // | PagerDuty
 |===
 
-{EDAcontroller} also supports four other specialized event streams that are based on the seven basic event stream types: 
+{EDAcontroller} also supports four other specialized event streams that are based on the six basic event stream types: 
 
 * GitLab Event Stream
 * GitHub Event Stream


### PR DESCRIPTION
Per AAP-38758, removed Mutual TLS from the event stream type table in [6.1 Event streams](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/simplified-event-routing#event-streams) in the [Using automation decisions guide](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/index).