### PR TITLE
AAP-31257: corrects typos and attributes in the managing automation content guide

### DIFF
--- a/downstream/modules/hub/proc-adding-containers-remotely-to-the-automation-hub.adoc
+++ b/downstream/modules/hub/proc-adding-containers-remotely-to-the-automation-hub.adoc
@@ -6,8 +6,8 @@
 
 You can add containers remotely to {HubName} in one of the following two ways:
 
-* Create Remotes
-* Execution Environment
+* By creating remotes
+* By using an {ExecEnvNameSing}
 
 .Procedure
 

--- a/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
+++ b/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
@@ -38,7 +38,7 @@ If the {ExecEnvShort} is not signed, it can only be pushed with any current sign
 
 .Troubleshooting
 
-The details page for each {ExecEnvName} indicates whether it has been signed. If the details page indicates that an image is *Unsigned*, you can sign the {ExecEnvName} from {HubName} using the following steps:
+The details page for each {ExecEnvShort} indicates whether it has been signed. If the details page indicates that an image is *Unsigned*, you can sign the {ExecEnvShort} from {HubName} using the following steps:
 
 . Click the {ExecEnvShort} name to navigate to the details page.
 

--- a/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
+++ b/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
@@ -3,7 +3,7 @@
 
 = Pushing container images from your local environment
 
-Use the following procedure to sign {ExecEnvName} on a local system and push those signed {ExecEnvName} to the {HubName} registry.
+Use the following procedure to sign an {ExecEnvNameSing} on a local system and push the signed {ExecEnvShort} to the {HubName} registry.
 
 .Procedure
 . From a terminal, log in to Podman, or any container client currently in use:
@@ -12,25 +12,25 @@ Use the following procedure to sign {ExecEnvName} on a local system and push tho
 > podman pull <container-name>
 ----
 +
-. After the {ExecEnvName} is pulled, add tags (for example: latest, rc, beta, or version numbers, such as 1.0; 2.3, and so on):
+. After the {ExecEnvShort} is pulled, add tags (for example: latest, rc, beta, or version numbers, such as 1.0; 2.3, and so on):
 +
 ----
 > podman tag <container-name> <server-address>/<container-name>:<tag name>
 ----
 +
-. Sign the {ExecEnvName} after changes have been made, and push it back up to the {HubName} registry:
+. Sign the {ExecEnvShort} after changes have been made, and push it back up to the {HubName} registry:
 +
 ----
 > podman push <server-address>/<container-name>:<tag name> --tls-verify=false --sign-by <reference to the gpg key on your local>
 ----
 +
-If the {ExecEnvName} is not signed, it can only be pushed with any current signature embedded. Alternatively, you can use the following script to push the {ExecEnvName} without signing it:
+If the {ExecEnvShort} is not signed, it can only be pushed with any current signature embedded. Alternatively, you can use the following script to push the {ExecEnvShort} without signing it:
 +
 ----
 > podman push <server-address>/<container-name>:<tag name> --tls-verify=false
 ----
 +
-. Once the {ExecEnvName} has been pushed, navigate to {MenuACExecEnvironments}.
+. Once the {ExecEnvShort} has been pushed, navigate to {MenuACExecEnvironments}.
 
 . To display the new {ExecEnvShort}, click the *Refresh* icon.
 
@@ -40,7 +40,7 @@ If the {ExecEnvName} is not signed, it can only be pushed with any current signa
 
 The details page for each {ExecEnvName} indicates whether it has been signed. If the details page indicates that an image is *Unsigned*, you can sign the {ExecEnvName} from {HubName} using the following steps:
 
-. Click the {ExecEnvName} name to navigate to the details page.
+. Click the {ExecEnvShort} name to navigate to the details page.
 
 . Click the btn:[More Actions] icon *{MoreActionsIcon}*.
 Three options are available:
@@ -51,5 +51,5 @@ Three options are available:
 
 . Click *Sign {ExecEnvShort}* from the drop-down menu.
 
-The signing service signs the {ExecEnvName}.
-After the {ExecEnvName} is signed, the status changes to "signed".
+The signing service signs the {ExecEnvShort}.
+After the {ExecEnvShort} is signed, the status changes to "signed".


### PR DESCRIPTION
See [AAP-31257](https://issues.redhat.com/browse/AAP-31257) for more info. 