### PR TITLE
removed information regarding role mapping from superuser mapping (#2830)

### DIFF
--- a/downstream/modules/platform/proc-gw-superuser-mapping.adoc
+++ b/downstream/modules/platform/proc-gw-superuser-mapping.adoc
@@ -6,10 +6,6 @@
 
 Superuser mapping is the mapping of a user to the superuser role, such as System Administrator.
 
-When a Team and/or Organization is specified together with the appropriate Role, the behavior is identical with Organization mapping or Team mapping. 
-
-Role mapping can be specified separately for each account authentication.
-
 .Procedure
 
 . After configuring the authentication details for your authentication type, select *Superuser* from the *Add authentication mapping* list. 


### PR DESCRIPTION
This PR backports the changes from #2830 to the 2.5 branch. 