### PR TITLE
Update receptor inventory file vars in appendix

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -62,33 +62,28 @@ Valid options are `active`, `deprovision` to remove a node from a cluster, or `i
 
 Default = `active`
 
-| `node_type` | | For `[automationcontroller]` group.
+| `node_type` | See `receptor_type` for the container equivalent variable. a| 
 
-Two valid `node_types` can be assigned for this group.
+For the `[automationcontroller]` group the two options are:
 
-A `node_type=control` means that the node only runs project and inventory updates, but not regular jobs.
+* `node_type=control` - The node only runs project and inventory updates, but not regular jobs.
 
-A `node_type=hybrid` can run everything.
+* `node_type=hybrid` - The node runs everything.
 
 Default for this group = `hybrid`.
 
-For `[execution_nodes]` group:
+For the `[execution_nodes]` group the two options are:
 
-Two valid `node_types` can be assigned for this group.
+* `node_type=hop` - The node forwards jobs to an execution node.
+* `node_type=execution` - The node can run jobs.
 
-A `node_type=hop` implies that the node forwards jobs to an execution node.
+Default for this group = `execution`
 
-A `node_type=execution` implies that the node can run jobs.
+| `peers` | See `receptor_peers` for the container equivalent variable. | 
 
-Default for this group = `execution`.
-| `peers` | | _Optional_
+Used to indicate which nodes a specific host or group connects to. Wherever this variable is defined, an outbound connection to the specific host or group is established.
 
-The `peers` variable is used to indicate which nodes a specific host or group connects to. Wherever this variable is defined, an outbound connection to the specific host or group is established.
-
-This variable is used to add `tcp-peer` entries in the `receptor.conf` file used for establishing network connections with other nodes.
-
-The peers variable can be a comma-separated list of hosts and groups from the inventory.
-This is resolved into a set of hosts that is used to construct the `receptor.conf` file.
+The `peers` variable can be a comma-separated list of hosts and groups from the inventory. This is resolved into a set of hosts that is used to construct the `receptor.conf` file.
 
 | `awx_pg_cert_auth` | `controller_pg_cert_auth` | Set this variable to `true` to enable client certificate authentication.
 

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -29,7 +29,9 @@ Used to indicate which nodes a specific host connects to. Wherever this variable
 
 The `peers` variable can be a comma-separated list of hosts only and not groups from the inventory. This is resolved into a set of hosts that is used to construct the `receptor.conf` file.
 
-Default = an empty list
+For example usage, see link:{URLContainerizedInstall}/aap-containerized-installation#adding-execution-nodes_aap-containerized-installation[Adding execution nodes].
+
+Default = []
 
 | `receptor_datadir` | | This variable configures the receptor data directory. By default, it is set to `/tmp/receptor`. To change the default location, run the installation script with `"-e receptor_datadir="` and specify the target directory that you want. 
 
@@ -63,16 +65,16 @@ Default = `false`
 
 For the `[automationcontroller]` group the two options are:
 
-* `node_type=control` - The node only runs project and inventory updates, but not regular jobs.
+* `receptor_type=control` - The node only runs project and inventory updates, but not regular jobs.
 
-* `node_type=hybrid` - The node runs everything.
+* `receptor_type=hybrid` - The node runs everything.
 
 Default for this group = `hybrid`.
 
 For the `[execution_nodes]` group the two options are:
 
-* `node_type=hop` - The node forwards jobs to an execution node.
-* `node_type=execution` - The node can run jobs.
+* `receptor_type=hop` - The node forwards jobs to an execution node.
+* `receptor_type=execution` - The node can run jobs.
 
 Default for this group = `execution`
 |====

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -23,7 +23,13 @@ Default = `info`
 
 Default = `false`
 
-| | `receptor_peers` | Receptor peers list. 
+| See `peers` for the RPM equivalent variable | `receptor_peers` | 
+
+Used to indicate which nodes a specific host connects to. Wherever this variable is defined, an outbound connection to the specific host is established.
+
+The `peers` variable can be a comma-separated list of hosts only and not groups from the inventory. This is resolved into a set of hosts that is used to construct the `receptor.conf` file.
+
+Default = an empty list
 
 | `receptor_datadir` | | This variable configures the receptor data directory. By default, it is set to `/tmp/receptor`. To change the default location, run the installation script with `"-e receptor_datadir="` and specify the target directory that you want. 
 
@@ -53,7 +59,20 @@ Default = `false`
 
 Default = `false`
 
-| | `receptor_type` | Receptor node type. 
+| See `node_type` for the RPM equivalent variable. | `receptor_type` a|
 
-Default = `execution`
+For the `[automationcontroller]` group the two options are:
+
+* `node_type=control` - The node only runs project and inventory updates, but not regular jobs.
+
+* `node_type=hybrid` - The node runs everything.
+
+Default for this group = `hybrid`.
+
+For the `[execution_nodes]` group the two options are:
+
+* `node_type=hop` - The node forwards jobs to an execution node.
+* `node_type=execution` - The node can run jobs.
+
+Default for this group = `execution`
 |====


### PR DESCRIPTION
Update the receptor-related inventory file vars to add more clarity and ensure RPM and CONT equivalents are defined.

In ref-controller-variables.adoc:
- note_type
- peers

In ref-receptor-variables.adoc:
- receptor_type
- receptor_peers

Containerized installation - improvements to receptor inventory vars in the appendix

https://issues.redhat.com/browse/AAP-39338