### PR TITLE
backport to 2.5: AAP-34599: updates procedure for signing EEs (#2821)

### DIFF
--- a/downstream/modules/hub/proc-adding-an-execution-environment.adoc
+++ b/downstream/modules/hub/proc-adding-an-execution-environment.adoc
@@ -1,26 +1,32 @@
 
 [id="adding-an-execution-environment"]
 
-= Adding an {ExecEnvShort}
+= Adding and signing an {ExecEnvShort}
 {ExecEnvNameStart} are container images that make it possible to incorporate system-level dependencies and collection-based content. Each {ExecEnvShort} allows you to have a customized image to run jobs, and each of them contain only what you need when running the job.
 
 .Procedure
 . From the navigation panel, select {MenuACExecEnvironments}.
 
-. Click btn:[Create execution environment].
+. Click btn:[Create execution environment] and enter the relevant information in the fields that appear.
 
-. Enter the name of the {ExecEnvShort}.
+.. The *Name* field displays the name of the {ExecEnvShort} on your local registry.
 
-. Enter the upstream name.
+.. The *Upstream name* field is the name of the image on the remote server.
 
-. Under *Registry*, select the name of the registry from the drop-down menu.
+.. Under *Registry*, select the name of the registry from the drop-down menu.
 
-. Enter tags in the *Add tag(s) to include* field.
+.. Optional: Enter tags in the *Add tag(s) to include* field.
 If the field is blank, all the tags are passed.
 You must specify which repository-specific tags to pass.
 
-. Optional: Enter tags to exclude in *Add tag(s) to exclude*. 
+.. Optional: Enter tags to exclude in the *Add tag(s) to exclude* field. 
 
-. Click btn:[Create {ExecEnvName}].
+. Click btn:[Create {ExecEnvShort}]. You should see your new {ExecEnvNameSing} in the list that appears.
 
-. Synchronize the image.
+. Sync and sign your new {ExecEnvNameSing}.
+
+.. Click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync execution environment*.
+
+.. Click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sign execution environment*.
+
+. Click on your new {ExecEnvNameSing}. On the Details page, find the *Signed* label to determine that your {ExecEnvNameSing} has been signed.

--- a/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
+++ b/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
@@ -3,9 +3,8 @@
 
 = Deploying your system for container signing
 
-{HubNameStart} implements image signing to offer better security for the {ExecEnvShort} container images.
 
-To deploy your system so that it is ready for container signing, create a signing script.
+To deploy your system so that it is ready for container signing, first ensure that you have link:{URLContainerizedInstall}/aap-containerized-installation#enabling-automation-hub-collection-and-container-signing_aap-containerized-installation[enabled automation content collection and container signing]. Then you can create a signing script, or xref:proc-adding-an-execution-environment.adoc[add and sign an {ExecEnvShort}] manually.
 
 [NOTE]
 ====


### PR DESCRIPTION
This PR backports the changes from [PR 2821](https://github.com/ansible/aap-docs/pull/2821) to the 2.5 branch. See [AAP-34599](https://issues.redhat.com/browse/AAP-34599) for more info. 