### PR TITLE
AAP-34599: adds additional resources block to containerized guide

### DIFF
--- a/downstream/modules/platform/ref-enabling-automation-hub-collection-and-container-signing.adoc
+++ b/downstream/modules/platform/ref-enabling-automation-hub-collection-and-container-signing.adoc
@@ -145,3 +145,8 @@ hub_container_signing_key=/home/aapuser/aap/ansible-automation-platform-containe
 # This variable is required if the key is protected by a passphrase
 hub_container_signing_pass=<password>
 ----
+
+[role="_additional-resources"]
+== Additional resources
+
+* For next steps see link:{URLHubManagingContent}/managing-containers-hub#working-with-signed-containers[Working with signed containers] in the {TitleHubManagingContent} guide.

--- a/downstream/modules/platform/ref-enabling-automation-hub-collection-and-container-signing.adoc
+++ b/downstream/modules/platform/ref-enabling-automation-hub-collection-and-container-signing.adoc
@@ -149,4 +149,4 @@ hub_container_signing_pass=<password>
 [role="_additional-resources"]
 == Additional resources
 
-* For next steps see link:{URLHubManagingContent}/managing-containers-hub#working-with-signed-containers[Working with signed containers] in the {TitleHubManagingContent} guide.
+* For more information on working with signed containers following an installation, see link:{URLHubManagingContent}/managing-containers-hub#working-with-signed-containers[Working with signed containers] in the {TitleHubManagingContent} guide.


### PR DESCRIPTION
This PR adds an additional resources block to the containerized install guide with a relevant link to the managing automation content guide. See [AAP-34599 ](https://issues.redhat.com/browse/AAP-34599)for more.