### PR TITLE
Remove snippet from known issues as it is resolved

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25-known-issues.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-known-issues.adoc
@@ -13,8 +13,6 @@ This section provides information about known issues in {PlatformNameShort} 2.5.
 
 * The unused *ANSIBLE_BASE_* settings are included as environment variables in the job execution. These variables suffixed with *SECRET* are no longer used in the {PlatformNameShort} and might be ignored until they are removed in a future patch. (AAP-32208)
 
-include::../snippets/known-issue-container-content-syncing.adoc[]
-
 == {EDAName}
 
 * mTLS event stream creation should be disallowed on all installation methods by default. It is currently disallowed on {OCPShort} installation, but not disallowed in the containerized installations or on RPM installations. (AAP-31337)


### PR DESCRIPTION
AAP-38830 resolved the known issue that necessetated the snippet in the RN. Now that it's resolved, the snippet should be removed from the release notes.

Update Docs for hub_seed_collections=true for containerized installer

https://issues.redhat.com/browse/AAP-38830