### PR TITLE
Fix xref in hub module

### DIFF
--- a/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
+++ b/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
@@ -4,7 +4,11 @@
 = Deploying your system for container signing
 
 
-To deploy your system so that it is ready for container signing, first ensure that you have link:{URLContainerizedInstall}/aap-containerized-installation#enabling-automation-hub-collection-and-container-signing_aap-containerized-installation[enabled automation content collection and container signing]. Then you can create a signing script, or xref:proc-adding-an-execution-environment.adoc[add and sign an {ExecEnvShort}] manually.
+To deploy your system so that it is ready for container signing, first ensure that you have 
+ink:{URLContainerizedInstall}/aap-containerized-installation#enabling-automation-hub-collection-and-container-signing_aap-containerized-installation[enabled automation content collection and container signing].
+Then you can create a signing script, or
+managing-containers-hub#adding-an-execution-environment
+link:{URLHubManagingContent}/managing-containers-hub#adding-an-execution-environment[add and sign an {ExecEnvShort}] manually.
 
 [NOTE]
 ====


### PR DESCRIPTION
Fix a broken xref in `titles/hub/managing-content` that was causing the build to fail.
Replace the xref with a link because this module will be used in an assembly in another book.