### PR TITLE
backport to 2.5: AAP-34599: adds additional resources block to containerized guide 

### DIFF
--- a/downstream/modules/platform/ref-enabling-automation-hub-collection-and-container-signing.adoc
+++ b/downstream/modules/platform/ref-enabling-automation-hub-collection-and-container-signing.adoc
@@ -145,3 +145,8 @@ hub_container_signing_key=/home/aapuser/aap/ansible-automation-platform-containe
 # This variable is required if the key is protected by a passphrase
 hub_container_signing_pass=<password>
 ----
+
+[role="_additional-resources"]
+== Additional resources
+
+* For more information on working with signed containers following an installation, see link:{URLHubManagingContent}/managing-containers-hub#working-with-signed-containers[Working with signed containers] in the {TitleHubManagingContent} guide.


### PR DESCRIPTION
This PR ports the changes from [PR 2856](https://github.com/ansible/aap-docs/pull/2856/files) to the 2.5 branch. See [AAP-34599](https://issues.redhat.com/browse/AAP-34599) for more info. 