### PR TITLE
AAP-35987 Added new procedure for copying credentials

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-credentials.adoc
+++ b/downstream/assemblies/eda/assembly-eda-credentials.adoc
@@ -12,4 +12,5 @@ You can grant users and teams the ability to use these credentials without expos
 include::eda/con-credentials-list-view.adoc[leveloffset=+1]
 include::eda/proc-eda-set-up-credential.adoc[leveloffset=+1]
 include::eda/proc-eda-edit-credential.adoc[leveloffset=+1]
+include::eda/proc-eda-duplicate-credential.adoc[leveloffset=+1]
 include::eda/proc-eda-delete-credential.adoc[leveloffset=+1]

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -12,6 +12,6 @@ When setting up a new credential that requires similar field inputs as your exis
 A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied." 
 . Click the btn:[Back to credentials] tab to view the credential you just copied. 
 +
-The copied credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (for example, *<Name of credential> @ 17:26:3*.). 
+The copied credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (for example, *<Name of credential> @ 17:26:3*). 
 . Edit the details you prefer for your copied credential.
 . Click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -2,7 +2,7 @@
 
 = Copying a credential
 
-When setting up a new credential that requires similar field inputs as your existing credentials, you can use the *Copy credential* feature in the Details tab to copy information. While setting up credentials can be a lengthy process, the ability to copy those required fields saves time and, in some cases, reduces the possibility of human error.
+When setting up a new credential that requires similar field inputs as your existing credentials, you can use the *Copy credential* feature in the Details tab to reproduce information instead of manually entering it. While setting up credentials can be a lengthy process, the ability to copy those required fields saves time and, in some cases, reduces the possibility of human error.
 
 .Procedure
 

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -2,7 +2,7 @@
 
 = Copying a credential
 
-When setting up a new credential that requires similar field inputs as your existing credentials, you can use the *Copy credential* feature in the Details tab to copy required field selections and input. While setting up credentials can be a lengthy process, the ability to duplicate those required fields saves time and, in some cases, eliminates the possibility of errors.
+When setting up a new credential that requires similar field inputs as your existing credentials, you can use the *Copy credential* feature in the Details tab to copy information. While setting up credentials can be a lengthy process, the ability to copy those required fields saves time and, in some cases, reduces the possibility of human error.
 
 .Procedure
 
@@ -10,6 +10,6 @@ When setting up a new credential that requires similar field inputs as your exis
 . Click btn:[Copy credential] button at the top of the Details tab. A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
 . Click the btn:[Back to credentials] tab and select the credential you just copied. 
 +
-The credential you copied is displayed with the same name as the credential you copied with a time stamp in 24-hour format. 
+The copied credential is displayed with the same name as the original credential along with a time stamp in 24-hour format. 
 . Edit the appropriate details for your copied credential.
 . Click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -1,0 +1,14 @@
+[id="eda-duplicate-credential"]
+
+= Duplicating a credential
+
+When setting up new credentials that require similar field inputs as your existing credentials, you can use the Duplicate credential feature in the Details tab to copy required field selections and input. While setting up credentials can be a lengthy process, the ability to duplicate those required fields helps save time and eliminate the possibility of errors in some cases.
+
+.Procedure
+
+. Select a credential from the Credentials list page.
+. Click btn:[Duplicate credential} button at the top of the Details tab. A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
+. Navigate back to your Credentials list and click the duplicate of the credential you just copied. 
+The duplicate credential is displayed with the same name as the credential you copied along with a time stamp in a 24 hour format. 
+. Edit the appropriate details to distinguish the new credential.
+. After updating the new credential, click Save credential.

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -6,9 +6,8 @@ When setting up a new credential that requires similar field inputs as your exis
 
 .Procedure
 
-. Click the linked credential on the Credentials list page. This takes you to the *Details* tab of the credential.
+. On the Credentials list page, click the name of the credential that you want to copy. This takes you to the *Details* tab of the credential.
 . Click btn:[Copy credential] in the upper right of the Details tab. 
-//[J. Self] Used "upper right" in accordance with IBM style guide.
 +
 A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied." 
 . Click the btn:[Back to credentials] tab to view the credential you just copied. 

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -2,13 +2,13 @@
 
 = Duplicating a credential
 
-When setting up new credentials that require similar field inputs as your existing credentials, you can use the Duplicate credential feature in the Details tab to copy required field selections and input. While setting up credentials can be a lengthy process, the ability to duplicate those required fields helps save time and eliminate the possibility of errors in some cases.
+When setting up a new credential that requires similar field inputs as your existing credentials, you can use the Duplicate credential feature in the Details tab to copy required field selections and input. While setting up credentials can be a lengthy process, the ability to duplicate those required fields helps save time and eliminate the possibility of errors in some cases.
 
 .Procedure
 
 . Select a credential from the Credentials list page.
-. Click btn:[Duplicate credential} button at the top of the Details tab. A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
-. Navigate back to your Credentials list and click the duplicate of the credential you just copied. 
-The duplicate credential is displayed with the same name as the credential you copied along with a time stamp in a 24 hour format. 
+. Click btn:[Duplicate credential] button at the top of the Details tab. A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
+. Click the btn:[Back to credentials] tab and select the duplicate of the credential you just copied. 
+The duplicate credential is displayed with the same name as the credential you copied along with a time stamp in a 24-hour format. 
 . Edit the appropriate details to distinguish the new credential.
-. After updating the new credential, click Save credential.
+. After updating the new credential, click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -2,7 +2,7 @@
 
 = Copying a credential
 
-When setting up a new credential that requires similar field inputs as your existing credentials, you can use the *Copy credential* feature in the Details tab to reproduce information instead of manually entering it. While setting up credentials can be a lengthy process, the ability to copy those required fields saves time and, in some cases, reduces the possibility of human error.
+When setting up a new credential that requires similar field inputs as your existing credentials, you can use the *Copy credential* feature in the Details tab to duplicate information instead of manually entering it. While setting up credentials can be a lengthy process, the ability to copy the required fields from an existing credential saves time and, in some cases, reduces the possibility of human error.
 
 .Procedure
 

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -2,7 +2,7 @@
 
 = Copying a credential
 
-When setting up a new credential that requires similar field inputs as your existing credentials, you can use the *Copy credential* feature in the Details tab to duplicate information instead of manually entering it. While setting up credentials can be a lengthy process, the ability to copy the required fields from an existing credential saves time and, in some cases, reduces the possibility of human error.
+When setting up a new credential with field inputs that are similar to your existing credentials, you can use the *Copy credential* feature in the Details tab to duplicate information instead of manually entering it. While setting up credentials can be a lengthy process, the ability to copy the required fields from an existing credential saves time and, in some cases, reduces the possibility of human error.
 
 .Procedure
 

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -6,12 +6,13 @@ When setting up a new credential that requires similar field inputs as your exis
 
 .Procedure
 
-. Select a credential from the Credentials list page.
-. Click btn:[Copy credential] at the top of the Details tab. 
+. Click the linked credential on the Credentials list page. This takes you to the *Details* tab of the credential.
+. Click btn:[Copy credential] in the upper right of the Details tab. 
+//[J. Self] Used "upper right" in accordance with IBM style guide.
 +
-A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
-. Click the btn:[Back to credentials] tab and select the credential you just copied. 
+A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied." 
+. Click the btn:[Back to credentials] tab to view the credential you just copied. 
 +
-The copied credential is displayed with the same name as the original credential along with a time stamp in 24-hour format. 
-. Edit the appropriate details for your copied credential.
+The copied credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (example, *<Name of credential> @ 17:26:3*.). 
+. Edit the details you prefer for your copied credential.
 . Click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -1,15 +1,15 @@
 [id="eda-duplicate-credential"]
 
-= Duplicating a credential
+= Copying a credential
 
-When setting up a new credential that requires similar field inputs as your existing credentials, you can use the Duplicate credential feature in the Details tab to copy required field selections and input. While setting up credentials can be a lengthy process, the ability to duplicate those required fields saves time and, in some cases, eliminates the possibility of errors .
+When setting up a new credential that requires similar field inputs as your existing credentials, you can use the *Copy credential* feature in the Details tab to copy required field selections and input. While setting up credentials can be a lengthy process, the ability to duplicate those required fields saves time and, in some cases, eliminates the possibility of errors.
 
 .Procedure
 
 . Select a credential from the Credentials list page.
-. Click btn:[Duplicate credential] button at the top of the Details tab. A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
-. Click the btn:[Back to credentials] tab and select the duplicate of the credential you just copied. 
+. Click btn:[Copy credential] button at the top of the Details tab. A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
+. Click the btn:[Back to credentials] tab and select the credential you just copied. 
 +
-The duplicate credential is displayed with the same name as the credential you copied with a time stamp in 24-hour format. 
-. Edit the appropriate details to distinguish your new credential from your previous one.
+The credential you copied is displayed with the same name as the credential you copied with a time stamp in 24-hour format. 
+. Edit the appropriate details for your copied credential.
 . Click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -12,4 +12,4 @@ When setting up a new credential that requires similar field inputs as your exis
 +
 The duplicate credential is displayed with the same name as the credential you copied with a time stamp in 24-hour format. 
 . Edit the appropriate details to distinguish your new credential from your previous one.
-. After updating the new credential, click btn:[Save credential].
+. Click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -7,7 +7,9 @@ When setting up a new credential that requires similar field inputs as your exis
 .Procedure
 
 . Select a credential from the Credentials list page.
-. Click btn:[Copy credential] button at the top of the Details tab. A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
+. Click btn:[Copy credential] button at the top of the Details tab. 
++
+A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
 . Click the btn:[Back to credentials] tab and select the credential you just copied. 
 +
 The copied credential is displayed with the same name as the original credential along with a time stamp in 24-hour format. 

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -16,6 +16,6 @@ You can also click the btn:[Copy credential] icon next to the desired credential
 A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied." 
 . Click the btn:[Back to credentials] tab to view the credential you just copied. 
 +
-The copied credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (for example, *<Name of credential> @ 17:26:3*). 
+The copied credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (for example, *<Name of credential> @ 17:26:30*). 
 . Edit the details you prefer for your copied credential.
 . Click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -9,6 +9,7 @@ When setting up a new credential that requires similar field inputs as your exis
 . Select a credential from the Credentials list page.
 . Click btn:[Duplicate credential] button at the top of the Details tab. A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
 . Click the btn:[Back to credentials] tab and select the duplicate of the credential you just copied. 
-The duplicate credential is displayed with the same name as the credential you copied along with a time stamp in a 24-hour format. 
++
+The duplicate credential is displayed with the same name as the credential you copied with a time stamp in 24-hour format. 
 . Edit the appropriate details to distinguish the new credential.
 . After updating the new credential, click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -7,7 +7,7 @@ When setting up a new credential that requires similar field inputs as your exis
 .Procedure
 
 . Select a credential from the Credentials list page.
-. Click btn:[Copy credential] button at the top of the Details tab. 
+. Click btn:[Copy credential] at the top of the Details tab. 
 +
 A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied."
 . Click the btn:[Back to credentials] tab and select the credential you just copied. 

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -9,6 +9,10 @@ When setting up a new credential that requires similar field inputs as your exis
 . On the Credentials list page, click the name of the credential that you want to copy. This takes you to the *Details* tab of the credential.
 . Click btn:[Copy credential] in the upper right of the Details tab. 
 +
+[NOTE]
+====
+You can also click the btn:[Copy credential] icon next to the desired credential on the Credentials list page.
+====
 A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied." 
 . Click the btn:[Back to credentials] tab to view the credential you just copied. 
 +

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -2,7 +2,7 @@
 
 = Duplicating a credential
 
-When setting up a new credential that requires similar field inputs as your existing credentials, you can use the Duplicate credential feature in the Details tab to copy required field selections and input. While setting up credentials can be a lengthy process, the ability to duplicate those required fields helps save time and eliminate the possibility of errors in some cases.
+When setting up a new credential that requires similar field inputs as your existing credentials, you can use the Duplicate credential feature in the Details tab to copy required field selections and input. While setting up credentials can be a lengthy process, the ability to duplicate those required fields saves time and, in some cases, eliminates the possibility of errors .
 
 .Procedure
 
@@ -11,5 +11,5 @@ When setting up a new credential that requires similar field inputs as your exis
 . Click the btn:[Back to credentials] tab and select the duplicate of the credential you just copied. 
 +
 The duplicate credential is displayed with the same name as the credential you copied with a time stamp in 24-hour format. 
-. Edit the appropriate details to distinguish the new credential.
+. Edit the appropriate details to distinguish your new credential from your previous one.
 . After updating the new credential, click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -13,6 +13,6 @@ When setting up a new credential that requires similar field inputs as your exis
 A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied." 
 . Click the btn:[Back to credentials] tab to view the credential you just copied. 
 +
-The copied credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (example, *<Name of credential> @ 17:26:3*.). 
+The copied credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (for example, *<Name of credential> @ 17:26:3*.). 
 . Edit the details you prefer for your copied credential.
 . Click btn:[Save credential].


### PR DESCRIPTION
Added a new module to the [Credentials](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credentials) chapter: 
- "Copying a credential", downstream/modules/eda/proc-eda-duplicate-credential.adoc