### PR TITLE
AAP-34926 updated Planning guide organization

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-platform-components.adoc
+++ b/downstream/assemblies/platform/assembly-aap-platform-components.adoc
@@ -10,15 +10,15 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 {PlatformNameShort} is composed of services that are connected together to meet your automation needs. These services provide the ability to store, make decisions for, and execute automation. All of these functions are available through with a user interface (UI) and RESTful application programming interface (API). Deploy each of the following components so that all features and capabilities are available for use without the need to take further action:
 
-* Platform gateway
-* Ansible automation hub
-* Private automation hub
-* High availability automation hub
-* Event-Driven Ansible controller
-* Automation mesh
-* Automation execution environments
-* Ansible galaxy
-* Automation content navigator
+* {GatewayStart}
+* {HubNameStart}
+* {PrivateHubNameStart}
+* High availability {HubName}
+* {EDAcontroller}
+* {AutomationMeshStart}
+* {ExecEnvNameStart}
+* {Galaxy}
+* {NavigatorStart}
 
 include::platform/con-about-platform-gateway.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-aap-platform-components.adoc
+++ b/downstream/assemblies/platform/assembly-aap-platform-components.adoc
@@ -10,6 +10,16 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 {PlatformNameShort} is a modular platform composed of separate components that can be connected together to meet your deployment needs. {PlatformNameShort} deployments start with {ControllerName} which is the enterprise framework for controlling, securing, and managing Ansible automation with a user interface (UI) and RESTful application programming interface (API). Then, you can add to your deployment any combination of the following automation platform components:
 
+* Platform gateway
+* Ansible automation hub
+* Private automation hub
+* High availability automation hub
+* Event-Driven Ansible controller
+* Automation mesh
+* Automation execution environments
+* Ansible galaxy
+* Automation content navigator
+
 include::platform/con-about-platform-gateway.adoc[leveloffset=+1]
 
 include::platform/con-about-automation-hub.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-aap-platform-components.adoc
+++ b/downstream/assemblies/platform/assembly-aap-platform-components.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-{PlatformNameShort} is a modular platform composed of separate components that are connected together to meet your deployment needs. {PlatformNameShort} deployments start with {ControllerName}, which is the enterprise framework for controlling, securing, and managing Ansible automation with a user interface (UI) and RESTful application programming interface (API). Deploy each of the following components so that all features and capabilities are available for use without the need to take further action:
+{PlatformNameShort} is composed of services that are connected together to meet your automation needs. These services provide the ability to store, make decisions for, and execute automation. All of these functions are available through with a user interface (UI) and RESTful application programming interface (API). Deploy each of the following components so that all features and capabilities are available for use without the need to take further action:
 
 * Platform gateway
 * Ansible automation hub

--- a/downstream/assemblies/platform/assembly-aap-platform-components.adoc
+++ b/downstream/assemblies/platform/assembly-aap-platform-components.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-{PlatformNameShort} is a modular platform composed of separate components that can be connected together to meet your deployment needs. {PlatformNameShort} deployments start with {ControllerName} which is the enterprise framework for controlling, securing, and managing Ansible automation with a user interface (UI) and RESTful application programming interface (API). Then, you can add to your deployment any combination of the following automation platform components:
+{PlatformNameShort} is a modular platform composed of separate components that are connected together to meet your deployment needs. {PlatformNameShort} deployments start with {ControllerName}, which is the enterprise framework for controlling, securing, and managing Ansible automation with a user interface (UI) and RESTful application programming interface (API). Deploy each of the following components so that all features and capabilities are available for use without the need to take further action:
 
 * Platform gateway
 * Ansible automation hub

--- a/downstream/titles/aap-planning-guide/master.adoc
+++ b/downstream/titles/aap-planning-guide/master.adoc
@@ -16,10 +16,11 @@ Use the information in this guide to plan your {PlatformName} installation.
 
 include::{Boilerplate}[]
 include::platform/assembly-planning-installation.adoc[leveloffset=+1]
-include::platform/assembly-aap-architecture.adoc[leveloffset=+1]
+// emurtough removed to avoid duplication with topologies chapter include::platform/assembly-aap-architecture.adoc[leveloffset=+1]
 include::platform/assembly-aap-platform-components.adoc[leveloffset=+1]
 include::platform/assembly-HA-redis.adoc[leveloffset=+1]
 :aap-plan:
+include::topologies/assembly-overview-tested-deployment-models.adoc[leveloffset=+1]
 include::platform/assembly-system-requirements.adoc[leveloffset=+1]
 :!aap-plan:
 include::platform/assembly-network-ports-protocols.adoc[leveloffset=+1]
@@ -27,4 +28,3 @@ include::platform/assembly-network-ports-protocols.adoc[leveloffset=+1]
 include::platform/assembly-choosing-obtaining-installer.adoc[leveloffset=+1]
 include::platform/assembly-inventory-introduction.adoc[leveloffset=+1]
 // emurtough removed to avoid duplication with topologies docs include::platform/assembly-supported-installation-scenarios.adoc[leveloffset=+1]
-include::topologies/assembly-overview-tested-deployment-models.adoc[leveloffset=+1]


### PR DESCRIPTION
[AAP-34926](https://issues.redhat.com/browse/AAP-34926)

Removed [Chapter 2: Red Hat Ansible Automation Platform Architecture](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/planning_your_installation/index#aap_architecture) from _Planning your Installation_ and re-organize the guide as follows:
- Chapter 1. Planning your Red Hat Ansible Automation Platform Installation
- Chapter 2. Red Hat Ansible Automation Platform components
- Chapter 3. Caching and queueing system
- Chapter 4. Overview of tested deployment models
- Chapter 5. System requirements
- Chapter 6. Network ports and protocols
- Chapter 7. Choosing and obtaining a Red Hat Ansible Automation Platform installer
- Chapter 8. About the installer inventory file

Files modified: 
- master.adoc
- assembly-aap-platform-components.adoc
