### PR TITLE
Update storage backend options for more clarity (#2869)

### DIFF
--- a/downstream/modules/platform/ref-configuring-inventory-file.adoc
+++ b/downstream/modules/platform/ref-configuring-inventory-file.adoc
@@ -36,6 +36,8 @@ include::snippets/redis-colocation-containerized.adoc[]
 
 == Additional information for configuring your inventory file
 
+For more information about the variables you can use to configure your inventory file, see link:{URLContainerizedInstall}/appendix-inventory-files-vars[Inventory file variables]
+
 .Offline or bundled installation
 
 * To perform an offline installation, add the following under the `[all:vars]` group:
@@ -60,17 +62,66 @@ gateway_main_url=<https://load_balancer_url>
 HAProxy SSL passthrough mode is not supported with {Gateway}.
 ====
 
-.Configuring shared storage for {HubName}
+.Configuring Network File System (NFS) storage for {HubName}
 
-Shared storage is required when installing more than one instance of {HubName} with a `file` storage backend. When installing a single instance of the {HubName}, shared storage is optional.
+NFS is a type of shared storage that is supported in containerized installations. Shared storage is required when installing more than one instance of {HubName} with a `file` storage backend. When installing a single instance of the {HubName}, shared storage is optional.
 
-* To configure shared storage for {HubName}, set the following variable in the inventory file, ensuring your network file system (NFS) share has read, write, and execute permissions:
+* To configure shared storage for {HubName}, set the following variable in the inventory file, ensuring your NFS share has read, write, and execute permissions:
 
 ----
 hub_shared_data_path=<path_to_nfs_share>
 ----
 
 * To change the mount options for your NFS share, use the `hub_shared_data_mount_opts` variable. This variable is optional and the default value is `rw,sync,hard`.
+
+.Configuring Amazon S3 storage for {HubName}
+
+Amazon S3 storage is a type of object storage that is supported in containerized installations. When using an AWS S3 storage backend, set `hub_storage_backend` to `s3`. The AWS S3 bucket needs to exist before running the installation program.
+
+The variables you can use to configure this storage backend type in your inventory file are:
+
+* `hub_s3_access_key`
+* `hub_s3_secret_key`
+* `hub_s3_bucket_name`
+* `hub_s3_extra_settings`
+
+Extra parameters can be passed through an Ansible `hub_s3_extra_settings` dictionary.
+
+For example, you can set the following parameters:
+
+----
+hub_s3_extra_settings:
+  AWS_S3_MAX_MEMORY_SIZE: 4096
+  AWS_S3_REGION_NAME: eu-central-1
+  AWS_S3_USE_SSL: True
+----
+
+For more information about the list of parameters, see link:https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings[django-storages documentation - Amazon S3].
+
+.Configuring Azure Blob Storage for {HubName}
+
+Azure Blob storage is a type of object storage that is supported in containerized installations. 
+When using an Azure blob storage backend, set `hub_storage_backend` to `azure`. The Azure container needs to exist before running the installation program.
+
+The variables you can use to configure this storage backend type in your inventory file are:
+
+* `hub_azure_account_key`
+* `hub_azure_account_name`
+* `hub_azure_container`
+* `hub_azure_extra_settings`
+
+Extra parameters can be passed through an Ansible `hub_azure_extra_settings` dictionary.
+
+For example, you can set the following parameters:
+
+----
+hub_azure_extra_settings:
+  AZURE_LOCATION: foo
+  AZURE_SSL: True
+  AZURE_URL_EXPIRATION_SECS: 60
+----
+
+For more information about the list of parameters, see link:https://django-storages.readthedocs.io/en/latest/backends/azure.html#settings[django-storages documentation - Azure Storage].
 
 
 .Loading an {ControllerName} license file

--- a/downstream/modules/platform/ref-ha-hub-reqs.adoc
+++ b/downstream/modules/platform/ref-ha-hub-reqs.adoc
@@ -2,11 +2,13 @@
 
 = High availability {HubName} requirements
 
-Before deploying a high availability (HA) {HubName}, ensure that you have a shared filesystem installed in your environment and that you have configured your network storage system, if applicable.
+Before deploying a high availability (HA) {HubName}, ensure that you have a shared storage file system installed in your environment and that you have configured your network storage system, if applicable.
 
-== Required shared filesystem
+== Required shared storage
 
-A high availability {HubName} requires you to have a shared file system, such as NFS, already installed in your environment. Before you run the {PlatformName} installer, verify that you installed the `/var/lib/pulp` directory across your cluster as part of the shared file system installation. 
+Shared storage is required when installing more than one {HubNameStart} with a `file` storage backend. The supported shared storage type for RPM-based installations is Network File System (NFS).
+
+Before you run the {PlatformName} installer, verify that you installed the `/var/lib/pulp` directory across your cluster as part of the shared storage file system installation. 
 The {PlatformName} installer returns an error if `/var/lib/pulp` is not detected in one of your nodes, causing your high availability {HubName} setup to fail.
 
 If you receive an error stating `/var/lib/pulp` is not detected in one of your nodes, ensure `/var/lib/pulp` is properly mounted in all servers and re-run the installer.

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -218,7 +218,23 @@ Default = `63072000` seconds, or two years.
 | `pulp_db_fields_key` |  | Relative or absolute path to the Fernet symmetric encryption key that you want to import.
 The path is on the Ansible management node. It is used to encrypt certain fields in the database, such as credentials.
 If not specified, a new key will be generated.
+| | `hub_azure_account_key` | Required when using an Azure blob storage backend.
 
+The Azure blob storage account key.
+
+| | `hub_azure_account_name` | Required when using an Azure blob storage backend.
+
+The account name associated with the Azure blob storage.
+
+| | `hub_azure_container` | The name of the Azure blob storage container.
+
+Default = `pulp`
+
+| | `hub_azure_extra_settings` | Used to define extra parameters for the Azure blob storage backend.
+
+For more information about the list of parameters, see link:https://django-storages.readthedocs.io/en/latest/backends/azure.html#settings[django-storages documentation - Azure Storage].
+
+Default = `{}`
 |  | `hub_tls_remote` | {HubNameStart} TLS remote files. 
 
 Default = `false`
@@ -243,7 +259,11 @@ Default = `[TLSv1.2, TLSv1.3]`
 
 |  | `hub_secret_key` | The secret key value used by {HubName} to sign and encrypt data, ensuring secure communication and data integrity between services. 
 
-|  | `hub_storage_backend` | {HubNameStart} storage backend. 
+|  | `hub_storage_backend` | {HubNameStart} storage backend type. 
+
+Possible values include: `azure`, `file`, `s3`.
+
+Default = `file`
 
 |  | `hub_workers` | {HubNameStart} workers count. 
 
@@ -278,14 +298,30 @@ Default = `30`
 Default = `main`
 
 |  | `hub_postinstall_repo_url` | {HubNameStart} repository URL.
-| | `hub_shared_data_path` | Required when installing more than one instance of {HubName} with a file storage backend. When installing a single instance of {HubName}, it is optional.
+| | `hub_shared_data_path` | Required when installing more than one instance of {HubName} with a `file` storage backend. When installing a single instance of {HubName}, it is optional.
 
-Path to a Network File System (NFS) share with read, write, and execute (RWX) access.
+Path to the Network File System (NFS) share with read, write, and execute (RWX) access.
 
-| | `hub_shared_data_mount_opts` | _Optional_
-
-Mount options for NFS share.
+| | `hub_shared_data_mount_opts` | Mount options for the Network File System (NFS) share.
 
 Default = `rw,sync,hard`
+
+| | `hub_s3_access_key` | Required when using an AWS S3 storage backend. 
+
+The AWS S3 access key. 
+
+| | `hub_s3_secret_key` | Required when using an AWS S3 storage backend.
+
+The AWS S3 secret key. 
+
+| | `hub_s3_bucket_name` | The name of the AWS S3 storage bucket.
+
+Default = `pulp`
+
+| | `hub_s3_extra_settings` | Used to define extra parameters for the AWS S3 storage backend.
+
+For more information about the list of parameters, see link:https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings[django-storages documentation - Amazon S3].
+
+Default = `{}`
 
 |====


### PR DESCRIPTION
- Update ref-ha-hub-reqs.adoc to denote NFS is the supported shared storage type for RPM installs.
- Update ref-configuring-inventory-file.adoc to ensure all supported storage backend options are documented for Container installs - NFS, Azure Blob, and S3.
- Update ref-hub-variables.adoc to ensure all inventory file vars relevant to storage backends for hub are documented.

Document supported automation hub shared storage options

https://issues.redhat.com/browse/AAP-29150