### PR TITLE
Backport to 2.5: AAP-37377 Updates attribute in Managing automation content guide

### DIFF
--- a/downstream/modules/hub/proc-adding-an-execution-environment.adoc
+++ b/downstream/modules/hub/proc-adding-an-execution-environment.adoc
@@ -21,7 +21,7 @@ You must specify which repository-specific tags to pass.
 
 .. Optional: Enter tags to exclude in the *Add tag(s) to exclude* field. 
 
-. Click btn:[Create {ExecEnvShort}]. You should see your new {ExecEnvNameSing} in the list that appears.
+. Click btn:[Create {ExecEnvShort}]. You should see your new {ExecEnvShort} in the list that appears.
 
 . Sync and sign your new {ExecEnvNameSing}.
 
@@ -29,4 +29,4 @@ You must specify which repository-specific tags to pass.
 
 .. Click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sign execution environment*.
 
-. Click on your new {ExecEnvNameSing}. On the Details page, find the *Signed* label to determine that your {ExecEnvNameSing} has been signed.
+. Click on your new {ExecEnvShort}. On the Details page, find the *Signed* label to determine that your {ExecEnvShort} has been signed.

--- a/downstream/modules/hub/proc-configuring-the-client-to-verify-signatures.adoc
+++ b/downstream/modules/hub/proc-configuring-the-client-to-verify-signatures.adoc
@@ -3,7 +3,7 @@
 
 = Configuring the client to verify signatures
 
-To ensure an {ExecEnvName} pulled from the remote registry is properly signed, you must first configure the {ExecEnvName} with the proper public key in a policy file. 
+To ensure an {ExecEnvShort} pulled from the remote registry is properly signed, you must first configure the {ExecEnvShort} with the proper public key in a policy file. 
 
 .Prerequisites
 * The client must have sudo privileges configured to verify signatures.
@@ -75,7 +75,7 @@ name of your key file.
 > podman pull <server-address>/<container-name>:<tag name> --tls-verify=false
 ----
 
-This response verifies the {ExecEnvName} has been signed with no errors. If the {ExecEnvName} is not signed, the command fails.
+This response verifies the {ExecEnvShort} has been signed with no errors. If the {ExecEnvShort} is not signed, the command fails.
 
 .Additional resources
 * For more information about policy.json, see link:https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#signedby[documentation for containers-policy.json]. 

--- a/downstream/modules/hub/proc-using-podman-ensure-image-signed.adoc
+++ b/downstream/modules/hub/proc-using-podman-ensure-image-signed.adoc
@@ -1,7 +1,7 @@
 [id="using-podman-ensure-image-signed"]
 
 = Using podman to ensure an image is signed by a specific signature
-When ensuring an {ExecEnvName} is signed by specific signatures, the signature must be on your local environment.
+To ensure an {ExecEnvShort} is signed by specific signatures, the signatures must first be on your local environment.
 
 .Procedure
 


### PR DESCRIPTION
This PR ports the changes from [PR 2896](https://github.com/ansible/aap-docs/pull/2896) to the 2.5 branch. See [AAP-37377](https://issues.redhat.com/browse/AAP-37377) for more. 