### PR TITLE
Correct custom resource definition (#2904)

### DIFF
--- a/downstream/modules/platform/ref-operator-crs.adoc
+++ b/downstream/modules/platform/ref-operator-crs.adoc
@@ -128,7 +128,7 @@ spec:
     disabled: false
 
   eda:
-    disabled: false
+    disabled: true
 
   hub:
     name: existing-hub


### PR DESCRIPTION
Set eda.disabled to true

BUG - Logic error within the custom resource definition for gateway that would deploy EDA instead of just connecting to Controller and Hub

https://issues.redhat.com/browse/AAP-40045