### PR TITLE
AAP-38726 - Removed incorrect access notes for org admin for tokens/apps (#2907)

### DIFF
--- a/downstream/modules/platform/ref-gw-access-rules-apps-tokens.adoc
+++ b/downstream/modules/platform/ref-gw-access-rules-apps-tokens.adoc
@@ -1,11 +1,12 @@
 [id="ref-gw-access-rules-apps-tokens"]
 
-= Access Rules for applications and tokens
+= Access rules for applications and tokens
 
 Access rules for applications are as follows:
 
 * System administrators can view and manipulate all applications in the system.
-* Organization administrators can view and manipulate all applications belonging to organization members.
+//[ddacosta-aap-38726] Org administrators do not have this access in gateway.
+//* Organization administrators can view and manipulate all applications belonging to organization members.
 * Other users can only view, update, and delete their own applications, but cannot create any new applications.
 * Tokens, on the other hand, are resources used to authenticate incoming requests and mask the permissions of the underlying user.
 
@@ -13,7 +14,8 @@ Access rules for tokens are as follows:
 
 * Users can create a token if they are able to view the related application and can also create a personal token for themselves.
 * System administrators are able to view and manipulate every token in the system.
-* Organization administrators are able to view and manipulate all tokens belonging to organization members.
+//[ddacosta-aap-38726] Org administrators do not have this access in gateway.
+//* Organization administrators are able to view and manipulate all tokens belonging to organization members.
 * System Auditors can view all tokens and applications.
 * Other normal users are only able to view and manipulate their own tokens.
 


### PR DESCRIPTION
This PR backports the changes from #2907 to the 2.5 branch. 