### PR TITLE
Add hstore proc to Containerized installation

### DIFF
--- a/downstream/modules/platform/proc-enable-hstore-extension.adoc
+++ b/downstream/modules/platform/proc-enable-hstore-extension.adoc
@@ -2,13 +2,13 @@
 
 = Enabling the hstore extension for the {HubName} PostgreSQL database
 
-Added in {PlatformNameShort} {PlatformVers}, the database migration script uses `hstore` fields to store information, therefore the `hstore` extension to the {HubName} PostgreSQL database must be enabled.
+Added in {PlatformNameShort} {PlatformVers}, the database migration script uses `hstore` fields to store information, therefore the `hstore` extension must be enabled in the {HubName} PostgreSQL database.
 
 This process is automatic when using the {PlatformNameShort} installer and a managed PostgreSQL server.
 
-If the PostgreSQL database is external, you must enable the `hstore` extension to the {HubName} PostreSQL database manually before {HubName} installation.
+If the PostgreSQL database is external, you must enable the `hstore` extension in the {HubName} PostgreSQL database manually before installation.
 
-If the `hstore` extension is not enabled before {HubName} installation, a failure is raised during database migration.
+If the `hstore` extension is not enabled before installation, a failure raises during database migration.
 
 .Procedure
 . Check if the extension is available on the PostgreSQL server ({HubName} database).
@@ -49,20 +49,14 @@ To install the RPM package, use the following command:
 ----
 dnf install postgresql-contrib
 ----
-. Create the `hstore` PostgreSQL extension on the {HubName} database with the following command:
+. Load the `hstore` PostgreSQL extension into the {HubName} database with the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 $ psql -d <{HubName} database> -c "CREATE EXTENSION hstore;"
 ----
 +
-The output of which is:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-CREATE EXTENSION
-----
-In the following output, the `installed_version` field contains the `hstore` extension used, indicating that `hstore` is enabled.
+In the following output, the `installed_version` field lists the `hstore` extension used, indicating that `hstore` is enabled.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/downstream/modules/platform/proc-setup-postgresql-ext-database-containerized.adoc
+++ b/downstream/modules/platform/proc-setup-postgresql-ext-database-containerized.adoc
@@ -96,6 +96,8 @@ eda_pg_username=<set your own>
 eda_pg_password=<set your own>
 ----
 
+include::proc-enable-hstore-extension.adoc[leveloffset=+1]
+
 == Optional: enabling mutual TLS (mTLS) authentication
 
 mTLS authentication is disabled by default. To configure each component's database with mTLS authentication, add the following variables to your inventory file under the `[all:vars]` group and ensure each component has a different TLS certificate and key:
@@ -126,5 +128,3 @@ eda_pg_tls_cert=/path/to/eda.cert
 eda_pg_tls_key=/path/to/eda.key
 eda_pg_sslmode=verify-full
 ----
-
-


### PR DESCRIPTION
[Docs] hstore extension information is missing for the AAP Containerized Installation

https://issues.redhat.com/browse/AAP-39769