### PR TITLE
Adding CR details to Installing chapter

### DIFF
--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -6,11 +6,47 @@
 . Search for {PlatformNameShort} and click btn:[Install].
 . Select an *Update Channel*:
 +
-* *stable-2.x*: installs a namespace-scoped operator, which limits deployments of {HubName} and {ControllerName} instances to the namespace the operator is installed in. This is suitable for most cases. The stable-2.x channel does not require administrator privileges and utilizes fewer resources because it only monitors a single namespace.
-* *stable-2.x-cluster-scoped*: deploys {HubName} and {ControllerName} across multiple namespaces in the cluster and requires administrator privileges for all namespaces in the cluster.
+* *stable-2.x*: installs a namespace-scoped operator, which limits deployments of {HubName} and {ControllerName} instances to the namespace the operator is installed in, this is suitable for most cases.
+The stable-2.x channel does not require administrator privileges and utilizes fewer resources because it only monitors a single namespace.
+* *stable-2.x-cluster-scoped*: installs the {OperatorPlatformNameShort} in a single namespace that manages {PlatformNameShort} custom resources and deployments in all namespaces.
+The {OperatorPlatformNameShort} requires administrator privileges for all namespaces in the cluster.
 . Select *Installation Mode*, *Installed Namespace*, and *Approval Strategy*.
 . Click btn:[Install].
 
 The installation process begins. When installation finishes, a modal appears notifying you that the {OperatorPlatformNameShort} is installed in the specified namespace.
 
-* Click btn:[View Operator] to view your newly installed {OperatorPlatformNameShort}.
+.Verification
+
+* Click btn:[View Operator] to view your newly installed {OperatorPlatformNameShort} and verify the following operator custom resources are present:
+
+[cols="a,a,a,a"]
+|===
+|{ControllerNameStart}  | {HubNameStart} |{EDAName} (EDA) |{LightspeedShortName}
+
+|
+
+* Automation Controller
+* Automation Controller Backup
+* Automation Controller Restore
+* Automation Controller Mesh Ingress
+
+
+|
+
+* Automation Hub
+* Automation Hub Backup
+* Automation Hub Restore
+
+
+|
+
+* EDA
+* EDA Backup
+* EDA Restore
+
+
+| 
+
+* Ansible Lightspeed
+
+|===


### PR DESCRIPTION
AnsibleLightspeed Custom Resource and Ansible Lightspeed Operator is being deployed when installing the AAP 2.4 and 2.5 operator which is not accounted for in the documentation

- Adding a verification section to the install chapter where a user can confirm what should be including in their deployment 
- Also touched up the information for cluster scoped channel 