### PR TITLE
AAP-32834 2.4 specific changes

### DIFF
--- a/downstream/modules/platform/proc-install-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-aap-operator.adoc
@@ -13,7 +13,34 @@
 
 The installation process begins. When installation finishes, a modal appears notifying you that the {OperatorPlatformNameShort} is installed in the specified namespace.
 
-* Click btn:[View Operator] to view your newly installed {OperatorPlatformNameShort}.
+.Verification
+
+* Click btn:[View Operator] to view your newly installed {OperatorPlatformNameShort} and verify the following operator custom resources are present:
+[cols="a,a,a,a"]
+|===
+|{ControllerNameStart}  | {HubNameStart} |{EDAName} (EDA) |{LightspeedShortName}
+
+|
+
+* Automation Controller
+* Automation Controller Backup
+* Automation Controller Restore
+* Automation Controller Mesh Ingress
+|
+
+* Automation Hub
+* Automation Hub Backup
+* Automation Hub Restore
+|
+
+* EDA
+* EDA Backup
+* EDA Restore
+| 
+
+* Ansible Lightspeed
+|===
+
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
AnsibleLightspeed Custom Resource and Ansible Lightspeed Operator is being deployed when installing the AAP 2.4 operator which is not accounted for in the documentation

Adding a verification section to the install chapter where a user can confirm what should be including in their deployment