### PR TITLE
AAP-39927 Added descriptions for the service level administrator checkboxes (#2925)

### DIFF
--- a/downstream/modules/platform/proc-gw-editing-a-user.adoc
+++ b/downstream/modules/platform/proc-gw-editing-a-user.adoc
@@ -6,7 +6,13 @@
 
 You can modify the properties of a user account after it is created.
 
-In upgrade scenarios, there might be pre-existing user accounts from {ControllerName} or {HubName} services. When editing these user accounts, the *User type* checkboxes indicate whether the account had service level administrator privileges. You can revoke or assign administrator permissions for the individual services and designate the user as either an *{PlatformNameShort} Administrator*, *{PlatformNameShort} Auditor* or normal user. Assigning administrator privileges to all of the individual services automatically designates the user as an *{PlatformNameShort} Administrator*. See xref:proc-controller-creating-a-user[Creating a user] for more information about user types.
+In upgrade scenarios, there might be pre-existing user accounts from {ControllerName} or {HubName} services. When editing these user accounts, the *User type* checkboxes indicate whether the account had one of the following service level administrator privileges: 
+
+Automation Execution Administrator:: A previously defined {ControllerName} administrator with full read and write privileges over automation execution resources only.
+Automation Decisions Administrator:: A previously defined {EDAName} administrator with full read and write privileges over automation decision resources only.
+Automation Content Administrator:: A previously defined {HubName} administrator with full read and write privileges over automation content resources only.
+
+Platform administrators can revoke or assign administrator permissions for the individual services and designate the user as either an *{PlatformNameShort} Administrator*, *{PlatformNameShort} Auditor* or normal user. Assigning administrator privileges to all of the individual services automatically designates the user as an *{PlatformNameShort} Administrator*. See xref:proc-controller-creating-a-user[Creating a user] for more information about user types.
 
 To see whether a user had service level auditor privileges, you must refer to the API.
 


### PR DESCRIPTION
This PR backports the changes from #2925 to the 2.5 branch and includes the following:

* AAP-39927 Added descriptions for the service level administrator checkboxes

* AAP-39927 - updated statement to indicate that Platform admins can revoke or assign

* AAP-39927 - implement peer review changes

* AAP-39927 - changed hub to content in description