### PR TITLE
Updated release note content for asyn-20250213

### DIFF
--- a/downstream/titles/release-notes/async/aap-25-20250213.adoc
+++ b/downstream/titles/release-notes/async/aap-25-20250213.adoc
@@ -4,7 +4,7 @@
 
 This release includes the following components and versions:
 
-[cols="2a,3a", options="header"]
+[cols="1a,3a", options="header"]
 |===
 | Release Date | Component versions
 
@@ -12,9 +12,11 @@ This release includes the following components and versions:
 * {ControllerNameStart} 4.6.8
 * {HubNameStart} 4.10.1
 * {EDAName} 1.1.4
-* Container-based {PlatformNameShort} 2.5-10
+* Container-based installer {PlatformNameShort} (bundle) 2.5-10
+* Container-based installer {PlatformNameShort} (online) 2.5-10
 * Receptor 1.5.1
-* RPM-based {PlatformNameShort} 2.5-8.1
+* RPM-based installer {PlatformNameShort} (bundle) 2.5-8.1
+* RPM-based installer {PlatformNameShort} (online) 2.5-8
 
 |===
 
@@ -56,7 +58,7 @@ Keycloak now allows for the configuration of the claim key/name for the field co
 
 === {ExecEnvNameStart}
 
-The *file* command has been added to *ee-minimal* and *ee-supported* container images.(AAP-40009)
+* The *file* command has been added to *ee-minimal* and *ee-supported* container images.(AAP-40009)
 
 == Bug fixes
 
@@ -66,27 +68,27 @@ The *file* command has been added to *ee-minimal* and *ee-supported* container i
 
 === {PlatformNameShort}
 
-Fixed a bug in the collections token module where it was unable to find an application if multiple organizations had the same application name.(AAP-38625)
+* Fixed a bug in the collections token module where it was unable to find an application if multiple organizations had the same application name.(AAP-38625)
 
-Fixed an issue where upgrading {PlatformNameShort} 2.5 caused an occasional internal server error for all users with {EDAName} and {HubNameStart} post upgrade.(AAP-39293)
+* Fixed an issue where upgrading {PlatformNameShort} 2.5 caused an occasional internal server error for all users with {EDAName} and {HubNameStart} post upgrade.(AAP-39293)
 
-Fixed an issue where the administrator was not allowed to configure auto migration of legacy authenticators.(AAP-39949)
+* Fixed an issue where the administrator was not allowed to configure auto migration of legacy authenticators.(AAP-39949)
 
-Fixed an issue where there were two launch/relaunch icons displayed from the jobs list for failed jobs.(AAP-38483)
+* Fixed an issue where there were two launch/relaunch icons displayed from the jobs list for failed jobs.(AAP-38483)
 
-Fixed an issue where the *Schedules Add* wizard returned a `RequestError` *Not Found*.(AAP-37909)
+* Fixed an issue where the *Schedules Add* wizard returned a `RequestError` *Not Found*.(AAP-37909)
 
-Fixed an issue where the *EC2 Inventory Source* type required credentials, which is not necessary when using IAM instance profiles.(AAP-37346)
+* Fixed an issue where the *EC2 Inventory Source* type required credentials, which is not necessary when using IAM instance profiles.(AAP-37346)
 
-Fixed an issue when attempting to assign the *Automation Decisions - Organization Admin* role to a user in an organization resulted in the error, *Not managed locally, use the resource server instead*. Administrators can now be added by using the *Organization -> Administrators* tab.(AAP-37106)
+* Fixed an issue when attempting to assign the *Automation Decisions - Organization Admin* role to a user in an organization resulted in the error, *Not managed locally, use the resource server instead*. Administrators can now be added by using the *Organization -> Administrators* tab.(AAP-37106)
 
-Fixed an issue where when updating a workflow node, the Job Tags were lost and Skip Tags were not saved.(AAP-35956)
+* Fixed an issue where when updating a workflow node, the Job Tags were lost and Skip Tags were not saved.(AAP-35956)
 
-Fixed an issue where new users who logged in with legacy authentication were not merged when switching to Gateway authentication.(AAP-40120)
+* Fixed an issue where new users who logged in with legacy authentication were not merged when switching to Gateway authentication.(AAP-40120)
 
-Fixed an issue where the user was unable to link legacy SSO accounts to Gateway.(AAP-40050)
+* Fixed an issue where the user was unable to link legacy SSO accounts to Gateway.(AAP-40050)
 
-Fixed an issue where updating {PlatformNameShort} to 2.5 caused an Internal Service Error for all users with {EDAName} and {HubNameStart} post upgrade. The migration process will now detect and fix users who were created in services via JWT auth and improperly linked to the service instead of the {Gateway}.(AAP-39914)
+* Fixed an issue where updating {PlatformNameShort} to 2.5 caused an Internal Service Error for all users with {EDAName} and {HubNameStart} post upgrade. The migration process will now detect and fix users who were created in services via JWT auth and improperly linked to the service instead of the {Gateway}.(AAP-39914)
 
 
 === {OperatorPlatformNameShort}
@@ -120,8 +122,10 @@ Fixed an issue where updating {PlatformNameShort} to 2.5 caused an Internal Serv
 
 === {EDAName}
 
-Fixed an issue where the btn:[Generate extra vars] button did not handle file/env injected credentials.(AAP-36003)
+* Fixed an issue where the btn:[Generate extra vars] button did not handle file/env injected credentials.(AAP-36003)
 
 === Known Issues
 
-In the {Gateway}, the tooltip for *Projects -> Create Project - Project Base Path* is undefined.(AAP-27631)
+* In the {Gateway}, the tooltip for *Projects -> Create Project - Project Base Path* is undefined.(AAP-27631)
+
+* Deploying the {Gateway} on FIPS enabled RHEL 9 is currently not supported.(AAP-39146)


### PR DESCRIPTION
Added/updated the following to the version table:
Container-based installer Ansible Automation Platform (bundle) 2.5-10 
Container-based installer Ansible Automation Platform (online) 2.5-10 
RPM-based installer Ansible Automation Platform (bundle) 2.5-8.1
RPM-based installer Ansible Automation Platform (online) 2.5-8

Added the following to Known Issues:
Deploying the platform gateway on FIPS enabled RHEL 9 is currently not supported.(AAP-39146)