### PR TITLE
backport to 2.5: AAP-40325: updates ansible core version in EE guide (#2931)

### DIFF
--- a/downstream/modules/builder/con-about-ee.adoc
+++ b/downstream/modules/builder/con-about-ee.adoc
@@ -9,8 +9,8 @@ All automation in {PlatformName} runs on container images called {ExecEnvName}.
 
 An {ExecEnvNameSing} should contain the following:
 
-* Ansible Core 2.15 or later
-* Python 3.8-3.11
+* Ansible Core 2.16 or later
+* Python 3.10 or later
 * {Runner}
 * Ansible content collections and their dependencies
 * System dependencies


### PR DESCRIPTION
This PR ports the changes from[ PR 2931](https://github.com/ansible/aap-docs/pull/2931) to the 2.5 branch. See [AAP-40325](https://issues.redhat.com/browse/AAP-40325) for more. 