### PR TITLE
40016 - Adding post upgrade assembly to the OCP guide

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -17,6 +17,7 @@ include::platform/con-operator-upgrade-prereq.adoc[leveloffset=+1]
 include::platform/con-operator-channel-upgrade.adoc[leveloffset=+1]
 include::platform/proc-operator-upgrade.adoc[leveloffset=+1]
 include::platform/proc-operator-create_crs.adoc[leveloffset=+1]
+include::assembly-aap-post-upgrade.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
This PR includes the post upgrade steps for the migration of users and SSO configurations to AAP 2.5 after a successful upgrade. 