### PR TITLE
[Backport] 40016 - Adding post upgrade assembly to the OCP guide (#2933)

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -17,6 +17,7 @@ include::platform/con-operator-upgrade-prereq.adoc[leveloffset=+1]
 include::platform/con-operator-channel-upgrade.adoc[leveloffset=+1]
 include::platform/proc-operator-upgrade.adoc[leveloffset=+1]
 include::platform/proc-operator-create_crs.adoc[leveloffset=+1]
+include::assembly-aap-post-upgrade.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
This PR backports the changes from #2933 to the 2.5 branch. 