### PR TITLE
AAP-40435 - Typo fix

### DIFF
--- a/downstream/modules/platform/proc-operator-deploy-redis.adoc
+++ b/downstream/modules/platform/proc-operator-deploy-redis.adoc
@@ -18,7 +18,7 @@ For more information about Redis, refer to Caching and queueing system in the _P
 . Select the *Details* tab. 
 . On the *{PlatformNameShort}* tile click btn:[Create instance].
 .. For existing instances, you can edit the YAML view by clicking the {MoreActionsIcon} icon and then btn:[Edit AnsibleAutomationPlatform].
-.. Change the *redis_mode* value to "clustered".
+.. Change the *redis_mode* value to "cluster".
 .. Click btn:[Reload], then btn:[Save].
 . Click to expand *Advanced configuration*.
 . For the *Redis Mode* list, select *Cluster*.


### PR DESCRIPTION
[AAP-40435](https://issues.redhat.com/browse/AAP-40435)

[Step 5.ii ](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/installing_on_openshift_container_platform/index#installing-hub-operator) "redis_mode: clustered", should be "redis_mode: cluster" 