### PR TITLE
Backport to 2.4: AAP-40425 updates admonition about container image pulls in hub guide (#2943)

### DIFF
--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -21,16 +21,32 @@ You must follow a specific workflow to populate your {PrivateHubName} container 
 
 [IMPORTANT]
 ====
-Image manifests and filesystem blobs were both originally served directly from `registry.redhat.io` and `registry.access.redhat.com`.
-As of 1 May 2023, filesystem blobs are served from `quay.io` instead.
+As of *April 1st, 2025*, `quay.io` is adding three additional endpoints. As a result, customers must adjust the allow/block lists within their firewall systems lists to include the following endpoints:
 
-* Ensure that the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_planning_guide/ref-network-ports-protocols_planning[Network ports and protocols] listed in _Table 5.4 Execution Environments (EE)_ are available to avoid problems pulling container images.
+* `cdn04.quay.io`
+* `cdn05.quay.io`
+* `cdn06.quay.io`
 
-Make this change to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
+To avoid problems pulling container images, customers must allow outbound TCP connections (ports 80 and 443) to the following hostnames:
+
+* `cdn.quay.io`
+* `cdn01.quay.io`
+* `cdn02.quay.io`
+* `cdn03.quay.io`
+* `cdn04.quay.io`
+* `cdn05.quay.io`
+* `cdn06.quay.io`
+
+This change should be made to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
 
 Use the hostnames instead of IP addresses when configuring firewall rules.
 
-After making this change you can continue to pull images from `registry.redhat.io` and `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+After making this change, you can continue to pull images from `registry.redhat.io` or `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+
+For more information, see link:https://access.redhat.com/articles/7084334[Firewall changes for container image pulls 2024/2025].
+
+Ensure that the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[Network ports and protocols] listed in _Table 6.4. Execution Environments (EE)_ are available to avoid problems pulling container images.
+
 ====
 
 include::hub/proc-obtain-images.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR ports the changes from https://github.com/ansible/aap-docs/pull/2943 to the 2.4 branch. See [AAP-40425](https://issues.redhat.com/browse/AAP-40425) for more.