### PR TITLE
Backport to 2.3: AAP-40425 updates admonition for pulling container images

### DIFF
--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -14,20 +14,29 @@ By default, {PrivateHubName} does not include container images. To populate your
 
 [IMPORTANT]
 ====
-Image manifests and filesystem blobs are served directly from `registry.redhat.io` and `registry.access.redhat.com`. 
-However, from 1st of May 2023, filesystem blobs are served from `quay.io` instead. 
-To avoid problems pulling container images, you must enable outbound connections to the following hostnames:
+As of *April 1st, 2025*, `quay.io` is adding three additional endpoints. As a result, customers must adjust the allow/block lists within their firewall systems lists to include the following endpoints:
+
+* `cdn04.quay.io`
+* `cdn05.quay.io`
+* `cdn06.quay.io`
+
+To avoid problems pulling container images, customers must allow outbound TCP connections (ports 80 and 443) to the following hostnames:
 
 * `cdn.quay.io`
 * `cdn01.quay.io`
 * `cdn02.quay.io`
 * `cdn03.quay.io`
+* `cdn04.quay.io`
+* `cdn05.quay.io`
+* `cdn06.quay.io`
 
-Make this change to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
+This change should be made to any firewall configuration that specifically enables outbound connections to `registry.redhat.io` or `registry.access.redhat.com`.
 
-Use the hostnames instead of IP addresses when configuring firewall rules. 
+Use the hostnames instead of IP addresses when configuring firewall rules.
 
-After making this change you can continue to pull images from `registry.redhat.io` and `registry.access.redhat.com`. You do not need a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+After making this change, you can continue to pull images from `registry.redhat.io` or `registry.access.redhat.com`. You do not require a `quay.io` login, or need to interact with the `quay.io` registry directly in any way to continue pulling Red Hat container images.
+
+For more information, see link:https://access.redhat.com/articles/7084334[Firewall changes for container image pulls 2024/2025].
 ====
 
 == Prerequisites


### PR DESCRIPTION
This PR ports the changes from https://github.com/ansible/aap-docs/pull/2943 to the 2.3 branch. See [AAP-40425](https://issues.redhat.com/browse/AAP-40425) for more.