### PR TITLE
AAP-40555 edits to migration section

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -28,9 +28,7 @@ include::platform/proc-create-secret-key-secret.adoc[leveloffset=+2]
 include::platform/proc-create-postresql-secret.adoc[leveloffset=+2]
 include::platform/proc-verify-network-connectivity.adoc[leveloffset=+2]
 include::platform/proc-aap-migration.adoc[leveloffset=+1]
-include::platform/proc-aap-create_controller.adoc[leveloffset=+2]
-include::platform/proc-aap-create_hub.adoc[leveloffset=+2]
-include::platform/proc-aap-create_eda.adoc[leveloffset=+2]
+include::platform/proc-aap-create-aap.adoc[leveloffset=+2]
 include::platform/proc-post-migration-cleanup.adoc[leveloffset=+1]
 
 

--- a/downstream/modules/platform/proc-aap-create-aap.adoc
+++ b/downstream/modules/platform/proc-aap-create-aap.adoc
@@ -1,0 +1,46 @@
+[id="aap-create-aap"]
+
+= Creating an AnsibleAutomationPlatform object
+
+[role=_abstract]
+
+Use the following steps to create an *AnsibleAutomationPlatform* custom resource object.
+
+.Procedure
+. Log in to *{OCP}*.
+. Navigate to menu:Operators[Installed Operators].
+. Select the {OperatorPlatformNameShort} installed on your project namespace.
+. Select the *{PlatformNameShort}* tab.
+. Click btn:[Create AnsibleAutomationPlatform]. 
+. Select *YAML view* and paste in the following modified accordingly:
++
+----
+# Migrating from 2.4 (containerized or rpm installer) to Openshift
+# Note that in 2.4 controller, hub, and eda were deployed as separate CRs to 2.5 where they are deployed as nested CRs under the AAP CR.
+---
+apiVersion: aap.ansible.com/v1alpha1
+kind: AnsibleAutomationPlatform
+metadata:
+  name: myaap
+spec:
+  # Development purposes only
+  no_log: false
+  postgres_configuration_secret: external-postgres-configuration
+
+  controller:
+    disabled: false
+    postgres_configuration_secret: external-controller-postgres-configuration
+    secret_key_secret: controller-secret-key
+
+  eda:
+    disabled: false
+    postgres_configuration_secret: external-eda-postgres-configuration
+    db_fields_encryption_secret: eda-db-fields-encryption-secret
+
+  hub:
+    disabled: false
+    postgres_configuration_secret: external-hub-postgres-configuration
+    db_fields_encryption_secret: hub-db-fields-encryption-secret
+----
++
+. Click btn:[Create].

--- a/downstream/modules/platform/proc-aap-migration.adoc
+++ b/downstream/modules/platform/proc-aap-migration.adoc
@@ -1,7 +1,22 @@
 [id="aap-data-migration_{context}"]
 
-= Migrating data to the {PlatformNameShort} Operator
+= Migrating data to the {OperatorPlatformNameShort} 
 
 [role=_abstract]
 
-After you have set your secret key, postgresql credentials, verified network connectivity, and installed the {OperatorPlatformNameShort}, you must create a custom resource controller object before you can migrate your data.
+When migrating a 2.4 containerized or RPM installed deployment to {OCPShort} you must create a custom resource {PlatformNameShort} object before you can migrate your data.
+
+[NOTE]
+====
+The operator does not support {EDAName} migration at this time.
+====
+
+.Prerequisites 
+
+You have completed the following procedures:
+
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_openshift_container_platform/index#install-aap-operator_operator-platform-doc[Installing the Red Hat Ansible Automation Platform Operator on Red Hat OpenShift Container Platform] 
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_openshift_container_platform/index#create-secret-key-secret_aap-migration[Creating a secret key]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_openshift_container_platform/index#create-postresql-secret_aap-migration[Creating a postgresql configuration secret]
+* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_openshift_container_platform/index#verify-network-connectivity_aap-migration[Verifying network connectivity]
+


### PR DESCRIPTION
[AAP-40555](https://issues.redhat.com/browse/AAP-40555) 

external-db-migration (2.5 only) AAP CR example missing. 

- Updating data migration assembly,
- creating AAP module
- removing controller, hub , and eda modules