### PR TITLE
AAP-34926A fixed typo

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-platform-components.adoc
+++ b/downstream/assemblies/platform/assembly-aap-platform-components.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 
 
 [role="_abstract"]
-{PlatformNameShort} is composed of services that are connected together to meet your automation needs. These services provide the ability to store, make decisions for, and execute automation. All of these functions are available through with a user interface (UI) and RESTful application programming interface (API). Deploy each of the following components so that all features and capabilities are available for use without the need to take further action:
+{PlatformNameShort} is composed of services that are connected together to meet your automation needs. These services provide the ability to store, make decisions for, and execute automation. All of these functions are available through a user interface (UI) and RESTful application programming interface (API). Deploy each of the following components so that all features and capabilities are available for use without the need to take further action:
 
 * {GatewayStart}
 * {HubNameStart}


### PR DESCRIPTION
Fixed typo in https://github.com/ansible/aap-docs/pull/2891

[AAP-34926](https://issues.redhat.com/browse/AAP-34926)

Files modified:
- assembly-aap-platform-components.adoc