### PR TITLE
AAP-36148: adds note reminding users that basic auth/service accounts are not supported for hub authentication

### DIFF
--- a/downstream/modules/hub/con-token-management-hub.adoc
+++ b/downstream/modules/hub/con-token-management-hub.adoc
@@ -8,6 +8,11 @@
 
 Before you can interact with {HubName} by uploading or downloading collections, you must create an API token. The {HubName} API token authenticates your `ansible-galaxy` client to the Red Hat {HubName} server.
 
+[NOTE]
+====
+{HubName} does not support basic authentication or authenticating through service accounts. You must authenticate through token management.
+====
+
 Your method for creating the API token differs according to the type of {HubName} that you are using:
 
 * {HubNameStart} uses offline token management. See xref:proc-create-api-token_cloud-sync[Creating the offline token in {HubName}].

--- a/downstream/modules/hub/con-token-management-hub.adoc
+++ b/downstream/modules/hub/con-token-management-hub.adoc
@@ -10,7 +10,7 @@ Before you can interact with {HubName} by uploading or downloading collections, 
 
 [NOTE]
 ====
-{HubName} does not support basic authentication or authenticating through service accounts. You must authenticate through token management.
+{HubName} does not support authenticating through service accounts. You must authenticate using token management.
 ====
 
 Your method for creating the API token differs according to the type of {HubName} that you are using:

--- a/downstream/modules/hub/con-token-management-hub.adoc
+++ b/downstream/modules/hub/con-token-management-hub.adoc
@@ -10,7 +10,7 @@ Before you can interact with {HubName} by uploading or downloading collections, 
 
 [NOTE]
 ====
-{HubName} does not support authenticating through service accounts. You must authenticate using token management.
+{HubName} does not support basic authentication or authenticating through service accounts. You must authenticate using token management.
 ====
 
 Your method for creating the API token differs according to the type of {HubName} that you are using:


### PR DESCRIPTION
See [AAP-36148](https://issues.redhat.com/browse/AAP-36148) for more