### PR TITLE
AAP-40151 - added note about adding users and teams to organizations

### DIFF
--- a/downstream/modules/platform/proc-controller-user-permissions.adoc
+++ b/downstream/modules/platform/proc-controller-user-permissions.adoc
@@ -7,6 +7,11 @@
 You can assign permissions to teams, such as edit and administer resources and other elements.
 You can set permissions through an inventory, project, job template and other resources, or within the Organizations view.
 
+[NOTE]
+====
+Teams can not be assigned to an organization by adding roles. Refer to the steps provided in link:{URLCentralAuth}/gw-managing-access#proc-gw-add-team-organization[Adding a team to an organization] for detailed instructions.
+====
+
 .Procedure
 . From the navigation panel, select {MenuAMTeams}.
 . Select the team *Name* to which you want to add roles.

--- a/downstream/modules/platform/ref-controller-user-roles.adoc
+++ b/downstream/modules/platform/ref-controller-user-roles.adoc
@@ -6,6 +6,11 @@
 
 You can grant access for users to use, read, or write credentials by assigning roles to them.
 
+[NOTE]
+====
+Users can not be assigned to an organization by adding roles. Refer to the steps provided in link:{URLCentralAuth}/gw-managing-access#proc-controller-add-organization-user[Adding a user to an organization] for detailed instructions.
+====
+
 .Procedure
 . From the navigation panel, select {MenuAMUsers}.
 . From the *Users* list view, click on the user to which you want to add roles.


### PR DESCRIPTION
This PR adds a note that explicitly states the users and teams can not be added to organizations through the Roles procedure to address https://issues.redhat.com/browse/AAP-40151.