### PR TITLE
AAP-40686: AAP-40686: Updated the Lightspeed User Guide with latest IBM doc URLs

### DIFF
--- a/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
+++ b/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
@@ -28,7 +28,7 @@ To see the rest of the {PlatformName} system requirements, see the link:{URLPlan
 
 [NOTE]
 ====
-You must also have installed {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data. The installation includes a base model that you can use to set up your {LightspeedshortName} on-premise deployment. For installation information, see the link:https://www.ibm.com/docs/SSQNUZ_5.0.x/svc-welcome/wxca-ansible.html[IBM watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation]. 
+You must also have installed {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data. The installation includes a base model that you can use to set up your {LightspeedshortName} on-premise deployment. For installation information, see the link:https://www.ibm.com/docs/en/software-hub/5.1.x?topic=services-watsonx-code-assistant-red-hat-ansible-lightspeed[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation]. 
 ====
 
 == Prerequisites
@@ -43,7 +43,7 @@ You must also have installed {ibmwatsonxcodeassistant} for {LightspeedshortName}
 
 * You have obtained an API key and a model ID from {ibmwatsonxcodeassistant}. 
 +
-For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/SSQNUZ_5.0.x/svc-welcome/wxca-ansible.html[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
+For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/en/software-hub/5.1.x?topic=services-watsonx-code-assistant-red-hat-ansible-lightspeed[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
 
 * You have an existing external PostgreSQL database configured for the {PlatformName}, or have a database created for you when configuring the {LightspeedshortName} on-premise deployment. 
 

--- a/lightspeed/modules/proc_create-connection-secrets.adoc
+++ b/lightspeed/modules/proc_create-connection-secrets.adoc
@@ -11,7 +11,7 @@ You must create an authorization secret to connect to {PlatformName}, and a mode
 * You have created an OAuth application in the {ControllerName}.
 * You have obtained an API key and a model ID from {ibmwatsonxcodeassistant}. 
 +
-For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/SSQNUZ_5.0.x/svc-welcome/wxca-ansible.html[watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
+For information about obtaining an API key and model ID from {ibmwatsonxcodeassistant}, see the link:https://cloud.ibm.com/docs/watsonx-code-assistant[{ibmwatsonxcodeassistant} documentation]. For information about installing {ibmwatsonxcodeassistant} for {LightspeedshortName} on Cloud Pak for Data, see the link:https://www.ibm.com/docs/en/software-hub/5.1.x?topic=services-watsonx-code-assistant-red-hat-ansible-lightspeed[ watsonx Code Assistant for {LightspeedshortName} on Cloud Pak for Data documentation].
 
 == Creating authorization and model secrets
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-40686.

Changes made:

- Updated the URLs of 'watsonx Code Assistant for Red Hat Ansible Lightspeed on Cloud Pak for Data docs' with the latest version URLs. 