### PR TITLE
Update using custom TLS certs ref

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -124,23 +124,19 @@ Default = `awx`
 
 | `pgclient_sslcert` | `controller_pg_tls_cert` | Required if using client certificate authentication.
 
-The path to the PostgreSQL SSL/TLS certificate file for {ControllerName}.
+Path to the PostgreSQL SSL/TLS certificate file for {ControllerName}.
 
 | `pgclient_sslkey` | `controller_pg_tls_key` | Required if using client certificate authentication.
 
-The path to the PostgreSQL SSL/TLS key file for {ControllerName}.
+Path to the PostgreSQL SSL/TLS key file for {ControllerName}.
 
 | `web_server_ssl_cert` | `controller_tls_cert` | _Optional_
 
-`/path/to/webserver.cert`
-
-Same as `automationhub_ssl_cert` but for web server UI and API.
+Path to the SSL/TLS certificate file for {ControllerName}.
 
 | `web_server_ssl_key` | `controller_tls_key` | _Optional_
 
-`/path/to/webserver.key`
-
-Same as `automationhub_server_ssl_key` but for web server UI and API.
+Path to the SSL/TLS key file for {ControllerName}.
 
 | | `controller_event_workers` | {ControllerNameStart} event workers.
 

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -17,13 +17,9 @@ See link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref
 
 Default = `1024`
 
-| `postgres_ssl_cert` | `postgresql_tls_cert` | Location of the PostgreSQL SSL/TLS certificate file.
+| `postgres_ssl_cert` | `postgresql_tls_cert` | Path to the PostgreSQL SSL/TLS certificate file.
 
-`/path/to/pgsql_ssl.cert`
-
-| `postgres_ssl_key` | `postgresql_tls_key` | Location of the PostgreSQL SSL/TLS key file.
-
-`/path/to/pgsql_ssl.key`
+| `postgres_ssl_key` | `postgresql_tls_key` | Path to the PostgreSQL SSL/TLS key file.
 
 | `postgres_use_cert` | | Location of the PostgreSQL user certificate file.
 

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -111,11 +111,11 @@ Container default = `eda`
 
 | `automationedacontroller_pgclient_sslcert` | `eda_pg_tls_cert` | Required if using client certificate authentication.
 
-The path to the PostgreSQL SSL/TLS certificate file for {EDAName}.
+Path to the PostgreSQL SSL/TLS certificate file for {EDAName}.
 
 | `automationedacontroller_pgclient_sslkey` | `eda_pg_tls_key` | Required if using client certificate authentication.
 
-The path to the PostgreSQL SSL/TLS key file for {EDAName}.
+Path to the PostgreSQL SSL/TLS key file for {EDAName}.
 
 | `automationedacontroller_redis_host` | `eda_redis_host` | The Redis hostname used by {EDAcontroller}.
 
@@ -127,15 +127,11 @@ Default = (# of cores or threads) * 2 + 1
 
 | `automationedacontroller_ssl_cert` | `eda_tls_cert` | _Optional_
 
-`/root/ssl_certs/eda.<example>.com.crt`
-
-Same as `automationhub_ssl_cert` but for {EDAcontroller} UI and API.
+Path to the SSL/TLS certificate file for {EDAName}.
 
 | `automationedacontroller_ssl_key` | `eda_tls_key` | _Optional_
 
-`/root/ssl_certs/eda.<example>.com.key`
-
-Same as `automationhub_server_ssl_key` but for {EDAcontroller} UI and API.
+Path to the SSL/TLS key file for {EDAName}.
 
 | `automationedacontroller_user_headers` | `eda_nginx_user_headers` | List of additional NGINX headers to add to {EDAcontroller}'s NGINX configuration. 
 
@@ -185,15 +181,11 @@ Default = `false`
 
 | | `eda_redis_tls_cert` | _Optional_
 
-`/path/to/edaredis.crt`
-
-Location of the {EDAcontroller} Redis TLS certificate.
+Path to the {EDAName} Redis certificate file.
 
 | | `eda_redis_tls_key` | _Optional_
 
-`/path/to/edaredis.key`
-
-Location of the {EDAcontroller} Redis TLS key.
+Path to the {EDAName} Redis key file.
 
 | | `eda_redis_username` | Redis {EDAcontroller} username (for many nodes).
 

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -93,11 +93,11 @@ Container default = `gateway`
 
 | `automationgateway_pgclient_sslcert` | `gateway_pg_tls_cert` | Required if using client certificate authentication.
 
-The path to the PostgreSQL SSL/TLS certificate file for {Gateway}.
+Path to the PostgreSQL SSL/TLS certificate file for {Gateway}.
 
 | `automationgateway_pgclient_sslkey` | `gateway_pg_tls_key` | Required if using client certificate authentication.
 
-The path to the PostgreSQL SSL/TLS key file for {Gateway}.
+Path to the PostgreSQL SSL/TLS key file for {Gateway}.
 
 | `automationgateway_redis_host` | `gateway_redis_host` | The Redis hostname used by {Gateway}.
 
@@ -107,15 +107,11 @@ Default = `6379`
 
 | `automationgateway_ssl_cert` | `gateway_tls_cert` | _Optional_
 
-`/path/to/automationgateway.cert`
-
-Same as `automationhub_ssl_cert` but for {Gateway} UI and API.
+Path to the SSL/TLS certificate file for {Gateway}.
 
 | `automationgateway_ssl_key` | `gateway_tls_key` | _Optional_
 
-`/path/to/automationgateway.key`
-
-Same as `automationhub_server_ssl_key` but for {Gateway} UI and API.
+Path to the SSL/TLS key file for {Gateway}.
 
 | | `gateway_nginx_client_max_body_size` | NGINX maximum body size.
 
@@ -143,15 +139,11 @@ Default = `false`
 
 | | `gateway_redis_tls_cert` | _Optional_
 
-`/path/to/gatewayredis.crt`
-
-Location of the {Gateway} Redis TLS certificate.
+Path to the {Gateway} Redis certificate file.
 
 | | `gateway_redis_tls_key` | _Optional_
 
-`/path/to/gatewayredis.key`
-
-Location of the {Gateway} Redis TLS key.
+Path to the {Gateway} Redis key file.
 
 | | `gateway_redis_username` | Redis {Gateway} username.
 

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -55,8 +55,8 @@ Default = `tcp`
 
 Default = `false`
 
-| | `receptor_tls_cert` | Receptor TLS certificate. 
-| | `receptor_tls_key` | Receptor TLS key. 
+| | `receptor_tls_cert` | Path to the SSL/TLS certificate file for receptor. 
+| | `receptor_tls_key` | Path to the SSL/TLS key file for receptor. 
 | | `receptor_tls_remote` | Receptor TLS remote files. 
 
 Default = `false`

--- a/downstream/modules/platform/ref-using-custom-tls-certificates.adoc
+++ b/downstream/modules/platform/ref-using-custom-tls-certificates.adoc
@@ -8,47 +8,58 @@
 
 [role="_abstract"]
 
-By default, the installation program generates TLS certificates and keys for all services that are signed by a custom Certificate Authority (CA). You can provide a custom TLS certificate and key for each service. If that certificate is signed by a custom CA, you must provide the CA TLS certificate and key.
+By default, the installation program generates self-signed TLS certificates and keys for all {PlatformNameShort} services.
 
-* Certificate Authority
-----
-ca_tls_cert=/full/path/to/tls/certificate
-ca_tls_key=/full/path/to/tls/key
-----
+If you want to replace these with your own custom certificate and key, then set the following inventory file variables:
 
-* {GatewayStart}
 ----
-gateway_tls_cert=/full/path/to/tls/certificate
-gateway_tls_key=/full/path/to/tls/key
+ca_tls_cert=<path_to_ca_tls_certificate>
+ca_tls_key=<path_to_ca_tls_key>
 ----
 
-* {ControllerNameStart}
+If you want to use your own TLS certificates and keys for each service (for example {ControllerName}, {HubName}, {EDAName}), then set the following inventory file variables:
+
+[source,yaml,subs="+attributes"]
 ----
-controller_tls_cert=/full/path/to/tls/certificate
-controller_tls_key=/full/path/to/tls/key
+# {GatewayStart}
+gateway_tls_cert=<path_to_tls_certificate>
+gateway_tls_key=<path_to_tls_key>
+gateway_pg_tls_cert=<path_to_tls_certificate>
+gateway_pg_tls_key=<path_to_tls_key>
+gateway_redis_tls_cert=<path_to_tls_certificate>
+gateway_redis_tls_key=<path_to_tls_key>
+
+# {ControllerNameStart}
+controller_tls_cert=<path_to_tls_certificate>
+controller_tls_key=<path_to_tls_key>
+controller_pg_tls_cert=<path_to_tls_certificate>
+controller_pg_tls_key=<path_to_tls_key>
+
+# {HubNameStart}
+hub_tls_cert=<path_to_tls_certificate>
+hub_tls_key=<path_to_tls_key>
+hub_pg_tls_cert=<path_to_tls_certificate>
+hub_pg_tls_key=<path_to_tls_key>
+
+# {EDAName}
+eda_tls_cert=<path_to_tls_certificate>
+eda_tls_key=<path_to_tls_key>
+eda_pg_tls_cert=<path_to_tls_certificate>
+eda_pg_tls_key=<path_to_tls_key>
+eda_redis_tls_cert=<path_to_tls_certificate>
+eda_redis_tls_key=<path_to_tls_key>
+
+# PostgreSQL
+postgresql_tls_cert=<path_to_tls_certificate>
+postgresql_tls_key=<path_to_tls_key>
+
+# Receptor
+receptor_tls_cert=<path_to_tls_certificate>
+receptor_tls_key=<path_to_tls_key>
 ----
 
-* {HubNameStart}
-----
-hub_tls_cert=/full/path/to/tls/certificate
-hub_tls_key=/full/path/to/tls/key
-----
+If any of your certificates are signed by a custom Certificate Authority (CA), then you must specify the Certificate Authority's certificate by using the `custom_ca_cert` inventory file variable:
 
-* {EDAName}
 ----
-eda_tls_cert=/full/path/to/tls/certificate
-eda_tls_key=/full/path/to/tls/key
+custom_ca_cert=<path_to_custom_ca_certificate>
 ----
-
-* PostgreSQL
-----
-postgresql_tls_cert=/full/path/to/tls/certificate
-postgresql_tls_key=/full/path/to/tls/key
-----
-
-* Receptor
-----
-receptor_tls_cert=/full/path/to/tls/certificate
-receptor_tls_key=/full/path/to/tls/key
-----
-


### PR DESCRIPTION
Update the section "Using custom TLS certificates" in Containerized installation

- Ensure all vars are correctly documented for use
- Ensure it's clear what vars to use for what scenarios
- Referenced vars are documented in the appendix

Containerized installation - Add Redis TLS certs to Using custom TLS certs section

https://issues.redhat.com/browse/AAP-39523