### PR TITLE
[Backport] AAP-37564: Added ICU support for PostgreSQL database (#2901)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -53,10 +53,14 @@ Each virtual machine (VM) has the following system requirements:
 | RAM      | 16 GB
 | CPUs         | 4 
 | Local disk  | 60 GB  
-| Disk IOPS   | 3000    
+| Disk IOPS   | 3000   
 |====
 
 If performing a bundled installation of the growth topology with `hub_seed_collections=true`, then 32 GB RAM is recommended. Note that with this configuration the install time is going to increase and can take 45 or more minutes alone to complete seeding the collections.
+
+=== PostgreSQL requirements
+{PlatformName} {PlatformVers} uses {PostgresVers} and requires the external (customer supported) databases to have ICU support.  
+
 
 include::platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc[leveloffset=+1]
 include::platform/proc-downloading-containerized-aap.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-setup-postgresql-ext-database-containerized.adoc
+++ b/downstream/modules/platform/proc-setup-postgresql-ext-database-containerized.adoc
@@ -6,6 +6,8 @@
 ====
 * When using an external database with {PlatformNameShort}, you must create and maintain that database. Ensure that you clear your external database when uninstalling {PlatformNameShort}.
 
+* {PlatformName} {PlatformVers} uses {PostgresVers} and requires the external (customer supported) databases to have ICU support.
+
 * During configuration of an external database, you must check the external database coverage. For more information, see link:https://access.redhat.com/articles/4010491[{PlatformName} Database Scope of Coverage].
 ====  
 

--- a/downstream/modules/platform/proc-setup-postgresql-ext-database.adoc
+++ b/downstream/modules/platform/proc-setup-postgresql-ext-database.adoc
@@ -4,10 +4,12 @@
 
 [IMPORTANT]
 ====
-When using an external database with {PlatformNameShort}, you must create and maintain that database. Ensure that you clear your external database when uninstalling {PlatformNameShort}.
+* When using an external database with {PlatformNameShort}, you must create and maintain that database. Ensure that you clear your external database when uninstalling {PlatformNameShort}.
+
+* {PlatformName} {PlatformVers} uses {PostgresVers} and requires the external (customer supported) databases to have ICU support.
 ====  
 
-Use the following procedure to configure an external PostgreSQL compliant database for use with an {PlatformNameShort} component, for example {ControllerName}, {EDAName}, {HubName}, and {Gateway}.
+{PlatformName} {PlatformVers} uses {PostgresVers} and requires the external (customer supported) databases to have ICU support. Use the following procedure to configure an external PostgreSQL compliant database for use with an {PlatformNameShort} component, for example {ControllerName}, {EDAName}, {HubName}, and {Gateway}.
 
 .Procedure
 . Connect to a PostgreSQL compliant database server with superuser privileges.

--- a/downstream/modules/platform/ref-postgresql-requirements.adoc
+++ b/downstream/modules/platform/ref-postgresql-requirements.adoc
@@ -2,7 +2,7 @@
 
 = PostgreSQL requirements
 
-{PlatformName} uses PostgreSQL 15. PostgreSQL user passwords are hashed with SCRAM-SHA-256 secure hashing algorithm before storing in the database.
+{PlatformName} {PlatformVers} uses {PostgresVers} and requires the external (customer supported) databases to have ICU support. PostgreSQL user passwords are hashed with SCRAM-SHA-256 secure hashing algorithm before storing in the database. 
 
 To determine if your {ControllerName} instance has access to the database, you can do so with the command, `awx-manage check_db` command.
 

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -5,8 +5,8 @@
 = {PlatformName} system requirements
 
 Your system must meet the following minimum system requirements to install and run {PlatformName}. 
-A resilient deployment requires 10 virtual machines with a minimum of 16 gigabytes(GB) of ram and 4 virtual cpus(vCPU). 
-See, link:{LinkTopologies} for more information on topology options.
+A resilient deployment requires 10 virtual machines with a minimum of 16 gigabytes (GB) of RAM and 4 virtual CPUs (vCPU). 
+See link:{LinkTopologies} for more information on topology options.
 
 
 .Base system
@@ -21,7 +21,7 @@ h| OS | {RHEL} 8.8 or later (x86_64, aarch64), or {RHEL} 9.2 or later (x86_64, a
 
 h| Ansible-core | Ansible-core version {CoreInstVers} or later | {PlatformNameShort} uses the system-wide ansible-core package to install the platform, but uses ansible-core {CoreUseVers} for both its control plane and built-in execution environments.
 
-h| Database | PostgreSQL version 15 |
+h| Database | {PostgresVers}  | {PlatformName} {PlatformVers} requires the external (customer supported) databases to have ICU support.
 
 |===
 

--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -65,6 +65,7 @@ a|
 * instance_class: "db.t4g.small"
 * multi_az: true
 * backup_retention_period: 5
+* database: must have ICU support
 | AWS Memcached Service
 a|
 * engine: "redis"


### PR DESCRIPTION
This PR backports the changes from #2901 to the 2.5 branch and includes the following:

* AAP-37564: Added ICU support for PostgreSQL database

* AAP-37564: Added ICU support for containerized install and operator enterprise topology

* AAP-37564: Incorporated SME and peer feedback