### PR TITLE
Adding Git Hub app token proc (#3015)

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-secret-management.adoc
+++ b/downstream/assemblies/platform/assembly-controller-secret-management.adoc
@@ -18,6 +18,7 @@ With external credentials backed by credential plugins, you can map credential f
 * {Azure} _Key Management System_ (KMS)
 * Thycotic DevOps Secrets Vault
 * Thycotic Secret Server
+* GitHub app token lookup
 
 These external secret values are fetched before running a playbook that needs them. 
 
@@ -36,6 +37,4 @@ include::platform/ref-hashicorp-signed-ssh.adoc[leveloffset=+2]
 include::platform/ref-azure-key-vault-lookup.adoc[leveloffset=+2]
 include::platform/ref-thycotic-devops-vault.adoc[leveloffset=+2]
 include::platform/ref-thycotic-secret-server.adoc[leveloffset=+2]
-
-
-
+include::platform/proc-controller-github-app-token.adoc[leveloffset=+2]

--- a/downstream/modules/platform/proc-controller-configure-secret-lookups.adoc
+++ b/downstream/modules/platform/proc-controller-configure-secret-lookups.adoc
@@ -11,7 +11,7 @@ The metadata input fields are part of the external credential type definition of
 Use the following procedure to use {ControllerName} to configure and use each of the supported third-party secret management systems.
 
 .Procedure
-. Create an external credential for authenticating with the secret management system. At minimum, give a name for the external credential and select one of the following for the *Credential Type* field:
+. Create an external credential for authenticating with the secret management system. At minimum, give a name for the external credential and select one of the following for the *Credential type* field:
 +
 * xref:ref-aws-secrets-manager-lookup[AWS Secrets Manager Lookup]
 * xref:ref-centrify-vault-lookup[Centrify Vault Credential Provider Lookup]
@@ -22,6 +22,7 @@ Use the following procedure to use {ControllerName} to configure and use each of
 * xref:ref-azure-key-vault-lookup[{Azure} Key Vault]
 * xref:ref-thycotic-devops-vault[Thycotic DevOps Secrets Vault]
 * xref:ref-thycotic-secret-server[Thycotic Secret Server]
+* xref:controller-github-app-token[GitHub app token lookup]
 +
 In this example, the _Demo Credential_ is the target credential.
 
@@ -52,7 +53,7 @@ You return to the *Details* screen of your target credential.
 . Repeat these steps, starting with Step 3 to complete the remaining input fields for the target credential. 
 By linking the information in this manner, {ControllerName} retrieves sensitive information, such as username, password, keys, certificates, and tokens from the third-party management systems and populates the remaining fields of the target credential form with that data.
 . If necessary, supply any information manually for those fields that do not use linking as a way of retrieving sensitive information. 
-For more information about each of the fields, see the appropriate [Credential Types].
+For more information about each of the fields, see the appropriate link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution/controller-credentials#ref-controller-credential-types[Credential types].
 . Click btn:[Save].
 
 .Additional resources

--- a/downstream/modules/platform/proc-controller-github-app-token.adoc
+++ b/downstream/modules/platform/proc-controller-github-app-token.adoc
@@ -1,0 +1,57 @@
+[id="controller-github-app-token"]
+
+= Configuring a GitHub app token lookup
+
+With this plugin you can use a GitHub app token as a credential input source to pull secrets from the GitHub app. 
+{GatewayStart} uses existing GitHub authorization from organizations' GitHub repositories. 
+
+For more information, see link:https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app[Generating an installation access token for a GitHub App].
+
+.Procedure
+
+. Create a lookup credential that stores your secrets. 
+For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution/controller-credentials#controller-create-credential[Creating new credentials].
+
+. Select *GitHub App Installation Access Token lookup* for *Credential type*, and enter the following attributes to properly configure your lookup:
+
+** *GitHub App ID*: Enter the app ID used for communicating with your GitHub app.
+** *GitHub App Installation ID*: Enter the ID of the installation that you want to authenticate as.
+** *RSA Private Key*: Enter the generated private key from the GitHub organization in your repository. 
+For more information, see link:https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps[Managing private keys for GitHub Apps].
+
+. Click btn:[Create credential] to confirm and save the credential.
+
+. Create a target credential that looks up the lookup credential. 
+To use your lookup in a private repository, select *Source Control* as your *Credential type*. 
+Enter the following attributes to properly configure your target credential:
+
+** *Username*: Enter the username `x-access-token`.
+** *Password*: Click the image:leftkey.png[Link,15,15] icon for managing external credentials in the input field. 
+You are prompted to set the input source to use to retrieve your secret information. 
+This is the lookup credential that you have already created.
+
+. Enter an optional description for the metadata requested and click btn:[Finish].
+
+. Click btn:[Create credential] to confirm and save the credential.
+
+. Verify both your lookup credential and your target credential are now available on the *Credentials* list view.
+To use the target credential in a project, create a project and enter the following information:
+
+** *Name*: Enter the name for your project.
+** *Organization*: Select the name of the organization from the drop-down menu..
+** *Execution environment*: Optionally select an execution environment, if applicable.
+** *Source control type*: If you are syncing with a private repository, select *Git* for your source control.
++
+The *Type Details* view opens for additional input. 
+Enter the following information:
+
+** *Source control URL*: Enter the URL of the private repository you want to access. 
+The other related fields pertaining to *branch/tag/commit* and *refspec* are not pertinent for use with a lookup credential.
+** *Source control credential*: Select the target credential that you have already created.
+
+. Click btn:[Create project] and the project sync automatically starts. 
+The project *Details* tab displays the progress of the job.
+
+.Troubleshooting 
+
+If your project sync fails, you might have to manually re-enter `https://api.github.com/` in the *GitHub API endpoint URL* field from Step 2 and re-run your project sync.


### PR DESCRIPTION
* Adding Git Hub app token proc

Docs for Ansible Automation Platform source control authentication with GitHub Apps instead of PAT

https://issues.redhat.com/browse/AAP-37274

Affects `titles/controller-admin-guide`

* Fixing UI spelling error