### PR TITLE
[2.5 Backport] AAP-35987 [DOC] Document Copy Credential in EDA for parity with AAP

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-credentials.adoc
+++ b/downstream/assemblies/eda/assembly-eda-credentials.adoc
@@ -12,4 +12,5 @@ You can grant users and teams the ability to use these credentials without expos
 include::eda/con-credentials-list-view.adoc[leveloffset=+1]
 include::eda/proc-eda-set-up-credential.adoc[leveloffset=+1]
 include::eda/proc-eda-edit-credential.adoc[leveloffset=+1]
+include::eda/proc-eda-duplicate-credential.adoc[leveloffset=+1]
 include::eda/proc-eda-delete-credential.adoc[leveloffset=+1]

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -1,0 +1,21 @@
+[id="eda-duplicate-credential"]
+
+= Copying a credential
+
+When setting up a new credential with field inputs that are similar to your existing credentials, you can use the *Copy credential* feature in the Details tab to duplicate information instead of manually entering it. While setting up credentials can be a lengthy process, the ability to copy the required fields from an existing credential saves time and, in some cases, reduces the possibility of human error.
+
+.Procedure
+
+. On the Credentials list page, click the name of the credential that you want to copy. This takes you to the *Details* tab of the credential.
+. Click btn:[Copy credential] in the upper right of the Details tab. 
++
+[NOTE]
+====
+You can also click the btn:[Copy credential] icon next to the desired credential on the Credentials list page.
+====
+A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied." 
+. Click the btn:[Back to credentials] tab to view the credential you just copied. 
++
+The copied credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (for example, *<Name of credential> @ 17:26:30*). 
+. Edit the details you prefer for your copied credential.
+. Click btn:[Save credential].


### PR DESCRIPTION
Added a new module to the [Credentials](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credentials) chapter:

- "Copying a credential", downstream/modules/eda/proc-eda-duplicate-credential.adoc