### PR TITLE
Correct port service type

### DIFF
--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -68,8 +68,8 @@ If you choose to configure them to suit your environment, you might experience a
 | 5432 | TCP | PostgreSQL | {EDAName} node | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationedacontroller_pg_port`
 | 5432 | TCP | PostgreSQL | {HubNameStart} | PostgreSQL database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationhub_pg_port`
 | 5432 | TCP | PostgreSQL | {GatewayStart} | External database | Open only if the internal database is used along with another component. Otherwise, this port should not be open. | `automationgateway_pg_port`
-| 6379 | TCP | PostgreSQL | {EDAName} | Redis node | Job launching | 
-| 6379 | TCP | PostgreSQL | {GatewayStart} | Redis node | Data storage and retrieval | 
+| 6379 | TCP | Redis | {EDAName} | Redis node | Job launching | 
+| 6379 | TCP | Redis | {GatewayStart} | Redis node | Data storage and retrieval | 
 | 8443 | TCP | HTTPS | {GatewayStart} | {GatewayStart} | nginx | 
 | 16379 | TCP | Redis | Redis nodes | Redis nodes | Redis cluster bus port for a resilient Redis configuration | 
 | 27199 | TCP | Receptor | Controller node | Execution node | Configurable


### PR DESCRIPTION
Change postgreSQL to Redis

[Docs] Wrong Redis services in "Network Ports and Protocols"

https://issues.redhat.com/browse/AAP-41021