### PR TITLE
 AAP-40833 edits

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -49,6 +49,7 @@ include::platform/proc-operator-external-db-hub.adoc[leveloffset=+1]
 include::platform/proc-enable-hstore-extension.adoc[leveloffset=+2]
 include::platform/proc-find-delete-PVCs.adoc[leveloffset=+1]
 include::platform/ref-ocp-additional-configs.adoc[leveloffset=+1]
+include::platform/proc-aap-add-allowed-registries.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources

--- a/downstream/modules/platform/proc-aap-add-allowed-registries.adoc
+++ b/downstream/modules/platform/proc-aap-add-allowed-registries.adoc
@@ -10,7 +10,7 @@ Before you can deploy a container image in {HubName}, you must add the registry 
 
 . Log in to *{OCP}*.
 . Navigate to menu:Home[Search].
-. Select the *Resources* drop list and type "Image".
+. Select the *Resources* drop-down list and type "Image".
 . Select *Image (config,openshift.io/v1)*.
 . Click btn:[Cluster] under the *Name* heading. 
 . Select the btn:[YAML] tab.

--- a/downstream/modules/platform/proc-aap-add-allowed-registries.adoc
+++ b/downstream/modules/platform/proc-aap-add-allowed-registries.adoc
@@ -1,0 +1,29 @@
+[id="aap-add-allowed-registries_{context}"]
+
+= Adding allowed registries to the {ControllerName} image configuration
+
+[role=_abstract]
+
+Before you can deploy a container image in {HubName}, you must add the registry to the `allowedRegistries` in the {ControllerName} image configuration. To do this you can copy and paste the following code into your {ControllerName} image YAML.
+
+.Procedure
+
+. Log in to *{OCP}*.
+. Navigate to menu:Home[Search].
+. Select the *Resources* drop list and type "Image".
+. Select *Image (config,openshift.io/v1)*.
+. Click btn:[Cluster] under the *Name* heading. 
+. Select the btn:[YAML] tab.
+. Paste in the following under spec value:
++
+----
+spec:
+  registrySources:
+    allowedRegistries:
+    - quay.io
+    - registry.redhat.io
+    - image-registry.openshift-image-registry.svc:5000
+    - <OCP route for your automation hub>
+----
++
+. Click btn:[Save].


### PR DESCRIPTION
[AAP-40833](https://issues.redhat.com/browse/AAP-40833)   Manually adding Hub Operator as an EE image source to the OCP cluster policy

New module added to Section 7 in 2.5. 
Same module to be added to Section 13 in 2.4