### PR TITLE
AAP-40833 2.4 edits

### DIFF
--- a/downstream/assemblies/platform/assembly-using-rhsso-operator-with-automation-hub.adoc
+++ b/downstream/assemblies/platform/assembly-using-rhsso-operator-with-automation-hub.adoc
@@ -32,6 +32,7 @@ include::platform/proc-create-a-user.adoc[leveloffset=1]
 //include::platform/proc-installing-the-ansible-platform-operator.adoc[leveloffset=2]
 include::platform/proc-creating-a-secret.adoc[leveloffset=1]
 include::platform/proc-installing-hub-using-operator.adoc[leveloffset=1]
+include::platform/proc-aap-add-allowed-registries.adoc[leveloffset=1]
 include::platform/proc-determine-hub-route.adoc[leveloffset=1]
 include::platform/proc-update-rhsso-client.adoc[leveloffset=1]
 

--- a/downstream/modules/platform/proc-aap-add-allowed-registries.adoc
+++ b/downstream/modules/platform/proc-aap-add-allowed-registries.adoc
@@ -1,0 +1,29 @@
+[id="aap-add-allowed-registries_{context}"]
+
+= Adding allowed registries to the {ControllerName} image configuration
+
+[role=_abstract]
+
+Before you can deploy a container image in {HubName}, you must add the registry to the `allowedRegistries` in the {ControllerName} image configuration. To do this you can copy and paste the following code into your {ControllerName} image YAML.
+
+.Procedure
+
+. Log in to *{OCP}*.
+. Navigate to menu:Home[Search].
+. Select the *Resources* drop-down list and type "Image".
+. Select *Image (config,openshift.io/v1)*.
+. Click btn:[Cluster] under the *Name* heading. 
+. Select the btn:[YAML] tab.
+. Paste in the following under spec value:
++
+----
+spec:
+  registrySources:
+    allowedRegistries:
+    - quay.io
+    - registry.redhat.io
+    - image-registry.openshift-image-registry.svc:5000
+    - <OCP route for your automation hub>
+----
++
+. Click btn:[Save].


### PR DESCRIPTION
[AAP-40833](https://issues.redhat.com/browse/AAP-40833) Manually adding Hub Operator as an EE image source to the OCP cluster policy

New module added to Section 7 in 2.5.
Same module to be added to Section 13 in 2.4