### PR TITLE
Add callout for RHEL support in aap-docs

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -24,14 +24,6 @@ This guide helps you to understand the installation requirements and processes b
 include::snippets/container-upgrades.adoc[]
 ====
 
-.Prerequisites
-* A host running {RHEL} (RHEL) 9.2 or later. Use a minimal operating system base install.
-* A non-root user for the {RHEL} host, with sudo or other Ansible supported privilege escalation (sudo recommended). This user is responsible for the installation of containerized {PlatformNameShort}.
-* SSH public key authentication for the non-root user. For guidelines on setting up SSH public key authentication for the non-root user, see link:https://access.redhat.com/solutions/4110681[How to configure SSH public key authentication for passwordless login].
-** SSH keys are only required when installing on remote hosts. If doing a self contained local VM based installation, you can use `ansible_connection=local`.
-* Internet access from the {RHEL} host if you are using the default online installation method.
-* The appropriate network ports are open if a firewall is in place. For more information about the ports to open, see link:{URLTopologies}/container-topologies[Container topologies] in _{TitleTopologies}_.
-
 == Tested deployment topologies
 
 Red Hat tests {PlatformNameShort} {PlatformVers} with a defined set of topologies to give you opinionated deployment options. The supported topologies include infrastructure topology diagrams, tested system configurations, example inventory files, and network ports information.
@@ -45,18 +37,31 @@ For containerized {PlatformNameShort}, there are two infrastructure topology sha
 For more information about the tested deployment topologies for containerized {PlatformNameShort}, see link:{URLTopologies}/container-topologies[Container topologies] in _{TitleTopologies}_.
 
 == System requirements
+Use this information when planning your installation of containerized {PlatformNameShort}.
+
+.Prerequisites
+* A non-root user for the {RHEL} host, with sudo or other Ansible supported privilege escalation (sudo is recommended). This user is responsible for the installation of containerized {PlatformNameShort}.
+* SSH public key authentication for the non-root user (if installing on remote hosts). For guidelines on setting up SSH public key authentication for the non-root user, see link:https://access.redhat.com/solutions/4110681[How to configure SSH public key authentication for passwordless login].
+** If doing a self contained local VM based installation, you can use `ansible_connection=local`.
+* Internet access from the {RHEL} host if you are using the default online installation method.
+* The appropriate network ports are open if a firewall is in place. For more information about the ports to open, see link:{URLTopologies}/container-topologies[Container topologies] in _{TitleTopologies}_.
+
+=== {PlatformNameShort} system requirements
+
+Your system must meet the following minimum system requirements to install and run {PlatformName}. 
+
+.Base system requirements
+include::snippets/cont-tested-system-config.adoc[]
+
 Each virtual machine (VM) has the following system requirements:
 
-[cols=2,options="header"]
-|====
-| Requirement | Minimum requirement
-| RAM      | 16 GB
-| CPUs         | 4 
-| Local disk  | 60 GB  
-| Disk IOPS   | 3000   
-|====
+.Virtual machine requirements
+include::snippets/cont-tested-vm-config.adoc[]
 
+[NOTE]
+====
 If performing a bundled installation of the growth topology with `hub_seed_collections=true`, then 32 GB RAM is recommended. Note that with this configuration the install time is going to increase and can take 45 or more minutes alone to complete seeding the collections.
+====
 
 === PostgreSQL requirements
 {PlatformName} {PlatformVers} uses {PostgresVers} and requires the external (customer supported) databases to have ICU support.  

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -17,7 +17,7 @@ See link:{LinkTopologies} for more information on topology options.
 
 h| Subscription | Valid {PlatformName} |
 
-h| OS | {RHEL} 8.8 or later (x86_64, aarch64), or {RHEL} 9.2 or later (x86_64, aarch64) |{PlatformName} are also supported on OpenShift, see link:{LinkOperatorInstallation} for more information.
+h| OS | {RHEL} 8.8 or later minor versions of {RHEL} 8 (x86_64, aarch64). {RHEL} 9.2 or later minor versions of {RHEL} 9 (x86_64, aarch64). |{PlatformName} are also supported on OpenShift, see link:{LinkOperatorInstallation} for more information.
 
 h| Ansible-core | Ansible-core version {CoreInstVers} or later | {PlatformNameShort} uses the system-wide ansible-core package to install the platform, but uses ansible-core {CoreUseVers} for both its control plane and built-in execution environments.
 

--- a/downstream/modules/topologies/ref-cont-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-a-env-a.adoc
@@ -9,9 +9,17 @@ The following diagram outlines the infrastructure topology that Red{nbsp}Hat has
 .Infrastructure topology diagram
 image::cont-a-env-a.png[Container growth topology diagram]
 
-A single VM has been tested with the following component requirements: 16 GB RAM, 4 CPUs, 60 GB local disk, and 3000 IOPS. Resources, such as storage, can be increased based on the needs of the deployment.
+A single VM has been tested with the following component requirements: 
 
-If performing a bundled installation with `hub_seed_collections=true`, then 32 GB RAM is recommended. Note that with this configuration the install time is going to increase and can take 45 or more minutes alone to complete seeding the collections.
+.Virtual machine requirements
+include::snippets/cont-tested-vm-config.adoc[]
+
+Resources, such as storage, can be increased based on the needs of the deployment.
+
+[NOTE]
+====
+If performing a bundled installation of the growth topology with `hub_seed_collections=true`, then 32 GB RAM is recommended. Note that with this configuration the install time is going to increase and can take 45 or more minutes alone to complete seeding the collections.
+====
 
 .Infrastructure topology
 [options="header"]
@@ -31,19 +39,8 @@ a|
 Red{nbsp}Hat has tested the following configurations to install and run {PlatformName}:
 
 .Tested system configurations
-[options="header"]
-|====
-| Type | Description 
-| Subscription 
-a| 
-* Valid {PlatformName} subscription
-* Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
-| Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
-| Ansible-core | Ansible-core version {CoreInstVers} or later
-| Browser | A currently supported version of Mozilla Firefox or Google Chrome
-| Database | {PostgresVers}
-|====
+include::snippets/cont-tested-system-config.adoc[]
+
 
 == Network ports
 

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -9,7 +9,10 @@ The following diagram outlines the infrastructure topology that Red{nbsp}Hat has
 .Infrastructure topology diagram
 image::cont-b-env-a.png[Container enterprise topology diagram]
 
-Each VM has been tested with the following component requirements: 16 GB RAM, 4 CPUs, 60 GB local disk, and 3000 IOPS. 
+Each VM has been tested with the following component requirements:
+
+.Virtual machine requirements
+include::snippets/cont-tested-vm-config.adoc[]
 
 .Infrastructure topology
 [options="header"]
@@ -35,19 +38,7 @@ include::snippets/redis-colocation-containerized.adoc[]
 Red{nbsp}Hat has tested the following configurations to install and run {PlatformName}:
 
 .Tested system configurations
-[options="header"]
-|====
-| Type | Description 
-| Subscription 
-a| 
-* Valid {PlatformName} subscription
-* Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
-| Operating system | {RHEL} 9.2 or later
-| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
-| Ansible-core | Ansible-core version {CoreInstVers} or later
-| Browser | A currently supported version of Mozilla Firefox or Google Chrome.
-| Database | {PostgresVers}
-|====
+include::snippets/cont-tested-system-config.adoc[]
 
 == Network ports
 

--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -46,7 +46,7 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later
+| Operating system | {RHEL} 9.2 or later minor versions of {RHEL} 9
 | CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Red Hat OpenShift  
 a| 

--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -45,7 +45,7 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 9.2 or later
+| Operating system | {RHEL} 9.2 or later minor versions of {RHEL} 9
 | CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Red Hat OpenShift  
 a| 

--- a/downstream/modules/topologies/ref-rpm-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-a.adoc
@@ -32,7 +32,10 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 8.8 or later, or {RHEL} 9.2 or later
+| Operating system 
+a| 
+* {RHEL} 8.8 or later minor versions of {RHEL} 8. 
+* {RHEL} 9.2 or later minor versions of {RHEL} 9.
 | CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome

--- a/downstream/modules/topologies/ref-rpm-a-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-b.adoc
@@ -32,7 +32,10 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 8.8 or later, or {RHEL} 9.2 or later
+| Operating system 
+a| 
+* {RHEL} 8.8 or later minor versions of {RHEL} 8. 
+* {RHEL} 9.2 or later minor versions of {RHEL} 9.
 | CPU architecture | x86_64, AArch64
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -39,7 +39,10 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 8.8 or later, or {RHEL} 9.2 or later
+| Operating system 
+a| 
+* {RHEL} 8.8 or later minor versions of {RHEL} 8. 
+* {RHEL} 9.2 or later minor versions of {RHEL} 9.
 | CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -39,7 +39,10 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 |====
 | Type | Description 
 | Subscription | Valid {PlatformName} subscription
-| Operating system | {RHEL} 8.8 or later, or {RHEL} 9.2 or later
+| Operating system 
+a| 
+* {RHEL} 8.8 or later minor versions of {RHEL} 8. 
+* {RHEL} 9.2 or later minor versions of {RHEL} 9.
 | CPU architecture | x86_64, AArch64
 | Ansible-core | Ansible-core version {CoreInstVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome

--- a/downstream/snippets/cont-tested-system-config.adoc
+++ b/downstream/snippets/cont-tested-system-config.adoc
@@ -1,0 +1,13 @@
+[options="header"]
+|====
+| Type | Description 
+| Subscription 
+a| 
+* Valid {PlatformName} subscription
+* Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
+| Operating system | {RHEL} 9.2 or later minor versions of {RHEL} 9
+| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
+| Ansible-core | Ansible-core version {CoreInstVers} or later
+| Browser | A currently supported version of Mozilla Firefox or Google Chrome.
+| Database | {PostgresVers}
+|====

--- a/downstream/snippets/cont-tested-vm-config.adoc
+++ b/downstream/snippets/cont-tested-vm-config.adoc
@@ -1,0 +1,8 @@
+[cols=2,options="header"]
+|====
+| Requirement | Minimum requirement
+| RAM      | 16 GB
+| CPUs         | 4 
+| Local disk  | 60 GB  
+| Disk IOPS   | 3000   
+|====


### PR DESCRIPTION
Minimum Supported Versions Need to Call Out Specific Major RHEL Versions

https://issues.redhat.com/browse/AAP-41627