### PR TITLE
2.5 Add firewall zone vars to inventory appendix (#3069)

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -25,6 +25,10 @@ Default = `admin`
 
 Default = `false`
 
+| `controller_firewalld_zone` | `controller_firewall_zone` | The firewall zone where {ControllerName} related firewall rules are applied. This controls which networks can access {ControllerName} based on the zone's trust level.
+
+Default = `public`
+
 | `controller_tls_files_remote` | `controller_tls_remote` | {ControllerNameStart} TLS remote files.
 
 Default = `false`

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -11,6 +11,10 @@ Set to `verify-full` for client-side enforced SSL/TLS.
 
 Default = `prefer`
 
+| `postgres_firewalld_zone` | `postgresql_firewall_zone` | The firewall zone where PostgreSQL related firewall rules are applied. This controls which networks can access PostgreSQL based on the zone's trust level. 
+
+Default = `public`
+
 | `postgres_max_connections` | `postgresql_max_connections` | Maximum database connections setting to apply if you are using an installer-managed database.
 
 See link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref-controller-database-settings[PostgreSQL database configuration and maintenance for {ControllerName}] for help selecting a value.

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -53,6 +53,10 @@ Default = `false`
 
 Default = `/eda-event-streams`
 
+| `automationedacontroller_firewalld_zone` | `eda_firewall_zone` | The firewall zone where {EDAName} related firewall rules are applied. This controls which networks can access {EDAName} based on the zone's trust level.
+
+Default = `public`
+
 | `automationedacontroller_gunicorn_workers` | `eda_gunicorn_workers` | Number of workers for the API served through Gunicorn.
 
 Default = (# of cores or threads) * 2 + 1

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -33,6 +33,10 @@ Disable NGINX HTTPS.
 
 Default = `false`
 
+| `automationgateway_firewalld_zone` | `gateway_proxy_firewall_zone` | The firewall zone where {Gateway} related firewall rules are applied. This controls which networks can access {Gateway} based on the zone's trust level.
+
+Default = `public`
+
 | `automationgateway_grpc_auth_service_timeout` | `gateway_grpc_auth_service_timeout` | {GatewayStart} auth server timeout.
 
 Default = `30s`

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -51,9 +51,17 @@ Each element in the list is provided into `http nginx config` as a separate line
 
 Default = {}
 
+| | `pcp_firewall_zone` | The firewall zone where Performance Co-Pilot related firewall rules are applied. This controls which networks can access Performance Co-Pilot based on the zone's trust level. 
+
+Default = `public`
+
 | `redis_cluster_ip` | `redis_cluster_ip` | The IPv4 address used by the Redis cluster to identify each host in the cluster.
 
 Redis clusters cannot use hostnames or IPv6 addresses. When defining hosts in the `[redis]` group, use this variable to identify the IPv4 address if the default is not what you want. 
+
+| `redis_firewalld_zone` | `redis_firewall_zone` | The firewall zone where Redis related firewall rules are applied. This controls which networks can access Redis based on the zone's trust level.
+
+Default = `public`
 
 | `redis_mode` | `redis_mode` | The Redis mode to use for your {PlatformNameShort} installation.
 

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -120,6 +120,12 @@ Set this variable to `true` to enable download of read-only collections.
 | Optional
 | `false`
 
+| `automationhub_firewalld_zone`
+| `hub_firewall_zone`
+| The firewall zone where {HubName} related firewall rules are applied. This controls which networks can access {HubName} based on the zone's trust level.
+| Optional
+| `public`
+
 | `automationhub_force_change_admin_password`
 |
 | Denote whether or not to require the change of the default administrator password for {HubName} during installation. +

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -15,6 +15,10 @@ Default = `false`
 
 Default = `false`
 
+| | `receptor_firewall_zone` | The firewall zone where receptor related firewall rules are applied. This controls which networks can access receptor based on the zone's trust level.
+
+Default = `public`
+
 | | `receptor_log_level` | Receptor logging level.
 
 Default = `info`


### PR DESCRIPTION
Add firewall zone variables to the inventory var appendix

AAP 2.5 Containerize Firewall zone for Redis defaults to public firewalld profile

https://issues.redhat.com/browse/AAP-40545