### PR TITLE
Adding Edge Manager intro/overview to docs (#2991)

### DIFF
--- a/downstream/assemblies/platform/assembly-edge-manager-intro.adoc
+++ b/downstream/assemblies/platform/assembly-edge-manager-intro.adoc
@@ -1,0 +1,15 @@
+[id="assembly-edge-manager-intro"]
+
+= {RedHatEdge} overview
+
+The {RedHatEdge} provides streamlined management of edge devices and applications through a declarative approach. 
+By defining the required state of your edge devices, which includes your operating system versions, host configurations, and application deployments, the {RedHatEdge} automatically implements and maintains these configurations across your entire device fleet.
+
+The {RedHatEdge} on {PlatformNameShort} offers elevated integration with your automations.
+You can then focus more on orchestrating the environment without worrying about updating the operating system. 
+
+See the following topics to learn more about using {RedHatEdge} on {PlatformNameShort}:
+
+[ADD XREFS WHEN ALL PRS MERGED]
+
+//include::platform/con-edge-manager-core-capabilities.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-edge-manager-core-capabilities.adoc
+++ b/downstream/modules/platform/con-edge-manager-core-capabilities.adoc
@@ -1,0 +1,17 @@
+[id="edge-manager-core-capabilities"]
+
+= Core capabilities
+
+The {RedHatEdge} offers the following automated edge device management:
+
+* Define and keep consistent configurations across your edge device fleet
+* Manage operating system updates, host configurations, and application deployments
+* Check device health and deployment status through centralized reporting
+* Support for modern container workloads using Podman, Docker, or Kubernetes
+
+== Tool integration
+
+* Kubernetes-style declarative APIs that complement your existing Ansible workflows
+* Support for both container and VM workloads using Podman
+* Compatible with image-based Linux operating systems running bootc or ostree
+* Web-based interface for device monitoring and management

--- a/downstream/titles/edge-manager/edge-manager-user-guide/master.adoc
+++ b/downstream/titles/edge-manager/edge-manager-user-guide/master.adoc
@@ -14,6 +14,7 @@ You can declare the operating system version, host configuration, and set of app
 
 include::{Boilerplate}[]
 
+include::platform/assembly-edge-manager-intro.adoc[leveloffset=+1]
 include::platform/assembly-edge-manager-manage-devices.adoc[leveloffset=+1]
 include::platform/assembly-edge-manager-install.adoc[leveloffset=+1]
 include::platform/assembly-edge-manager-config.adoc[leveloffset=+1]


### PR DESCRIPTION
* Adding Edge Manager intro/overview to docs

[Docs] Flight Control Introduction

https://issues.redhat.com/browse/AAP-39616

Affects `titles/edgem-manager-user-guide`

* Tech review edits

* Tech review edits of intro section

* Edits to intro section