### PR TITLE
Adding service account info to controller docs (#2978)

### DIFF
--- a/downstream/modules/platform/proc-controller-configure-analytics.adoc
+++ b/downstream/modules/platform/proc-controller-configure-analytics.adoc
@@ -4,10 +4,15 @@
 
 When you imported your license for the first time, you were automatically opted in for the collection of data that powers {Analytics}, a cloud service that is part of the {PlatformNameShort} subscription.
 
+.Prerequisites
+
+* A service account created with the Analytics Administrator viewer role in console.redhat.com.
+For more information see, link:https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[Creating a service account].
+
 .Procedure
 . From the navigation panel, select {MenuSetSubscription}.
 The *Subscription* page is displayed.
-. If you have not already set up a subscription, do so now, and ensure that on the next page you have selected *{Analytics}* to use analytics data to enhance future releases of {PlatformNameShort} and to provide the Red Hat insights service to subscribers.
+. If you have not already set up a subscription, do so now, and ensure that on the next page you have selected *{Analytics}* to use analytics data to enhance future releases of {PlatformNameShort} and to give the Red Hat Insights service to subscribers.
 +
 image::automation_analytics.png[Automation analytics page]
 
@@ -16,8 +21,8 @@ image::automation_analytics.png[Automation analytics page]
 . Toggle the *Gather data for {Analytics}* switch and enter your Red Hat customer credentials.
 . You can also configure the following options:
 +
-* *Red Hat Customer Name*: This username is used to send data to {Analytics}.
-* *Red Hat Customer Password*: This password is used to send data to {Analytics}.
+* *Red Hat Customer Name*: Enter the client ID you received when you created your service account.
+* *Red Hat Customer Password*: Enter the client secret you received when you created your service account..
 * *Red Hat or Satellite Username*: This username is used to send data to {Analytics}.
 * *Red Hat or Satellite password*: This password is used to send data to {Analytics}.
 * *Last gather date for Automation Analytics*: Set the date and time

--- a/downstream/modules/platform/proc-controller-create-insights-credential.adoc
+++ b/downstream/modules/platform/proc-controller-create-insights-credential.adoc
@@ -2,7 +2,28 @@
 
 = Creating Red Hat Insights credentials
 
-Use the following procedure to create a new credential for use with Red Hat Insights:
+.Prerequisites
+
+* To use token-based authentication, you must link:https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[create a Red Hat service account] to generate a *Client ID* and *Client secret*. 
+* Assign this service account to the appropriate *User Access* group with necessary permissions. 
+
+To enable integration between {PlatformNameShort} and {InsightsShort}, assign the service account with the following permissions:
+
+* *inventory:hosts:read* (included in the Inventory Hosts viewer role)
+//* *patch::read* (included in the Patch viewer role)
+* *remediations:remediation:read* and *playbook-dispatcher:run:read* (included in the Remediations user role)
+
+You might consider associating your service account to an existing user access group with required permissions, or creating a new one. 
+
+[NOTE]
+====
+In adherence to security guidelines, service accounts are not automatically included in the default access group. 
+To grant access, you must manually add them to the appropriate user access groups.
+
+If you are not an Organization Administrator, you can create a service account and then ask your administrator to add your account to the appropriate user access groups.
+====
+
+Use the following procedure to create a new credential for use with {InsightsShort}:
 
 .Procedure
 
@@ -17,7 +38,40 @@ Use the following procedure to create a new credential for use with Red Hat Insi
 +
 image::ug-credential-types-popup-window-insights.png[Credentials insights pop up]
 +
-* *Username*: Enter a valid Red Hat Insights credential.
+* *Username*: Enter a valid Red Hat Insights credential. 
 * *Password*: Enter a valid Red Hat Insights credential.
-The Red Hat Insights credentials are the user's link:https://access.redhat.com/[Red Hat Customer Portal] account username and password.
++
+The {InsightsShort} credentials are the user's link:https://access.redhat.com/[Red Hat Customer Portal] account username and password.
++
+[NOTE]
+====
+Use the *Username* and *Password* fields for Basic authentication. 
+You can leave it blank if using *Client ID* and *Client secret*.
+====
++
+* *Client ID*: Enter the client ID you received when you created your service account. 
+* *Client secret*: Enter the client secret you received when you created your service account. 
+
 . Click btn:[Create credential].
++
+You can now use this credential in an xref:proc-controller-inv-source-insights[{InsightsShort}-sourced inventory] and xref:controller-create-insights-project[{InsightsShort} project].
+
+.Troubleshooting
+
+* If you receive a project sync failure, see the steps in xref:controller-remediate-insights-inventory[Remediating a Red Hat Insights inventory] and check your analytics logs.
+
+[IMPORTANT]
+====
+//* You must recreate existing credentials and reassociate them with existing projects and inventory sources to support token-based authentication.
+//Note: The following is true for now, but there is a plan to fix this come Q3 or Q4. 
+* Only remediations you create using the service account are visible in {PlatformNameShort} for that account. 
+This aligns with the current policy, which does not allow a user to view remediations created by other users.
+* For more information about the Insights inventory source plugin, see link:https://console.redhat.com/ansible/automation-hub/repo/published/redhat/insights/content/inventory/insights?extIdCarryOver=true&intcmp=701f2000001OEGhAAO&percmp=7013a000002ppOOAAY&sc_cid=7013a000002q6eLAAQ[inventory > insights] in {HubName}.
+====
+
+.Additional resources
+
+For more information about service accounts, see the following resources:
+
+* link:https://docs.redhat.com/en/documentation/red_hat_customer_portal/1/html/creating_and_managing_service_accounts/index[Creating and Managing Service Accounts]
+* link:https://www.youtube.com/watch?v=UvNcmJsbg1w[How to use Service Accounts on the Hybrid Cloud Console]


### PR DESCRIPTION
* Adding service account info to controller docs

Document controller changes needed for service accounts

https://issues.redhat.com/browse/AAP-36066

Affects `titles/controller-user-guide``

* Tech review edits

* Fixing punctuation error

* Tech review further edits

* Minor wording edit in service account proc

* Final tech review changes

* Peer review update