### PR TITLE
AAP-42062 Correct the URL for the EDA API docs in Chapt 1 of Using automation decisions

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -24,7 +24,7 @@ The following procedures form the user configuration:
 [NOTE]
 
 ====
-* API documentation for {EDAcontroller} is available at \https://<platform-host>/api/eda/v1/docs
+* API documentation for {EDAcontroller} is available at \https://<gateway-host>/api/eda/v1/docs
 * To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable, you will not be able to create or sync projects, or enable rulebook activations.
 ====
 

--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -24,7 +24,7 @@ The following procedures form the user configuration:
 [NOTE]
 
 ====
-* API documentation for {EDAcontroller} is available at \https://<eda-server-host>/api/eda/v1/docs
+* API documentation for {EDAcontroller} is available at \https://<platform-host>/api/eda/v1/docs
 * To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable, you will not be able to create or sync projects, or enable rulebook activations.
 ====
 


### PR DESCRIPTION
In the Notes admonition of [Chapter 1. Event-Driven Ansible controller overview](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-user-guide-overview), updated the current URL for EDA API docs