### PR TITLE
Backport-2.5-3092: AAP-42122 Fixed typo in topologies (#3092)

### DIFF
--- a/downstream/titles/topologies/docinfo.xml
+++ b/downstream/titles/topologies/docinfo.xml
@@ -4,7 +4,7 @@
 <subtitle>Plan your deployment of Ansible Automation Platform
 </subtitle>
 <abstract>
-<para>This guide provides the Red Hat tested and supported toplogies for Red Hat Ansible Automation Platform.
+<para>This guide provides the Red Hat tested and supported topologies for Red Hat Ansible Automation Platform.
 </para>
 </abstract>
 <authorgroup>


### PR DESCRIPTION
Backport for:

Fixed a typo in the abstract sentence of "topologies".

https://issues.redhat.com/browse/AAP-42122
