### PR TITLE
AAP-42057 edits

### DIFF
--- a/downstream/assemblies/platform/assembly-install-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-install-aap-operator.adoc
@@ -26,6 +26,11 @@ This can also be helpful when debugging because the operator logs pertain to cus
 
 For help with installing a namespace or cluster-scoped operator see the following procedure.
 
+[IMPORTANT]
+====
+You cannot deploy {PlatformNameShort} in the default namespace on your OpenShift Cluster. The `aap` namespace is recommended. You can use a custom namespace, but it should run only Ansible Automation Platform.
+====
+
 
 .Prerequisites
 * You have installed the {PlatformName} catalog in OperatorHub.

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -10,6 +10,8 @@ Use this procedure to subscribe a namespace to an operator.
 
 [IMPORTANT]
 ====
+You cannot deploy {PlatformNameShort} in the default namespace on your OpenShift Cluster. The `aap` namespace is recommended. You can use a custom namespace, but it should run only Ansible Automation Platform.
+
 You can only subscribe a single instance of the {OperatorPlatformNameShort} into a single namespace. 
 Subscribing multiple instances in the same namespace can lead to improper operation for both operator instances. 
 ====


### PR DESCRIPTION
[AAP-42057](https://issues.redhat.com/browse/AAP-42057) 

We need to add some context around namespaces, in particular not using default as the namespace. SME approved messaging:

Deploying AAP in the default namespace on your openshift cluster is not allowed.  The aap namespace is recommended.  You can use a custom namespace, however AAP should be the only service running in that namespace.

