### PR TITLE
AAP-42057 edits

### DIFF
--- a/downstream/assemblies/platform/assembly-install-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-install-aap-operator.adoc
@@ -16,6 +16,10 @@ ifdef::context[:parent-context: {context}]
 ** For information about the AWS Elastic Block Store (EBS) or to use the `aws-ebs` storage class, see link:{BaseURL}/openshift_container_platform/4.10/html-single/storage/index#persistent-storage-aws[Persistent storage using AWS Elastic Block Store].
 ** To use multi-attach `ReadWriteMany` access mode for AWS EBS, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volumes-multi.html[Attaching a volume to multiple instances with Amazon EBS Multi-Attach].
 
+[IMPORTANT]
+====
+You cannot deploy {PlatformNameShort} in the default namespace on your OpenShift Cluster. The `aap` namespace is recommended. You can use a custom namespace, but it should run only {PlatformNameShort}.
+====
 
 include::platform/proc-install-aap-operator.adoc[leveloffset=+2]
 

--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -10,6 +10,8 @@ Use this procedure to subscribe a namespace to an operator.
 
 [IMPORTANT]
 ====
+You cannot deploy {PlatformNameShort} in the default namespace on your OpenShift Cluster. The `aap` namespace is recommended. You can use a custom namespace, but it should run only {PlatformNameShort}.
+
 You can only subscribe a single instance of the {OperatorPlatformNameShort} into a single namespace. 
 Subscribing multiple instances in the same namespace can lead to improper operation for both operator instances. 
 ====


### PR DESCRIPTION
[AAP-42057](https://issues.redhat.com/browse/AAP-42057)

We need to add some context around namespaces, in particular not using default as the namespace. SME approved messaging:

Deploying AAP in the default namespace on your openshift cluster is not allowed. The aap namespace is recommended. You can use a custom namespace, however AAP should be the only service running in that namespace.