### PR TITLE
AAP-38389 Ext DB upgrade edits

### DIFF
--- a/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
@@ -27,6 +27,7 @@ include::platform/proc-operator-link-components.adoc[leveloffset=+1]
 include::platform/proc-operator-access-aap.adoc[leveloffset=+1]
 include::platform/proc-operator-deploy-central-config.adoc[leveloffset=+1]
 include::platform/proc-operator-external-db-gateway.adoc[leveloffset=+1]
+include::platform/proc-operator-upgrade-external-db-gateway.adoc[leveloffset=+1]
 include::platform/proc-operator-enable-https-redirect.adoc[leveloffset=+1]
 include::platform/proc-operator-aap-faq.adoc[leveloffset=+1]
 

--- a/downstream/modules/platform/proc-operator-upgrade-external-db-gateway.adoc
+++ b/downstream/modules/platform/proc-operator-upgrade-external-db-gateway.adoc
@@ -38,7 +38,7 @@ To upgrade from {PlatformNameShort} 2.4 to 2.5 with an external database, you mu
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
 . Click the {MoreActionsIcon} icon next to your deployment and then click btn:[Edit Subscription].
-. From the *Details* tab, select *Update Channel*.
+. From the *Details* tab, select btn:[Update Channel].
 . Select *stable-2.5* as the channel and click btn:[Save].
 . Deploy {PlatformNameShort} {PlatformVers} using the following custom resource (CR):
 +
@@ -64,4 +64,4 @@ spec:
 
 .Verification 
 
-To verify your upgrade was successful go to your users, collection, job history or similar and confirm that they are on the new {PlatformVers} instance and in the new {PostgresVers} databases. 
+To verify your upgrade was successful, go to your users, collection, job history or similar and confirm that they are on the new {PlatformVers} instance and in the new {PostgresVers} databases. 

--- a/downstream/modules/platform/proc-operator-upgrade-external-db-gateway.adoc
+++ b/downstream/modules/platform/proc-operator-upgrade-external-db-gateway.adoc
@@ -1,0 +1,67 @@
+[id="proc-operator-upgrade-external-db-gateway"]
+
+= Upgrading an external database for {Gateway} on {OperatorPlatformName}
+
+[role="_abstract"]
+
+To upgrade from {PlatformNameShort} 2.4 to 2.5 with an external database, you must scale down your Operator deployment, upgrade your PostgreSQL, then scale your deployment back up. 
+
+.Prerequisites
+
+* A 2.4 {ControllerName} and {HubName} deployment with an external PostgreSQL 13 database
+
+.Procedure
+
+. Scale down your deployments in their respective namespaces using:
++
+`oc scale deployment --replicas=0 -n <component-namespace> <component-deployment>`
++
+.. {ControllerNameStart}:
+... `automation-controller-operator-controller-manager`
+... `<controller-name>-controller-task`
+... `<controller-name>-controller-web`
+.. {HubNameStart}:
+... `automation-hub-operator-controller-manager`
+... `<hub-name>-hub-api`
+... `<hub-name>-hub-content`
+... `<hub-name>-hub-redis`
+... `<hub-name>-hub-worker`
+.. The remaining operators:
+... `ansible-lightspeed-operator-controller-manager`
+... `eda-server-operator-controller-manager`
+... `resource-operator-controller-manager`
+. Upgrade your PostgreSQL 13 to {PostgresVers}.
+. Scale your deployments back up using:
++
+`oc scale deployment --replicas=1 -n <component-namespace> <component-deployment>`
++
+. Log in to {OCP}.
+. Navigate to menu:Operators[Installed Operators].
+. Click the {MoreActionsIcon} icon next to your deployment and then click btn:[Edit Subscription].
+. From the *Details* tab, select *Update Channel*.
+. Select *stable-2.5* as the channel and click btn:[Save].
+. Deploy {PlatformNameShort} {PlatformVers} using the following custom resource (CR):
++
+----
+apiVersion: aap.ansible.com/v1alpha1
+kind: AnsibleAutomationPlatform
+metadata:
+  name: aap
+spec:
+
+  database:
+    database_secret: postgres-config-gateway
+
+  controller:
+    name: existing-controller
+
+  eda:
+    disabled: true
+
+  hub:
+    name: existing-hub
+----
+
+.Verification 
+
+To verify your upgrade was successful go to your users, collection, job history or similar and confirm that they are on the new {PlatformVers} instance and in the new {PostgresVers} databases. 


### PR DESCRIPTION
[AAP-38389](https://issues.redhat.com/browse/AAP-38389) 

Our [current documentation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_on_openshift_container_platform/operator-upgrade_operator-platform-doc#upgrading-operator_operator-upgrade) for AAP operator contains steps for upgrading AAP2.4 to AAP2.5 but the steps to upgrade are missing for the scenario when the database is external. 

[Draft](https://docs.google.com/document/d/1p6PV40xWe4E2XEQ9MChaURAklf3X-zJ91dJZzJE4YwU/edit?tab=t.0) with SME approved edits 