### PR TITLE
AAP-39112: Developed docs for Lightspeed REST API

### DIFF
--- a/lightspeed/assemblies/assembly_administering-ansible-lightspeed.adoc
+++ b/lightspeed/assemblies/assembly_administering-ansible-lightspeed.adoc
@@ -16,6 +16,12 @@ As an organization administrator, you can use {LightspeedShortName} to manage th
 * View and manage the Admin dashboard telemetry data
 * Configure custom models
 
+[NOTE]
+====
+If you are using a free 90-day trial account, you need a trial or paid subscription to the {PlatformName}, but you do not need a trial or paid subscription to {ibmwatsonxcodeassistant}. This means that you do not need to configure the API key or model ID when setting up or using a trial account.
+====
+
+
 include::modules/proc_log-in-administrator-portal.adoc[leveloffset=+1]
 include::modules/proc_log-out-of-portal.adoc[leveloffset=+2]
 include::modules/con_view-manage-admin-dashboard-telemetry.adoc[leveloffset=+1]

--- a/lightspeed/assemblies/assembly_configuring-lightspeed-onpremise.adoc
+++ b/lightspeed/assemblies/assembly_configuring-lightspeed-onpremise.adoc
@@ -30,6 +30,7 @@ include::modules/proc_update-redirect-uri.adoc[leveloffset=+1]
 include::modules/proc_configure-vscode-extension-onpremise-deployment.adoc[leveloffset=+1]
 include::modules/proc_update-connection-secrets.adoc[leveloffset=+1]
 include::modules/proc_monitor-onpremise-deployment.adoc[leveloffset=+1]
+include::modules/proc_use-rest-api.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/lightspeed/assemblies/assembly_starting-lightspeed-trial.adoc
+++ b/lightspeed/assemblies/assembly_starting-lightspeed-trial.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-{LightspeedShortName} cloud service provides a free 90-day trial for existing Ansible users. To start a free trial, you need a trial or paid subscription to the {PlatformName}, but you do not need a trial or paid subscription to {ibmwatsonxcodeassistant}. Using the trial account, you can create single-task and multitask recommendations, generate playbooks, and view playbook explanations. 
+{LightspeedShortName} cloud service provides a free 90-day trial for existing Ansible users. To start a free trial, you need a trial or paid subscription to the {PlatformName}, but you do not need a trial or paid subscription to {ibmwatsonxcodeassistant}. This means that you do not need to configure the API key or model ID when setting up a trial account. Using the trial account, you can create single-task and multitask recommendations, generate playbooks, and view playbook explanations. 
 
 include::modules/proc_start-lightspeed-trial.adoc[leveloffset=+1]
 

--- a/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
+++ b/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
@@ -66,3 +66,5 @@ Perform the following tasks to install and configure a {LightspeedshortName} on-
 . Optional: If you want to connect to a different {ibmwatsonxcodeassistant}, xref:update-connection-secrets_configuring-lightspeed-onpremise[update the connection secrets on an existing {PlatformName} operator]
 
 . Optional: xref:monitor-lightspeed-onpremise-deployment_configuring-lightspeed-onpremise[Monitor your {LightspeedShortName} on-premise deployment]
+
+. Optional: xref:use-rest-api_configuring-lightspeed-onpremise[Use the Ansible Lightspeed REST API to build custom automation development and tooling workflow outside of VS Code]

--- a/lightspeed/modules/proc_monitor-onpremise-deployment.adoc
+++ b/lightspeed/modules/proc_monitor-onpremise-deployment.adoc
@@ -9,7 +9,7 @@ After the {LightspeedShortName} on-premise deployment is successful, use the fol
 .Procedure
 
 . Create a *system auditor* user:
-.. Create a user with a *system auditor* role in the the {PlatformName}. For the procedure, see the link:{URLGettingStarted}/assembly-gs-platform-admin#proc-gs-platform-admin-create-user[Creating a user] section of _{TitleGettingStarted}_.
+.. Create a user with a *system auditor* role in the {PlatformName}. For the procedure, see the link:{URLGettingStarted}/assembly-gs-platform-admin#proc-gs-platform-admin-create-user[Creating a user] section of _{TitleGettingStarted}_.
 
 .. Verify that you can log in to the Ansible Lightspeed portal for on-premise deployment (`\https://<lightspeed_route>/`) as the newly-created system auditor user, and then log out.
 

--- a/lightspeed/modules/proc_multi-task-recs.adoc
+++ b/lightspeed/modules/proc_multi-task-recs.adoc
@@ -41,7 +41,7 @@ The Ansible Lightspeed service reads the text, interacts with the {ibmwatsonxcod
 * Use an existing YAML file: 
 ... On the bottom right of the screen, click the existing language mode, and in the language mode settings, select *Ansible*. 
 +
-NOTE: If you do not see the language mode section in your VS Code editor, from the Command Palette, select menu:Configure Langauge Mode[Ansible].
+NOTE: If you do not see the language mode section in your VS Code editor, from the Command Palette, select menu:Configure Language Mode[Ansible].
 +
 . Verify that you see an entry for *Lightspeed* on the status bar at the lower right of VS Code.
 +

--- a/lightspeed/modules/proc_remove-seat-licenses.adoc
+++ b/lightspeed/modules/proc_remove-seat-licenses.adoc
@@ -10,7 +10,6 @@ You can remove users who no longer need to access {LightspeedShortName}, which m
 [IMPORTANT]
 ====
 To prevent deactivated RH-SSO users from accessing {LightspeedShortName}, you must remove their {LightspeedShortName} seat licenses. When RH-SSO users are deactivated, their {LightspeedShortName} seat licenses are not removed automatically. These users can continue accessing {LightspeedShortName} until the next time they are forced to reauthenticate with RH-SSO. Removing the users' seat licenses revokes their access to {LightspeedShortName} immediately. 
-
 ====
 
 .Procedure

--- a/lightspeed/modules/proc_use-rest-api.adoc
+++ b/lightspeed/modules/proc_use-rest-api.adoc
@@ -1,0 +1,53 @@
+:_content-type: PROCEDURE
+
+[id="use-rest-api_{context}"]
+
+= Using the Ansible Lightspeed REST API 
+
+As the platform administrator, you can configure and use the Ansible Lightspeed REST API to build a custom automation development and tooling workflow outside of VS Code. For information about the Ansible Lightspeed REST API, see link:https://developers.redhat.com/api-catalog/api/ansible-lightspeed[Ansible AI Connect. 1.0.0 (v1)] in the API catalog.
+ 
+[NOTE]
+====
+The Ansible Lightspeed REST API is available for {PlatformNameShort} 2.5 and later. 
+====
+
+.Prerequisite
+
+* Ensure that you are using the {PlatformName} operator patch version 2.5-20250305.9 and {LightspeedShortName} operator version 2.5.250225.
+
+.Procedure
+
+. Select the platform user for whom you want to grant REST API access. 
++
+You can select an existing user or create a platform user in the {PlatformName}. For the procedure, see the link:{URLGettingStarted}/assembly-gs-platform-admin#proc-gs-platform-admin-create-user[Creating a user] section of _{TitleGettingStarted}_.
+
+. Verify that you can log in to the Ansible Lightspeed portal for on-premise deployment (`\https://<lightspeed_route>/`) as the platform user you selected or created, and then log out.
+
+. Create a token for the platform user:
+.. Log in to the Ansible Lightspeed portal for on-premise deployment (`\https://<lightspeed_route>/admin`) as an administrator by using the following credentials:
++
+* Username: *admin*
+* Password: The secret that is named as `<lightspeed-custom-resource-name>-admin-password` in the {OCP} cluster namespace where {LightspeedShortName} is deployed. 
+
+.. On the Django administration window, select *Users* from the Users area. A list of users is displayed.
+.. Verify that the platform user is listed in the *Users* list.
+.. From the Django Oauth toolkit area, select menu:Access tokens[Add].
+.. Provide the following information and click *Save*:
+
+* *User*: Use the magnifying glass icon to search and select the newly-created or existing user for whom you want to grant API access.
+* *Token*: Specify a token for the user. Copy this token for later use.
+* *Id token*: Select the token ID. 
+* *Application*: Select *Ansible Lightspeed for VS Code*. 
+* *Expires*: Select the date and time when you want the token to expire.  
+* *Scope*: Specify the scope as *read write*. 
++
+An access token is created for the user.
+
+.. Log out from the Ansible Lightspeed portal for on-premise deployment.
+
+. Make a direct call to the Ansible Lightspeed REST API by specifying the newly-created token in the authorization header:
++
+----
+curl -H "Authorization: Bearer <token>" 
+https://<lightspeed_route>/api/v1/me/
+----


### PR DESCRIPTION
This PR addresses the following:

- JIRA https://issues.redhat.com/browse/AAP-39112  - docs for using Lightspeed REST API.
- Slack request to add info. about 'trial accounts not requiring API key and model ID'. Slack thread: https://redhat-internal.slack.com/archives/C068PH68Y6B/p1742198334830579. 