### PR TITLE
Backport-2.5-3117 (AAP-41743) Missing Information About Port 8443 being required for EDA …

### DIFF
--- a/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
+++ b/downstream/assemblies/platform/assembly-network-ports-protocols.adoc
@@ -112,7 +112,8 @@ ALLOW connection from controller(s) to Receptor port |
 `receptor_listener_port`
 
 `peers`
-| 27199 | TCP | Receptor | OCP cluster | Execution node |  | 
+| 27199 | TCP | Receptor | OCP cluster | Execution node |  |
+| 8443 | TCP | HTTPS | {GatewayStart} | {EDAName} node | Receiving event stream traffic |  |
 //| 50051 | TCP | GRPC | {GatewayStart} | {GatewayStart} |  | 
 |===
 


### PR DESCRIPTION
[AAP-41743](https://issues.redhat.com/browse/AAP-41743) requests for an update to [Chapter 6. Network ports and protocols](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/planning_your_installation/index#ref-network-ports-protocols_planning) in the Ansible Automation Platform Network ports and protocols table. Specifically, we need to add an entry for Port 8443, which must be open for Event-Driven Ansible.

cc: @emurtoug (owner of the Planning guide)