### PR TITLE
Backport-2.5-42064 for AAP-42064: Add unmasking requirements to gateway for RPM Installation…

### DIFF
--- a/downstream/modules/platform/ref-gateway-system-requirements.adoc
+++ b/downstream/modules/platform/ref-gateway-system-requirements.adoc
@@ -3,3 +3,5 @@
 = {GatewayStart} system requirements
 
 The {Gateway} is the service that handles authentication and authorization for {PlatformNameShort}. It provides a single entry into the platform and serves the platform's user interface.
+
+You are required to set `umask=0022`.


### PR DESCRIPTION
Backport for PR https://github.com/ansible/aap-docs/pull/3115

Added the unmask requirement to the Gateway requirements in the RPM Installation guide.

https://issues.redhat.com/projects/AAP/issues/AAP-42064?filter=myopenissues

… … (#3115)

* AAP-42064 Add unmasking requirements to gateway for RPM Installation guide

* Updated unmask Gateway requirement for RPM Installation

* Tweaked the requirement wording for Gateway in RPM Installation

* Fixed typo in unmask=0022

* Fixed typo again for umask