### PR TITLE
AAP-34928-update: Added URLs in release notes blurb

### DIFF
--- a/lightspeed/modules/proc_configure-vscode-extension.adoc
+++ b/lightspeed/modules/proc_configure-vscode-extension.adoc
@@ -16,7 +16,7 @@ You can configure the Ansible VS Code extension to enable {LightspeedshortName} 
 . From the Installed Extensions list, select *Ansible*.
 . From the *Ansible* extension page, click the *Settings* icon and select *Extension Settings*. 
 . Select *Ansible Lightspeed* settings, and specify the following information:
-.. Select the *Enable Ansible Lightspeed* checkbox.
+.. Ensure that the *Enable Ansible Lightspeed with watsonx Code Assistant inline suggestions* checkbox is selected.
 .. In the *URL for Ansible Lightspeed* field, verify that you have the following URL: `\https://c.ai.ansible.redhat.com/`. 
 .. Select the *Enable Ansible Lightspeed with watsonx Code Assistant inline suggestions* checkbox.
 . Optional: If you want to use the custom model instead of the default model, in the *Model ID Override* field, enter the custom model ID. The *model-override* setting enables you to override the default model and use the custom model, after your organization administrator has created a custom model and has shared the model ID with you separately. 

--- a/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-20march2025.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/modules/lightspeed-rn-20march2025.adoc
@@ -7,12 +7,12 @@ This release {LightspeedShortName} features the following enhancement:
 
 * Ability to generate roles and view role explanations 
 +
-Role generation and viewing role explanations are now supported on the {LightspeedShortName} cloud service. You can create roles within Ansible collections from the Ansible VS Code extension using a natural language interface in English. You can also view the explanations for new or existing roles.
+Role generation and viewing role explanations are now supported on the {LightspeedShortName} cloud service. You can create roles within Ansible collections from the Ansible VS Code extension using a natural language interface in English. You can also view the explanations for new or existing roles. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/developing-ansible-content_lightspeed-user-guide#role-creation_developing-ansible-content[Creating roles and viewing role explanations].
 
 * Availability of REST API on on-premise deployments
 +
-Platform administrators can now configure and use the {LightspeedShortName} REST API to build a custom automation development and tooling workflow outside of VS Code.
+Platform administrators can now configure and use the {LightspeedShortName} REST API to build a custom automation development and tooling workflow outside of VS Code. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/set-up-lightspeed_lightspeed-user-guide#use-rest-api_configuring-lightspeed-onpremise[Using the Ansible Lightspeed REST API] and link:https://developers.redhat.com/api-catalog/api/ansible-lightspeed[Ansible AI Connect. 1.0.0 (v1)] in the API catalog.
 
 * Removal of unnecessary settings from the initial configuration of Ansible VS Code extension 
 +
-The initial configuration of the Ansible VS Code extension now has fewer settings that are enabled by default.
+The initial configuration of the Ansible VS Code extension now has fewer settings that are enabled by default. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/developing-ansible-content_lightspeed-user-guide#configure-vscode-extension_developing-ansible-content[Configuring the Ansible VS Code extension].


### PR DESCRIPTION
This JIRA addresses minor updates to PR https://github.com/ansible/aap-docs/pull/3110  as part of JIRA https://issues.redhat.com/browse/AAP-34928 .

Changes made: Added hyperlinks to release notes blurb.