### PR TITLE
AAP-41247 Rework ansible-builder chapter

### DIFF
--- a/downstream/assemblies/builder/assembly-definition-file-breakdown.adoc
+++ b/downstream/assemblies/builder/assembly-definition-file-breakdown.adoc
@@ -8,11 +8,11 @@ The following sections breaks down the different parts of a definition file.
 
 include::builder/ref-build-args-base-image.adoc[leveloffset=+1]
 //include::builder/con-ansible-config-file-path.adoc[leveloffset=+1]
-include::builder/con-definition-dependencies.adoc[leveloffset=+1]
 include::builder/con-galaxy-dependencies.adoc[leveloffset=+2]
 include::builder/con-python-dependencies.adoc[leveloffset=+2]
 include::builder/con-system-dependencies.adoc[leveloffset=+2]
 include::builder/ref-definition-file-images.adoc[leveloffset=+1]
+include::builder/con-definition-dependencies.adoc[leveloffset=+1]
 include::builder/con-additional-build-files.adoc[leveloffset=+1]
 include::builder/con-additional-custom-build-steps.adoc[leveloffset=+1]
 

--- a/downstream/modules/builder/con-building-definition-file.adoc
+++ b/downstream/modules/builder/con-building-definition-file.adoc
@@ -2,9 +2,19 @@
 
 = Building a definition file
 
-After you install {Builder}, you can create a definition file that {Builder} uses to create your {ExecEnvNameSing} image. {Builder} makes an {ExecEnvNameSing} image by reading and validating your definition file, then creating a `Containerfile`, and finally passing the `Containerfile` to Podman, which then packages and creates your {ExecEnvNameSing} image. The definition file that you create must be in `yaml` format and contain different sections. The default definition filename, if not provided, is `execution-environment.yml`. For more information on the parts of a definition file, see xref:assembly-definition-file-breakdown[Breakdown of definition file content].
+{Builder} is used to create an execution environment.
+Building a new execution environment involves a definition that specifies which content you want to include in your execution environment, such as collections, Python requirements, and system-level packages. 
 
-The following is an example of a version 3 definition file. Each definition file must specify the major version number of the {Builder} feature set it uses. If not specified, {Builder} defaults to version 1, making most new features and definition keywords unavailable.
+After you install {Builder}, you can create a definition file that {Builder} uses to create your {ExecEnvNameSing} image.
+The definition file that you create must be in `YAML` format with a `.yml` or `.yaml` extension, and contain different sections.
+The default definition filename, if not provided, is `execution-environment.yml`.
+For more information on the parts of a definition file, see xref:assembly-definition-file-breakdown[Breakdown of definition file content].
+
+{Builder} makes an {ExecEnvNameSing} image by reading and validating your definition file, then creating a `Containerfile`, and finally passing the `Containerfile` to Podman, which then packages and creates your {ExecEnvNameSing} image.
+
+The following is an example of a version 3 definition file.
+Each definition file must specify the major version number of the {Builder} feature set it uses.
+If not specified, {Builder} defaults to version 1, making most new features and definition keywords unavailable.
 
 .Definition file example
 ====
@@ -52,7 +62,7 @@ additional_build_steps: <5>
 ====
 
 <1> Lists default values for build arguments.
-<2> Specifies the location of various requirements files.
+<2> Specifies the location of various requirements files. It can be a filename or inline content.
 <3> Specifies the base image to be used. Red Hat support is only provided for the redhat.registry.io base image.
 <4> Specifies options that can affect builder runtime functionality.
 <5> Commands for additional custom build steps.
@@ -60,4 +70,4 @@ additional_build_steps: <5>
 [role="_additional-resources"]
 .Additional resources
 * For more information about the definition file content, see xref:assembly-definition-file-breakdown[Breakdown of definition file content].
-* To read more about the differences between {Builder} versions 2 and 3, see the link:https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_3.html[Ansible 3 Porting Guide].
+* To read more about the differences between {Builder} versions 2 and 3, see the link:https://ansible.readthedocs.io/projects/builder/en/latest/porting_guides/porting_guide/[{Builder} 3 Porting Guide].

--- a/downstream/modules/builder/con-python-dependencies.adoc
+++ b/downstream/modules/builder/con-python-dependencies.adoc
@@ -4,7 +4,9 @@
 
 The `python` entry in the definition file points to a valid requirements file or to an inline list of Python requirements in PEP508 format for the `pip install -r ...` command.
 
-The entry `requirements.txt` is a file that installs extra Python requirements on top of what the Collections already list as their Python dependencies. It may be listed as a relative path from the directory of the {ExecEnvNameSing} definition's folder, or an absolute path. The contents of a `requirements.txt` file should be formatted like the following example, similar to the standard output from a `pip freeze` command:
+The entry `requirements.txt` is a file that installs extra Python requirements on top of what the Collections already list as their Python dependencies.
+It might be listed as a relative path from the directory of the {ExecEnvNameSing} definition's folder, or an absolute path.
+The contents of a `requirements.txt` file should be formatted like the following example, similar to the standard output from a `pip freeze` command:
 
 .Python entry
 [example]
@@ -25,3 +27,5 @@ openstacksdk>=0.13
 ovirt-engine-sdk-python>=4.4.10
 ----
 ====
+
+For more information about the PEP 508 format, see the link:https://ansible.readthedocs.io/projects/builder/en/latest/porting_guides/porting_guide_v3.1/#pep-508-standard[Python requirements handling] section of the _{Builder} 3.1 Porting guide_.

--- a/downstream/modules/builder/con-why-builder.adoc
+++ b/downstream/modules/builder/con-why-builder.adoc
@@ -2,6 +2,6 @@
 
 = Why use {Builder}?
 
-Before {Builder} was developed, {PlatformName} users could run into dependency issues and errors when creating custom virtual environments or containers that included all of the required dependencies installed.
+With {Builder}, you can easily create a customizable {ExecEnvName} definition file that specifies the content you want included in your {ExecEnvName} such as Ansible Core, Python, Collections, third-party Python requirements, and system level packages.
+This allows you to fulfill all of the necessary requirements and dependencies to get jobs running.
 
-Now, with {Builder}, you can easily create a customizable {ExecEnvName} definition file that specifies the content you want included in your {ExecEnvName} such as Ansible Core, Python, Collections, third-party Python requirements, and system level packages. This allows you to fulfill all of the necessary requirements and dependencies to get jobs running.

--- a/downstream/modules/builder/proc-executing-build.adoc
+++ b/downstream/modules/builder/proc-executing-build.adoc
@@ -18,10 +18,11 @@ To build an {ExecEnvNameSing} image, run the following from the command line:
 $ ansible-builder build
 ----
 
-By default, {Builder} looks for a definition file named `execution-environment.yml` but a different file path can be specified as an argument with the `-f` flag:
+By default, {Builder} looks for a definition file named `execution-environment.yml` or `execution-environment.yaml`,
+but you can specify a different file path with the `-f` or `--file` flag:
 [subs=+quotes]
 ----
-$ ansible-builder build -f _definition-file-name_.yml
+$ ansible-builder build -f <_definition-file-name_>.yml
 ----
 
-where _definition-file-name_ specifies the name of your definition file.
+Replace <_`definition-file-name`_> with the name of your definition file.

--- a/downstream/modules/builder/ref-build-args-base-image.adoc
+++ b/downstream/modules/builder/ref-build-args-base-image.adoc
@@ -1,6 +1,6 @@
 [id="ref-build-args-base-image"]
 
-= Build args and base image
+= Build args
 
 The `build_arg_defaults` section of the definition file is a dictionary whose keys can provide default values for arguments to {Builder}. See the following table for a list of values that can be used in `build_arg_defaults`:
 
@@ -18,4 +18,13 @@ The `build_arg_defaults` section of the definition file is a dictionary whose ke
 
 The values given inside `build_arg_defaults` will be hard-coded into the `Containerfile`, so these values will persist if `podman build` is called manually.
 
+// ariordan TODO
+// You should add a section explaining how this is done for advanced needs, i.e. call ansible-builder create -> customize Containerfile -> call podman build. 
+// I would add a note that it's generally easier (especially in a pipeline context) to first customize the base image into a custom base image using podman, and then call ansible-builder on this custom image.
+
 NOTE: If the same variable is specified in the CLI `--build-arg` flag, the CLI value will take higher precedence.
+
+// ariordan TODO
+// Wouldn't a note that similar files contained in collections will be considered recursively make sense at this stage?
+// It would be interesting to document (I didn't try) what happens if different collections have conflicting dependencies (e.g. in terms of versions) between themselves or with the base dependencies.
+

--- a/downstream/modules/builder/ref-definition-file-images.adoc
+++ b/downstream/modules/builder/ref-definition-file-images.adoc
@@ -2,9 +2,10 @@
 
 = Images
 
-The `images` section of the definition file identifies the base image. Verification of signed container images is supported with the `podman` container runtime.
+The `images` section of the definition file identifies the base image.
+Verification of signed container images is supported with the `podman` container runtime.
 
-See the following table for a list of values that you can use in `images`:
+The following table shows a list of values that you can use in `images`:
 
 [cols="a,a"]
 |===
@@ -19,4 +20,3 @@ The default image is `registry.redhat.io/ansible-automation-platform-24/ee-minim
 
 |===
 
-NOTE: If the same variable is specified in the CLI `--build-arg` flag, the CLI value will take higher precedence.

--- a/downstream/modules/platform/con-building-an-execution-environment-in-a-disconnected-environment.adoc
+++ b/downstream/modules/platform/con-building-an-execution-environment-in-a-disconnected-environment.adoc
@@ -5,16 +5,16 @@
 
 = Building an {ExecEnvShort} in a disconnected environment
 
+Creating execution environments for {PlatformNameShort} is a common task which works differently in disconnected environments.
+When building a custom {ExecEnvShort}, the ansible-builder tool defaults to downloading content from the following locations on the internet:
 
-Creating execution environments for {PlatformNameShort} is a common task which works differently in disconnected environments. When building a custom {ExecEnvShort}, the ansible-builder tool defaults to downloading content from the following locations on the internet:
-
-* Red Hat {HubNameStart} ({Console}) or {Galaxy} (galaxy.ansible.com) for any Ansible content collections added to the {ExecEnvShort} image.
+* Red Hat {HubNameStart} (`{Console}`) or {Galaxy} (`galaxy.ansible.com`) for any Ansible content collections added to the {ExecEnvShort} image.
 
 * PyPI (pypi.org) for any python packages required as collection dependencies.
 
 * RPM repositories such as the RHEL or UBI repositories (cdn.redhat.com) for adding or updating RPMs to the {ExecEnvShort} image, if needed. 
 
-* registry.redhat.io for access to the base container images.
+* `registry.redhat.io` for access to the base container images.
 
 Building an {ExecEnvShort} image in a disconnected environment requires mirroring content from these locations.
 For information about importing collections from {Galaxy} or {HubName} into a {PrivateHubName}, see link:{URLHubManagingContent}/managing-collections-hub#proc-import-collection[Importing an automation content collection in {HubName}] .


### PR DESCRIPTION
AAP-41247 Update the ansible-builder chapter of the execution environments guide.

Affects `titles/builder`