### PR TITLE
AAP-42276: Fixed broken link to containerized installation requirements

### DIFF
--- a/downstream/modules/platform/ref-containerized-system-requirements.adoc
+++ b/downstream/modules/platform/ref-containerized-system-requirements.adoc
@@ -4,4 +4,5 @@
 
 = System requirements for containerized installation
 
-For system requirements for the containerized installation method of {PlatformNameShort}, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/Ansible_automation_platform_containerized_installation#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.
+For system requirements for the containerized installation method of {PlatformNameShort}, see
+the link:{URLContainerizedInstall}/ansible_automation_platform_containerized_installation#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.

--- a/downstream/modules/platform/ref-containerized-system-requirements.adoc
+++ b/downstream/modules/platform/ref-containerized-system-requirements.adoc
@@ -4,4 +4,4 @@
 
 = System requirements for containerized installation
 
-For system requirements for the containerized installation method of {PlatformNameShort}, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/aap-containerized-installation#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.
+For system requirements for the containerized installation method of {PlatformNameShort}, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/Ansible_automation_platform_containerized_installation#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.


### PR DESCRIPTION
In the Planning your installation guide, fixed broken link to containerized installation requirements.

https://issues.redhat.com/projects/AAP/issues/AAP-42276?filter=myopenissues