### PR TITLE
Backport-2.5-3134 for AAP-42276: Fixed broken link to containerized installation requiremen…

### DIFF
--- a/downstream/modules/platform/ref-containerized-system-requirements.adoc
+++ b/downstream/modules/platform/ref-containerized-system-requirements.adoc
@@ -4,4 +4,5 @@
 
 = System requirements for containerized installation
 
-For system requirements for the containerized installation method of {PlatformNameShort}, see the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/aap-containerized-installation#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.
+For system requirements for the containerized installation method of {PlatformNameShort}, see
+the link:{URLContainerizedInstall}/ansible_automation_platform_containerized_installation#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.


### PR DESCRIPTION
…ts (#3134)


* Fixed broken link to continerized installation requirements

* Changed the link formatting to use the attribute instead

Related to:

PR: https://github.com/ansible/aap-docs/pull/3134
Jira: https://issues.redhat.com/browse/AAP-42276