### PR TITLE
AAP-42027: Added automation controller v4.5 in upgrade prerequirements

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
+++ b/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
@@ -18,6 +18,8 @@ You have reviewed the link:{URLPlanningGuide}/ha-redis_planning#gw-centralized-r
 
 Prior to upgrading your {PlatformName}, ensure you have reviewed link:{LinkPlanningGuide} for a successful upgrade. You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
 
+Prior to upgrading your {PlatformName}, ensure you have upgraded to {ControllerName} 2.5 or later. 
+
 include::platform/con-aap-upgrade-planning.adoc[leveloffset=+1]
 
 include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -22,6 +22,7 @@ When upgrading from {PlatformNameShort} 2.4 to 2.5, the API endpoints for the {C
 * Verify that you have a valid subscription before upgrading from a previous version of {PlatformNameShort}. Existing subscriptions are carried over during the upgrade process. 
 * Ensure you have a backup of an {PlatformNameShort} 2.4 environment before upgrading in case any issues occur. See link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] and link:{LinkOperatorBackup} for the specific topology of the environment.
 * Ensure you capture your inventory or instance group details before upgrading.
+* Ensure you have upgraded to {ControllerName} 2.5 or later before upgrading your {PlatformName}.  
 * Upgrades of {EDAName} version 2.4 to 2.5 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.5 are not compatible. For more information, see xref:upgrade-controller-hub-eda-unified-ui_aap-upgrading-platform[{ControllerName} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades].
 +
 If you are currently running {EDAcontroller} 2.5, it is recommended that you disable all {EDAName} activations before upgrading to ensure that only new activations run after the upgrade process is complete.

--- a/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
+++ b/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
@@ -8,7 +8,7 @@
 {PlatformNameShort} 2.5 supports upgrades from {PlatformNameShort} 2.4 environments for all components, with the exception of {EDAName}. You can also configure a mixed environment with {EDAName} from 2.5 connected to a legacy 2.4 cluster. Combining install methods (OCP, RPM, Containerized) within such a topology is not supported by {PlatformNameShort}.
 
 [NOTE]
-If you are running the 2.4 version of {EDAName} in production, before you upgrade, contact Red Hat support or your account represenative for more information on how to move to {PlatformNameShort} 2.5.
+If you are running the 2.4 version of {EDAName} in production, before you upgrade, contact Red Hat support or your account representative for more information on how to move to {PlatformNameShort} 2.5.
 
 Supported topologies described in this document assume that:
 
@@ -19,7 +19,7 @@ Supported topologies described in this document assume that:
 == Upgrade considerations
 
 * You must maintain two separate inventory files: one for the 2.4 services and one for the 2.5 services.
-* You must maintain two separate "installations" wihtin this scenario: one for the 2.4 services and one for the 2.5 services. 
+* You must maintain two separate "installations" within this scenario: one for the 2.4 services and one for the 2.5 services. 
 * You must "upgrade" the two separate "installations" separately.
 * To upgrade to a consistent component version topology, consider the following: 
 ** You must manually combine the inventory file configuration from the 2.4 inventory into the 2.5 inventory and run upgrade on ONLY the 2.5 inventory file. 
@@ -29,12 +29,14 @@ Supported topologies described in this document assume that:
 
 .Prerequisites
 
-* An inventory from 2.4 for {ControllerName} and {HubName} and a 2.5 inventory for unified UI ({Gateway}) and {EDAName}. You must run upgrades on 2.4 services (using the inventory file to specify only {ControllerName} and {HubName} VMs) to get them to the invitial version of {PlatformNameShort} 2.5 first. When all the services are at the same version, run an upgrade (using a complete inventory file) on all the services to go to the latest version of {PlatformNameShort} 2.5.
+* An inventory from 2.4 for {ControllerName} and {HubName} and a 2.5 inventory for unified UI ({Gateway}) and {EDAName}. You must run upgrades on 2.4 services (using the inventory file to specify only {ControllerName} and {HubName} VMs) to get them to the initial version of {PlatformNameShort} 2.5 first. When all the services are at the same version, run an upgrade (using a complete inventory file) on all the services to go to the latest version of {PlatformNameShort} 2.5.
 
 [IMPORTANT]
 ====
 DO NOT upgrade {EDAName} and the unified UI ({Gateway}) to the latest version of {PlatformNameShort} 2.5 without first upgrading the individual services ({ControllerName} and {HubName}) to the initial version of {PlatformNameShort} 2.5.
 ====
+
+* Ensure you have upgraded to {ControllerName} 2.5 or later before upgrading your {PlatformName}.
 
 .Procedure
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-42027.

Changes made:

- Added prerequisite that controller 4.5 is the minimum version supported to upgrade to AAP 2.5.
- Fixed a few typos.