### PR TITLE
Fixing titles to be uniform

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -1,7 +1,7 @@
 ifdef::context[:parent-context: {context}]
 
 [id="installing-aap-operator-cli_{context}"]
-= Installing {OperatorPlatformName} from the {OCPShort} CLI
+= Installing {OperatorPlatformName} from the {OCP} CLI
 
 :context: installing-aap-operator-cli
 

--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 
 [id="operator-upgrade_{context}"]
 
-= Upgrading {OperatorPlatformName} on {OCPShort}
+= Upgrading {OperatorPlatformName} on {OCP}
 
 :context: operator-upgrade
 

--- a/downstream/assemblies/platform/assembly-update-ocp.adoc
+++ b/downstream/assemblies/platform/assembly-update-ocp.adoc
@@ -1,6 +1,6 @@
 [id="update-ocp"]
 
-= Updating {PlatformNameShort} on {OCPShort}
+= Updating {PlatformName} on {OCP}
 
 You can use an upgrade patch to update your operator-based {PlatformNameShort}.
 


### PR DESCRIPTION
[AAP-42431](https://issues.redhat.com/browse/AAP-42431) - Add consistent attribute and OCP title usage to the Operator docs

Some chapter titles use the full "Red Hat OpenShift Container Platform" title while others use "OpenShift Container Platform". We need to update this for a consistent approach throughout. 
Titles that need updating:

Chapter 3
Chapter 4
Chapter 10