### PR TITLE
Title edits for 2.4

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
+++ b/downstream/assemblies/platform/assembly-installing-aap-operator-cli.adoc
@@ -9,7 +9,7 @@ See also the complementary step on the last line of this file.
 ifdef::context[:parent-context: {context}]
 
 [id="installing-aap-operator-cli"]
-= Installing {OperatorPlatformName}  from the {OCPShort} CLI
+= Installing {OperatorPlatformName}  from the {OCP} CLI
 
 :context: installing-aap-operator-cli
 

--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 
 [id="operator-upgrade_{context}"]
 
-= Upgrading {OperatorPlatformName} on {OCPShort}
+= Upgrading {OperatorPlatformName} on {OCP}
 
 :context: operator-upgrade
 

--- a/downstream/assemblies/platform/assembly-using-rhsso-operator-with-automation-hub.adoc
+++ b/downstream/assemblies/platform/assembly-using-rhsso-operator-with-automation-hub.adoc
@@ -24,17 +24,17 @@ This chapter describes the process to configure {RHSSO} and integrate it with {P
 * You have installed the {OperatorRHSSO}.
 To install the {OperatorRHSSO}, follow the procedure in link:{BaseURL}/red_hat_single_sign-on/{RHSSOVers}/html/server_installation_and_configuration_guide/operator#doc-wrapper[Installing {RHSSO} using a custom resource] in the {RHSSO} documentation.
 
-include::platform/proc-create-keycloak-instance.adoc[leveloffset=1]
-include::platform/proc-create-keycloak-realm.adoc[leveloffset=1]
-include::platform/proc-create-keycloak-client.adoc[leveloffset=1]
-include::platform/proc-create-a-user.adoc[leveloffset=1]
+include::platform/proc-create-keycloak-instance.adoc[leveloffset=+1]
+include::platform/proc-create-keycloak-realm.adoc[leveloffset=+1]
+include::platform/proc-create-keycloak-client.adoc[leveloffset=+1]
+include::platform/proc-create-a-user.adoc[leveloffset=+1]
 //[gmurray] Commenting out for now, but can probably just delete or archive as this is already covered in chapter 2. 
 //include::platform/proc-installing-the-ansible-platform-operator.adoc[leveloffset=2]
-include::platform/proc-creating-a-secret.adoc[leveloffset=1]
-include::platform/proc-installing-hub-using-operator.adoc[leveloffset=1]
-include::platform/proc-aap-add-allowed-registries.adoc[leveloffset=1]
-include::platform/proc-determine-hub-route.adoc[leveloffset=1]
-include::platform/proc-update-rhsso-client.adoc[leveloffset=1]
+include::platform/proc-creating-a-secret.adoc[leveloffset=+1]
+include::platform/proc-installing-hub-using-operator.adoc[leveloffset=+1]
+include::platform/proc-aap-add-allowed-registries.adoc[leveloffset=+1]
+include::platform/proc-determine-hub-route.adoc[leveloffset=+1]
+include::platform/proc-update-rhsso-client.adoc[leveloffset=+1]
 
 == Additional resources
 


### PR DESCRIPTION
[AAP-42431](https://issues.redhat.com/browse/AAP-42431) - Add consistent attribute and OCP title usage to the Operator docs

Some chapter titles use the full "Red Hat OpenShift Container Platform" title while others use "OpenShift Container Platform". We need to update this for a consistent approach throughout.

Also fixing a formatting issue.