### PR TITLE
Release note update async-2.5.20250326

### DIFF
--- a/downstream/titles/release-notes/async/aap-25-20250326.adoc
+++ b/downstream/titles/release-notes/async/aap-25-20250326.adoc
@@ -8,12 +8,11 @@ This release includes the following components and versions:
 |===
 | Release date | Component versions
 
-| March 01, 2025  | 
+| March 26, 2025  | 
 * {ControllerNameStart} 4.6.10
 * {HubNameStart} 4.10.3
 * {EDAName} 1.1.6
 * Container-based installer {PlatformNameShort} (bundle) 2.5-11
-* Container-based installer {PlatformNameShort} (online) 2.5-11
 * Receptor 1.5.3
 * RPM-based installer {PlatformNameShort} (bundle) 2.5-10
 * RPM-based installer {PlatformNameShort} (online) 2.5-10


### PR DESCRIPTION
Deleted container-based online installer line.
Updated the date in the table.