### PR TITLE
Backport to 2.5:AAP-42638 removes info about analytics opt-in in first login process (#3171)

### DIFF
--- a/downstream/modules/platform/proc-gs-logging-in.adoc
+++ b/downstream/modules/platform/proc-gs-logging-in.adoc
@@ -22,7 +22,6 @@ After your first login, you are prompted to add your subscription manifest.
 Your subscription appears in the list menu labeled *Subscription*. 
 Select your subscription.
 . After you have added your subscription, click btn:[Next].
-. On the screen labeled *Analytics*, check the box if you want to share data with Red Hat and click btn:[Next].
 . Check the box indicating that you agree to the *End User License Agreement*. 
 . Review your information and click btn:[Finish].
 


### PR DESCRIPTION
This PR ports the changes from [PR 3171](https://github.com/ansible/aap-docs/pull/3171) to the 2.5 branch. See [AAP-42638](https://issues.redhat.com/browse/AAP-42638) for more.