### PR TITLE
Updated version numbers and added content (#3177)

### DIFF
--- a/downstream/titles/release-notes/async/aap-25-20250326.adoc
+++ b/downstream/titles/release-notes/async/aap-25-20250326.adoc
@@ -9,10 +9,12 @@ This release includes the following components and versions:
 | Release date | Component versions
 
 | March 26, 2025  | 
+* {GatewayStart} 2.5.20250326
 * {ControllerNameStart} 4.6.10
 * {HubNameStart} 4.10.3
 * {EDAName} 1.1.6
-* Container-based installer {PlatformNameShort} (bundle) 2.5-11
+* Container-based installer {PlatformNameShort} (bundle) 2.5-11.1
+* Container-based  installer {PlatformNameShort} (online) 2.5-11
 * Receptor 1.5.3
 * RPM-based installer {PlatformNameShort} (bundle) 2.5-10
 * RPM-based installer {PlatformNameShort} (online) 2.5-10


### PR DESCRIPTION
Added {GatewayStart} 2.5.20250326
Added Container-based  installer {PlatformNameShort} (online) 2.5-11 
Updated container-based installer to versoin 2.5-11.1