### PR TITLE
[Backport] - 41494 - removed details about migrating via the API (#3181)

### DIFF
--- a/downstream/modules/platform/proc-aap-migrate-SAML-users.adoc
+++ b/downstream/modules/platform/proc-aap-migrate-SAML-users.adoc
@@ -12,26 +12,26 @@ When upgrading from {PlatformNameShort} 2.4 to 2.5, you must migrate your Single
 
 *SSO configurations are not migrated automatically during upgrade to 2.5:* While the legacy authentication settings are carried over during the upgrade process and allow seamless initial access to the platform after upgrade, SSO configurations must be manually migrated over to a new {PlatformNameShort} 2.5 authentication configuration. The legacy configuration acts as a reference to preserve existing authentication capabilities and facilitate the migration process. The legacy authentication configuration should not be modified directly or used after migration is complete.
 
-*SSO migration is not currently supported in the UI:* While migration of SSO accounts is supported in 2.5,  the configuration is not supported through the platform UI and must be done through the API `/api/gateway/v1/authenticators/`.
+*SSO migration is supported in the UI:* Migration of legacy SSO accounts is supported in 2.5 UI, and is done by selecting your legacy authenticator from the *Auto migrate users from* list when you configure a new authentication method. This is the legacy authenticator from which to automatically migrate users to a new {Gateway} authentication configuration.
 
 *Migration of SSO must happen before users log in and start account linking:* You must enable the *Auto migrate users to* setting _after_ configuring SSO in 2.5 and _before_ any users log in.
 
-.Prerequisites
-
-You have configured a SSO authentication method in the {Gateway} following the steps in link:{URLCentralAuth}/gw-configure-authentication#gw-config-authentication-type[Configuring an authentication type]. This will be the configuration that you will migrate your previous SSO users to. 
+[Removed for AAP-41494]
+//.Prerequisites
+//You have configured a SSO authentication method in the {Gateway} following the steps in link:{URLCentralAuth}/gw-configure-authentication#gw-config-authentication-type[Configuring an authentication type]. This will be the configuration that you will migrate your previous SSO users to. 
 
 [NOTE]
 ====
 {PlatformNameShort} 2.4 SSO configurations are renamed during the upgrade process and are displayed in the *Authentication Methods* list view with a prefix to indicate a legacy configuration: for example,  `legacy_sso-saml-<entity id>`. The *Authentication type* is also listed as *legacy sso*. These configurations can not be modified.
 ====
 
-.Procedure
-
-. Log in to the {Gateway} API.
-. Go to `/api/gateway/v1/authenticators/`, locate the legacy authenticator and click the link. 
-. This opens the HTML form for that authenticator. 
-. Select the new {Gateway} authenticator from the *Auto migrate users to* list. 
-. Click btn:[PUT]. 
+[This procedure is obsolete now that migration is supported in the UI AAP-41494]
+//.Procedure
+//. Log in to the {Gateway} API.
+//. Go to `/api/gateway/v1/authenticators/`, locate the legacy authenticator and click the link. 
+//. This opens the HTML form for that authenticator. 
+//. Select the new {Gateway} authenticator from the *Auto migrate users to* list. 
+//. Click btn:[PUT]. 
 
 Once you set up the auto migrate functionality, you should be able to login with SSO in the {Gateway} and it will automatically link any matching accounts from the legacy SSO authenticator.
 


### PR DESCRIPTION
This PR backports the changes from #3181 to the 2.5 branch. 