### PR TITLE
AAP-37305-DUP Document how to duplicate an existing rulebook activation

### DIFF
--- a/downstream/modules/eda/proc-eda-copy-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-copy-rulebook-activation.adoc
@@ -1,31 +1,31 @@
 [id="eda-copy-rulebook-activation"]
 
-= Copying a rulebook activation
+= Duplicating a rulebook activation
 
-When setting up a new rulebook activation with field inputs that are similar to one of your existing rulebook activations, you can use the *Copy rulebook activation* feature instead of manually entering input into each field. While setting up rulebook activations can be a lengthy process, the ability to copy the required fields from an existing activation saves time and, in some cases, reduces the possibility of human error.
+When setting up a new rulebook activation with field inputs that are similar to one of your existing rulebook activations, you can use the *Duplicate rulebook activation* feature instead of manually entering input into each field. While setting up rulebook activations can be a lengthy process, the ability to copy the required fields from an existing activation saves time and, in some cases, reduces the possibility of human error.
 
 .Procedure
 
-. On the Rulebook Activations page, click the *More Actions* icon *{MoreActionsIcon}* on the row of the activation you want to copy. The More Actions list is displayed with three options:
+. On the Rulebook Activations page, click the *More Actions* icon *{MoreActionsIcon}* on the row of the activation you want to duplicate. The More Actions list is displayed with three options:
 ** *Restart rulebook activation*
-** *Copy rulebook activation*
+** *Duplicate rulebook activation*
 ** *Delete rulebook activation*
 . Select btn:[Copy rulebook activation]. 
 +
-A message is displayed: "<Name of rulebook activation 1> copied." Initially, the newly copied activation is displayed as disabled on the Rulebook Activations page with the same name as the original activation followed by a time stamp in 24-hour format (for example, <Name of rulebook activation 1> @ 18:43:27).
+A message is displayed: "<Name of rulebook activation 1> duplicated." Initially, the newly duplicated activation is displayed as disabled on the Rulebook Activations page with the same name as the original activation followed by a time stamp in 24-hour format (for example, <Name of rulebook activation 1> @ 18:43:27).
 +
 [IMPORTANT]
 ====
-The original rulebook activation continues to run after you have copied it. If you try to enable the copied activation without editing the fields (including the Name field) to distinguish it from the original, a message is displayed reminding you that the rulebook activation was copied from an original, and enabling it might fail or result in duplicate jobs and other complications.
+The original rulebook activation continues to run after you have duplicated it. If you try to enable the copied activation without editing the fields (including the Name field) to distinguish it from the original, a message is displayed reminding you that the rulebook activation was copied from an original, and enabling it might fail or result in duplicate jobs and other complications.
 ====
  
-. Before you run the copied rulebook activation, edit the fields by completing the following: 
-.. Next to the copied rulebook activation, click the *Edit* icon. This takes you to the Edit form. 
+. Before you run the duplicated rulebook activation, edit the fields by completing the following: 
+.. Next to the duplicated rulebook activation, click the *Edit* icon. This takes you to the Edit form. 
 .. Edit the desired fields.
 +
 [NOTE]
 ====
-Ensure that you have given your newly copied activation a meaningful *Name* that distinguishes it from the original activation.
+Ensure that you have given your newly duplicated activation a meaningful *Name* that distinguishes it from the original activation.
 ====
 . Toggle the btn:[Enable rulebook activation] button to the on position. 
 . After confirming all of your edits are complete, click btn:[Save rulebook activation].

--- a/downstream/modules/eda/proc-eda-copy-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-copy-rulebook-activation.adoc
@@ -2,7 +2,7 @@
 
 = Duplicating a rulebook activation
 
-When setting up a new rulebook activation with field inputs that are similar to one of your existing rulebook activations, you can use the *Duplicate rulebook activation* feature instead of manually entering input into each field. While setting up rulebook activations can be a lengthy process, the ability to copy the required fields from an existing activation saves time and, in some cases, reduces the possibility of human error.
+When setting up a new rulebook activation with field inputs that are similar to one of your existing rulebook activations, you can use the *Duplicate rulebook activation* feature instead of manually entering input into each field. While setting up rulebook activations can be a lengthy process, the ability to duplicate the required fields from an existing activation saves time and, in some cases, reduces the possibility of human error.
 
 .Procedure
 
@@ -10,13 +10,13 @@ When setting up a new rulebook activation with field inputs that are similar to 
 ** *Restart rulebook activation*
 ** *Duplicate rulebook activation*
 ** *Delete rulebook activation*
-. Select btn:[Copy rulebook activation]. 
+. Select btn:[Duplicate rulebook activation]. 
 +
 A message is displayed: "<Name of rulebook activation 1> duplicated." Initially, the newly duplicated activation is displayed as disabled on the Rulebook Activations page with the same name as the original activation followed by a time stamp in 24-hour format (for example, <Name of rulebook activation 1> @ 18:43:27).
 +
 [IMPORTANT]
 ====
-The original rulebook activation continues to run after you have duplicated it. If you try to enable the copied activation without editing the fields (including the Name field) to distinguish it from the original, a message is displayed reminding you that the rulebook activation was copied from an original, and enabling it might fail or result in duplicate jobs and other complications.
+The original rulebook activation continues to run after you have duplicated it. If you try to enable the duplicated activation without editing the fields (including the Name field) to distinguish it from the original, a message is displayed reminding you that the rulebook activation was duplicated from an original, and enabling it might fail or result in duplicate jobs and other complications.
 ====
  
 . Before you run the duplicated rulebook activation, edit the fields by completing the following: 


### PR DESCRIPTION
**Note:** This PR updates changes that were applied in the original PR #[3147](https://github.com/ansible/aap-docs/pull/3147), changing instances of "copy" to "duplicate", per request from the PDT.

[AAP-37305](https://issues.redhat.com/browse/AAP-37305) Create a sub-section in the [Rulebook Activation chapter of the Using automation decisions guide](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-rulebook-activations) that focuses on how to create a copy of an existing rulebook activation.