### PR TITLE
AAP-42948 Update docs to reflect change from "Copy" to "Duplicate"

### DIFF
--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -17,6 +17,6 @@ A message is displayed confirming that your selected credential has been duplica
 . Click the btn:[Back to credentials] tab to view the credential you just duplicated. 
 +
 The duplicated credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (for example, *<Name of credential> @ 17:26:30*). 
-. Edit the details you prefer for your duplicated credential. For more information, see Editing a credential.
+. Edit the details you prefer for your duplicated credential.
 // add a link to the Editing a credential topic
 . Click btn:[Save credential].

--- a/downstream/modules/eda/proc-eda-duplicate-credential.adoc
+++ b/downstream/modules/eda/proc-eda-duplicate-credential.adoc
@@ -1,21 +1,22 @@
 [id="eda-duplicate-credential"]
 
-= Copying a credential
+= Duplicating a credential
 
-When setting up a new credential with field inputs that are similar to your existing credentials, you can use the *Copy credential* feature in the Details tab to duplicate information instead of manually entering it. While setting up credentials can be a lengthy process, the ability to copy the required fields from an existing credential saves time and, in some cases, reduces the possibility of human error.
+When setting up a new credential with field inputs that are similar to your existing credentials, you can use the *Duplicate credential* feature in the Details tab to duplicate information instead of manually entering it. While setting up credentials can be a lengthy process, the ability to duplicate the required fields from an existing credential saves time and, in some cases, reduces the possibility of human error.
 
 .Procedure
 
-. On the Credentials list page, click the name of the credential that you want to copy. This takes you to the *Details* tab of the credential.
-. Click btn:[Copy credential] in the upper right of the Details tab. 
+. On the Credentials list page, click the name of the credential that you want to duplicate. This takes you to the *Details* tab of the credential.
+. Click btn:[Duplicate credential] in the upper right of the Details tab. 
 +
 [NOTE]
 ====
-You can also click the btn:[Copy credential] icon next to the desired credential on the Credentials list page.
+You can also click the btn:[Duplicate credential] icon next to the desired credential on the Credentials list page.
 ====
-A message is displayed confirming that your selected credential has been copied: "<Name of credential> copied." 
-. Click the btn:[Back to credentials] tab to view the credential you just copied. 
+A message is displayed confirming that your selected credential has been duplicated: "<Name of credential> duplicated." 
+. Click the btn:[Back to credentials] tab to view the credential you just duplicated. 
 +
-The copied credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (for example, *<Name of credential> @ 17:26:30*). 
-. Edit the details you prefer for your copied credential.
+The duplicated credential is displayed with the same name as the original credential followed by a time stamp in 24-hour format (for example, *<Name of credential> @ 17:26:30*). 
+. Edit the details you prefer for your duplicated credential. For more information, see Editing a credential.
+// add a link to the Editing a credential topic
 . Click btn:[Save credential].

--- a/downstream/modules/platform/ref-eda-system-requirements.adoc
+++ b/downstream/modules/platform/ref-eda-system-requirements.adoc
@@ -11,9 +11,15 @@ If you want to use {EDAName} 2.5 with a 2.4 {ControllerName} version, see link:{
  
 Use the following minimum requirements to run, by default, a maximum of 12 simultaneous activations:
 
+<<<<<<< HEAD
 [cols=2*,options="header"]
 |===
 | Requirement | Required
+=======
+[cols="a,a",options="header"]
+|===
+h| Requirement | Required
+>>>>>>> 211aa11ca (Fix merge conflict)
 | *RAM* | 16 GB
 | *CPUs* | 4
 | *Local disk* a| 


### PR DESCRIPTION
[AAP-42948](https://issues.redhat.com/browse/AAP-42948) required updates to all EDA resources that had the capability to duplicate fields during set-up. This includes the section formerly entitled "[Copying a credential](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credentials#eda-duplicate-credential)", which will become "Duplicating a credential" after the upcoming release (May 7th) and publishing.

(Note: The other resource that required this update is rulebook activations. Those updates were handled under AAP-37305 in a new section, "Duplicating a rulebook activation."

