### PR TITLE
AAP-43262: Fixed code formatting for infra.controller_configuration in table

### DIFF
--- a/downstream/modules/aap-hardening/ref-infrastructure-as-code.adoc
+++ b/downstream/modules/aap-hardening/ref-infrastructure-as-code.adoc
@@ -18,7 +18,7 @@ The following Ansible content collections are available for managing {PlatformNa
 | *Validated Collection* | *Collection Purpose*
 | `infra.aap_utilities` | Ansible content for automating day 1 and day 2 operations of {PlatformNameShort}, including installation, backup and restore, certificate management, and more.
 
-| `infra.aap_configuration` | A collection of roles to manage the creation of {PlatformNameShort} components, including users and groups (RBAC), projects, job templates and workflows, credentials, and more. This collection includes functionality from the older 'infra.controller_configuration`, `infra.ah_configuration` and `infra.eda_configuration` and should be used in their place with {PlatformNameShort} {PlatformVers}.
+| `infra.aap_configuration` | A collection of roles to manage the creation of {PlatformNameShort} components, including users and groups (RBAC), projects, job templates and workflows, credentials, and more. This collection includes functionality from the older `infra.controller_configuration`, `infra.ah_configuration` and `infra.eda_configuration` and should be used in their place with {PlatformNameShort} {PlatformVers}.
 
 | `infra.ee_utilities` | A collection of roles for creating and managing {ExecEnvShort} images, or migrating from the older Tower virtualenvs to execution environments.
 |===


### PR DESCRIPTION
Changed ' to a backtick for `infra.controller_configuration`

This shouldn't require a SME review, just needs a peer review.


https://issues.redhat.com/browse/AAP-43262