### PR TITLE
Backport PR #3221 from main to AAP 2.5

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
+++ b/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
@@ -12,13 +12,15 @@ You can then download the desired version of the {PlatformNameShort} installer, 
 
 == Prerequisites
 
-Upgrades to {PlatformNameShort} 2.5 include the link:{URLPlanningGuide}/ref-aap-components#con-about-platform-gateway_planning[{Gateway}]. Ensure you review the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[2.5 Network ports and protocols] for architectural changes and link:{LinkTopologies} for information on opinionated deployment models. 
+* Upgrades to {PlatformNameShort} 2.5 include the link:{URLPlanningGuide}/ref-aap-components#con-about-platform-gateway_planning[{Gateway}]. Ensure you review the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[2.5 Network ports and protocols] for architectural changes and link:{LinkTopologies} for information on opinionated deployment models. 
 
-You have reviewed the link:{URLPlanningGuide}/ha-redis_planning#gw-centralized-redis_planning[centralized Redis] instance offered by {PlatformNameShort} for both standalone and clustered topologies.
+* You have reviewed the link:{URLPlanningGuide}/ha-redis_planning#gw-centralized-redis_planning[centralized Redis] instance offered by {PlatformNameShort} for both standalone and clustered topologies.
 
-Prior to upgrading your {PlatformName}, ensure you have reviewed link:{LinkPlanningGuide} for a successful upgrade. You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
+* Prior to upgrading your {PlatformName}, ensure you have reviewed link:{LinkPlanningGuide} for a successful upgrade. You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
 
-Prior to upgrading your {PlatformName}, ensure you have upgraded to {ControllerName} 2.5 or later. 
+* Prior to upgrading your {PlatformName}, ensure you have upgraded to {ControllerName} 2.5 or later. 
+
+* When upgrading to {PlatformNameShort} {PlatformVers}, you must use the latest installer. If you use an earlier version of the installer with the latest RPMs, the installation will fail.
 
 include::platform/con-aap-upgrade-planning.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR backports PR https://github.com/ansible/aap-docs/pull/3221 from main to AA 2.5 repo. 