### PR TITLE
Editing container group proc in 2.4 doc

### DIFF
--- a/downstream/modules/platform/proc-controller-create-container-group.adoc
+++ b/downstream/modules/platform/proc-controller-create-container-group.adoc
@@ -38,15 +38,38 @@ metadata:
   name: role-containergroup-service-account
   namespace: containergroup-namespace
 rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["pods/log"]
-  verbs: ["get"]
-- apiGroups: [""]
-  resources: ["pods/attach"]
-  verbs: ["get", "list", "watch", "create"]
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - pods
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - pods/log
+  - verbs:
+      - create
+    apiGroups:
+      - ''
+    resources:
+      - pods/attach
+  - verbs:
+      - get
+      - create
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - secrets
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,25 +93,18 @@ roleRef:
 oc apply -f containergroup-sa.yml
 ----
 +
-. Get the secret name associated with the service account:
+. Get an API token by generating a service account token:
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-export SA_SECRET=$(oc get sa containergroup-service-account -o json | jq '.secrets[0].name' | tr -d '"')
-----
-+
-. Get the token from the secret:
-+
-[literal, options="nowrap" subs="+attributes"]
-----
-oc get secret $(echo ${SA_SECRET}) -o json | jq '.data.token' | xargs | base64 --decode > containergroup-sa.token
+oc create token containergroup-service-account --duration=$((365*24))h > containergroup-sa.token
 ----
 +
 . Get the CA certificate:
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-oc get secret $SA_SECRET -o json | jq '.data["ca.crt"]' | xargs | base64 --decode > containergroup-ca.crt
+oc get secret  -n openshift-ingress wildcard-tls -o jsonpath='{.data.ca\.crt}' | base64 -d > containergroup-ca.crt
 ----
 +
 . Use the contents of `containergroup-sa.token` and `containergroup-ca.crt` to provide the information for the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/automation_controller_user_guide/index#ref-controller-credential-openShift[OpenShift or Kubernetes API Bearer Token] required for the container group.


### PR DESCRIPTION
Container Group documentation is incorrect for recent versions of OpenShift

https://issues.redhat.com/browse/AAP-41641

Affects `titles/controller-user-guide`