### PR TITLE
AAP-43648 Adding note on EDA 2.4-2.5 support

### DIFF
--- a/downstream/modules/platform/proc-operator-upgrade.adoc
+++ b/downstream/modules/platform/proc-operator-upgrade.adoc
@@ -14,6 +14,11 @@ To upgrade to the latest version of {OperatorPlatformNameShort} on {OCPShort}, y
 ** AutomationHubBackup
 ** EDABackup 
 
+[IMPORTANT]
+====
+Upgrading from {EDAName} 2.4 is not supported. If you are using {EDAName} 2.4 in production, contact Red{nbsp}Hat before you upgrade.
+====
+
 .Prodedure
 . Log in to {OCPShort}.
 . Navigate to menu:Operators[Installed Operators].


### PR DESCRIPTION
[AAP-43648](https://issues.redhat.com/browse/AAP-43648)
[OCP docs] EDA 2.4 to 2.5 upgrades are not supported

EDA 2.4 is not supported for upgrade to 2.5. A user should remove the EDA deployment, then clean EDA database and upgrade. A very low number of customers experience this issue, so rather than detail the full steps a important admonition with the following needs to be added to the Upgrades section:


"Upgrading from Event-Driven Ansible 2.4 is not supported. If you’re using Event-Driven Ansible 2.4 in production, contact Red Hat before you upgrade."