### PR TITLE
AAP-43744 updating title for 2.4 and 2.5

### DIFF
--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -4,7 +4,7 @@
 
 [id="install-cli-aap-operator_{context}"]
 
-= Subscribing a namespace to an operator using the {OCPShort} CLI
+= Installing the {OperatorPlatformNameShort} in a namespace
 
 Use this procedure to subscribe a namespace to an operator.
 


### PR DESCRIPTION
[AAP-43744](https://issues.redhat.com/browse/AAP-43744) Update the wording for section 4.2

The wording in section 4.2 for the 2.5 AAP Operator docs is confusing.  I think we should refer to "Installing the AAP Operator in a namespace" as that, rather than "Subscribing a namespace to an operator".