### PR TITLE
AAP-43744 sentence to be removed

### DIFF
--- a/downstream/modules/platform/proc-install-cli-aap-operator.adoc
+++ b/downstream/modules/platform/proc-install-cli-aap-operator.adoc
@@ -11,9 +11,6 @@ Use this procedure to subscribe a namespace to an operator.
 [IMPORTANT]
 ====
 You cannot deploy {PlatformNameShort} in the default namespace on your OpenShift Cluster. The `aap` namespace is recommended. You can use a custom namespace, but it should run only {PlatformNameShort}.
-
-You can only subscribe a single instance of the {OperatorPlatformNameShort} into a single namespace. 
-Subscribing multiple instances in the same namespace can lead to improper operation for both operator instances. 
 ====
 
 .Procedure


### PR DESCRIPTION
[AAP-43744](https://issues.redhat.com/browse/AAP-43744) Update the wording for section 4.2

Also, this part does not make sense:

"You can only subscribe a single instance of the Ansible Automation Platform Operator into a single namespace. Subscribing multiple instances in the same namespace can lead to improper operation for both operator instances." 

The Openshift UI will not let you install multiple of the same operator in a given namespace.  So I think we could probably remove that line entirely.