### PR TITLE
bp 2.5: AAP-3241 corrects login instructions (#3241)

### DIFF
--- a/downstream/modules/hub/proc-push-container.adoc
+++ b/downstream/modules/hub/proc-push-container.adoc
@@ -12,15 +12,15 @@ You can push tagged {ExecEnvShort}s to {PrivateHubName} to create new containers
 .Prerequisites
 
 * You have permissions to create new containers.
-* You have the FQDN or IP address of the {HubName} instance.
+* You have the FQDN or IP address of the {PlatformNameShort} instance.
 
 .Procedure
 
-. Log in to Podman using your {HubName} location and credentials:
+. Log in to Podman using your {PlatformNameShort} location and credentials:
 +
 [subs="+quotes"]
 -----
-$ podman login -u=__<username>__ -p=__<password>__ __<automation_hub_url>__
+$ podman login -u=__<username>__ -p=__<password>__ __<aap_url>__
 -----
 +
 [WARNING]
@@ -43,8 +43,7 @@ This may lead to image-layer digest changes and a failed push operation, resulti
 .Verification
 
 . Log in to your {PlatformNameShort}.
-//[ddacosta] I see no such selection. Should this be changed to Execution Environments > Remote Registries? If so, replace with {MenuACAdminRemoteRegistries} 
-// [hherbly] I think it's {MenuACExecEnvironments} based on the context but need to double check. 
+
 . Navigate to {MenuACExecEnvironments}.
 
 . Locate the container in the container repository list.


### PR DESCRIPTION
This PR ports the changes from [PR 3241 ](https://github.com/ansible/aap-docs/pull/3241) to the 2.5 branch. See[ AAP-39723](https://issues.redhat.com/browse/AAP-39723) for more.