### PR TITLE
[Backport] AAP-40546 - Add Migrating LDAP users content to the Upgrade guide (#3264)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-post-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-aap-post-upgrade.adoc
@@ -17,7 +17,8 @@ There are important notes and considerations for each type of user migration, in
 
 * Admin users
 * Normal users
-* SAML users
+* SSO users
+* LDAP users
 
 Be sure to read through the important notes highlighted for each user type to help make the migration process as smooth as possible.
 
@@ -25,6 +26,11 @@ include::platform/proc-aap-migrate-admin-users.adoc[leveloffset=+1]
 include::platform/con-aap-migrate-normal-users.adoc[leveloffset=+1]
 include::platform/proc-account-linking.adoc[leveloffset=+2]
 include::platform/proc-aap-migrate-SAML-users.adoc[leveloffset=+1]
+include::platform/con-aap-migrate-LDAP-users.adoc[leveloffset=+1]
+include::platform/con-aap-legacy-user-login.adoc[leveloffset=+2]
+include::platform/proc-aap-migrate-LDAP-users.adoc[leveloffset=+2]
+
+
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:] 

--- a/downstream/modules/platform/con-aap-legacy-user-login.adoc
+++ b/downstream/modules/platform/con-aap-legacy-user-login.adoc
@@ -1,0 +1,13 @@
+
+
+[id="legacy-user-login_{context}"]
+
+= Legacy user login and account linking
+ 
+[role="_abstract"]
+
+Users can log in using their legacy accounts by selecting “I have a <component> account” and entering their credentials (username and password). If the login is successful, they may be prompted to link their account with another component account for example, {HubName} and {ControllerName}. If the login credentials are the same for both {HubName} and {ControllerName}, account linking is automatically done for that user.
+
+After successful account linking, user accounts from both components are merged into a `gateway:legacy external password` authenticator. If user accounts are not automatically merged into the `gateway:legacy external password` authenticator, you must auto migrate directly to LDAP without linking accounts.
+
+For more information about account linking, see link:{URLUpgrade}/aap-post-upgrade#account-linking_aap-post-upgrade[Linking your accounts].

--- a/downstream/modules/platform/con-aap-migrate-LDAP-users.adoc
+++ b/downstream/modules/platform/con-aap-migrate-LDAP-users.adoc
@@ -1,0 +1,22 @@
+
+
+[id="con-migrate-LDAP-users_{context}"]
+
+= Migrating LDAP users
+ 
+[role="_abstract"]
+
+As a platform administrator upgrading from {PlatformNameShort} 2.4 to 2.5, you must migrate your LDAP user accounts if you want to continue using LDAP authentication capabilities after the upgrade. Follow the steps in this procedure to  ensure the smoothest possible LDAP user migration.
+
+There are two primary scenarios for migrating users from legacy authentication systems to LDAP-based authentication:
+
+. Legacy user login and account linking
+. Migration to LDAP without account linking
+
+== Key considerations
+
+*LDAP configurations are not migrated automatically during upgrade to 2.5:* While the legacy LDAP authentication settings are carried over during the upgrade process and allow seamless initial access to the platform after upgrade, LDAP configurations must be manually migrated over to a new {PlatformNameShort} 2.5 LDAP  configuration. The legacy configuration acts as a reference to preserve existing  authentication capabilities and facilitate the migration process. The legacy authentication configuration should not be modified directly or used after migration is complete.
+
+*UID collision risk:* LDAP and legacy password authenticators both use usernames as the UID. This can cause UID collisions between users or users with the same name owned by different people. Any user accounts that are not secure for auto-migration due to UID conflicts must be manually migrated to ensure proper handling. You can manually migrate these users through the API `/api/gateway/v1/authenticator_users/` before setting auto-migrations.
+
+*Do not log in using legacy LDAP authentication if you do not have a user account in the platform prior to the upgrade:* Instead, you must xref:proc-migrate-LDAP-users[auto migrate directly to LDAP without linking accounts].

--- a/downstream/modules/platform/proc-aap-migrate-LDAP-users.adoc
+++ b/downstream/modules/platform/proc-aap-migrate-LDAP-users.adoc
@@ -1,0 +1,33 @@
+
+
+[id="proc-migrate-LDAP-users"]
+
+= Migrating LDAP users without account linking
+
+ 
+[role="_abstract"]
+
+If a user is unable to link their accounts because there is no linking option for their {HubName} account, you must immediately configure the auto-migrate feature on all legacy password authenticators to target the new gateway LDAP authenticator.
+
+Then, when a user logs in, the {Gateway} will automatically migrate the user to the LDAP authenticator if a matching UID is found.
+
+.Prerequisites
+
+* Verify that all legacy accounts are properly linked and merged before proceeding with auto-migration.
+
+* Verify that there are no UID collisions or ensure they are manually migrated before proceeding with auto-migration.
+
+.Procedure
+
+. Log in to the {PlatformNameShort} UI.
+. Set up a new LDAP authentication method in the {Gateway} following the steps in link:{URLCentralAuth}/gw-configure-authentication#controller-set-up-LDAP[Configuring LDAP authentication]. This will be the configuration that you will migrate your previous LDAP users to.
++
+[NOTE]
+====
+{PlatformNameShort} 2.4 LDAP configurations are renamed during the upgrade process and are displayed in the *Authentication Methods* list view prefixed to indicate that it is a legacy configuration, for example,  `<controller/hub/eda>: legacy_password`. The *Authentication type* is listed as *Legacy password*. These configurations can not be modified.
+====
++
+. Select the legacy LDAP authenticator from the *Auto migrate users from* list. This is the legacy authenticator you want to use for migrating users to your {Gateway} LDAP authenticator.
+
+Once you set up the auto migrate functionality, you should be able to login with LDAP in the {Gateway} and any matching accounts from the legacy 2.4 LDAP authenticator will automatically be linked.
+

--- a/downstream/modules/platform/proc-aap-migrate-SAML-users.adoc
+++ b/downstream/modules/platform/proc-aap-migrate-SAML-users.adoc
@@ -25,7 +25,7 @@ When upgrading from {PlatformNameShort} 2.4 to 2.5, you must migrate your Single
 {PlatformNameShort} 2.4 SSO configurations are renamed during the upgrade process and are displayed in the *Authentication Methods* list view with a prefix to indicate a legacy configuration: for example,  `legacy_sso-saml-<entity id>`. The *Authentication type* is also listed as *legacy sso*. These configurations can not be modified.
 ====
 
-[This procedure is obsolete now that migration is supported in the UI AAP-41494]
+//[This procedure is obsolete now that migration is supported in the UI AAP-41494]
 //.Procedure
 //. Log in to the {Gateway} API.
 //. Go to `/api/gateway/v1/authenticators/`, locate the legacy authenticator and click the link. 


### PR DESCRIPTION
This PR backports the changes from #3264 to the 2.5 branch and includes the following:

* AAP-40546 - Add Migrating LDAP users content to the Upgrade guide

* AAP-40546 - minor formatting fixes

* AAP-40546 - implemented peer review suggestions