### PR TITLE
Update IOPS to a standardized 3000

### DIFF
--- a/downstream/modules/platform/ref-controller-capacity-planning-exercise.adoc
+++ b/downstream/modules/platform/ref-controller-capacity-planning-exercise.adoc
@@ -12,7 +12,7 @@ For this example, the cluster must support the following capacity:
 * Forks set to 5 on playbooks. This is the default.
 * Average event size is 1 Mb
 
-The virtual machines have 4 CPU and 16 GB RAM, and disks that have 3000 IOPs.
+The virtual machines have 4 CPU and 16 GB RAM, and disks that have 3000 IOPS.
 
 include::ref-controller-example-workload-reqs.adoc[leveloffset=+1]
 
@@ -20,16 +20,16 @@ include::ref-controller-example-workload-reqs.adoc[leveloffset=+1]
 |===
 | Node | API capacity | Default execution capacity | Default control capacity | Mean event processing rate at 100% capacity usage | Mean events
 processing rate at 50% capacity usage | Mean event processing rate at 40% capacity usage
-| 4 CPU at 2.5Ghz, 16 GB RAM control node, a maximum of 3000 IOPs disk | about 10 requests per second | n/a | 137 jobs | 1100 per second | 1400 per second | 1630 per second
-| 4 CPU at 2.5Ghz, 16 GB RAM execution node, a maximum of 3000 IOPs disk | n/a | 137 | n/a | n/a | n/a | n/a
-| 4 CPU at 2.5Ghz, 16 GB RAM database node, a maximum of 3000 IOPs disk | n/a | n/a | n/a | n/a | n/a | n/a
+| 4 CPU at 2.5Ghz, 16 GB RAM control node, a maximum of 3000 IOPS disk | about 10 requests per second | n/a | 137 jobs | 1100 per second | 1400 per second | 1630 per second
+| 4 CPU at 2.5Ghz, 16 GB RAM execution node, a maximum of 3000 IOPS disk | n/a | 137 | n/a | n/a | n/a | n/a
+| 4 CPU at 2.5Ghz, 16 GB RAM database node, a maximum of 3000 IOPS disk | n/a | n/a | n/a | n/a | n/a | n/a
 |===
 
 Because controlling jobs competes with job event processing on the control node, over-provisioning control capacity can reduce processing times. When processing times are high, you can experience a delay between when the job runs and when you can view the output in the API or UI.
 
 For this example, for a workload on 300 managed hosts, executing 1000 tasks per hour per host, 10 concurrent jobs with forks set to 5 on playbooks, and an average event size 1 Mb, use the following procedure:
 
-* Deploy 1 execution node, 1 control node, 1 database node of 4 CPU at 2.5Ghz, 16 GB RAM, and disks that have about 3000 IOPs.
+* Deploy 1 execution node, 1 control node, 1 database node of 4 CPU at 2.5Ghz, 16 GB RAM, and disks that have about 3000 IOPS.
 * Keep the default fork setting of 5 on job templates.
 * Use the capacity change feature in the instance view of the UI on the control node to reduce the capacity down to 16, the lowest value, to reserve more of the control node's capacity for processing events.
 

--- a/downstream/modules/platform/ref-controller-system-requirements.adoc
+++ b/downstream/modules/platform/ref-controller-system-requirements.adoc
@@ -30,7 +30,7 @@ Control nodes process events and run cluster jobs including project updates and 
 //Control nodes have the following storage requirements:
 
 * 40GB minimum with at least 20GB available under /var/lib/awx
-* Storage volume must be rated for a minimum baseline of 1500 IOPS
+* Storage volume must be rated for a minimum baseline of 3000 IOPS
 * Projects are stored on control and hybrid nodes, and for the duration of jobs, are also stored on execution nodes. If the cluster has many large projects, consider doubling the GB in /var/lib/awx/projects, to avoid disk space errors.
 
 *Hop nodes*

--- a/downstream/modules/platform/ref-eda-system-requirements.adoc
+++ b/downstream/modules/platform/ref-eda-system-requirements.adoc
@@ -18,7 +18,7 @@ Use the following minimum requirements to run, by default, a maximum of 12 simul
 | *CPUs* | 4
 | *Local disk* a| 
 * Hard drive must be 40 GB minimum with at least 20 GB available under /var.
-* Storage volume must be rated for a minimum baseline of 1500 IOPS.
+* Storage volume must be rated for a minimum baseline of 3000 IOPS.
 * If the cluster has many large projects or decision environment images, consider doubling the GB in /var to avoid disk space errors.
 |===
 

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -27,17 +27,17 @@ h| Database | {PostgresVers}  | {PlatformName} {PlatformVers} requires the exter
 
 .Virtual machine requirements
 
-[cols="a,a,a,a", options="header"]
+[cols="a,a,a,a,a", options="header"]
 |===
-| Component                     | RAM   | VCPU   | Storage
+| Component             | RAM   | VCPU | Disk IOPS |  Storage
 
-| {GatewayStart}               | 16GB  | 4      | 20GB minimum
-| Control nodes                  | 16GB  | 4      | 80GB minimum with at least 20GB available under `/var/lib/awx`
-| Execution nodes                | 16GB  | 4      | 40GB minimum
-| Hop nodes                      | 16GB  | 4      | 40GB minimum
-| {HubNameStart}                 | 16GB  | 4      | 40GB minimum allocated to `/var/lib/pulp`
-| Database                       | 16GB  | 4      | 100GB minimum allocated to `/var/lib/pgsql`
-| {EDAcontroller} | 16GB  | 4      | 40GB minimum
+| {GatewayStart}        | 16GB  | 4    | 3000   | 20GB minimum
+| Control nodes         | 16GB  | 4    | 3000   | 80GB minimum with at least 20GB available under `/var/lib/awx`
+| Execution nodes       | 16GB  | 4    | 3000   | 40GB minimum
+| Hop nodes             | 16GB  | 4    | 3000   | 40GB minimum
+| {HubNameStart}        | 16GB  | 4    | 3000   | 40GB minimum allocated to `/var/lib/pulp`
+| Database              | 16GB  | 4    | 3000   | 100GB minimum allocated to `/var/lib/pgsql`
+| {EDAcontroller}       | 16GB  | 4    | 3000   | 40GB minimum
 |===
 
 [NOTE]

--- a/downstream/modules/topologies/ref-rpm-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-a.adoc
@@ -9,6 +9,9 @@ The following diagram outlines the infrastructure topology that Red{nbsp}Hat has
 .Infrastructure topology diagram
 image::rpm-a-env-a.png[RPM {GrowthTopology} diagram]
 
+Each VM has been tested with the following component requirements:
+
+.Virtual machine requirements
 include::snippets/rpm-tested-vm-config.adoc[]
 
 .Infrastructure topology

--- a/downstream/modules/topologies/ref-rpm-a-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-b.adoc
@@ -15,6 +15,9 @@ image::rpm-a-env-b.png[RPM mixed {GrowthTopology} diagram]
 Here, {ControllerName} and {HubName} are at 2.4x while the {EDAName} and {Gateway} components are at {PlatformVers}
 ====
 
+Each VM has been tested with the following component requirements:
+
+.Virtual machine requirements
 include::snippets/rpm-tested-vm-config.adoc[]
 
 .Infrastructure topology

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -9,6 +9,9 @@ The following diagram outlines the infrastructure topology that Red{nbsp}Hat has
 .Infrastructure topology diagram
 image::rpm-b-env-a.png[RPM {EnterpriseTopology} diagram]
 
+Each VM has been tested with the following component requirements:
+
+.Virtual machine requirements
 include::snippets/rpm-tested-vm-config.adoc[]
 
 .Infrastructure topology

--- a/downstream/modules/topologies/ref-rpm-b-env-b.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-b.adoc
@@ -14,6 +14,9 @@ image::rpm-b-env-b.png[RPM mixed {EnterpriseTopology} diagram]
 Here, {ControllerName} and {HubName} are at 2.4x while the {EDAName} and {Gateway} components are at {PlatformVers}
 ====
 
+Each VM has been tested with the following component requirements:
+
+.Virtual machine requirements
 include::snippets/rpm-tested-vm-config.adoc[]
 
 .Infrastructure topology

--- a/downstream/snippets/rpm-tested-vm-config.adoc
+++ b/downstream/snippets/rpm-tested-vm-config.adoc
@@ -1,2 +1,9 @@
 //Tested VM configuration snippet for RPM topologies
-Each virtual machine (VM) has been tested with the following component requirements: 16 GB RAM, 4 CPUs, 60 GB local disk, and 3000 IOPS. 
+[cols=2,options="header"]
+|====
+| Requirement | Minimum requirement
+| RAM      | 16 GB
+| CPUs         | 4 
+| Local disk  | 60 GB  
+| Disk IOPS   | 3000   
+|====


### PR DESCRIPTION
- Update references to IOPS to ensure it's capitalized as IOPS not IOPs.
- Also update all IOPS requirements to 3000.

Missing disk IOPS information in AAP Installation Documentation

https://issues.redhat.com/browse/AAP-43311