### PR TITLE
AAP-40240 Added Important admonitions to encourage use of credentials…

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-credentials.adoc
+++ b/downstream/assemblies/eda/assembly-eda-credentials.adoc
@@ -8,6 +8,10 @@ Credentials authenticate users when launching jobs against machines and importin
 
 You can grant users and teams the ability to use these credentials without exposing the credential to the user. If a user moves to a different team or leaves the organization, you do not have to rekey all of your systems just because that credential was previously available.
 
+[IMPORTANT]
+====
+In the context of {ControllerName} and {EDAcontroller}, you can use both `extra_vars` and credentials to store a variety of information. However, credentials are the preferred method of storing sensitive information such as passwords or API keys because they offer better security and centralized management, whereas `extra_vars` are more suitable for passing dynamic, non-sensitive data.
+====
 
 include::eda/con-credentials-list-view.adoc[leveloffset=+1]
 include::eda/proc-eda-set-up-credential.adoc[leveloffset=+1]

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -51,6 +51,11 @@ Service name:: This defines a service name for Kubernetes to configure inbound c
 Rulebook activation enabled?:: This automatically enables the rulebook activation to run.
 Variables:: The variables for the rulebook are in a JSON or YAML format.
 The content would be equivalent to the file passed through the `--vars` flag of ansible-rulebook command.
++
+[IMPORTANT]
+====
+In the context of {ControllerName} and {EDAcontroller}, you can use both `extra_vars` and credentials to store a variety of information. However, credentials are the preferred method of storing sensitive information such as passwords or API keys because they offer better security and centralized management, whereas `extra_vars` are more suitable for passing dynamic, non-sensitive data.
+====
 Options:: Check the *Skip audit events* option if you do not want to see your events in the Rule Audit.
 
 . Click btn:[Create rulebook activation].


### PR DESCRIPTION
In response to the request in AAP-40240, added two "Important" admonitions to encourage users to use credentials instead of `extra_vars` (variables) in two sections of the Using automation decisions guide: 

1. Credentials (downstream/assemblies/eda/assembly-eda-credentials.adoc)
2. Setting up a rulebook activation (downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc)