### PR TITLE
Adding clarity to additional settings for controller

### DIFF
--- a/downstream/modules/platform/con-controller-additional-settings.adoc
+++ b/downstream/modules/platform/con-controller-additional-settings.adoc
@@ -7,3 +7,5 @@ There are additional advanced settings that can affect {ControllerName} behavior
 For traditional virtual machine based deployments, these settings can be provided to {ControllerName} by creating a file in `/etc/tower/conf.d/custom.py`. When settings are provided to {ControllerName} through file-based settings, the settings file must be present on all control plane nodes. These include all of the hybrid or control type nodes in the `automationcontroller` group in the installer inventory. 
 
 For these settings to be effective, restart the service with `automation-controller-service` restart on each node with the settings file. If the settings provided in this file are also visible in the {ControllerName} UI, then they are marked as "Read only" in the UI.
+
+For containerized based deployments use, `controller_extra_settings` in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables[Automation controller variables].

--- a/downstream/modules/platform/con-controller-additional-settings.adoc
+++ b/downstream/modules/platform/con-controller-additional-settings.adoc
@@ -8,5 +8,5 @@ For traditional virtual machine based deployments, these settings can be provide
 
 For these settings to be effective, restart the service with `automation-controller-service` restart on each node with the settings file. If the settings provided in this file are also visible in the {ControllerName} UI, then they are marked as "Read only" in the UI.
 
-For container-based installations, use `controller_extra_settings` in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables[Automation controller variables].
+For container-based installations, use `controller_extra_settings` in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables].
 The containerized version does not support `custom.py`.

--- a/downstream/modules/platform/con-controller-additional-settings.adoc
+++ b/downstream/modules/platform/con-controller-additional-settings.adoc
@@ -8,5 +8,5 @@ For traditional virtual machine based deployments, these settings can be provide
 
 For these settings to be effective, restart the service with `automation-controller-service` restart on each node with the settings file. If the settings provided in this file are also visible in the {ControllerName} UI, then they are marked as "Read only" in the UI.
 
-For containerized based deployments use, `controller_extra_settings` in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables[Automation controller variables].
+For container-based installations, use `controller_extra_settings` in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables[Automation controller variables].
 The containerized version does not support `custom.py`.

--- a/downstream/modules/platform/con-controller-additional-settings.adoc
+++ b/downstream/modules/platform/con-controller-additional-settings.adoc
@@ -9,3 +9,4 @@ For traditional virtual machine based deployments, these settings can be provide
 For these settings to be effective, restart the service with `automation-controller-service` restart on each node with the settings file. If the settings provided in this file are also visible in the {ControllerName} UI, then they are marked as "Read only" in the UI.
 
 For containerized based deployments use, `controller_extra_settings` in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables[Automation controller variables].
+The containerized version does not support `custom.py`.


### PR DESCRIPTION
Clarify references to "custom.py" in "Configuring automaton execution" documentation

https://issues.redhat.com/browse/AAP-43895

Affects `titles/controller-admin-guide`