### PR TITLE
Update python version (#3292)

### DIFF
--- a/downstream/modules/builder/con-about-ee.adoc
+++ b/downstream/modules/builder/con-about-ee.adoc
@@ -10,7 +10,7 @@ All automation in {PlatformName} runs on container images called {ExecEnvName}.
 An {ExecEnvNameSing} should contain the following:
 
 * Ansible Core 2.16 or later
-* Python 3.10 or later
+* Python 3.11 or later
 * {Runner}
 * Ansible content collections and their dependencies
 * System dependencies


### PR DESCRIPTION
AAP 2.5 EE uses Python 3.11 introducing non-obvious manual changes

https://issues.redhat.com/browse/AAP-40730