### PR TITLE
AAP-42705: Updated the storage requirements for VMs (#3297)

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -27,17 +27,17 @@ h| Database | {PostgresVers}  | {PlatformName} {PlatformVers} requires the exter
 
 .Virtual machine requirements
 
-[cols="a,a,a,a,a", options="header"]
+[cols="25%,10%,10%,10,45%", options="header"]
 |===
 | Component             | RAM   | VCPU | Disk IOPS |  Storage
 
-| {GatewayStart}        | 16GB  | 4    | 3000   | 20GB minimum
+| {GatewayStart}        | 16GB  | 4    | 3000   | 60GB minimum
 | Control nodes         | 16GB  | 4    | 3000   | 80GB minimum with at least 20GB available under `/var/lib/awx`
-| Execution nodes       | 16GB  | 4    | 3000   | 40GB minimum
-| Hop nodes             | 16GB  | 4    | 3000   | 40GB minimum
-| {HubNameStart}        | 16GB  | 4    | 3000   | 40GB minimum allocated to `/var/lib/pulp`
+| Execution nodes       | 16GB  | 4    | 3000   | 60GB minimum
+| Hop nodes             | 16GB  | 4    | 3000   | 60GB minimum
+| {HubNameStart}        | 16GB  | 4    | 3000   | 60GB minimum with at least 40GB allocated to `/var/lib/pulp`
 | Database              | 16GB  | 4    | 3000   | 100GB minimum allocated to `/var/lib/pgsql`
-| {EDAcontroller}       | 16GB  | 4    | 3000   | 40GB minimum
+| {EDAcontroller}       | 16GB  | 4    | 3000   | 60GB minimum
 |===
 
 [NOTE]


### PR DESCRIPTION
This PR backports PR #3297 from main to AAP 2.5 branch.

