### PR TITLE
AAP-42905 - Corrected gateway token API path

### DIFF
--- a/downstream/modules/platform/ref-controller-refresh-existing-token.adoc
+++ b/downstream/modules/platform/ref-controller-refresh-existing-token.adoc
@@ -60,4 +60,4 @@ Strict-Transport-Security: max-age=15768000
 
 The refresh operation replaces the existing token by deleting the original and then immediately creating a new token with the same scope and related application as the original one. 
 
-Verify that the new token is present and the old one is deleted in the `gateway/api/v1/tokens/` endpoint.
+Verify that the new token is present and the old one is deleted in the `api/gateway/v1/tokens/` endpoint.

--- a/downstream/modules/platform/ref-controller-revoke-access-token.adoc
+++ b/downstream/modules/platform/ref-controller-revoke-access-token.adoc
@@ -27,4 +27,4 @@ This setting can be configured from the {MenuSetGateway} menu.
 Alternatively, to revoke OAuth2 tokens, you can use the `manage` utility, see xref:ref-controller-revoke-oauth2-token[Revoke oauth2 tokens].
 
 On success, a response of `200 OK` is displayed. 
-Verify the deletion by checking whether the token is present in the `gateway/api/v1/tokens/` endpoint.
+Verify the deletion by checking whether the token is present in the `api/gateway/v1/tokens/` endpoint.


### PR DESCRIPTION
This PR updates the gateway api token path as described in https://issues.redhat.com/browse/AAP-42905.