### PR TITLE
backport to 2.4: AAP-39751: Notes that hub does not check other repos for dependencies

### DIFF
--- a/downstream/modules/hub/con-rh-certified-synclist.adoc
+++ b/downstream/modules/hub/con-rh-certified-synclist.adoc
@@ -8,4 +8,9 @@ Use synclists to manage only the content that you want and exclude unnecessary c
 Design and manage your synclist from the content available as part of Red Hat content on {Console}
 
 Each synclist has its own unique repository URL that you can use to designate as a remote source for content in {HubName}.
-You securely access each synclist by using an API token.
+You can securely access each synclist by using an API token.
+
+[NOTE]
+====
+When syncing content, keep in mind that {HubName} does not check other repositories for dependencies. To avoid an error, turn off dependency downloading by editing your remote settings. See link:{URLHubManagingContent}/managing-collections-hub#proc-create-remote_remote-management[Creating a remote configuration in {HubName}] for more information.
+====

--- a/downstream/modules/hub/proc-create-remote.adoc
+++ b/downstream/modules/hub/proc-create-remote.adoc
@@ -20,6 +20,8 @@ You can use {PlatformName} to create a remote configuration to an external colle
 To find the remote server URL and repository path, navigate to {MenuACAdminRepositories}, select your repository, and click btn:[Copy CLI configuration].
 ====
 +
+. To sync signed collections only, check the box labeled *Signed collections only*.
+. To sync dependencies, check the box labeled *Sync all dependencies*. To turn off dependency syncing, leave this box unchecked.
 . Configure the credentials to the remote server by entering a *Token* or *Username* and *Password* required to access the external collection.
 +
 [NOTE]
@@ -37,11 +39,7 @@ Collections:
  		version:”>=5.0.0”
 -----
 +
-[NOTE]
-====
-All collection dependencies are downloaded during the Sync process.
-====
-+
+
 . Optional: To configure your remote further, use the options available under *Advanced configuration*:
 .. If there is a corporate proxy in place for your organization, enter a *Proxy URL*, *Proxy Username* and *Proxy Password*.
 .. Enable or disable transport layer security using the *TLS validation* checkbox.


### PR DESCRIPTION
This PR ports the changes from https://github.com/ansible/aap-docs/pull/3287 to the 2.4 branch. See [AAP-39751](https://issues.redhat.com/browse/AAP-39751) for more.