### PR TITLE
AAP-44196 Adding Tip Admonition

### DIFF
--- a/downstream/assemblies/platform/assembly-appendix-operator-crs.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-operator-crs.adoc
@@ -9,6 +9,12 @@ ifdef::context[:parent-context: {context}]
 
 This appendix provides a reference for the {PlatformNameShort} custom resources for various deployment scenarios.
 
+[TIP]
+====
+You can link in existing components by specifying the component name under the `name` variable.
+You can also use `name` to create a custom name for a new component.
+====
+
 include::platform/ref-operator-crs.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]


### PR DESCRIPTION
[AAP-44196](https://issues.redhat.com/browse/AAP-44196) - Add clarity on name variable usage in CRs

Adding the following tip to help users understand the 'name' variable has multi use

"Tip: You can link in existing components by specifying the component name under the `name` variable. You can also use `name` to create a custom name for a new component."