### PR TITLE
bp to 2.5: AAP-41334: Updates content syncing instructions (#3328)

### DIFF
--- a/downstream/assemblies/hub/assembly-synclists.adoc
+++ b/downstream/assemblies/hub/assembly-synclists.adoc
@@ -9,5 +9,5 @@ Remotes are configurations that enable you to synchronize content to your custom
 As of the 2.4 release you can still synchronize content, but synclists are deprecated, and will be removed in a future version.
 ====
 
-include::hub/con-rh-certified-synclist.adoc[leveloffset=+1]
+// include::hub/con-rh-certified-synclist.adoc[leveloffset=+1]
 include::hub/proc-create-synclist.adoc[leveloffset=+1]

--- a/downstream/modules/hub/con-rh-certified-synclist.adoc
+++ b/downstream/modules/hub/con-rh-certified-synclist.adoc
@@ -10,7 +10,3 @@ Design and manage your synclist from the content available as part of Red Hat co
 Each synclist has its own unique repository URL that you can designate as a remote source for content in {HubName}.
 You can securely access each synclist by using an API token.
 
-[NOTE]
-====
-When syncing content, keep in mind that {HubName} does not check other repositories for dependencies. To avoid an error, turn off dependency downloading by editing your remote settings. See link:{URLHubManagingContent}/managing-collections-hub#proc-create-remote_remote-management[Creating a remote configuration in {HubName}] for more information.
-====

--- a/downstream/modules/hub/proc-create-synclist.adoc
+++ b/downstream/modules/hub/proc-create-synclist.adoc
@@ -2,13 +2,19 @@
 // obtaining-token/master.adoc
 [id="proc-create-synclist"]
 
-= Creating a synclist of Red Hat {CertifiedName}
+= Syncing {CertifiedName}
 
-You can create a synclist of curated {CertifiedCon} in {HubNameMain} on {Console}.
+You can sync curated {CertifiedCon} in {HubNameMain} on {Console}.
 //[ddacosta]This needs to be checked. I don't see a Repositories selection in the console verion. I think the way I've rewritten is correct.
-Your synclist repository is located on the {HubName} navigation panel under {MenuACAdminRepositories}, which is updated whenever you manage content within {CertifiedName}.
+// [hherbly] Looks like there is no synclist info in console or the test instance; commenting out this info for 2.5
+// Your synclist repository is located on the {HubName} navigation panel under {MenuACAdminRepositories}, which is updated whenever you manage content within {CertifiedName}.
 
-All {CertifiedName} are included by default in your initial organization synclist.
+//All {CertifiedName} are included by default in your initial organization synclist.
+
+[NOTE]
+====
+When syncing content, keep in mind that {HubName} does not check other repositories for dependencies. To avoid an error, turn off dependency downloading by editing your remote settings. See link:{URLHubManagingContent}/managing-collections-hub#proc-create-remote_remote-management[Creating a remote configuration in {HubName}] for more information.
+====
 
 .Prerequisites
 


### PR DESCRIPTION
This PR ports the changes from [PR 3328](https://github.com/ansible/aap-docs/pull/3328) to the 2.5 branch. See [AAP-41334](https://issues.redhat.com/browse/AAP-41334) for more context.