### PR TITLE
2.5 Update Adding execution nodes in Containerized installation (#3342)

### DIFF
--- a/downstream/modules/platform/ref-adding-execution-nodes.adoc
+++ b/downstream/modules/platform/ref-adding-execution-nodes.adoc
@@ -8,25 +8,41 @@
 
 [role="_abstract"]
 
-The containerized installer can deploy remote execution nodes. The `execution_nodes` group in the inventory file handles this.
+Containerized {PlatformNameShort} can deploy remote execution nodes. 
+
+You can define remote execution nodes in the `[execution_nodes]` group of your inventory file:
 
 ----
 [execution_nodes]
 <fqdn_of_your_execution_host>
 ----
 
-An execution node is by default configured as an execution type running on port 27199 (TCP).
-This can be changed by the following variables:
+By default, an execution node is configured with the following settings which can be modified as needed:
 
 ----
 receptor_port=27199
 receptor_protocol=tcp
-receptor_type=hop
+receptor_type=execution
 ----
 
-The `receptor_type` value can be either `execution` or `hop`, while the `receptor_protocol` is either `tcp` or `udp`. By default, the nodes in the `execution_nodes` group are added as peers for the controller node. However, you can change the peers configuration by using the `receptor_peers` variable.
+* `receptor_port` - The port number that receptor listens on for incoming connections from other receptor nodes.
+* `receptor_type` - The role of the node. Valid options include `execution` or `hop`.
+* `receptor_protocol` -  The protocol used for communication. Valid options include `tcp` or `udp`.
+
+By default, all nodes in the `[execution_nodes]` group are added as peers for the controller node. To change the peer configuration, use the `receptor_peers` variable.
+
+[NOTE]
+====
+The value of `receptor_peers` must be a comma-separated list of host names. Do not use inventory group names.
+====
+
+Example configuration:
+
 ----
 [execution_nodes]
-fqdn_of_your_execution_host
-fqdn_of_your_hop_host receptor_type=hop receptor_peers='["<fqdn_of_your_execution_host>"]'
+# Execution nodes
+exec1.example.com
+exec2.example.com
+# Hop node that peers with the two execution nodes above
+hop1.example.com receptor_type=hop receptor_peers='["exec1.example.com","exec2.example.com"]'
 ----

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -59,8 +59,10 @@ For the `[execution_nodes]` group: `execution`.
 
 | See `peers` for the RPM equivalent variable 
 | `receptor_peers` 
-| Used to indicate which nodes a specific host connects to. Wherever this variable is defined, an outbound connection to the specific host is established. +
-This variable can be a comma-separated list of hosts only and not groups from the inventory. This is resolved into a set of hosts that is used to construct the `receptor.conf` file. +
+a| Used to indicate which nodes a specific host connects to. Wherever this variable is defined, an outbound connection to the specific host is established. The value must be a comma-separated list of hostnames. Do not use inventory group names.
+
+This is resolved into a set of hosts that is used to construct the `receptor.conf` file. 
+
 For example usage, see link:{URLContainerizedInstall}/ansible_automation_platform_containerized_installation#adding-execution-nodes_aap-containerized-installation[Adding execution nodes].
 | Optional
 | `[]`


### PR DESCRIPTION
Backports #3342 from main to 2.5

Update ref-adding-execution-nodes.adoc to denote that using groups for receptor_peers is not currently possible.

Containerised Installation (Mesh) - Can't establish connections from the execution nodes to the controller nodes

https://issues.redhat.com/browse/AAP-42614