### PR TITLE
Updating API references in controller API guide

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-api-search.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-search.adoc
@@ -8,12 +8,12 @@
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<server name>/api/v2/model_verbose_name?search=findme
+https://<controller server name>/api/v2/model_verbose_name?search=findme
 ----
 
 * To search across related fields, use the following:
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<server name>/api/v2/model_verbose_name?related__search=findme
+https://<controller server name>/api/v2/model_verbose_name?related__search=findme
 ----

--- a/downstream/assemblies/platform/assembly-controller-api-sorting.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-sorting.adoc
@@ -6,7 +6,7 @@ To give you examples that are easy to follow, we use the following URL throughou
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<server name>/api/v2/groups/
+https://<controller server name>/api/v2/groups/
 ----
 
 include::platform/proc-controller-api-sorting.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-controller-api-browsing-api.adoc
+++ b/downstream/modules/platform/proc-controller-api-browsing-api.adoc
@@ -4,7 +4,7 @@
 
 . Go to the {ControllerName} REST API in a web browser at: 
 +
-\https://<server name>/api/controller/v2
+\https://<gateway server name>/api/controller/v2
 +
 . Click the **"v2"** link next to **"current versions"** or **"available versions"**.
 {ControllerNameStart} supports version 2 of the API.

--- a/downstream/modules/platform/proc-controller-api-sorting.adoc
+++ b/downstream/modules/platform/proc-controller-api-sorting.adoc
@@ -6,20 +6,20 @@
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<server name>/api/v2/model_verbose_name_plural?order_by={{ order_field }}
+https://<controller server name>/api/v2/model_verbose_name_plural?order_by={{ order_field }}
 ----
 +
 ** Prefix the field name with a dash (`-`) to sort in reverse:
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<server name>/api/v2/model_verbose_name_plural?order_by=-{{ order_field }}
+https://<controller server name>/api/v2/model_verbose_name_plural?order_by=-{{ order_field }}
 ----
 +
 ** You can specify the sorting fields by separating the field names with a comma (`,`):
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<server name>/api/v2/model_verbose_name_plural?order_by={{ order_field }},some_other_field
+https://<controller server name>/api/v2/model_verbose_name_plural?order_by={{ order_field }},some_other_field
 ----
 

--- a/downstream/modules/platform/proc-controller-api-using-pagination.adoc
+++ b/downstream/modules/platform/proc-controller-api-using-pagination.adoc
@@ -17,7 +17,7 @@ However, you can change this limit by setting the value in `/etc/tower/conf.d/<s
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-http://<server name>/api/v2/model_verbose_name?page_size=100&page=2
+http://<controller server name>/api/v2/model_verbose_name?page_size=100&page=2
 ----
 
 The preceding and following links returned with the results set these query string parameters automatically.


### PR DESCRIPTION
Update Automation Controller 2.5 Documentation to Correct REST API References

https://issues.redhat.com/browse/AAP-40896

Affects `titles/controller-api-overview`