### PR TITLE
Backport 2.5 3284 Changes admonition from IMPORTANT to NOTE, per discussion

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-credentials.adoc
+++ b/downstream/assemblies/eda/assembly-eda-credentials.adoc
@@ -8,7 +8,7 @@ Credentials authenticate users when launching jobs against machines and importin
 
 You can grant users and teams the ability to use these credentials without exposing the credential to the user. If a user moves to a different team or leaves the organization, you do not have to rekey all of your systems just because that credential was previously available.
 
-[IMPORTANT]
+[NOTE]
 ====
 In the context of {ControllerName} and {EDAcontroller}, you can use both `extra_vars` and credentials to store a variety of information. However, credentials are the preferred method of storing sensitive information such as passwords or API keys because they offer better security and centralized management, whereas `extra_vars` are more suitable for passing dynamic, non-sensitive data.
 ====

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -52,7 +52,7 @@ Rulebook activation enabled?:: This automatically enables the rulebook activatio
 Variables:: The variables for the rulebook are in a JSON or YAML format.
 The content would be equivalent to the file passed through the `--vars` flag of ansible-rulebook command.
 +
-[IMPORTANT]
+[NOTE]
 ====
 In the context of {ControllerName} and {EDAcontroller}, you can use both `extra_vars` and credentials to store a variety of information. However, credentials are the preferred method of storing sensitive information such as passwords or API keys because they offer better security and centralized management, whereas `extra_vars` are more suitable for passing dynamic, non-sensitive data.
 ====


### PR DESCRIPTION
This update, which changes changes the admonition from "IMPORTANT" to "NOTE", will be added to the changes for the original ticket, [AAP-40240](https://issues.redhat.com/browse/AAP-40240), covered by PR #[3272](https://github.com/ansible/aap-docs/pull/3272). This is also according to RH and IBM styles and standards.
