### PR TITLE
AAP-44016 - removed case-sensitive statement

### DIFF
--- a/downstream/modules/platform/con-gw-authenticator-map-triggers.adoc
+++ b/downstream/modules/platform/con-gw-authenticator-map-triggers.adoc
@@ -25,7 +25,7 @@ See the *Operation* field to determine the behavior of the trigger if more than 
 +
 [NOTE]
 ====
-Group identifiers are case-sensitive and must be entered in lowercase. For example, `cn=johnsmith,dc=example,dc=com` instead of `CN=johnsmith,DC=example,DC=com`.
+Group identifiers must be entered in lowercase. For example, `cn=johnsmith,dc=example,dc=com` instead of `CN=johnsmith,DC=example,DC=com`.
 ====
 +
 Attribute:: The map is true or false based on a users attributes coming from the source system. See link:{URLCentralAuth}/gw-configure-authentication#gw-authenticator-map-examples[Authenticator map examples] for information on using *Attribute* triggers.


### PR DESCRIPTION
This PR removes the phrase "..are case-sensitive and..." based on https://issues.redhat.com/browse/AAP-44016.