### PR TITLE
Removing section not applicable to 2.5 docs

### DIFF
--- a/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
+++ b/downstream/assemblies/platform/assembly-configure-aap-operator.adoc
@@ -31,8 +31,6 @@ include::platform/proc-operator-deploy-central-config.adoc[leveloffset=+1]
 
 include::platform/proc-operator-external-db-gateway.adoc[leveloffset=+1]
 
-include::platform/proc-operator-upgrade-external-db-gateway.adoc[leveloffset=+1]
-
 include::platform/proc-operator-troubleshoot-ext-db.adoc[leveloffset=+1]
 
 include::platform/proc-operator-enable-https-redirect.adoc[leveloffset=+1]


### PR DESCRIPTION
[AAP-44926](https://issues.redhat.com/browse/AAP-44926) - Remove section 5.5 (upgrade EDB) from 2.5 docs