### PR TITLE
2.5 AAP-43858 AAP-43859 Fix YAML syntax in RHDH operator install (#3358)

### DIFF
--- a/downstream/modules/devtools/proc-rhdh-operator-add-sidecar-container.adoc
+++ b/downstream/modules/devtools/proc-rhdh-operator-add-sidecar-container.adoc
@@ -29,7 +29,7 @@ spec:
                 image: registry.redhat.io/ansible-automation-platform-25/ansible-dev-tools-rhel8:latest
                 imagePullPolicy: always
                 ports:
-                  - containerPort:8000
+                  - containerPort: 8000
                     protocol: TCP
                 terminationMessagePolicy: file
 ----

--- a/downstream/modules/devtools/proc-rhdh-uninstall-ocp-operator-sidecar-container.adoc
+++ b/downstream/modules/devtools/proc-rhdh-uninstall-ocp-operator-sidecar-container.adoc
@@ -28,7 +28,7 @@ spec:
                 image: ghcr.io/ansible/community-ansible-dev-tools:latest
                 imagePullPolicy: always
                 ports:
-                  - containerPort:8000
+                  - containerPort: 8000
                     protocol: TCP
                 terminationMessagePolicy: file
 


### PR DESCRIPTION
Backports #3358 
AAP-43858 AAP-43859 Fix YAML syntax in RHDH operator install and uninstall procedures
Affects `/titles/aap-plugin-rhdh-install` 