### PR TITLE
Adding content from RHEM upstream to chapter 7 (#3340)

### DIFF
--- a/downstream/assemblies/platform/assembly-edge-manager-manage-apps.adoc
+++ b/downstream/assemblies/platform/assembly-edge-manager-manage-apps.adoc
@@ -13,7 +13,11 @@ The {RedHatEdge} supports the `podman-compose` tool as the application runtime a
 * You must install the {RedHatEdge} CLI.
 * You must log in to the {RedHatEdge} service.
 * Your device must run an operating system image with the `podman-compose` tool installed. 
+
 For more information, see xref:edge-manager-build-bootc[Building a _bootc_ operating system image for use with the {RedHatEdge}].
 
 include::platform/proc-edge-manager-build-app-packages.adoc[leveloffset=+1]
+
+include::platform/ref-edge-manager-specify-apps-inline.adoc[leveloffset=+1]
+
 include::platform/proc-edge-manager-deploy-apps.adoc[leveloffset=+1]

--- a/downstream/modules/platform/ref-edge-manager-specify-apps-inline.adoc
+++ b/downstream/modules/platform/ref-edge-manager-specify-apps-inline.adoc
@@ -1,0 +1,44 @@
+[id="edge-manager-specify-apps-inline"]
+
+= Specify applications inline in the device specification
+
+Application manifests are specified inline in a device's specification, so you do not need to build an OCI registry application package.
+ 
+The inline application provider accepts a list of application content with the following parameters:
+ 
+|===
+| Parameter | Description 
+| Path | The relative path to the file on the device. Note that any existing file is overwritten. 
+| Content (Optional) | The plain text (UTF-8) or base64-encoded content of the file. 
+| ContentEncoding | How the contents are encoded. Must be either "plain" or "base64". Defaults to "plain". 
+|===
+
+.Example
+
+[source,yaml]
+----
+apiVersion: flightctl.io/v1alpha1
+kind: Device
+metadata:
+  name: some_device_name
+spec:
+[...]
+  applications:
+    - name: my-app
+      appType: compose
+      inline:
+        - content: |
+            version: "3.8"
+            services:
+              service1:
+                image:  quay.io/flightctl-tests/alpine:v1
+                command: ["sleep", "infinity"]
+          path: podman-compose.yaml
+[...]
+----
+
+[NOTE]
+====
+Inline compose applications can have two paths at most. 
+You must name the first one `podman-compose.yaml`, and the second (override) `podman-compose.override.yaml`.
+====


### PR DESCRIPTION
* Adding content from RHEM upstream to chapter 7

Add "Specifying Applications Inline" section to Chapter 7

https://issues.redhat.com/browse/AAP-44688

Affects `titles/edge-manager-user-guide`

* Adding module to assembly

* Peer review edits