### PR TITLE
Adding `rollout policies` to RHEM doc (#3334)

### DIFF
--- a/downstream/assemblies/platform/assembly-edge-manager-device-fleets.adoc
+++ b/downstream/assemblies/platform/assembly-edge-manager-device-fleets.adoc
@@ -36,5 +36,23 @@ A device cannot be a member of more than one fleet at the same time.
 For more information, see xref:edge-manager-labels[Labels and label selectors].
 
 include::platform/ref-edge-manager-device-selection.adoc[leveloffset=+1]
+
 include::platform/ref-edge-manager-device-templates.adoc[leveloffset=+1]
-include::platform/proc-edge-manager-select-devices.adoc[leveloffset=+1]
+
+include::platform/proc-edge-manager-add-devices-ui.adoc[leveloffset=+1]
+
+include::platform/proc-edge-manager-add-devices-cli.adoc[leveloffset=+1]
+
+include::platform/con-edge-manager-rollout-device-selection.adoc[leveloffset=+1]
+
+include::platform/con-edge-manager-device-targeting.adoc[leveloffset=+2]
+
+include::platform/con-edge-manager-device-selection-strat.adoc[leveloffset=+2]
+
+include::platform/con-edge-manager-limit-device.adoc[leveloffset=+2]
+
+include::platform/ref-edge-manager-success-threshold.adoc[leveloffset=+2]
+
+include::platform/con-edge-manager-rollout-disruption.adoc[leveloffset=+1]
+
+include::platform/ref-edge-manager-disruption-parameters.adoc[leveloffset=+2]

--- a/downstream/modules/platform/con-edge-manager-device-selection-strat.adoc
+++ b/downstream/modules/platform/con-edge-manager-device-selection-strat.adoc
@@ -1,0 +1,18 @@
+[id="edge-manager-device-selection-strat"]
+
+= Device selection strategy
+
+The {RedHatEdge} supports only the `BatchSequence` strategy for device selection. 
+This strategy defines a stepwise rollout process where devices are added in batches based on specific criteria.
+Batches are executed sequentially. 
+After each batch completes, execution proceeds to the next batch only if the success rate of the previous batch meets or exceeds the configured success threshold. 
+
+The success rate is determined as:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+# of successful rollouts in the batch / # of devices in the batch >= success threshold
+----
+
+In a batch sequence, the final batch is an implicit batch and it is not specified in the batch sequence. 
+It selects all devices in a fleet that have not been selected by the explicit batches in the sequence.

--- a/downstream/modules/platform/con-edge-manager-device-targeting.adoc
+++ b/downstream/modules/platform/con-edge-manager-device-targeting.adoc
@@ -1,0 +1,11 @@
+[id="edge-manager-device-targeting"]
+
+= Device targeting
+
+A rollout applies only to devices that belong to a fleet. 
+Each device can belong to only a single fleet. 
+Since rollout definitions are done at the fleet level, the selection process determines which devices within a fleet that participate in a batch rollout based on label criteria. 
+After processing all batches, all fleet devices are rolled out.
+
+* *Labels*: Devices with specific metadata labels can be targeted for rollouts.
+* *Fleet membership*: Rollouts apply only to devices within the specified fleet.

--- a/downstream/modules/platform/con-edge-manager-limit-device.adoc
+++ b/downstream/modules/platform/con-edge-manager-limit-device.adoc
@@ -1,0 +1,12 @@
+[id="edge-manager-limit-device"]
+
+= Limit in device selection
+
+Each batch in the `BatchSequence` strategy might use an optional `limit` parameter to define how many devices should be included in the batch. 
+You can specify the limit can in two ways:
+
+* *Absolute number*: A fixed number of devices to be selected.
+* *Percentage*: The percentage of the total matching device population to be selected.
+
+** If you provide a `selector` with labels, the percentage is calculated based on the number of devices that match the label criteria within the fleet.
+** If you do not provide a `selector`, the percentage is applied to all devices in the fleet.

--- a/downstream/modules/platform/con-edge-manager-rollout-device-selection.adoc
+++ b/downstream/modules/platform/con-edge-manager-rollout-device-selection.adoc
@@ -1,0 +1,8 @@
+[id="edge-manager-device-rollout-device-selection"]
+
+= Rollout device selection
+
+When performing a rollout by using `flightctl`, you must manage which devices participate in the rollout and how much disruption is acceptable. 
+The device selection process and the rollout disruption budget concept ensure controlled and predictable rollouts.
+
+The process and configuration for selecting devices during a rollout includes targeting strategies, batch sequencing, and success criteria for controlled software deployment.

--- a/downstream/modules/platform/con-edge-manager-rollout-disruption.adoc
+++ b/downstream/modules/platform/con-edge-manager-rollout-disruption.adoc
@@ -1,0 +1,6 @@
+[id="edge-manager-rollout-disruption"]
+
+= Rollout disruption budget
+
+A rollout disruption budget defines the acceptable level of service impact during a rollout. 
+This ensures that a deployment does not take down too many devices at once, maintaining overall system stability.

--- a/downstream/modules/platform/proc-edge-manager-add-devices-cli.adoc
+++ b/downstream/modules/platform/proc-edge-manager-add-devices-cli.adoc
@@ -1,6 +1,6 @@
-[id="edge-manager-select-devices"]
+[id="edge-manager-add-devices-cli"]
 
-= Selecting devices into a fleet by using the CLI
+= Adding devices to a fleet on the CLI
 
 Define the label selector to add devices into a fleet.
 

--- a/downstream/modules/platform/proc-edge-manager-add-devices-ui.adoc
+++ b/downstream/modules/platform/proc-edge-manager-add-devices-ui.adoc
@@ -1,0 +1,19 @@
+[id="edge-manager-add-devices-ui"]
+
+= Adding devices to a fleet on the web UI
+
+Define the label selector to add devices into a fleet on the web UI.
+
+Complete the following tasks:
+
+.Procedure
+
+. From the navigation panel, select menu:Application Links[Edge Manager]. 
+This opens the external Edge Manager instance.
+. From the navigation panel, select *Fleets*.
+Select the fleet that you want to add devices to.
+. Click btn:[Actions] and select *Edit fleet*.
+. In the *General info* tab, click *Add label* under the *Device selector* option. 
+. Add the label to select devices for your fleet. 
+Any devices with that label are added to the fleet.
+

--- a/downstream/modules/platform/ref-edge-manager-disruption-parameters.adoc
+++ b/downstream/modules/platform/ref-edge-manager-disruption-parameters.adoc
@@ -1,0 +1,33 @@
+[id="edge-manager-disruption-parameters"]
+
+= Disruption budget parameters
+
+* `groupBy`: Defines how devices are grouped when applying the disruption budget. 
+The grouping is done by label keys.
+* `minAvailable`: Specifies the minimum number of devices that must remain available during a rollout.
+* `maxUnavailable`: Limits the number of devices that can be unavailable at the same time.
+
+.Example 
+
+The following shows an example YAML configuration for a fleet specification:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+apiVersion: v1alpha1
+kind: Fleet
+metadata:
+  name: default
+spec:
+  selector:
+    matchLabels:
+      fleet: default
+  rolloutPolicy:
+    disruptionBudget:
+      groupBy: ['site', 'function']
+      minAvailable: 1
+      maxUnavailable: 10
+----
+
+In this example, the grouping is performed on 2 label keys: *site* and *function*. 
+A group for disruption budget consists of all devices in a fleet having the same label values for the preceding label keys. 
+For every such group the conditions defined in this specification are continuously enforced.

--- a/downstream/modules/platform/ref-edge-manager-success-threshold.adoc
+++ b/downstream/modules/platform/ref-edge-manager-success-threshold.adoc
@@ -1,0 +1,51 @@
+[id="edge-manager-success-threshold"]
+
+= Success threshold
+
+The `successThreshold` defines the percentage of successfully updated devices required to continue the rollout. 
+If the success rate falls below this threshold, the rollout might be paused to prevent further failures.
+
+.Example
+
+The following shows an example YAML configuration for a fleet specification:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+apiVersion: v1alpha1
+kind: Fleet
+metadata:
+  name: default
+spec:
+  selector:
+    matchLabels:
+      fleet: default
+  rolloutPolicy:
+    deviceSelection:
+      strategy: 'BatchSequence'
+      sequence:
+        - selector:
+            matchLabels:
+              site: madrid
+          limit: 1  # Absolute number
+        - selector:
+            matchLabels:
+              site: madrid
+          limit: 80%  # Percentage of devices matching the label criteria within the fleet
+        - limit: 50%  # Percentage of all devices in the fleet
+        - selector:
+            matchLabels:
+              site: paris
+        - limit: 80%
+        - limit: 100%
+    successThreshold: 95%
+----
+
+In this example, there are 6 explicit batches and 1 implicit batch:
+
+* The first batch selects 1 device having a label *site:madrid*.
+* With the second batch 80% of all devices having the label *site:madrid* are either selected for rollout in the current batch or were previously selected for rollout.
+* With the third batch 50% of all devices are either selected for rollout in the current batch or were previously selected for rollout.
+* With the fourth batch all devices that were not previously selected and have the label *site:paris* are selected.
+* With the fifth batch 80% of all devices are either selected for rollout in the current batch or were previously selected for rollout.
+* With the sixth batch 100% of all devices are either selected for rollout in the current batch or were previously selected for rollout.
+* The last implicit batch selects all devices that have not been selected in any previous batch (might be none).


### PR DESCRIPTION
* Adding `rollout policies` to RHEM doc

Add "Rollout policies" section to Chapter 8

https://issues.redhat.com/browse/AAP-44689

Affects `titles/edge-manager-user-guide`

* Fixing title format

* Fixing grammar error

* Fixing line breaks in assembly