### PR TITLE
2.5 Update tested topology support wording (#3372)

### DIFF
--- a/downstream/assemblies/topologies/assembly-overview-tested-deployment-models.adoc
+++ b/downstream/assemblies/topologies/assembly-overview-tested-deployment-models.adoc
@@ -6,7 +6,7 @@ Red Hat tests {PlatformNameShort} {PlatformVers} with a defined set of topologie
 
 Red Hat tests the installation of {PlatformNameShort} {PlatformVers} based on a defined set of infrastructure topologies or reference architectures. Enterprise organizations can use one of the {EnterpriseTopologyPlural} for production deployments to ensure the highest level of uptime, performance, and continued scalability. Organizations or deployments that are resource constrained can use a {GrowthTopology}.
 
-It is possible to install the {PlatformNameShort} on different infrastructure topologies and with different environment configurations. Red Hat does not fully test topologies outside of published reference architectures. Use a tested topology for all new deployments. 
+It is possible to install {PlatformNameShort} on different infrastructure topologies and with different environment configurations. Red Hat does not fully test topologies outside of published reference architectures. Red Hat recommends using a tested topology for all new deployments and provides commercially reasonable support for deployments that meet minimum requirements. 
 
 == Installation and deployment models
 

--- a/downstream/modules/aap-hardening/ref-architecture.adoc
+++ b/downstream/modules/aap-hardening/ref-architecture.adoc
@@ -13,8 +13,8 @@ Organizations or deployments that are resource constrained can use a "growth" re
 Review the link:{LinkTopologies} document to determine the reference architecture that best suits your requirements. 
 The reference architecture chosen will include planning information such as an architecture diagram, the number of {RHEL} servers required, the network ports and protocols used by the deployment, and load balancer information for enterprise architectures.
 
-It is possible to install the {PlatformNameShort} on different infrastructure reference architectures and with different environment configurations. 
-Red Hat does not fully test architectures outside of published deployment models.
+It is possible to install {PlatformNameShort} on different infrastructure reference architectures and with different environment configurations. Red Hat does not fully test architectures outside of published reference architectures. Red Hat recommends using a tested reference architecture for all new deployments and provides commercially reasonable support for deployments that meet minimum requirements. 
+
 //This diagram might need to be updated.
 The following diagram is a tested container enterprise architecture:
 

--- a/downstream/snippets/container-upgrades.adoc
+++ b/downstream/snippets/container-upgrades.adoc
@@ -1,1 +1,1 @@
-Upgrades from 2.4 Containerized {PlatformNameShort} Tech Preview to 2.5 Containerized {PlatformNameShort} are not supported at this time.
+Upgrades from 2.4 Containerized {PlatformNameShort} Tech Preview to 2.5 Containerized {PlatformNameShort} are not supported.

--- a/downstream/titles/release-notes/async/aap-25-3-28-oct.adoc
+++ b/downstream/titles/release-notes/async/aap-25-3-28-oct.adoc
@@ -9,7 +9,7 @@ The following enhancements and bug fixes have been implemented in this release o
 === {PlatformNameShort}
 
 * With this update, upgrades from {PlatformNameShort} 2.4 to 2.5 are supported for RPM and Operator-based deployments. For more information on how to upgrade, see link:{URLUpgrade}[{TitleUpgrade}]. (ANSTRAT-809)
-** Upgrades from 2.4 Containerized {PlatformNameShort} Tech Preview to 2.5 Containerized {PlatformNameShort} are unsupported at this time. 
+** Upgrades from 2.4 Containerized {PlatformNameShort} Tech Preview to 2.5 Containerized {PlatformNameShort} are unsupported. 
 ** Upgrades for {EDAName} are unsupported from {PlatformNameShort} 2.4 to {PlatformNameShort} 2.5.
 
 === {OperatorPlatformNameShort}

--- a/downstream/titles/release-notes/topics/aap-25.adoc
+++ b/downstream/titles/release-notes/topics/aap-25.adoc
@@ -8,11 +8,13 @@
 == Installation changes
 Starting with {PlatformNameShort} 2.5, three different on-premise deployment models are fully tested. In addition to the existing RPM-based installer and operator, support for the containerized installer is being added. 
 
-As the platform moves toward a container-first model, the RPM-based installer will be removed in a future release, and a deprecation warning is being issued with the release of {PlatformNameShort} 2.5. While the RPM installer will still be supported for {PlatformNameShort} 2.5 until it is removed, the investment will focus on the {ContainerBase} for RHEL deployments and the {OperatorBase} for OpenShift deployments. Upgrades from 2.4 containerized {PlatformNameShort} Technology Preview to 2.5 containerized {PlatformNameShort} are unsupported at this time. 
+As the platform moves toward a container-first model, the RPM-based installer will be removed in a future release, and a deprecation warning is being issued with the release of {PlatformNameShort} 2.5. While the RPM installer will still be supported for {PlatformNameShort} 2.5 until it is removed, the investment will focus on the {ContainerBase} for RHEL deployments and the {OperatorBase} for OpenShift deployments. Upgrades from 2.4 containerized {PlatformNameShort} Technology Preview to 2.5 containerized {PlatformNameShort} are unsupported. 
 
 == Deployment topologies
-Red Hat tests {PlatformNameShort} 2.5 with a defined set of topologies to provide you with opinionated deployment options. While it is possible to install the {PlatformNameShort} on different infrastructure topologies and with different environment configurations, Red Hat guarantees support for the topologies outlined in the following table. 
- 
+Red Hat tests {PlatformNameShort} 2.5 with a defined set of topologies to give you opinionated deployment options. Deploy all components of {PlatformNameShort} so that all features and capabilities are available for use without the need to take further action.
+
+It is possible to install {PlatformNameShort} on different infrastructure topologies and with different environment configurations. Red Hat does not fully test topologies outside of published reference architectures. Red Hat recommends using a tested topology for all new deployments and provides commercially reasonable support for deployments that meet minimum requirements.  
+
 At the time of the {PlatformNameShort} 2.5 GA release, a limited set of topologies are fully tested. Red Hat will regularly add new topologies to iteratively expand the scope of fully tested deployment options. As new topologies roll out, we will include them in the release notes. 
 
 The following table shows the tested topologies for {PlatformNameShort} 2.5:


### PR DESCRIPTION
Backports #3372 from main to 2.5 

The topology support statement in Tested deployment models is updated to clarify support for deployments outside of the published reference architectures.

Update Statement for Supported Topologies

https://issues.redhat.com/browse/AAP-44586