### PR TITLE
2.5 Add compression vars to backup proc for Containerized installation (#…

### DIFF
--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -8,6 +8,37 @@ Perform a backup of your {ContainerBase} of {PlatformNameShort}.
 
 . Go to the {PlatformName} installation directory on your {RHEL} host.
 
+. To control compression of the backup artifacts before they are sent to the host running the backup operation, you can use the following variables in your inventory file:
+.. For control of compression for filesystem related backup files:
++
+----
+# For global control of compression for filesystem related backup files 
+use_archive_compression=true
+
+# For component-level control of compression for filesystem related backup files
+#controller_use_archive_compression=true
+#eda_use_archive_compression=true
+#gateway_use_archive_compression=true 
+#hub_use_archive_compression=true
+#pcp_use_archive_compression=true
+#postgresql_use_archive_compression=true
+#receptor_use_archive_compression=true
+#redis_use_archive_compression=true
+----
++
+.. For control of compression for database related backup files:
++
+----
+# For global control of compression for database related backup files 
+use_db_compression=true  
+
+# For component-level control of compression for database related backup files
+#controller_use_db_compression=true
+#eda_use_db_compression=true
+#hub_use_db_compression=true
+#gateway_use_db_compression=true
+----
+
 . Run the `backup` playbook:
 +
 ----

--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -31,6 +31,18 @@ Use of special characters for this variable is limited. The password can include
 | Optional
 | `5m`
 
+| `automationcontroller_use_archive_compression`
+| `controller_use_archive_compression`
+| Controls whether archive compression is enabled or disabled for {ControllerName}. You can control this functionality globally by using `use_archive_compression`.
+| Optional
+| `true`
+
+| `automationcontroller_use_db_compression`
+| `controller_use_db_compression`
+| Controls whether database compression is enabled or disabled for {ControllerName}. You can control this functionality globally by using `use_db_compression`.
+| Optional
+| `true`
+
 | `awx_pg_cert_auth` 
 | `controller_pg_cert_auth` 
 | Controls whether client certificate authentication is enabled or disabled on the {ControllerName} PostgreSQL database. +

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -6,11 +6,11 @@
 |===
 | RPM variable name | Container variable name | Description | Required or optional | Default
 
-| 
-| `postgresql_admin_database`
-| Database name used for connections to the PostgreSQL database server.
+| `install_pg_port`
+| `postgresql_port` 
+| Port number for the PostgreSQL database.
 | Optional
-| `postgres`
+| `5432`
 
 | `postgres_firewalld_zone` 
 | `postgresql_firewall_zone` 
@@ -24,13 +24,6 @@
 See link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref-controller-database-settings[PostgreSQL database configuration and maintenance for {ControllerName}] for help selecting a value.
 | Optional
 | `1024`
-
-| 
-| `postgresql_admin_password` 
-| Password for the PostgreSQL admin user. +
-When used, the installation program creates each component’s database and credentials.
-| Required if using `postgresql_admin_username`.
-|
 
 | `postgres_ssl_cert` 
 | `postgresql_tls_cert` 
@@ -49,6 +42,19 @@ When used, the installation program creates each component’s database and cred
 | Controls whether SSL/TLS is enabled or disabled for the PostgreSQL database.
 | Optional
 | `false`
+
+| 
+| `postgresql_admin_database`
+| Database name used for connections to the PostgreSQL database server.
+| Optional
+| `postgres`
+
+| 
+| `postgresql_admin_password` 
+| Password for the PostgreSQL admin user. +
+When used, the installation program creates each component’s database and credentials.
+| Required if using `postgresql_admin_username`.
+|
 
 | 
 | `postgresql_admin_username` 
@@ -83,12 +89,6 @@ Set to `true` to keep databases during uninstall.
 | Optional
 | `scram-sha-256`
 
-| `install_pg_port`
-| `postgresql_port` 
-| Port number for the PostgreSQL database.
-| Optional
-| `5432`
-
 | 
 | `postgresql_shared_buffers` 
 | Memory allocation (in MB) for shared memory buffers.
@@ -100,5 +100,11 @@ Set to `true` to keep databases during uninstall.
 | Denote whether the PostgreSQL provided certificate files are local to the installation program (`false`) or on the remote component server (`true`).
 | Optional
 | `false`
+
+| 
+| `postgresql_use_archive_compression`
+| Controls whether archive compression is enabled or disabled for PostgreSQL. You can control this functionality globally by using `use_archive_compression`.
+| Optional
+| `true`
 
 |===

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -233,6 +233,18 @@
 | Optional
 | `[]`
 
+| `automationedacontroller_use_archive_compression`
+| `eda_use_archive_compression`
+| Controls whether archive compression is enabled or disabled for {EDAName}. You can control this functionality globally by using `use_archive_compression`.
+| Optional
+| `true`
+
+| `automationedacontroller_use_db_compression`
+| `eda_use_db_compression`
+| Controls whether database compression is enabled or disabled for {EDAName}. You can control this functionality globally by using `use_db_compression`.
+| Optional
+| `true`
+
 | `automationedacontroller_user_headers` 
 | `eda_nginx_user_headers` 
 | List of additional NGINX headers to add to {EDAName}'s NGINX configuration.

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -199,12 +199,6 @@
 | Optional
 |
 
-| `automationgateway_verify_ssl` 
-|  
-| Denotes whether or not to verify {Gateway}'s web certificates when making calls from {Gateway} to itself during installation. Set to false to disable web certificate verification. 
-| Optional
-| `true`
-
 | `automationgateway_ssl_cert` 
 | `gateway_tls_cert` 
 | Path to the SSL/TLS certificate file for {Gateway}.
@@ -223,11 +217,29 @@
 | Optional
 | `false`
 
+| `automationgateway_use_archive_compression`
+| `gateway_use_archive_compression`
+| Controls whether archive compression is enabled or disabled for {Gateway}. You can control this functionality globally by using `use_archive_compression`.
+| Optional
+| `true`
+
+| `automationgateway_use_db_compression`
+| `gateway_use_db_compression`
+| Controls whether database compression is enabled or disabled for {Gateway}. You can control this functionality globally by using `use_db_compression`.
+| Optional
+| `true`
+
 | `automationgateway_user_headers`
 | `gateway_nginx_user_headers`
 | List of additional NGINX headers to add to {Gateway}'s NGINX configuration.
 | Optional
 | `[]`
+
+| `automationgateway_verify_ssl` 
+|  
+| Denotes whether or not to verify {Gateway}'s web certificates when making calls from {Gateway} to itself during installation. Set to `false` to disable web certificate verification. 
+| Optional
+| `true`
 
 | `automationgatewayproxy_disable_https`
 | `envoy_disable_https`

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -187,6 +187,22 @@ For further information, see link:https://docs.ansible.com/ansible/latest/invent
 | Optional 
 | 
 
+| `use_archive_compression` 
+| `use_archive_compression`
+a| Controls at a global level whether the filesystem-related backup files are compressed before being sent to the host to run the backup operation. If set to `true`, a `tar.gz` file is generated on each {PlatformNameShort} host and then gzip compression is used. If set to `false`, a simple tar file is generated. 
+
+You can control this functionality at a component level by using the `<component_name>_use_archive_compression` variables. 
+| Optional
+| `true`
+
+| `use_db_compression` 
+| `use_db_compression`
+a| Controls at a global level whether the database-related backup files are compressed before being sent to the host to run the backup operation. 
+
+You can control this functionality at a component level by using the `<component_name>_use_db_compression` variables. 
+| Optional
+| `true`
+
 |  
 | `ca_tls_key_passphrase` 
 | Passphrase used to decrypt the key provided in `ca_tls_key`. 
@@ -220,6 +236,12 @@ Set to `false` to prevent pulling newer container images during installation.
 | public
 
 | 
+| `pcp_use_archive_compression`
+| Controls whether archive compression is enabled or disabled for Performance Co-Pilot. You can control this functionality globally by using `use_archive_compression`.
+| Optional
+| `true`
+
+| 
 | `registry_auth` 
 | Set whether or not to use registry authentication. When this variable is set to true, `registry_username` and `registry_password` are required. 
 | Optional 
@@ -236,57 +258,6 @@ Set to `false` to prevent pulling newer container images during installation.
 | RHEL registry namespace. 
 | Optional 
 | `rhel8`
-
-| `use_archive_compression` 
-| 
-| Controls at the global level whether the filesystem-related backup files will be compressed before being sent to the host to run the backup operation. If set to true, a `tar.gz` file is generated on each {PlatformNameShort} host, and then the gzip compression is used. If set to false, a simple tar file is generated. 
-
-This functionality can be controlled at the component level using the `<componentName>_use_archive_compression` variable. 
-| Optional
-| `true`
-
-| `<componentName>_use_archive_compression` 
-| 
-a| Enables or disables archive compression on a component level by specifying the component in `<componentName>`.  
-
-For example:
-
-* `automationgateway_use_archive_compression=true`
-
-* `automationcontroller_use_archive_compression=true`
-
-* `automationhub_use_archive_compression=true`
-
-* `automationedacontroller_use_archive_compression=true`
-
-This functionality can be controlled at the global level using the `use_archive_compression` variable.
-| Optional
-| `true`
-
-| `use_db_compression` 
-| 
-| Controls at the global level whether the database-related backup files will be compressed before being sent to the host to run the backup operation. 
-This functionality can be controlled at the component level using the `<componentName>_use_db_compression` variable. 
-| Optional
-| `true`
-
-| `<componentName>_use_db_compression` 
-| 
-a| Enables or disables archive compression on a database level by specifying the component in `<componentName>`.  
-
-For example:
-
-* `automationgateway_use_db_compression=true`
-
-* `automationcontroller_use_db_compression=true`
-
-* `automationhub_use_db_compression=true`
-
-* `automationedacontroller_use_db_compression=true`
-
-This functionality can be controlled at the global level using the `use_db_compression` variable.
-| Optional
-| `true`
 
 |===
 

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -255,6 +255,18 @@ For the RPM-based installer, if you only want one type of content, set this vari
 | Optional
 | `false`
 
+| `automationhub_use_archive_compression`
+| `hub_use_archive_compression`
+| Controls whether archive compression is enabled or disabled for {HubName}. You can control this functionality globally by using `use_archive_compression`.
+| Optional
+| `true`
+
+| `automationhub_use_db_compression`
+| `hub_use_db_compression`
+| Controls whether database compression is enabled or disabled for {HubName}. You can control this functionality globally by using `use_db_compression`.
+| Optional
+| `true`
+
 | `automationhub_user_headers` 
 |  `hub_nginx_user_headers`
 | List of additional NGINX headers to add to {HubName}'s NGINX configuration.

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -130,4 +130,10 @@ Set to `true` to only accept connections that use TLS 1.3 or higher.
 | Optional
 | `false`
 
+| 
+| `receptor_use_archive_compression`
+| Controls whether archive compression is enabled or disabled for receptor. You can control this functionality globally by using `use_archive_compression`.
+| Optional
+| `true`
+
 |===

--- a/downstream/modules/platform/ref-redis-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-redis-inventory-variables.adoc
@@ -65,4 +65,10 @@ For more information about Redis, see link:{URLPlanningGuide}/ha-redis_planning[
 | Optional 
 | 
 
+| 
+| `redis_use_archive_compression`
+| Controls whether archive compression is enabled or disabled for Redis. You can control this functionality globally by using `use_archive_compression`.
+| Optional
+| `true`
+
 |===


### PR DESCRIPTION
…3381)

Backports #3381 from main to 2.5

* Add compression vars to backup proc for Containerized installation

Docs - Containerized installation - Document use of compression when performing a backup

https://issues.redhat.com/browse/AAP-39129

* Updates based on peer review feedback