### PR TITLE
Add Rootless Podman and NFS info to Containerized installation

### DIFF
--- a/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
+++ b/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
@@ -10,6 +10,12 @@ Use this information when planning your installation of containerized {PlatformN
 * Internet access from the {RHEL} host if you are using the default online installation method.
 * The appropriate network ports are open if a firewall is in place. For more information about the ports to open, see link:{URLTopologies}/container-topologies[Container topologies] in _{TitleTopologies}_.
 
+[IMPORTANT]
+====
+Storing container images on an NFS share is not supported by Podman. To use an NFS share for the user home directory, set up the Podman storage backend path outside of the NFS share. 
+For more information, see link:https://www.redhat.com/en/blog/rootless-podman-nfs[Rootless Podman and NFS]
+====
+
 == {PlatformNameShort} system requirements
 
 Your system must meet the following minimum system requirements to install and run {PlatformName}. 


### PR DESCRIPTION
Adds info about Podman limitations when using an NFS share for the user home directory.

Info added underneath the System requirements prerequisites section.

Affected guide: titles/aap-containerized-install

AAP 2.5 Containerized Deployment will not install properly if install user has shared NFS home directory - need note added to docs addressing this

https://issues.redhat.com/browse/AAP-44390