### PR TITLE
2.5 Update local disk req for CONT installs (#3429)

### DIFF
--- a/downstream/modules/platform/proc-downloading-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-downloading-containerized-aap.adoc
@@ -18,7 +18,7 @@ Choose the installation program you need based on your {RHEL} environment intern
 . Copy the installation program `.tar` file and the optional manifest `.zip` file onto your {RHEL} host.
 
 . Decide where you want the installation program to reside on the file system. 
-.. Installation related files are created under this location and require at least 10 GB for the initial installation.
+.. Installation related files are created under this location and require at least 15 GB for the initial installation.
 
 . Unpack the installation program `.tar` file into your installation directory, and go to the unpacked directory. 
 +

--- a/downstream/snippets/cont-tested-vm-config.adoc
+++ b/downstream/snippets/cont-tested-vm-config.adoc
@@ -2,8 +2,16 @@
 [cols=2,options="header"]
 |====
 | Requirement | Minimum requirement
-| RAM      | 16 GB
-| CPUs         | 4 
-| Local disk  | 60 GB  
-| Disk IOPS   | 3000   
+| RAM      
+| 16 GB
+
+| CPUs         
+| 4 
+
+| Local disk  
+a| * 60 GB
+* Minimum of 15 GB dedicated to the installation directory if it is in a dedicated partition.
+
+| Disk IOPS   
+| 3000   
 |====


### PR DESCRIPTION
Backports #3429 from main to 2.5

Update the system requirements for containerized installs to include guidance on sizing for installation directory if in a dedicated partition.

Containerized installation - add more clarity on storage size requirements

https://issues.redhat.com/browse/AAP-40799