### PR TITLE
Add a menu attribute for Settings>Policy

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -299,7 +299,7 @@
 :MenuSetJob: menu:{MenuAEAdminSettings}[Job]
 :MenuSetLogging: menu:{MenuAEAdminSettings}[Logging]
 :MenuSetTroubleshooting: menu:{MenuAEAdminSettings}[Troubleshooting]
-:MenuSetPolicy: menu:{MenuAESettings}[Policy]
+:MenuSetPolicy: menu:{MenuAEAdminSettings}[Policy]
 // Not yet implemented but look to be in the future scope 2.5-next plan
 //:MenuSetLogin: {MenuAEAdminSettings}[Log In Settings]
 //:MenuSetUI: {MenuAEAdminSettings}[User Interface Settings]

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -299,6 +299,7 @@
 :MenuSetJob: menu:{MenuAEAdminSettings}[Job]
 :MenuSetLogging: menu:{MenuAEAdminSettings}[Logging]
 :MenuSetTroubleshooting: menu:{MenuAEAdminSettings}[Troubleshooting]
+:MenuSetPolicy:menu:{MenuAESettings}[Policy]
 // Not yet implemented but look to be in the future scope 2.5-next plan
 //:MenuSetLogin: {MenuAEAdminSettings}[Log In Settings]
 //:MenuSetUI: {MenuAEAdminSettings}[User Interface Settings]

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -299,7 +299,7 @@
 :MenuSetJob: menu:{MenuAEAdminSettings}[Job]
 :MenuSetLogging: menu:{MenuAEAdminSettings}[Logging]
 :MenuSetTroubleshooting: menu:{MenuAEAdminSettings}[Troubleshooting]
-:MenuSetPolicy:menu:{MenuAESettings}[Policy]
+:MenuSetPolicy: menu:{MenuAESettings}[Policy]
 // Not yet implemented but look to be in the future scope 2.5-next plan
 //:MenuSetLogin: {MenuAEAdminSettings}[Log In Settings]
 //:MenuSetUI: {MenuAEAdminSettings}[User Interface Settings]


### PR DESCRIPTION
This PR adds an attribute for the new Policy selection of the Settings menu in the 2.5 navigation. 