### PR TITLE
[Backport] Add a menu attribute for Settings>Policy (#3435)

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -299,6 +299,7 @@
 :MenuSetJob: menu:{MenuAEAdminSettings}[Job]
 :MenuSetLogging: menu:{MenuAEAdminSettings}[Logging]
 :MenuSetTroubleshooting: menu:{MenuAEAdminSettings}[Troubleshooting]
+:MenuSetPolicy: menu:{MenuAEAdminSettings}[Policy]
 // Not yet implemented but look to be in the future scope 2.5-next plan
 //:MenuSetLogin: {MenuAEAdminSettings}[Log In Settings]
 //:MenuSetUI: {MenuAEAdminSettings}[User Interface Settings]


### PR DESCRIPTION
This PR backports the changes from #3435 to the 2.5 branch and includes the following:

* Add a menu attribute for Settings>Policy

* Fixed a spacing issue

* Fixed the nested attribute error