### PR TITLE
Ansible Plugins 1.5 - updates to plug-ins installation doc

### DIFF
--- a/downstream/assemblies/devtools/assembly-rhdh-ocp-required-installation.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-ocp-required-installation.adoc
@@ -13,6 +13,7 @@ include::devtools/proc-rhdh-add-devtools-container.adoc[leveloffset=+2]
 include::devtools/proc-rhdh-add-custom-configmap.adoc[leveloffset=+1]
 include::devtools/proc-rhdh-configure-devtools-server.adoc[leveloffset=+1]
 include::devtools/proc-rhdh-configure-aap-details.adoc[leveloffset=+1]
+include::devtools/proc-rhdh-configure-showcase-location.adoc[leveloffset=+1]
 include::devtools/proc-rhdh-add-plugin-software-templates.adoc[leveloffset=+1]
 include::devtools/proc-rhdh-configure-rbac.adoc[leveloffset=+1]
 

--- a/downstream/modules/devtools/proc-rhdh-add-plugin-config.adoc
+++ b/downstream/modules/devtools/proc-rhdh-add-plugin-config.adoc
@@ -12,8 +12,8 @@ global:
   ...
     plugins:
       - disabled: false
-        integrity: <SHA512 Integrity key for ansible-plugin-backstage-rhaap plugin>
-        package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz'
+        integrity: <SHA512 Integrity key for ansible-plugin-backstage-rhaap-dynamic plugin>
+        package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz'
         pluginConfig:
           dynamicPlugins:
             frontend:
@@ -28,17 +28,17 @@ global:
                       text: Ansible
                     path: /ansible
       - disabled: false
-        integrity: <SHA512 Integrity key for ansible-plugin-scaffolder-backend-module-backstage-rhaap plugin>
+        integrity: <SHA512 Integrity key for ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic plugin>
         package: >-
-          http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+          http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
         pluginConfig:
           dynamicPlugins:
             backend:
               ansible.plugin-scaffolder-backend-module-backstage-rhaap: null
       - disabled: false
-        integrity: <SHA512 Integrity key for ansible-plugin-backstage-rhaap-backend plugin>
+        integrity: <SHA512 Integrity key for ansible-plugin-backstage-rhaap-backend-dynamic plugin>
         package: >-
-          http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
+          http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
         pluginConfig:
           dynamicPlugins:
             backend:
@@ -66,7 +66,7 @@ To verify that the plug-ins have been installed, open the `install-dynamic-plugi
 The following example from the log indicates a successful installation for one of the plug-ins:
 +
 -----
-=> Successfully installed dynamic plugin http://plugin-registry-1:8080/ansible-plugin-backstage-rhaap-1.1.0.tgz
+=> Successfully installed dynamic plugin http://plugin-registry-1:8080/ansible-plugin-backstage-rhaap-dynamic-1.1.0.tgz
 -----
 +
 The following image shows the container log in the *Pod details* page.

--- a/downstream/modules/devtools/proc-rhdh-configure-showcase-location.adoc
+++ b/downstream/modules/devtools/proc-rhdh-configure-showcase-location.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="rhdh-configure-showcase-location_{context}"]
+= Configuring `showCaseLocation`
+
+You must configure `showCaseLocation` in your custom config map.
+
+// Prevents the following error:
+// cause: Error: Missing required config value at 'ansible.rhaap.showCaseLocation.type' in 'env'
+
+.Procedure
+
+. Edit your custom {RHDH} config map, `app-config-rhdh`, that you created in
+xref:rhdh-add-custom-configmap_rhdh-ocp-required-installation[Adding a custom ConfigMap].
+. Add the following code to your {RHDH} `app-config-rhdh.yaml` file.
++
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: app-config-rhdh
+...
+data:
+  app-config-rhdh.yaml: |-
+    ansible:
+      rhaap:
+      ...
+        showCaseLocation:
+          type: file
+          target: '/tmp/aap-showcases/'
+...
+
+----
+

--- a/downstream/modules/devtools/proc-rhdh-create-plugin-registry.adoc
+++ b/downstream/modules/devtools/proc-rhdh-create-plugin-registry.adoc
@@ -33,12 +33,12 @@ image::rhdh-plugin-registry.png[Developer perspective]
 +
 (2) Plug-in registry
 . Click the terminal tab and login to the container.
-. In the terminal, run `ls` to confirm that the .tar files are in the plugin registry.
+. In the terminal, run `ls` to confirm that the `.tar` files are in the plugin registry.
 +
 ----
-ansible-plugin-backstage-rhaap-x.y.z.tgz
-ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
-ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz
+ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
+ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
 ----
 +
 The version numbers and file names can differ.

--- a/downstream/modules/devtools/proc-rhdh-download-plugins.adoc
+++ b/downstream/modules/devtools/proc-rhdh-download-plugins.adoc
@@ -31,12 +31,12 @@ Run `ls` to verify that the extracted files are in the `$DYNAMIC_PLUGIN_ROOT_DIR
 
 ----
 $ ls $DYNAMIC_PLUGIN_ROOT_DIR
-ansible-plugin-backstage-rhaap-x.y.z.tgz
-ansible-plugin-backstage-rhaap-x.y.z.tgz.integrity
-ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
-ansible-plugin-backstage-rhaap-backend-x.y.z.tgz.integrity
-ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
-ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz.integrity
+ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz
+ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz.integrity
+ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
+ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz.integrity
+ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
+ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz.integrity
 
 ----
 

--- a/downstream/modules/devtools/proc-rhdh-install-dynamic-plugins-operator.adoc
+++ b/downstream/modules/devtools/proc-rhdh-install-dynamic-plugins-operator.adoc
@@ -17,7 +17,7 @@ The example ConfigMap used in the following procedure is called `rhaap-dynamic-p
 . Select the `rhaap-dynamic-plugins-config` ConfigMap from the list.
 . Select the *YAML* tab to edit the `rhaap-dynamic-plugins-config` ConfigMap.
 . In the `data.dynamic-plugins.yaml.plugins` block, add the three dynamic plug-ins from the plug-in registry.
-** For the `integrity` hash values, use the `.integrity` files in your `$DYNAMIC_PLUGIN_ROOT_DIR` directory that correspond to each plug-in, for example use `ansible-plugin-backstage-rhaap-x.y.z.tgz.integrity` for the `ansible-plugin-backstage-rhaap-x.y.z.tgz` plug-in.
+** For the `integrity` hash values, use the `.integrity` files in your `$DYNAMIC_PLUGIN_ROOT_DIR` directory that correspond to each plug-in, for example use `ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz.integrity` for the `ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz` plug-in.
 ** Replace `x.y.z` with the correct version of the plug-ins.
 +
 ----
@@ -30,8 +30,8 @@ data:
    ...
    plugins:
      - disabled: false
-       package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz'
-       integrity: <SHA512 value> # Use hash in ansible-plugin-backstage-rhaap-x.y.z.tgz.integrity
+       package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz'
+       integrity: <SHA512 value> # Use hash in ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz.integrity
        pluginConfig:
          dynamicPlugins:
            frontend:
@@ -47,16 +47,16 @@ data:
                    path: /ansible
      - disabled: false
        package: >-
-         http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
-       integrity: <SHA512 value> # Use hash in ansible-plugin-backstage-rhaap-backend-x.y.z.tgz.integrity
+         http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
+       integrity: <SHA512 value> # Use hash in ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz.integrity
        pluginConfig:
          dynamicPlugins:
            backend:
              ansible.plugin-backstage-rhaap-backend: null
      - disabled: false
        package: >-
-         http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
-       integrity: <SHA512 value> # Use hash in ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz.integrity
+         http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
+       integrity: <SHA512 value> # Use hash in ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz.integrity
        pluginConfig:
          dynamicPlugins:
            backend:

--- a/downstream/modules/devtools/proc-rhdh-uninstall-ocp-helm.adoc
+++ b/downstream/modules/devtools/proc-rhdh-uninstall-ocp-helm.adoc
@@ -16,7 +16,7 @@ global:
     plugins:
       - disabled: false
         integrity: <SHA512 value>
-        package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz'
+        package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz'
         pluginConfig:
           dynamicPlugins:
             frontend:
@@ -33,7 +33,7 @@ global:
       - disabled: false
         integrity: <SHA512 value>
         package: >-
-          http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+          http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
         pluginConfig:
           dynamicPlugins:
             backend:
@@ -41,7 +41,7 @@ global:
       - disabled: false
         integrity: <SHA512 value>
         package: >-
-          http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
+          http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
         pluginConfig:
           dynamicPlugins:
             backend:

--- a/downstream/modules/devtools/proc-rhdh-uninstall-ocp-operator-plugins-cm.adoc
+++ b/downstream/modules/devtools/proc-rhdh-uninstall-ocp-operator-plugins-cm.adoc
@@ -26,17 +26,17 @@ data:
    ...
    plugins: # Remove the Ansible plug-ins entries below the ‘plugins’ YAML key
      - disabled: false
-       package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz'
+       package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz'
        integrity: <SHA512 value>
 	 ...
      - disabled: false
        package: >-
-         http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
+         http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
        integrity: <SHA512 value>
        ...
      - disabled: false
        package: >-
-         http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+         http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
        integrity: <SHA512 value>
 	 ...
 

--- a/downstream/modules/devtools/proc-rhdh-uninstall-ocp-operator.adoc
+++ b/downstream/modules/devtools/proc-rhdh-uninstall-ocp-operator.adoc
@@ -19,26 +19,26 @@ You do not need to reload the deployment manually .
 +
 ----
      - disabled: false
-       package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz'
+       package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz'
        integrity: <SHA512 value>
 	 ...
      - disabled: false
        package: >-
-         http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
+         http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
        integrity: <SHA512 value>
        ...
      - disabled: false
        package: >-
-         http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+         http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
        integrity: <SHA512 value>
 ----
 .. Click btn:[Save].
 . To completely remove all the Ansible plugins remove the entire list entries that contain
 +
 ----
-http://plugin-registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz
-http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
-http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+http://plugin-registry:8080/ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz
+http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
+http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
 ----
 . Open the custom {RHDH}ConfigMap, `app-config-rhdh`.
 .. Remove the `locations:` block to delete the templates from the {RHDHShort} instance.

--- a/downstream/modules/devtools/proc-rhdh-update-plugins-helm-version-numbers.adoc
+++ b/downstream/modules/devtools/proc-rhdh-update-plugins-helm-version-numbers.adoc
@@ -16,7 +16,7 @@ global:
     plugins:
       - disabled: false
         integrity: <SHA512 value>
-        package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz'
+        package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz'
         pluginConfig:
           dynamicPlugins:
             frontend:
@@ -33,7 +33,7 @@ global:
       - disabled: false
         integrity: <SHA512 value>
         package: >-
-          http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+          http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
         pluginConfig:
           dynamicPlugins:
             backend:
@@ -41,7 +41,7 @@ global:
       - disabled: false
         integrity: <SHA512 value>
         package: >-
-          http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
+          http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
         pluginConfig:
           dynamicPlugins:
             backend:

--- a/downstream/modules/devtools/proc-rhdh-update-plugins-operator-version-numbers.adoc
+++ b/downstream/modules/devtools/proc-rhdh-update-plugins-operator-version-numbers.adoc
@@ -10,7 +10,7 @@
 This example uses a ConfigMap file called `rhaap-dynamic-plugins-config`.
 . Update `x.y.z` with the version numbers for the updated {AAPRHDHShort}.
 . Update the integrity values for each plug-in with the `.integrity` value from the corresponding extracted {AAPRHDHShort} `.tar` file.
-// For example, use the `.integrity` value from `ansible-plugin-backstage-rhaap-x.y.z.tgz` for the `ansible-plugin-backstage-rhaap-x.y.z.tgz.integrity` key.
+// For example, use the `.integrity` value from `ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz` for the `ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz.integrity` key.
 +
 ----
 kind: ConfigMap
@@ -22,18 +22,18 @@ data:
    ...
    plugins: # Update the Ansible plug-in entries below with the updated plugin versions
      - disabled: false
-       package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz'
-       integrity: <SHA512 value> # Use hash in ansible-plugin-backstage-rhaap-x.y.z.tgz.integrity
+       package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz'
+       integrity: <SHA512 value> # Use hash in ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz.integrity
 	 ...
      - disabled: false
        package: >-
-         http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
-       integrity: <SHA512 value> # Use hash in ansible-plugin-backstage-rhaap-backend-x.y.z.tgz.integrity
+         http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
+       integrity: <SHA512 value> # Use hash in ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz.integrity
        ...
      - disabled: false
        package: >-
-         http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
-       integrity: <SHA512 value> # Use hash in ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz.integrity
+         http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
+       integrity: <SHA512 value> # Use hash in ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz.integrity
 	 ...
 
 ----

--- a/downstream/modules/devtools/proc-self-service-download-tar.adoc
+++ b/downstream/modules/devtools/proc-self-service-download-tar.adoc
@@ -33,12 +33,12 @@ Run `ls` to verify that the extracted files are in the `$DYNAMIC_PLUGIN_ROOT_DIR
 
 ----
 $ ls $DYNAMIC_PLUGIN_ROOT_DIR
-ansible-plugin-backstage-rhaap-x.y.z.tgz
-ansible-plugin-backstage-rhaap-x.y.z.tgz.integrity
-ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
-ansible-plugin-backstage-rhaap-backend-x.y.z.tgz.integrity
-ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
-ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz.integrity
+ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz
+ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz.integrity
+ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
+ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz.integrity
+ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
+ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz.integrity
 
 ----
 

--- a/downstream/modules/devtools/proc-self-service-setup-registry-image.adoc
+++ b/downstream/modules/devtools/proc-self-service-setup-registry-image.adoc
@@ -38,9 +38,9 @@ image::self-service-plugin-registry.png[Developer perspective]
 . In the terminal, run `ls` to confirm that the `.tar` files are in the plugin registry.
 +
 ----
-ansible-plugin-backstage-rhaap-x.y.z.tgz
-ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
-ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz
+ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
+ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
 ----
 +
 The version numbers and file names can differ.

--- a/downstream/modules/devtools/ref-rhdh-full-aap-configmap-example.adoc
+++ b/downstream/modules/devtools/ref-rhdh-full-aap-configmap-example.adoc
@@ -19,6 +19,9 @@ data:
         baseUrl: '<https://MyControllerUrl>'
         token: '<AAP Personal Access Token>'
         checkSSL: <true or false>
+        showCaseLocation:
+          type: file
+          target: '/tmp/aap-showcases/'
       # Optional integrations 
       devSpaces:
         baseUrl: '<https://MyDevSpacesURL>'

--- a/downstream/modules/devtools/ref-rhdh-full-helm-chart-ansible-plugins.adoc
+++ b/downstream/modules/devtools/ref-rhdh-full-helm-chart-ansible-plugins.adoc
@@ -11,7 +11,7 @@ global:
     plugins:
       - disabled: false
         integrity: <SHA512 Integrity key for ansible-plugin-backstage-rhaap plugin>
-        package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-x.y.z.tgz'
+        package: 'http://plugin-registry:8080/ansible-plugin-backstage-rhaap-dynamic-x.y.z.tgz'
         pluginConfig:
           dynamicPlugins:
             frontend:
@@ -28,7 +28,7 @@ global:
       - disabled: false
         integrity: <SHA512 Integrity key for ansible-plugin-scaffolder-backend-module-backstage-rhaap plugin>
         package: >-
-          http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-x.y.z.tgz
+          http://plugin-registry:8080/ansible-plugin-scaffolder-backend-module-backstage-rhaap-dynamic-x.y.z.tgz
         pluginConfig:
           dynamicPlugins:
             backend:
@@ -36,7 +36,7 @@ global:
       - disabled: false
         integrity: <SHA512 Integrity key for ansible-plugin-backstage-rhaap-backend plugin>
         package: >-
-          http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-x.y.z.tgz
+          http://plugin-registry:8080/ansible-plugin-backstage-rhaap-backend-dynamic-x.y.z.tgz
         pluginConfig:
           dynamicPlugins:
             backend:


### PR DESCRIPTION
Update Ansible Plug-ins documentation to be compatible with Ansible plugins 1.5 file naming, and to add a parameter to the ConfigMap to allow the plug-ins to work.

Preview: https://ariordan-redhat.github.io/aap-builds/aap-plugin-rhdh-install-plugins-1.5-updates-2025-05-12.html

Affects `downstream/titles/aap-plugin-rhdh-install`