### PR TITLE
AAP-45780 Remove outdated modules

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-recovery.adoc
+++ b/downstream/assemblies/platform/assembly-aap-recovery.adoc
@@ -11,11 +11,5 @@ If you lose information on your system or experience issues with an upgrade, you
 
 include::platform/proc-aap-platform-gateway-restore.adoc[leveloffset=+1]
 
-include::platform/proc-aap-controller-restore.adoc[leveloffset=+1]
-
-include::platform/proc-aap-controller-yaml-restore.adoc[leveloffset=+1]
-
-include::platform/proc-aap-hub-restore.adoc[leveloffset=+1]
-
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
Removing recovery modules that are no longer needed as everything is through gateway now

Removing:

include::platform/proc-aap-controller-restore.adoc[leveloffset=+1]

include::platform/proc-aap-controller-yaml-restore.adoc[leveloffset=+1]

include::platform/proc-aap-hub-restore.adoc[leveloffset=+1]