### PR TITLE
bp to 2.5:AAP-41334: Updates info on requirements files in Managing automation …

### DIFF
--- a/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
+++ b/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
@@ -59,7 +59,7 @@ You can update these collections manually by downloading their packages.
 // Current testing requirements are focused on collections containing modules, and additional resources are currently in progress for testing collections containing only roles.
 // Contact ansiblepartners@redhat.com for more information.
 
-You can use {HubNameMain} to distribute the relevant {CertifiedColl}s to your users by creating a requirements file or a synclist. Use a requirements file to install collections to your {HubName}, as synclists can only be managed by users with platform administrator privileges. 
+You can use {HubNameMain} to distribute the relevant {CertifiedColl}s to your users by creating a requirements file.
 
 Before you can use a requirements file to install content, you must: 
 

--- a/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
+++ b/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
@@ -5,13 +5,6 @@
 
 Use remote configurations to configure your {PrivateHubName} to synchronize with {CertifiedName} hosted on `{Console}` or with your collections in {Galaxy}.
 
-[IMPORTANT]
-====
-To synchronize content, you can now upload a manually-created requirements file from the rh-certified remote. Remotes are configurations that allow you to synchronize content to your custom repositories from an external collection source.
-
-As of the 2.4 release you can still synchronize content, but synclists are deprecated, and will be removed in a future version.
-====
-
 Each remote configuration located in {MenuACAdminRemotes} provides information for both the *community* and *rh-certified* repository about when the repository was *last updated*.
 You can add new content to {HubNameMain} at any time using the *Edit* and *Sync* features included on the {MenuACAdminRepositories} page.
 

--- a/downstream/assemblies/hub/assembly-synclists.adoc
+++ b/downstream/assemblies/hub/assembly-synclists.adoc
@@ -1,13 +1,8 @@
 [id="assembly-synclists"]
 = Synchronizing Ansible Content Collections in {HubName}
 
-[IMPORTANT]
-====
-To synchronize content, you can now upload a manually-created requirements file from the rh-certified remote.
+To synchronize content, create and upload a requirements file to the appropriate remote.
 Remotes are configurations that enable you to synchronize content to your custom repositories from an external collection source.
-
-As of the 2.4 release you can still synchronize content, but synclists are deprecated, and will be removed in a future version.
-====
 
 // include::hub/con-rh-certified-synclist.adoc[leveloffset=+1]
 include::hub/proc-create-synclist.adoc[leveloffset=+1]

--- a/downstream/modules/hub/proc-create-requirements-file.adoc
+++ b/downstream/modules/hub/proc-create-requirements-file.adoc
@@ -5,7 +5,7 @@
 [id="create-requirements-file_{context}"]
 = Creating a requirements file
 
-Use a requirements file to add collections to your {HubName}. Requirements files are in YAML format and list the collections that you want to install in your {HubName}. After you create your requirements.yml file listing the collections you want to install, you will then run the install command to add the collections to your hub instance. 
+Use a requirements file to add collections to your {HubName}. Requirements files are in YAML format and list the collections that you want to install in your {HubName}. 
 
 A standard `requirements.yml` file contains the following parameters:
 
@@ -14,7 +14,7 @@ A standard `requirements.yml` file contains the following parameters:
 
 .Procedure
 
-. Create your requirements file.
+* Create your requirements file.
 +
 In YAML format, collection information in your requirements file should look like this:
 +
@@ -24,19 +24,9 @@ collections:
  name: namespace.collection_name
  version: 1.0.0
 ----
-+
-. After you have created your requirements file listing information for each collection that you want to install, navigate to the directory where the file is located and run the following command:
+[Important]
+====
+Be sure to specify the collection version number, otherwise you will sync all collection versions. Syncing all versions can require more space than expected.
+====
 
-[source,bash]
-----
-$ ansible-galaxy collection install -r requirements.yml
-----
-
-== Installing an individual collection from the command line
-
-To install an individual collection to your {HubName}, run the following command: 
-
-[source,bash]
-----
-$ ansible-galaxy collection install namespace.collection_name
-----
+To sync the collections in your requirements file, follow the steps in link:{URLHubManagingContent}/managing-cert-valid-content#proc-create-synclist[Syncing Ansible content collections].

--- a/downstream/modules/hub/proc-create-synclist.adoc
+++ b/downstream/modules/hub/proc-create-synclist.adoc
@@ -2,9 +2,9 @@
 // obtaining-token/master.adoc
 [id="proc-create-synclist"]
 
-= Syncing {CertifiedName}
+= Syncing Ansible content collections
 
-You can sync curated {CertifiedCon} in {HubNameMain} on {Console}.
+You can sync certified and validated collections in {HubNameMain} on {Console}.
 //[ddacosta]This needs to be checked. I don't see a Repositories selection in the console verion. I think the way I've rewritten is correct.
 // [hherbly] Looks like there is no synclist info in console or the test instance; commenting out this info for 2.5
 // Your synclist repository is located on the {HubName} navigation panel under {MenuACAdminRepositories}, which is updated whenever you manage content within {CertifiedName}.
@@ -20,6 +20,7 @@ When syncing content, keep in mind that {HubName} does not check other repositor
 
 * You have a valid {PlatformNameShort} subscription.
 * You have organization administrator permissions for {Console}.
+* You have created a link:{URLHubManagingContent}/managing-cert-valid-content#create-requirements-file_cloud-sync[requirements file].
 * The following domain names are part of either the firewall or the proxy's allowlist.
 They are required for successful connection and download of collections from {HubName} or Galaxy server:
 ** `galaxy.ansible.com`
@@ -34,15 +35,9 @@ The following domain names must be in the allow list:
 
 .Procedure
 
-. Log in to `{Console}`.
-. Navigate to menu:Automation Hub[Collections].
-. Set the *Sync* toggle switch on each collection to exclude or include it on your synclist.
-+
-[NOTE]
-====
-You will only see the *Sync* toggle switch if you have administrator permissions.
-====
-+
-. To initiate the remote repository synchronization, navigate to your {PlatformNameShort} and select {MenuACAdminRepositories}.
-. In the row containing the repository you want to sync, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync repository* to initiate the remote repository synchronization to your {PrivateHubName}. 
-. Optional: If your remote repository is already configured, update the collections content that you made available to local users by manually synchronizing Red Hat {CertifiedName} to your {PrivateHubName}.
+. From the navigation panel, select {MenuACAdminRemotes}.
+. Find the remote you want to sync from and click the pencil icon image:leftpencil.png[Edit,15,15] to edit. 
+. Find the field labeled *Requirements file*. There, you can either paste the contents of your requirements file, or upload the file from your hard drive by selecting the upload button.
+. Click btn:[Save remote].  
+. To begin synchronization, from the navigation panel select {MenuACAdminRepositories}.
+. In the row containing the repository you want to sync, click the {MoreActionsIcon} icon and select the image:sync.png[Sync repository,15,15] *Sync repository* icon to initiate the remote repository synchronization to your {PrivateHubName}. 

--- a/downstream/modules/hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/hub/proc-set-rhcertified-remote.adoc
@@ -26,7 +26,7 @@ For more information on permissions, see link:{LinkCentralAuth}.
 . In the *Token* field, paste the token you acquired from {Console}.
 . Click btn:[Save remote].
 +
-You can now synchronize collections between your organization synclist on {Console} and your {PrivateHubName}.
+You can now synchronize collections from {Console} to your {PrivateHubName}.
 +
 . From the navigation panel, select {MenuACAdminRepositories}. Next to *rh-certified* click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync repository*.
 . On the modal that appears, you can toggle the following options:


### PR DESCRIPTION
This PR ports the changes from [PR 3413](https://github.com/ansible/aap-docs/pull/3413) to the 2.5 branch. See [AAP-41334](https://issues.redhat.com/browse/AAP-41334) for more. 