### PR TITLE
AAP-45078 Check Using automation execution for UI and modular compliance.

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-login.adoc
+++ b/downstream/assemblies/platform/assembly-controller-login.adoc
@@ -1,12 +1,14 @@
-[id="controller-login"]
+:_mod-docs-content-type:ASSEMBLY
+[id="assembly-controller-login.adoc_{context}"]
 
 ifdef::controller-GS[]
-=  Logging into the {ControllerName} dashboard after installation
+=  (:CONTROLLER-GS-TITLE: Logging in to the {ControllerName} dashboard after installation)
 
 After you install {ControllerName}, you must log in to the Dashboard.
 endif::controller-GS[]
+
 ifdef::controller-UG[]
-=  Logging into {ControllerName} after installation
+=  (:CONTROLLER-GS-TITLE: Logging in to the {ControllerName} after installation)
 
 After you install {ControllerName}, you must log in.
 endif::controller-UG[]

--- a/downstream/assemblies/platform/assembly-controller-login.adoc
+++ b/downstream/assemblies/platform/assembly-controller-login.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type:ASSEMBLY
-[id="assembly-controller-login.adoc_{context}"]
+[id="assembly-controller-login_{context}"]
 
 ifdef::controller-GS[]
 =  Logging into the {ControllerName} dashboard after installation
 
 After you install {ControllerName}, you must log in to the Dashboard.
 endif::controller-GS[]
+
 ifdef::controller-UG[]
 =  Logging into {ControllerName} after installation
 

--- a/downstream/assemblies/platform/assembly-controller-login.adoc
+++ b/downstream/assemblies/platform/assembly-controller-login.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type:ASSEMBLY
-[id="assembly-controller-login_{context}"]
+[id="assembly-controller-login.adoc_{context}"]
 
 ifdef::controller-GS[]
 =  Logging into the {ControllerName} dashboard after installation

--- a/downstream/assemblies/platform/assembly-controller-login.adoc
+++ b/downstream/assemblies/platform/assembly-controller-login.adoc
@@ -2,13 +2,13 @@
 [id="assembly-controller-login"]
 
 ifdef::controller-GS[]
-=  Logging into the {ControllerName} dashboard after installation
+=  Logging in to the {ControllerName} dashboard after installation
 
 After you install {ControllerName}, you must log in to the Dashboard.
 endif::controller-GS[]
 
 ifdef::controller-UG[]
-=  Logging into {ControllerName} after installation
+=  Logging in to {ControllerName} after installation
 
 After you install {ControllerName}, you must log in.
 endif::controller-UG[]

--- a/downstream/assemblies/platform/assembly-controller-login.adoc
+++ b/downstream/assemblies/platform/assembly-controller-login.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type:ASSEMBLY
-[id="assembly-controller-login.adoc_{context}"]
+[id="assembly-controller-login.adoc"]
 
 ifdef::controller-GS[]
 =  Logging into the {ControllerName} dashboard after installation

--- a/downstream/assemblies/platform/assembly-controller-login.adoc
+++ b/downstream/assemblies/platform/assembly-controller-login.adoc
@@ -2,13 +2,12 @@
 [id="assembly-controller-login.adoc_{context}"]
 
 ifdef::controller-GS[]
-=  (:CONTROLLER-GS-TITLE: Logging in to the {ControllerName} dashboard after installation)
+=  Logging into the {ControllerName} dashboard after installation
 
 After you install {ControllerName}, you must log in to the Dashboard.
 endif::controller-GS[]
-
 ifdef::controller-UG[]
-=  (:CONTROLLER-GS-TITLE: Logging in to the {ControllerName} after installation)
+=  Logging into {ControllerName} after installation
 
 After you install {ControllerName}, you must log in.
 endif::controller-UG[]

--- a/downstream/assemblies/platform/assembly-controller-login.adoc
+++ b/downstream/assemblies/platform/assembly-controller-login.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type:ASSEMBLY
-[id="assembly-controller-login.adoc"]
+[id="assembly-controller-login"]
 
 ifdef::controller-GS[]
 =  Logging into the {ControllerName} dashboard after installation

--- a/downstream/titles/controller/controller-user-guide/master.adoc
+++ b/downstream/titles/controller/controller-user-guide/master.adoc
@@ -22,58 +22,87 @@ For more information about these and other Ansible concepts, see the link:https:
 include::{Boilerplate}[]
 
 include::platform/assembly-UG-overview.adoc[leveloffset=+1]
+
 //Moved to Access management doc
 //include::platform/assembly-controller-licensing.adoc[leveloffset=+1]
 include::platform/assembly-controller-login.adoc[leveloffset=+1]
+
 //Moved to Access management doc
 //include::platform/assembly-controller-managing-subscriptions.adoc[leveloffset=+1]
 //Rewritten for 2.5
 include::platform/assembly-controller-user-interface.adoc[leveloffset=+1]
+
 include::platform/assembly-controller-search.adoc[leveloffset=+1]
+
 //Jobs
 include::platform/assembly-ug-controller-jobs.adoc[leveloffset=+1]
+
 //Templates
 include::platform/assembly-ug-controller-job-templates.adoc[leveloffset=+1]
+
 include::platform/assembly-ug-controller-job-slicing.adoc[leveloffset=+1]
+
 //This includes workflow  approvals.
 include::platform/assembly-ug-controller-workflow-job-templates.adoc[leveloffset=+1]
+
 include::platform/assembly-ug-controller-workflows.adoc[leveloffset=+1]
+
 //Schedules
 include::platform/assembly-ug-controller-schedules.adoc[leveloffset=+1]
+
 //Projects
 include::platform/assembly-controller-projects.adoc[leveloffset=+1]
+
 include::platform/assembly-controller-project-signing.adoc[leveloffset=+1]
+
 //Infrastructure-Topology View
 include::platform/assembly-controller-topology-viewer.adoc[leveloffset=+1]
+
 //Infrastructure-Inventories
 include::platform/assembly-controller-inventories.adoc[leveloffset=+1]
+
 include::platform/assembly-controller-inventory-templates.adoc[leveloffset=+1]
+
 //Adding short Hosts assembly
 include::platform/assembly-controller-hosts.adoc[leveloffset=+1]
+
 //Infrastructure-Instance Groups
 include::platform/assembly-ug-controller-instance-groups.adoc[leveloffset=+1]
+
 include::platform/assembly-ag-instance-and-container-groups.adoc[leveloffset=+1]
+
 //Infrastructure-Instances
 include::platform/assembly-controller-instances.adoc[leveloffset=+1]
+
 //Infrastructure-Execution environments
 include::platform/assembly-controller-execution-environments.adoc[leveloffset=+1]
+
 include::platform/assembly-controller-ee-setup-reference.adoc[leveloffset=+1]
+
 //Moved to Donna's Access management document
 //include::platform/assembly-controller-organizations.adoc[leveloffset=+1]
 //include::platform/assembly-controller-users.adoc[leveloffset=+1]
 //include::platform/assembly-controller-teams.adoc[leveloffset=+1]
 //Possibly in Donna's credentials document
 include::platform/assembly-controller-credentials.adoc[leveloffset=+1]
+
 include::platform/assembly-controller-custom-credentials.adoc[leveloffset=+1]
+
 include::platform/assembly-controller-activity-stream.adoc[leveloffset=+1]
+
 //Moved to admin guide
 //include::platform/assembly-controller-secret-management.adoc[leveloffset=+1]
 //include::platform/assembly-controller-applications.adoc[leveloffset=+1]
 include::platform/assembly-ug-controller-notifications.adoc[leveloffset=+1]
+
 include::platform/assembly-ug-controller-attributes-custom-notifications.adoc[leveloffset=+1]
+
 include::platform/assembly-ug-controller-work-with-webhooks.adoc[leveloffset=+1]
+
 include::platform/assembly-ug-controller-setting-up-insights.adoc[leveloffset=+1]
+
 include::platform/assembly-controller-best-practices.adoc[leveloffset=+1]
+
 //RBAC contents to Donna's document, Jobs info to Jobs.
 //Moved to admin guide.
 //include::platform/assembly-controller-security.adoc[leveloffset=+1]

--- a/downstream/titles/controller/controller-user-guide/master.adoc
+++ b/downstream/titles/controller/controller-user-guide/master.adoc
@@ -5,6 +5,7 @@
 :experimental:
 :controller-UG:
 
+[id="assembly-using-automation-execution"]
 include::attributes/attributes.adoc[]
 
 


### PR DESCRIPTION
Added modular docs and UI compliance to Chapter 2 [Logging into automation controller after installation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_execution/index#controller-login) .

Includes adding a topic ID to the master.adoc file and spaces between include statements, per Emily Murphy, mod-docs SME.