### PR TITLE
AAP-45863 edits

### DIFF
--- a/stories/topics/con-saas-connectivity.adoc
+++ b/stories/topics/con-saas-connectivity.adoc
@@ -10,3 +10,7 @@ The execution plane can communicate with the control plane under the following c
 You can configure automation mesh nodes behind firewalls, proxy servers, and similar services. 
 These services route or proxy traffic originating from {PlatformNameShort} without altering headers, payload, or other information that would affect functionality of the automation mesh.
 
+You can restrict access to the control plane by providing CIDR blocks to the Red Hat support team through a link:https://access.redhat.com/support/cases/#/case/new/get-support?caseCreate=true[Customer support request]. 
+This controls the inbound access to the control plane limiting it to the IP ranges you provide for traffic over the public internet.
+The application of these rules do not apply to traffic over PrivateLink. 
+These restrictions do not affect outbound traffic that originates from the control plane.


### PR DESCRIPTION
[AAP-45863](https://issues.redhat.com/browse/AAP-45863) Product Documentation Updates for CIDR range request process for customers

location: aap-clouds-latest > Titles > saas-aws

No backport required.