### PR TITLE
2.4 Correct typo in Creating and consuming execution environments (#3463)

### DIFF
--- a/downstream/modules/builder/con-additional-build-files.adoc
+++ b/downstream/modules/builder/con-additional-build-files.adoc
@@ -2,7 +2,7 @@
 
 = Additional build files
 
-You can add any external file to the build context directory by referring or copying them to the `additional_build_steps` section of the definition file. The format is a list of dictionary values, each with a `src` and `dest` key and value.
+You can add any external file to the build context directory by referring or copying them to the `additional_build_files` section of the definition file. The format is a list of dictionary values, each with a `src` and `dest` key and value.
 
 Each list item must be a dictionary containing the following required keys:
 


### PR DESCRIPTION
Backports #3463  from main to 2.4

In con-additional-build-files.adoc the var `additional_build_steps` was referenced when it should be `additional_build_files`.

docs execution environment config has wrong value of additional_build_files

https://issues.redhat.com/browse/AAP-45864