### PR TITLE
Rename AAP self-service user guide

### DIFF
--- a/downstream/titles/self-service-using/docinfo.xml
+++ b/downstream/titles/self-service-using/docinfo.xml
@@ -1,9 +1,9 @@
-<title>Using Ansible Automation Platform self-service technical preview</title>
+<title>Using Ansible Automation Platform self-service technology preview</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.5</productnumber>
-<subtitle>Use Ansible Automation Platform self-service technical preview</subtitle>
+<subtitle>Use Ansible Automation Platform self-service technology preview</subtitle>
 <abstract>
-    <para>This guide describes how to use Ansible Automation Platform self-service technical preview to implement role-based access control and run automation.</para>
+    <para>This guide describes how to use Ansible Automation Platform self-service technology preview to implement role-based access control and run automation.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/self-service-using/master.adoc
+++ b/downstream/titles/self-service-using/master.adoc
@@ -7,7 +7,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Using Ansible Automation Platform self-service technical preview
+= Using Ansible Automation Platform self-service technology preview
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 


### PR DESCRIPTION
Rename AAP self-service user guide from "Technical preview" to "Technology preview"