### PR TITLE
Update self-service telemetry disable method

### DIFF
--- a/downstream/modules/devtools/proc-self-service-telemetry-disable.adoc
+++ b/downstream/modules/devtools/proc-self-service-telemetry-disable.adoc
@@ -5,44 +5,26 @@
 [id="self-service-telemetry-disable_{context}"]
 = Disabling telemetry data collection
 
-You can disable and enable the telemetry data collection feature for {SelfServiceShort} in the ConfigMap for your {OCPShort} project.
+You can disable and enable the telemetry data collection feature for {SelfServiceShort} by updating the Helm chart for your {OCPShort} project.
 
 . Log in to the {OCPShort} console and open the project for {SelfServiceShort} in the *Developer* perspective.
-. Open the ConfigMap:
-.. Select the *Topology* view.
-.. Select menu:Workloads[Config Maps].
-.. Select the `<installation-name>-backstage-app-config` ConfigMap, for example `my-aap-self-service-tech-preview-backstage-app-config`.
-.. Click the ConfigMap to open its *Details* page.
-.. Select the *YAML* tab.
-. Update the ConfigMap:
-** To disable telemetry data collection,
-set `disabled` to `true` for `package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment` in the `global.dynamic.plugins` section.  
+. Navigate to *Helm*.
+. Click the *More actions {MoreActionsIcon}* icon for your {SelfServiceShort} Helm chart and select *Upgrade*.
+. Select *YAML view*.
+. Locate the `redhat-developer-hub.global.dynamic.plugins` section of the Helm chart.
+. To disable telemetry data collection, add the following lines to the `redhat-developer-hub.global.dynamic.plugins` section.
 +
 ----
-global:
-  ...
-  dynamic:
-    ...
-    plugins:
-      ...
-      package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
-    - disabled: true
-
+redhat-developer-hub:
+  global:
+    ....
+    dynamic:
+      plugins:
+        - disabled: true
+          package: >-
+            ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
 ----
-** To enable telemetry data collection,
-set `disabled` to `false` for `package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment` in the `global.dynamic.plugins` section.  
 +
-----
-global:
-  ...
-  dynamic:
-    ...
-    plugins:
-      ...
-      package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
-    - disabled: false
-
-----
-. Click btn:[Save] to apply the changes to the ConfigMap.
-. Restart the pod so that your deployment uses the latest configuration.
+To re-enable telemetry data collection, delete these lines.
+. Click btn:[Upgrade] to apply the changes to the Helm chart and restart the pod.
 


### PR DESCRIPTION
Update the Disabling Telemetry for AAP self-service to use the Helm chart instead of a ConfigMap. This change means that telemetry settings will be preserved if the Helm chart is redeployed.