### PR TITLE
2.4 Update inventory file used in mixed deployment scenario

### DIFF
--- a/downstream/modules/platform/proc-RPM-install-eda-controller.adoc
+++ b/downstream/modules/platform/proc-RPM-install-eda-controller.adoc
@@ -15,9 +15,9 @@ Perform a new {PlatformNameShort} 2.5 RPM-based installation of {EDAcontroller} 
 +
 [subs="+attributes"]
 ----
-# This is the enterprise installer inventory file
-# Please consult the docs if you are unsure what to add
-# For all optional variables please consult the Red Hat documentation:
+# This is the {PlatformNameShort} mixed enterprise installer inventory file
+# Consult the docs if you are unsure what to add
+# For all optional variables consult the Red Hat documentation:
 # https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation
 
 # This section is for your platform gateway hosts
@@ -25,12 +25,22 @@ Perform a new {PlatformNameShort} 2.5 RPM-based installation of {EDAcontroller} 
 [automationgateway]
 gateway1.example.org
 gateway2.example.org
+gateway3.example.org
 
 # This section is for your {EDAcontroller} hosts
 # -----------------------------------------------------
 [automationedacontroller]
 eda1.example.org
 eda2.example.org
+eda3.example.org
+
+[redis]
+gateway1.example.org
+gateway2.example.org
+gateway3.example.org
+eda1.example.org
+eda2.example.org
+eda3.example.org
 
 [all:vars]
 # Common variables


### PR DESCRIPTION
Update the inventory file snippet used in "Using Event-Driven Ansible 2.5 with Ansible Automation Platform 2.4" to match the snippet used in Tested deployment models.

Affected title: `/titles/eda-controller/eda-controller-install`

This document is only present in 2.4.

Missing database group on the example inventory file on EDA documentation

https://issues.redhat.com/browse/AAP-44186

@jself-sudoku tagging you on this PR I believe you wrote this guide. No action needed just for awareness :) 