### PR TITLE
2.5 Update RPM-A-ENV-B inventory file (#3484)

### DIFF
--- a/downstream/snippets/inventory-rpm-a-env-b.adoc
+++ b/downstream/snippets/inventory-rpm-a-env-b.adoc
@@ -20,6 +20,11 @@ gateway.example.org
 [automationedacontroller]
 eda.example.org
 
+# This section is for the {PlatformNameShort} database
+# -----------------------------------------------------
+[database]
+db.example.org
+
 [all:vars]
 
 # Common variables


### PR DESCRIPTION
Update the RPM miixed growth topology inventory file to include the `[database]` group

Missing database group on the example inventory file on EDA documentation

https://issues.redhat.com/browse/AAP-44186