### PR TITLE
AAP-28022 - Added note re: access for Remote Registries

### DIFF
--- a/downstream/modules/platform/proc-gw-team-access-resources.adoc
+++ b/downstream/modules/platform/proc-gw-team-access-resources.adoc
@@ -5,6 +5,11 @@
 = Providing team access to a resource
 You can grant users access based on their team membership. When you add a user as a member of a team, they inherit access to the roles and resources defined for that team.
 
+[NOTE]
+====
+Direct team access cannot be granted to {MenuACAdminRemoteRegistries} resources.
+====
+
 .Procedure
 
 . From the navigation panel, select a resource to which you want to provide team access. For example, {MenuAETemplates}.

--- a/downstream/modules/platform/proc-gw-user-access-resources.adoc
+++ b/downstream/modules/platform/proc-gw-user-access-resources.adoc
@@ -6,6 +6,11 @@
 
 You can grant users access to resources through the roles to which they are assigned.
 
+[NOTE]
+====
+Direct user access cannot be granted to {MenuACAdminRemoteRegistries} resources.
+====
+
 .Procedure
 
 . From the navigation panel, select a resource to which you want to provide team access. For example, {MenuAETemplates}.


### PR DESCRIPTION
This PR addresses the docs changes for https://issues.redhat.com/browse/AAP-28022. Direct Team and User access is not available for remote registry resources. 