### PR TITLE
Applying mod doc checklist to 2.4 version

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-backup-recovery.adoc
+++ b/downstream/assemblies/platform/assembly-aap-backup-recovery.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 
 ifdef::context[:parent-context: {context}]
 

--- a/downstream/assemblies/platform/assembly-aap-backup.adoc
+++ b/downstream/assemblies/platform/assembly-aap-backup.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 
 ifdef::context[:parent-context: {context}]
 

--- a/downstream/assemblies/platform/assembly-aap-recovery.adoc
+++ b/downstream/assemblies/platform/assembly-aap-recovery.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
 
 ifdef::context[:parent-context: {context}]
 
 [id="aap-recovery"]
+
 = Recovering a {PlatformName} deployment
 
 :context: aap-recovery

--- a/downstream/assemblies/platform/assembly-aap-troubleshoot-backup-recovery.adoc
+++ b/downstream/assemblies/platform/assembly-aap-troubleshoot-backup-recovery.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 
 ifdef::context[:parent-context: {context}]
 

--- a/downstream/modules/platform/con-aap-backup-recommendations.adoc
+++ b/downstream/modules/platform/con-aap-backup-recommendations.adoc
@@ -1,7 +1,8 @@
-[id="aap-backup-recommendations"]
+:_mod-docs-content-type: CONCEPT
+
+[id="aap-backup-recommendations_{context}"]
 
 = Backup recommendations
-
 
 [role="_abstract"]
 Recovering from data loss requires that you plan for and create backup resources of your {PlatformName} deployments on a regular basis. At a minimum, Red Hat recommends backing up deployments of {PlatformName} under the following circumstances:

--- a/downstream/modules/platform/con-aap-backup-recovery.adoc
+++ b/downstream/modules/platform/con-aap-backup-recovery.adoc
@@ -1,4 +1,6 @@
-[id="aap-backup-recovery"]
+:_mod-docs-content-type: CONCEPT
+
+[id="aap-backup-recovery_{context}"]
 
 = About backup and recovery
 

--- a/downstream/modules/platform/proc-aap-controller-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-backup.adoc
@@ -1,4 +1,6 @@
-[id="aap-controller-backup"]
+:_mod-docs-content-type: PROCEDURE
+
+[id="aap-controller-backup_{context}"]
 
 = Backing up the {ControllerNameStart} deployment
 

--- a/downstream/modules/platform/proc-aap-controller-restore.adoc
+++ b/downstream/modules/platform/proc-aap-controller-restore.adoc
@@ -1,4 +1,6 @@
-[id="aap-controller-restore"]
+:_mod-docs-content-type: PROCEDURE
+
+[id="aap-controller-restore_{context}"]
 
 = Recovering the {ControllerNameStart} deployment
 

--- a/downstream/modules/platform/proc-aap-controller-yaml-backup.adoc
+++ b/downstream/modules/platform/proc-aap-controller-yaml-backup.adoc
@@ -1,11 +1,12 @@
-[id="aap-controller-yaml-backup"]
+:_mod-docs-content-type: PROCEDURE
+
+[id="aap-controller-yaml-backup_{context}"]
 
 = Using YAML to back up the {ControllerNameStart} deployment
 
 See the following procedure for how to back up a deployment of the {ControllerName} using YAML. 
 
 .Prerequisites
-
 
 * You must be authenticated with an OpenShift cluster.
 * You have installed {OperatorPlatformNameShort} on the cluster.
@@ -27,8 +28,11 @@ spec:
 ----
 +
 
-NOTE: The "deployment_name" above is the name of the {ControllerName} deployment you intend to backup from. 
+[NOTE]
+====
+The "deployment_name" above is the name of the {ControllerName} deployment you intend to backup from. 
 The namespace above is the one containing the {ControllerName} deployment you intend to back up.
+====
 
 . Use the `oc apply` command to create the backup object in your cluster:
 

--- a/downstream/modules/platform/proc-aap-controller-yaml-restore.adoc
+++ b/downstream/modules/platform/proc-aap-controller-yaml-restore.adoc
@@ -1,4 +1,6 @@
-[id="aap-controller-yaml-restore"]
+:_mod-docs-content-type: PROCEDURE
+
+[id="aap-controller-yaml-restore_{context}"]
 
 = Using YAML to recover the {ControllerNameStart} deployment
 See the following procedure for how to restore a deployment of the {ControllerName} using YAML. 

--- a/downstream/modules/platform/proc-aap-hub-backup.adoc
+++ b/downstream/modules/platform/proc-aap-hub-backup.adoc
@@ -1,4 +1,6 @@
-[id="aap-hub-backup"]
+:_mod-docs-content-type: PROCEDURE
+
+[id="aap-hub-backup_{context}"]
 
 = Backing up the {HubNameStart} deployment
 
@@ -23,5 +25,5 @@ For example, if your {HubName} must be backed up and the deployment name is `aap
 . If you want to use a custom, pre-created pvc:
 .. Optionally, enter the name of the *Backup persistent volume claim*, *Backup persistent volume claim namespace*, *Backup PVC storage requirements*, and *Backup PVC storage class*.
 . Click btn:[Create].
-+
+
 A backup of the specified deployment is created and available for data recovery or deployment rollback.

--- a/downstream/modules/platform/proc-aap-hub-restore.adoc
+++ b/downstream/modules/platform/proc-aap-hub-restore.adoc
@@ -1,4 +1,6 @@
-[id="aap-hub-restore"]
+:_mod-docs-content-type: PROCEDURE
+
+[id="aap-hub-restore_{context}"]
 
 = Recovering the {HubNameStart} deployment
 
@@ -26,5 +28,5 @@ The name specified for the new AutomationHub custom resource must not match an e
 . Select the *Backup source to restore* from. *Backup CR* is recommended.
 . Enter the *Backup Name* of the AutomationHubBackup object.
 . Click btn:[Create].
-+
+
 A new deployment is created and your backup is restored to it.

--- a/downstream/modules/platform/proc-troubleshoot-same-name.adoc
+++ b/downstream/modules/platform/proc-troubleshoot-same-name.adoc
@@ -1,4 +1,6 @@
-[id="troubleshoot-same-name"]
+:_mod-docs-content-type: PROCEDURE
+
+[id="troubleshoot-same-name_{context}"]
 
 = {ControllerNameStart} custom resource has the same name as an existing deployment
 


### PR DESCRIPTION
[AAP-45898](https://issues.redhat.com/browse/AAP-45898)
Review OCP Backup and restore documentation using the Mod doc templates checklist.

Reviewed the OCP backup and restore documentation using the [Mod doc templates checklist](https://docs.google.com/document/d/13NAUVAby1y1qfT77QFIZrMBhi872e7IEvAC9MUpGXbQ/edit?tab=t.0).

[Backup and restore](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/backup_and_recovery_for_operator_environments/index)