### PR TITLE
bp to 2.5:AAP-41334: reorganizes syncing procedures for clarity + adds KB on re…

### DIFF
--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -14,7 +14,7 @@ Validated collections are uploaded into the `validated` repository.
 You can change the default configuration by using two variables:
 
 * `automationhub_seed_collections` is a boolean that defines whether or not preloading is enabled.
-* `automationhub_collection_seed_repository`is a variable that enables you to specify the type of content to upload when it is set to `true`.
+* `automationhub_collection_seed_repository` is a variable that enables you to specify the type of content to upload when it is set to `true`.
 Possible values are `certified` or `validated`.
 If this variable is missing, both content sets will be uploaded.
 

--- a/downstream/modules/hub/con-token-management-hub.adoc
+++ b/downstream/modules/hub/con-token-management-hub.adoc
@@ -10,7 +10,7 @@ Before you can interact with {HubName} by uploading or downloading collections, 
 
 [NOTE]
 ====
-{HubName} does not support basic authentication or authenticating through service accounts. You must authenticate using token management.
+{HubNameStart} does not support basic authentication or authenticating through service accounts. You must authenticate using token management.
 ====
 
 Your method for creating the API token differs according to the type of {HubName} that you are using:

--- a/downstream/modules/hub/proc-create-synclist.adoc
+++ b/downstream/modules/hub/proc-create-synclist.adoc
@@ -33,6 +33,14 @@ The following domain names must be in the allow list:
 ** `ansible-galaxy.s3.amazonaws.com`
 * SSL inspection is disabled either when using self signed certificates or for the Red Hat domains.
 
+[IMPORTANT]
+
+====
+
+Before you begin your content sync, consult the Knowledgebase article link:https://access.redhat.com/articles/7118757[Resource requirements for syncing automation content] to ensure that you have the resources to sync the collections you need. 
+
+====
+
 .Procedure
 
 . From the navigation panel, select {MenuACAdminRemotes}.
@@ -40,4 +48,13 @@ The following domain names must be in the allow list:
 . Find the field labeled *Requirements file*. There, you can either paste the contents of your requirements file, or upload the file from your hard drive by selecting the upload button.
 . Click btn:[Save remote].  
 . To begin synchronization, from the navigation panel select {MenuACAdminRepositories}.
-. In the row containing the repository you want to sync, click the {MoreActionsIcon} icon and select the image:sync.png[Sync repository,15,15] *Sync repository* icon to initiate the remote repository synchronization to your {PrivateHubName}. 
+. In the row containing the repository you want to sync, click the {MoreActionsIcon} icon and select the image:sync.png[Sync repository,15,15] *Sync repository* icon to initiate the remote repository synchronization to your {PrivateHubName}.
+. On the modal that appears, you can toggle the following options:
+* *Mirror*: Select if you want your repository content to mirror the remote repository's content.
+* *Optimize*: Select if you want to sync only when no changes are reported by the remote server.
+. Click btn:[Sync] to complete the sync. 
+
+.Verification
+The *Sync status* column updates to notify you whether the  synchronization is successful.
+
+* Navigate to {MenuACCollections} to confirm that your collections content has synchronized successfully.

--- a/downstream/modules/hub/proc-set-community-remote.adoc
+++ b/downstream/modules/hub/proc-set-community-remote.adoc
@@ -2,7 +2,7 @@
 // obtaining-token/master.adoc
 [id="proc-set-community-remote"]
 ifndef::operationG[]
-= Configuring the community remote repository and syncing {Galaxy} collections
+= Configuring the community remote repository to sync {Galaxy} collections
 
 You can edit the *community* remote repository to synchronize chosen collections from {Galaxy} to your {PrivateHubName}.
 By default, your {PrivateHubName} community repository directs to `galaxy.ansible.com/api/`.
@@ -35,18 +35,9 @@ collections:
 . In the *Details* tab in the *Community* remote, click btn:[Edit remote].
 . In the *YAML requirements* field, paste the contents of your `requirements.yml` file.
 . Click btn:[Save remote].
-+
-You can now synchronize collections identified in your `requirements.yml` file from {Galaxy} to your {PrivateHubName}.
 
-. From the navigation panel, select {MenuACAdminRepositories}. Next to the *community* repository, click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync repository* to sync collections between {Galaxy} and {HubNameMain}.
-. On the modal that appears, you can toggle the following options:
-* *Mirror*: Select if you want your repository content to mirror the remote repository's content.
-* *Optimize*: Select if you want to sync only when no changes are reported by the remote server.
-. Click btn:[Sync] to complete the sync.
+You can now synchronize collections identified in your `requirements.yml` file from {Galaxy} to your {PrivateHubName}. See link:{URLHubManagingContent}/managing-cert-valid-content#assembly-synclists[Synchronizing Ansible content collections in {HubName}] for syncing steps.
 
-.Verification
-The *Sync status* column updates to notify you whether the {Galaxy} collections synchronization to your {HubNameMain} is successful.
 
-* Navigate to {MenuACCollections} and select *Community* to confirm successful synchronization.
 
 

--- a/downstream/modules/hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/hub/proc-set-rhcertified-remote.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // obtaining-token/master.adoc
 [id="proc-set-rhcertified-remote_{context}"]
-= Configuring the rh-certified remote repository and synchronizing {CertifiedColl}
+= Configuring the rh-certified remote repository to sync {CertifiedName}
 
 You can edit the *rh-certified* remote repository to synchronize collections from {HubName} hosted on {Console} to your {PrivateHubName}.
 By default, your {PrivateHubName} `rh-certified` repository includes the URL for the entire group of {CertifiedName}.
@@ -25,16 +25,5 @@ For more information on permissions, see link:{LinkCentralAuth}.
 . In the *URL* field, paste the *Sync URL*.
 . In the *Token* field, paste the token you acquired from {Console}.
 . Click btn:[Save remote].
-+
-You can now synchronize collections from {Console} to your {PrivateHubName}.
-+
-. From the navigation panel, select {MenuACAdminRepositories}. Next to *rh-certified* click the btn:[More Actions] icon *{MoreActionsIcon}* and select *Sync repository*.
-. On the modal that appears, you can toggle the following options:
-* *Mirror*: Select if you want your repository content to mirror the remote repository's content.
-* *Optimize*: Select if you want to sync only when no changes are reported by the remote server.
-. Click btn:[Sync] to complete the sync.
 
-.Verification
-The *Sync status* column updates to notify you whether the Red Hat Certified Content Collections synchronization is successful.
-
-* Navigate to {MenuACCollections} to confirm that your collections content has synchronized successfully.
+You can now synchronize collections from {Console} to your {PrivateHubName}. See link:{URLHubManagingContent}/managing-cert-valid-content#assembly-synclists[Synchronizing Ansible content collections in {HubName}] for syncing steps.


### PR DESCRIPTION
This PR ports the changes from [PR 3501](https://github.com/ansible/aap-docs/pull/3501) to the 2.5 branch. See [AAP-41334](https://issues.redhat.com/browse/AAP-41334) for more info.