### PR TITLE
Fixing spacing in assemblies and ensuring parent context is present

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-migration.adoc
+++ b/downstream/assemblies/platform/assembly-aap-migration.adoc
@@ -22,16 +22,22 @@ Use these procedures to migrate any of the following deployments to the {Operato
 * Virtual machine (VM) based or containerized VM {PlatformNameShort} 2.5 → {PlatformNameShort} 2.5
 
 include::platform/con-aap-migration-considerations.adoc[leveloffset=+1]
+
 include::platform/con-aap-migration-prepare.adoc[leveloffset=+1]
+
 include::platform/proc-aap-migration-backup.adoc[leveloffset=+2]
+
 include::platform/proc-create-secret-key-secret.adoc[leveloffset=+2]
+
 include::platform/proc-create-postresql-secret.adoc[leveloffset=+2]
+
 include::platform/proc-verify-network-connectivity.adoc[leveloffset=+2]
+
 include::platform/proc-aap-migration.adoc[leveloffset=+1]
+
 include::platform/proc-aap-create-aap-object.adoc[leveloffset=+2]
+
 include::platform/proc-post-migration-cleanup.adoc[leveloffset=+1]
-
-
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-appendix-operator-crs.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-operator-crs.adoc
@@ -1,6 +1,8 @@
 
 ifdef::context[:parent-context: {context}]
 
+:context: appendix-operator-crs
+
 [id="appendix-operator-crs_{context}"]
 
 = Appendix: {PlatformName} custom resources 

--- a/downstream/assemblies/platform/assembly-controller-resource-operator.adoc
+++ b/downstream/assemblies/platform/assembly-controller-resource-operator.adoc
@@ -6,15 +6,30 @@ ifdef::context[:parent-context: {context}]
 = {OperatorResource}
 
 include::platform/con-resource-operator-overview.adoc[leveloffset=+1]
+
 include::platform/proc-use-controller-resource-operator.adoc[leveloffset=+1]
+
 include::platform/proc-add-controller-access-token.adoc[leveloffset=+1]
+
 include::platform/proc-create-a-connection-secret.adoc[leveloffset=+1]
+
 include::platform/proc-create-crs-resource-operator.adoc[leveloffset=+1]
+
 include::platform/proc-create-an-ansiblejob.adoc[leveloffset=+2]
+
 include::platform/proc-create-a-jobtemplate.adoc[leveloffset=+2]
+
 include::platform/proc-operator-create-controller-project.adoc[leveloffset=+2]
+
 include::platform/proc-operator-create-controller-schedule.adoc[leveloffset=+2]
+
 include::platform/proc-operator-create-controller-workflow.adoc[leveloffset=+2]
+
 include::platform/proc-operator-create-controller-workflow-template.adoc[leveloffset=+2]
+
 include::platform/proc-operator-create-controller-inventory.adoc[leveloffset=+2]
+
 include::platform/proc-operator-create-controller-credential.adoc[leveloffset=+2]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/assemblies/platform/assembly-deploying-chatbot-operator.adoc
+++ b/downstream/assemblies/platform/assembly-deploying-chatbot-operator.adoc
@@ -79,8 +79,11 @@ For more information, see the following resources:
 
 == Deploying the {AAPchatbot}
 include::platform/proc-install-aap-operator-chatbot.adoc[leveloffset=+2]
+
 include::platform/proc-create-chatbot-config-secret.adoc[leveloffset=+2]
+
 include::platform/proc-update-aap-operator-yaml-chatbot.adoc[leveloffset=+2]
+
 include::platform/con-using-chatbot.adoc[leveloffset=+1]
 
 

--- a/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-controller-operator.adoc
@@ -10,7 +10,7 @@ ifdef::context[:parent-context: {context}]
 [id="installing-controller-operator"]
 = Configuring {ControllerName} on {OCP} web console
 
-:context: installing-contr-operator
+:context: installing-controller-operator
 
 
 [role="_abstract"]

--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -39,16 +39,27 @@ When an instance of {HubName} is removed, the PVCs are not automatically deleted
 // . Locate the *Automation hub* entry, then click btn:[Create instance].
 
 include::platform/con-storage-options-for-operator-installation-on-ocp.adoc[leveloffset=+2]
+
 include::platform/proc-provision-ocp-storage-with-readwritemany.adoc[leveloffset=+3]
+
 include::platform/proc-provision-ocp-storage-amazon-s3.adoc[leveloffset=+3]
+
 include::platform/proc-provision-ocp-storage-azure-blob.adoc[leveloffset=+3]
+
 include::platform/proc-hub-route-options.adoc[leveloffset=+2]
+
 include::platform/proc-hub-ingress-options.adoc[leveloffset=+2]
+
 include::platform/proc-access-hub-operator-ui.adoc[leveloffset=+1]
+
 include::platform/proc-operator-external-db-hub.adoc[leveloffset=+1]
+
 include::platform/proc-enable-hstore-extension.adoc[leveloffset=+2]
+
 include::platform/proc-find-delete-PVCs.adoc[leveloffset=+1]
+
 include::platform/ref-ocp-additional-configs.adoc[leveloffset=+1]
+
 include::platform/proc-aap-add-allowed-registries.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -12,11 +12,17 @@ ifdef::context[:parent-context: {context}]
 The {OperatorPlatformNameShort} simplifies the installation, upgrade, and deployment of new {PlatformName} instances in your {OCPShort} environment.
 
 include::platform/con-operator-upgrade-overview.adoc[leveloffset=+1]
+
 include::platform/con-operator-upgrade-considerations.adoc[leveloffset=+1]
+
 include::platform/con-operator-upgrade-prereq.adoc[leveloffset=+1]
+
 include::platform/con-operator-channel-upgrade.adoc[leveloffset=+1]
+
 include::platform/proc-operator-upgrade.adoc[leveloffset=+1]
+
 include::platform/proc-operator-create_crs.adoc[leveloffset=+1]
+
 include::assembly-aap-post-upgrade.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/platform/assembly-update-ocp.adoc
+++ b/downstream/assemblies/platform/assembly-update-ocp.adoc
@@ -5,3 +5,6 @@
 You can use an upgrade patch to update your operator-based {PlatformNameShort}.
 
 include::platform/proc-update-aap-on-ocp.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/proc-operator-create_crs.adoc
+++ b/downstream/modules/platform/proc-operator-create_crs.adoc
@@ -8,7 +8,7 @@ After upgrading to the latest version of {OperatorPlatformNameShort} on {OCPShor
 This example outlines the steps to deploy a new {EDAName} setup after upgrading to the latest version, with existing {ControllerName} and {HubName} deployments already in place.
 
 
-The xref:appendix-operator-crs_performance-considerations[Appendix] contains more examples of {PlatformNameShort} CRs for different deployments.
+The link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_openshift_container_platform/index#appendix-operator-crs_performance-considerations[Appendix] contains more examples of {PlatformNameShort} CRs for different deployments.
 
 . Log in to {OCP}.
 . Navigate to menu:Operators[Installed Operators].
@@ -16,7 +16,7 @@ The xref:appendix-operator-crs_performance-considerations[Appendix] contains mor
 . Select the *Details* tab. 
 . On the *{PlatformNameShort}* tile click btn:[Create instance].
 . From the *Create {PlatformNameShort}* page enter a name for your instance in the *Name* field.
-. Click btn:[YAML view] and paste the following YAML (xref:appendix-operator-crs_performance-considerations[aap-existing-controller-and-hub-new-eda.yml]):
+. Click btn:[YAML view] and paste the following YAML (link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_openshift_container_platform/index#appendix-operator-crs_performance-considerations[aap-existing-controller-and-hub-new-eda.yml]):
 +
 ----
 ---


### PR DESCRIPTION
[AAP-45897](https://issues.redhat.com/browse/AAP-45897) Review installing on OCP documentation using the Mod doc templates checklist.

Reviewed the Installing on OCP documentation using the [Mod doc templates checklist](https://docs.google.com/document/d/13NAUVAby1y1qfT77QFIZrMBhi872e7IEvAC9MUpGXbQ/edit?tab=t.0).

[Installing on OCP](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/installing_on_openshift_container_platform/index)