### PR TITLE
Add spaces between module refs in troubleshooting assembly

### DIFF
--- a/downstream/assemblies/platform/assembly-appendix-troubleshoot-containerized-aap.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-troubleshoot-containerized-aap.adoc
@@ -10,9 +10,13 @@ ifdef::context[:parent-context: {context}]
 Use this information to troubleshoot your containerized {PlatformNameShort} installation.
 
 include::platform/proc-containerized-troubleshoot-gathering-logs.adoc[leveloffset=+1]
+
 include::platform/ref-containerized-troubleshoot-diagnosing.adoc[leveloffset=+1]
+
 include::platform/ref-containerized-troubleshoot-install.adoc[leveloffset=+1]
+
 include::platform/ref-containerized-troubleshoot-config.adoc[leveloffset=+1]
+
 include::platform/ref-containerized-troubleshoot-ref.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]


### PR DESCRIPTION
Affected title: titles/aap-containerized-install

Containerized installation - Assembly - Troubleshooting

https://issues.redhat.com/browse/AAP-45976