### PR TITLE
Azure mod doc checklist review

### DIFF
--- a/stories/assembly-azure-connecting-to-aap.adoc
+++ b/stories/assembly-azure-connecting-to-aap.adoc
@@ -9,14 +9,21 @@ ifdef::context[:parent-context: {context}]
 When network peering is complete and your Azure routing configuration is established, you can choose how your team accesses {PlatformNameShort} through your Azure network configuration.
 
 include::topics/proc-azure-nw-access-details.adoc[leveloffset=+1]
+
 include::topics/proc-azure-nw-public-deploy.adoc[leveloffset=+1]
+
 include::topics/proc-azure-nw-private-deploy.adoc[leveloffset=+1]
+
 include::topics/proc-azure-nw-private-deploy-az-hosted-vm.adoc[leveloffset=+2]
+
 include::topics/proc-azure-nw-private-deploy-vpn.adoc[leveloffset=+2]
+
 // include::topics/proc-azure-nw-private-deploy-ssh-tunnel.adoc[leveloffset=+2]
 // Accessing AAP
 include::topics/proc-azure-accessing-aap.adoc[leveloffset=+1]
+
 include::topics/proc-azure-license-association.adoc[leveloffset=+2]
+
 include::topics/proc-azure-configure-ad-sso.adoc[leveloffset=+2]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/stories/assembly-azure-deploy.adoc
+++ b/stories/assembly-azure-deploy.adoc
@@ -11,8 +11,11 @@ ifdef::context[:parent-context-of-assembly-azure-deploy: {context}]
 // include::topics/proc-azure-deploy-aap.adoc[leveloffset=+1]
 
 include::topics/proc-azure-locate-aap-marketplace.adoc[leveloffset=+1]
+
 include::topics/proc-azure-provisioning-aap.adoc[leveloffset=+1]
+
 include::topics/proc-azure-monitor-deployment-engine.adoc[leveloffset=+1]
+
 include::topics/proc-azure-cancel-deployment.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-assembly-azure-deploy[:context: {parent-context-of-assembly-azure-deploy}]

--- a/stories/assembly-azure-install-prerequisites.adoc
+++ b/stories/assembly-azure-install-prerequisites.adoc
@@ -11,7 +11,7 @@ ifdef::context[:parent-context-of-assembly-azure-install-prerequisites: {context
 
 * A subscription for Microsoft Azure.
 * Contributor or Administrator access to that Azure subscription.
-* Access to the Azure comand line interface (CLI).
+* Access to the Azure command line interface (CLI).
 
 == {PlatformNameShort} requirements
 
@@ -22,11 +22,14 @@ ifdef::context[:parent-context-of-assembly-azure-install-prerequisites: {context
 // Prerequisites for Azure tenancies (tenancy resource limits, use of Azure private features, etc.). Link to Infrastructure modules
 
 include::topics/proc-azure-resource-quotas.adoc[leveloffset=+1]
+
 include::topics/proc-azure-resource-providers.adoc[leveloffset=+1]
 
 // Prerequisites - Network
 include::topics/con-azure-network.adoc[leveloffset=+1]
+
 include::topics/con-azure-vnet-cidr.adoc[leveloffset=+2]
+
 include::topics/con-azure-aks-cidr.adoc[leveloffset=+2]
 
 // Prerequisites - Service Principal
@@ -35,6 +38,7 @@ include::topics/con-azure-aks-cidr.adoc[leveloffset=+2]
 
 // Prerequisites - KB articles
 include::topics/con-azure-policy.adoc[leveloffset=+1]
+
 include::topics/con-azure-entitling-subscription.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-assembly-azure-install-prerequisites[:context: {parent-context-of-assembly-azure-install-prerequisites}]

--- a/stories/assembly-azure-intro.adoc
+++ b/stories/assembly-azure-intro.adoc
@@ -8,15 +8,25 @@ ifdef::context[:parent-context: {context}]
 // [role="_abstract"]
 
 include::topics/con-azure-about.adoc[leveloffset=+1]
+
 include::topics/con-azure-pricing.adoc[leveloffset=+1]
+
 include::topics/con-azure-architecture.adoc[leveloffset=+1]
+
 include::topics/con-azure-public-access.adoc[leveloffset=+2]
+
 include::topics/con-azure-private-access.adoc[leveloffset=+2]
+
 include::topics/con-azure-security.adoc[leveloffset=+2]
+
 include::topics/con-azure-disaster-recovery.adoc[leveloffset=+1]
+
 include::topics/con-azure-infrastructure-usage.adoc[leveloffset=+1]
+
 include::topics/con-azure-lifecycle.adoc[leveloffset=+1]
+
 include::topics/con-azure-scaling.adoc[leveloffset=+1]
+
 include::topics/con-azure-migration.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/stories/assembly-azure-post-deployment-requirements.adoc
+++ b/stories/assembly-azure-post-deployment-requirements.adoc
@@ -9,13 +9,18 @@ ifdef::context[:parent-context-of-assembly-azure-post-deployment-requirements: {
 // [role="_abstract"]
 
 include::assembly-azure-network-peering.adoc[leveloffset=+1]
+
 include::assembly-azure-hub-spoke-peering.adoc[leveloffset=+2]
+
 include::assembly-azure-vwan-peering.adoc[leveloffset=+2]
+
 include::assembly-azure-direct-peering.adoc[leveloffset=+2]
 
 // KB articles
 include::topics/con-azure-user-defined-routing-tables.adoc[leveloffset=+1]
+
 include::topics/con-azure-virtual-appliance-routing.adoc[leveloffset=+1]
+
 include::topics/con-azure-private-dns.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-assembly-azure-post-deployment-requirements[:context: {parent-context-of-assembly-azure-post-deployment-requirements}]

--- a/titles/aap-on-azure/stories.adoc
+++ b/titles/aap-on-azure/stories.adoc
@@ -1,6 +1,7 @@
 // AAP common content
 
 include::{Boilerplate}[]
+
 include::aap-common/external-site-disclaimer.adoc[]
 // AAP on Azure user stories
 //


### PR DESCRIPTION
[AAP-46214](https://issues.redhat.com/browse/AAP-46214) Update Azure documentation using the Mod doc templates checklist.

To prepare for the tool migration I need to review AoC documentation using the [Mod doc templates checklist](https://docs.google.com/document/d/13NAUVAby1y1qfT77QFIZrMBhi872e7IEvAC9MUpGXbQ/edit?tab=t.0). The following docs are in scope for Aoc:

[Red Hat Ansible Automation Platform Service on AWS](https://docs.redhat.com/en/documentation/ansible_on_clouds/2.x/html-single/red_hat_ansible_automation_platform_service_on_aws/index)

Note: After meeting with the ToolX team they confirmed they have a script for adding the :mod-docs-content-type: and for removing `{context}` so those can be ignored in this review.