### PR TITLE
AAP-45886 Document example based on Interact content

### DIFF
--- a/downstream/assemblies/eda/assembly-simplified-event-routing.adoc
+++ b/downstream/assemblies/eda/assembly-simplified-event-routing.adoc
@@ -16,7 +16,9 @@ include::eda/proc-eda-replace-sources-with-event-streams.adoc[leveloffset=+1]
 include::eda/proc-eda-resend-webhook-data-event-streams.adoc[leveloffset=+1]
 include::eda/proc-eda-check-rule-audit-event-stream.adoc[leveloffset=+1]
 
-
+[role="_additional-resources"]
+.Additional resources
+* To view an end-to-end demo of the simplified event routing process using event streams, see link:https://interact.redhat.com/share/E1HhKjGqhls8JF5NsBNz[Event-Driven Ansible with Event Streams].
 
 
 

--- a/downstream/assemblies/eda/assembly-simplified-event-routing.adoc
+++ b/downstream/assemblies/eda/assembly-simplified-event-routing.adoc
@@ -7,6 +7,10 @@ Simplified event routing enables {EDAcontroller} to capture and analyze data fro
 
 Event streams are an easy way to connect your sources to your rulebooks. This capability lets you create a single endpoint to receive alerts from an event source and then use the events in multiple rulebooks.
 
+[role="_additional-resources"]
+.Additional resources
+* To view an end-to-end demo of the simplified event routing process using event streams, see link:https://interact.redhat.com/share/E1HhKjGqhls8JF5NsBNz[Event-Driven Ansible with Event Streams].
+
 include::eda/con-event-streams.adoc[leveloffset=+1]
 include::eda/proc-eda-create-event-stream-credential.adoc[leveloffset=+1]
 include::eda/proc-eda-create-event-stream.adoc[leveloffset=+1]
@@ -16,9 +20,7 @@ include::eda/proc-eda-replace-sources-with-event-streams.adoc[leveloffset=+1]
 include::eda/proc-eda-resend-webhook-data-event-streams.adoc[leveloffset=+1]
 include::eda/proc-eda-check-rule-audit-event-stream.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* To view an end-to-end demo of the simplified event routing process using event streams, see link:https://interact.redhat.com/share/E1HhKjGqhls8JF5NsBNz[Event-Driven Ansible with Event Streams].
+
 
 
 


### PR DESCRIPTION
Added a new block title "Additional resources" that includes a link to the EDA with event streams arcade to [Chapter 6. Simplified event routing](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#simplified-event-routing) in the [Using automation decisions guide](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index). 