### PR TITLE
Update system requirements for Containerized installation (#3493)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -33,6 +33,8 @@ include::platform/ref-cont-aap-system-requirements.adoc[leveloffset=+1]
 
 include::platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc[leveloffset=+1]
 
+include::platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc[leveloffset=+1]
+
 include::platform/proc-downloading-containerized-aap.adoc[leveloffset=+1]
 
 include::platform/ref-configuring-inventory-file.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -1,8 +1,14 @@
-[id="proc-backup-aap-container"]
+[id="backing-up-containerized-ansible-automation-platform"]
 
 = Backing up containerized {PlatformNameShort}
 
 Perform a backup of your {ContainerBase} of {PlatformNameShort}.
+
+.Prerequisites
+
+You have done the following: 
+
+* Logged in to the {RHEL} host as your dedicated non-root user.
 
 .Procedure
 

--- a/downstream/modules/platform/proc-downloading-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-downloading-containerized-aap.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="downloading-containerized-aap"]
+[id="downloading-ansible-automation-platform"]
 
 = Downloading {PlatformNameShort}
 
@@ -11,7 +11,7 @@ Choose the installation program you need based on your {RHEL} environment intern
 
 .Procedure
 
-. Download the latest installer `.tar.gz` file from the link:{PlatformDownloadUrl}[{PlatformNameShort} download page]. 
+. Download the latest version of containerized {PlatformNameShort} from the link:{PlatformDownloadUrl}[{PlatformNameShort} download page]. 
 .. For online installations: *{PlatformNameShort} {PlatformVers} Containerized Setup*
 .. For offline or bundled installations: *{PlatformNameShort} {PlatformVers} Containerized Setup Bundle*
 

--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -11,7 +11,8 @@ After you prepare the {RHEL} host, download {PlatformNameShort}, and configure t
 You have done the following:
 
 * xref:preparing-the-rhel-host-for-containerized-installation[Prepared the {RHEL} host]
-* xref:downloading-containerized-aap[Downloaded {PlatformNameShort}]
+* xref:preparing-the-managed-nodes-for-containerized-installation[Prepared the managed nodes]
+* xref:downloading-ansible-automation-platform[Downloaded {PlatformNameShort}]
 * xref:configuring-inventory-file[Configured the inventory file]
 * Logged in to the {RHEL} host as your non-root user
 

--- a/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
@@ -1,0 +1,43 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="preparing-the-managed-nodes-for-containerized-installation"]
+
+= Preparing the managed nodes for containerized installation
+
+Managed nodes, also referred to as hosts, are the devices that {PlatformNameShort} is configured to manage.
+
+To ensure a consistent and secure setup of containerized {PlatformNameShort}, create a dedicated user on each host. {PlatformNameShort} connects as this user to run tasks on the host.
+
+Once configured, you can define the dedicated user for each host by adding `ansible_user=<username>` in your inventory file, for example: `aap.example.org ansible_user=aap`.
+
+.Procedure
+
+Complete the following steps for each host:
+
+. Log in to the host as the root user.
+. Create a new user. Replace `<username>` with the username you want, for example `aap`.
++
+----
+$ adduser <username>
+----
++
+. Set a password for the new user. Replace `<username>` with the username you created.
++
+----
+$ passwd <username>
+----
++
+. Configure the user to run sudo commands.
+.. To do this open the sudoers file:
++
+----
+$ vi /etc/sudoers
+----
++
+.. Add the following line to the file (replacing `<username>` with the username you created):
++
+----
+<username> ALL=(ALL) NOPASSWD: ALL
+----
++
+.. Save and exit the file.

--- a/downstream/modules/platform/proc-restore-aap-container.adoc
+++ b/downstream/modules/platform/proc-restore-aap-container.adoc
@@ -4,6 +4,12 @@
 
 Restore your {ContainerBase} of {PlatformNameShort} from a backup.
 
+.Prerequisites
+
+You have done the following: 
+
+* Logged in to the {RHEL} host as your dedicated non-root user.
+
 .Procedure
 
 . Go to the {PlatformName} installation directory on your {RHEL} host.

--- a/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
@@ -3,22 +3,32 @@
 [id="uninstalling-containerized-aap"]
 = Uninstalling containerized {PlatformNameShort}
 
-[role="_abstract"]
+Uninstall your {ContainerBase} of {PlatformNameShort}.
 
-When performing a reinstall following an uninstall that preserves the databases, you must use the previously generated {PlatformNameShort} secret key values to access the preserved databases.
+.Prerequisites
 
-Before performing an uninstall, collect the existing secret keys by running the following command:
+You have done the following: 
+
+* Logged in to the {RHEL} host as your dedicated non-root user.
+
+.Procedure
+
+* If you intend to reinstall {PlatformNameShort} and want to use the preserved databases, you must collect the existing secret keys by running the following command:
++
 ----
 $ podman secret inspect --showsecret <secret_key_variable> | jq -r .[].SecretData
 ----
++
 For example:
++
 ----
 $ podman secret inspect --showsecret controller_secret_key | jq -r .[].SecretData
 ----
++
+* For more information about the `*_secret_key` variables, see link:{URLContainerizedInstall}/appendix-inventory-files-vars[Inventory file variables].
 
-For more information about the `*_secret_key` variables, see link:{URLContainerizedInstall}/appendix-inventory-files-vars[Inventory file variables].
+* Run the `uninstall` playbook:
 
-To uninstall a containerized deployment, run the `uninstall` playbook:
 ----
 $ ansible-playbook -i inventory ansible.containerized_installer.uninstall
 ----

--- a/downstream/modules/platform/proc-update-aap-container.adoc
+++ b/downstream/modules/platform/proc-update-aap-container.adoc
@@ -1,4 +1,4 @@
-[id="proc-update-aap-container"]
+[id="updating-containerized-ansible-automation-platform"]
 
 = Updating containerized {PlatformNameShort}
 
@@ -14,32 +14,12 @@ You have done the following:
 
 * Created a backup of your {PlatformNameShort} deployment. For more information, see xref:proc-backup-aap-container[Backing up container-based {PlatformNameShort}].
 
+* Logged in to the {RHEL} host as your dedicated non-root user.
+
+* Followed the steps in link:{URLContainerizedInstall}/aap-containerized-installation#downloading-ansible-automation-platform[Downloading {PlatformNameShort}] to download the latest version of containerized {PlatformNameShort} and copied the installation program to your {RHEL} Host.
+
 .Procedure
 
-. Download the latest version of the containerized installer from the link:{PlatformDownloadUrl}[{PlatformNameShort} download].
-
-.. For online installations *{PlatformNameShort} {PlatformVers} Containerized Setup*
-
-.. For offline or bundled installations: *{PlatformNameShort} {PlatformVers} Containerized Setup Bundle*
-
-. Copy the installation program `.tar` file onto your {RHEL} host.
-
-. Decide where you want the installation program to reside on the filesystem. Installation related files will be created under this location and require at least 10 GB for the initial installation.
-
-. Unpack the installation program `.tar` file into your installation directory, and go to the unpacked directory.
-
-.. To unpack the online installer:
-+
-----
-$ tar xfvz ansible-automation-platform-containerized-setup-<version>.tar.gz
-----
-+
-.. To unpack the offline or bundled installer:
-+ 
-----
-$ tar xfvz ansible-automation-platform-containerized-setup-bundle-<version>-<arch name>.tar.gz
-----
-+
 . Edit the `inventory` file to match your required configuration. You can keep the same parameters from your existing {PlatformNameShort} deployment or you can change the parameters to match any modifications to your environment.
 
 . Run the `install` playbook:

--- a/downstream/modules/platform/ref-configuring-inventory-file.adoc
+++ b/downstream/modules/platform/ref-configuring-inventory-file.adoc
@@ -22,6 +22,9 @@ Use the example inventory file to perform an online installation for the contain
 
 include::snippets/inventory-cont-a-env-a.adoc[]
 
+* `ansible_connection=local` -  Used for all-in-one installations where the installation program is run on the same node that hosts {PlatformNameShort}. 
+** If the installation program is run from a separate node, do not include `ansible_connection=local`. In this case, an SSH connection should be used instead. 
+
 [role="_additional-resources"]
 .Additional resources
 * For more information about the container {GrowthTopology} (all-in-one), see link:{URLTopologies}/container-topologies#infrastructure_topology_5[Container {GrowthTopology}] in _{TitleTopologies}_.

--- a/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
+++ b/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
@@ -1,15 +1,23 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="cont-aap-system-requirements"]
+[id="system-requirements"]
 
 = System requirements
 Use this information when planning your installation of containerized {PlatformNameShort}.
 
 .Prerequisites
-* Ensure a non-root user is configured on the {RHEL} host, with `sudo` or other Ansible supported privilege escalation (`sudo` is recommended). This user is responsible for the installation of containerized {PlatformNameShort}.
+* Ensure a dedicated non-root user is configured on the {RHEL} host. 
+** This user requires `sudo` or other Ansible supported privilege escalation (`sudo` is recommended) to perform administrative tasks during the installation. 
+** This user is responsible for the installation of containerized {PlatformNameShort}.
+** This user is also the service account for the containers running {PlatformNameShort}.
+
+* For managed nodes, ensure a dedicated user is configured on each node. {PlatformNameShort} connects as this user to run tasks on the node.
+** For more information about configuring a dedicated user on each node, see link:{URLContainerizedInstall}/aap-containerized-installation#preparing-the-managed-nodes-for-containerized-installation[Preparing the managed nodes for containerized installation].
+
 * For remote host installations, ensure SSH public key authentication is configured for the non-root user. For guidelines on setting up SSH public key authentication for the non-root user, see link:https://access.redhat.com/solutions/4110681[How to configure SSH public key authentication for passwordless login].
-* For self-contained (All-in-one) installations, ensure each host entry in your inventory file is configured to connect to the local machine by adding `ansible_connection=local`, for example `<hostname> ansible_connection=local`.
-* Ensure internet access  is available from the {RHEL} host if you are using the default online installation method.
+
+* Ensure internet access is available from the {RHEL} host if you are using the default online installation method.
+
 * Ensure the appropriate network ports are open if a firewall is in place. For more information about the ports to open, see link:{URLTopologies}/container-topologies[Container topologies] in _{TitleTopologies}_.
 
 [IMPORTANT]
@@ -47,4 +55,4 @@ If performing a bundled installation of the {GrowthTopology} with `hub_seed_coll
 [role="_additional-resources"]
 .Additional resources
 * For more information about the scope of coverage for each variety of database, see link:https://access.redhat.com/articles/4010491[{PlatformName} Database Scope of Coverage].
-* For more information about setting up an external database, see link:{URLContainerizedInstall}/ansible_automation_platform_containerized_installation#proc-setup-postgresql-ext-database-containerized[Setting up a customer provided (external) database].
+* For more information about setting up an external database, see link:{URLContainerizedInstall}/aap-containerized-installation#proc-setup-postgresql-ext-database-containerized[Setting up a customer provided (external) database].

--- a/downstream/modules/platform/ref-containerized-system-requirements.adoc
+++ b/downstream/modules/platform/ref-containerized-system-requirements.adoc
@@ -5,4 +5,4 @@
 = System requirements for containerized installation
 
 For system requirements for the containerized installation method of {PlatformNameShort}, see
-the link:{URLContainerizedInstall}/ansible_automation_platform_containerized_installation#system_requirements[System requirements] section of _{TitleContainerizedInstall}_.
+the link:{URLContainerizedInstall}/aap-containerized-installation#system-requirements[System requirements] section of _{TitleContainerizedInstall}_.


### PR DESCRIPTION
Backports #3493 from main to 2.5

* Update system requirements for Containerized installation

- Update the system requirements prereqs in Containerized installation
- Add a new procedure for configuring user accounts on the hosts

Containerized Installation Documentation Lacks Details on User Accounts for AAP Components

https://issues.redhat.com/browse/AAP-37230

* updates to id values