### PR TITLE
2.5 Update inventory file vars appendix for mod docs (#3521)

### DIFF
--- a/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
@@ -1,5 +1,8 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="appendix-inventory-files-vars"]
 = Inventory file variables
+
 
 The following tables contain information about the variables used in {PlatformNameShort}'s installation `inventory` files. The tables include the variables that you can use for RPM-based installation and {ContainerBase}.
 
@@ -27,3 +30,4 @@ include::platform/ref-redis-inventory-variables.adoc[leveloffset=+1]
 //include::platform/ref-sso-variables.adoc[leveloffset=+1]
 // Catalog removed for 2.4
 //include::platform/ref-catalog-variables.adoc[leveloffset=+1]
+

--- a/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-scenario.adoc
@@ -22,7 +22,7 @@ There are several supported installation scenarios for {PlatformName}. To instal
 //* xref:ref-gateway-controller-hub-eda-ext-db[Single platform gateway, {ControllerName}, {HubName}, and {EDAcontroller} node with an external (installer managed) database]
 
 .Additional resources
-For a comprehensive list of pre-defined variables used in Ansible installation inventory files, see xref:ref-ansible-inventory-variables[Ansible variables].
+For a comprehensive list of predefined variables used in installation inventory files, see link:{URLInstallationGuide}/appendix-inventory-files-vars[Inventory file variables].
 
 // Removed for install scenario consolidation AAP-17771
 // * xref:ref-single-controller-ext-installer-managed-db[Single {ControllerName} with external (installer managed) database]

--- a/downstream/modules/eda/ref-installing-eda-controller-on-aap.adoc
+++ b/downstream/modules/eda/ref-installing-eda-controller-on-aap.adoc
@@ -10,5 +10,5 @@ To prepare for installation of {EDAcontroller}, review the following information
 
 When you are ready to install the {EDAcontroller}, see the procedures in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/index[Red Hat Ansible Automation Platform Installation Guide] beginning with link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/assembly-platform-install-scenario[Chapter 3. Installing {PlatformName}].  
 
-Lastly, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#event-driven-ansible-controller_platform-install-scenario[Appendix A. 5. Event-Driven Ansible controller variables] in the {PlatformName} Installation Guide to view predefined variables for {EDAcontroller}.
+Lastly, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#event-driven-ansible-variables_platform-install-scenario[{EDAcontroller} variables] in the {PlatformName} Installation Guide to view predefined variables for {EDAcontroller}.
 

--- a/downstream/modules/hub/ref-variables-connect-hub-sso.adoc
+++ b/downstream/modules/hub/ref-variables-connect-hub-sso.adoc
@@ -5,7 +5,7 @@ If you are installing {HubName} and {RHSSO} together for the first time or you h
 
 If you are installing {HubName} and you intend to connect it to an existing externally managed {RHSSO} instance, configure the variables for externally managed {RHSSO}.
 
-For more information about these inventory variables, refer to link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#ref-hub-variables[{HubNameMain} variables] in the _{PlatformName} Installation Guide_.
+For more information about these inventory variables, refer to link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/red_hat_ansible_automation_platform_installation_guide/appendix-inventory-files-vars#hub-variables[{HubNameMain} variables] in the _{PlatformName} Installation Guide_.
 
 The following variables can be configured for both {PlatformNameShort} managed and external {RHSSO}:
 

--- a/downstream/modules/platform/con-aap-installation-on-disconnected-rhel.adoc
+++ b/downstream/modules/platform/con-aap-installation-on-disconnected-rhel.adoc
@@ -8,7 +8,7 @@ You can install {PlatformNameShort} without an internet connection by using the 
 
 .Additional Resources
 
-For a comprehensive list of pre-defined variables used in Ansible installation inventory files, see xref:ref-ansible-inventory-variables[Ansible variables].
+For a comprehensive list of predefined variables used in installation inventory files, see link:{URLInstallationGuide}/appendix-inventory-files-vars[Inventory file variables].
 
 == System requirements for disconnected installation
 

--- a/downstream/modules/platform/con-controller-additional-settings.adoc
+++ b/downstream/modules/platform/con-controller-additional-settings.adoc
@@ -8,5 +8,5 @@ For traditional virtual machine based deployments, these settings can be provide
 
 For these settings to be effective, restart the service with `automation-controller-service` restart on each node with the settings file. If the settings provided in this file are also visible in the {ControllerName} UI, then they are marked as "Read only" in the UI.
 
-For container-based installations, use `controller_extra_settings` in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables].
+For container-based installations, use `controller_extra_settings` in the link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/containerized_installation/appendix-inventory-files-vars#controller-variables[{ControllerNameStart} variables].
 The containerized version does not support `custom.py`.

--- a/downstream/modules/platform/proc-change-ssl-installer.adoc
+++ b/downstream/modules/platform/proc-change-ssl-installer.adoc
@@ -9,7 +9,7 @@ The following procedure describes how to change the SSL certificate and key in t
 
 . Copy the new SSL certificates and keys to a path relative to the {PlatformNameShort} installer.
 . Add the absolute paths of the SSL certificates and keys to the inventory file. 
-Refer to the link:{URLInstallationGuide}/appendix-inventory-files-vars#ref-controller-variables[{ControllerNameStart} variables], link:{URLInstallationGuide}/appendix-inventory-files-vars#ref-hub-variables[{HubNameStart} variables], and link:{URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller[{EDAcontroller} variables] sections of link:{LinkInstallationGuide} for guidance on setting these variables.
+Refer to the link:{URLInstallationGuide}/appendix-inventory-files-vars#controller-variables[{ControllerNameStart} variables], link:{URLInstallationGuide}/appendix-inventory-files-vars#hub-variables[{HubNameStart} variables], and link:{URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-variables[{EDAcontroller} variables] sections of link:{LinkInstallationGuide} for guidance on setting these variables.
 +
 --
 ** {ControllerNameStart}: `web_server_ssl_cert`, `web_server_ssl_key`, `custom_ca_cert`

--- a/downstream/modules/platform/ref-ansible-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-ansible-inventory-variables.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="ref-ansible-inventory-variables"]
+[id="ansible-variables"]
 
 = Ansible variables
 

--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -1,4 +1,6 @@
-[id="ref-controller-variables"]
+:_mod-docs-content-type: REFERENCE
+
+[id="controller-variables"]
 
 = {ControllerNameStart} variables
 

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -1,4 +1,6 @@
-[id="ref-database-inventory-variables"]
+:_mod-docs-content-type: REFERENCE
+
+[id="database-variables"]
 
 = Database variables
 

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -1,4 +1,7 @@
-[id="event-driven-ansible-controller"]
+:_mod-docs-content-type: REFERENCE
+
+[id="event-driven-ansible-variables"]
+
 = {EDAcontroller} variables
 
 [cols="25%,25%,30%,10%,10%",options="header"]

--- a/downstream/modules/platform/ref-gateway-controller-hub-eda-ext-db.adoc
+++ b/downstream/modules/platform/ref-gateway-controller-hub-eda-ext-db.adoc
@@ -133,4 +133,4 @@ automationgateway_pg_sslmode='prefer'
 
 -----
 .Additional resources
-For more information about these inventory variables, refer to the link:{URLInstallationGuide}/index#ref-hub-variables[{HubNameMain} variables]. 
+For more information about these inventory variables, see link:{URLInstallationGuide}/appendix-inventory-files-vars#hub-variables[{HubNameMain} variables] in the _{PlatformName} Installation Guide_.

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -1,5 +1,7 @@
+:_mod-docs-content-type: REFERENCE
 
-[id="ref-gateway-variables"]
+[id="platform-gateway-variables"]
+
 = {GatewayStart} variables
 
 [cols="25%,25%,30%,10%,10%",options="header"]

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -1,4 +1,6 @@
-[id="ref-general-inventory-variables"]
+:_mod-docs-content-type: REFERENCE
+
+[id="general-variables"]
 
 = General variables
 
@@ -260,6 +262,3 @@ Set to `false` to prevent pulling newer container images during installation.
 | `rhel8`
 
 |===
-
-
-

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -1,4 +1,6 @@
-[id="ref-hub-variables"]
+:_mod-docs-content-type: REFERENCE
+
+[id="hub-variables"]
 
 = {HubNameStart} variables
 

--- a/downstream/modules/platform/ref-images-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-images-inventory-variables.adoc
@@ -1,4 +1,6 @@
-[id="ref-images-inventory-variables"]
+:_mod-docs-content-type: REFERENCE
+
+[id="image-variables"]
 
 = Image variables
 

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -1,5 +1,6 @@
+:_mod-docs-content-type: REFERENCE
 
-[id="ref-receptor-inventory-variables"]
+[id="receptor-variables"]
 
 = Receptor variables
 

--- a/downstream/modules/platform/ref-redis-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-redis-inventory-variables.adoc
@@ -1,4 +1,6 @@
-[id="ref-redis-inventory-variables"]
+:_mod-docs-content-type: REFERENCE
+
+[id="redis-variables"]
 
 = Redis variables
 

--- a/downstream/snippets/inventory-cont-a-env-a.adoc
+++ b/downstream/snippets/inventory-cont-a-env-a.adoc
@@ -42,7 +42,7 @@ aap.example.org
 ansible_connection=local
 
 # Common variables
-# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#general-variables
 # -----------------------------------------------------
 postgresql_admin_username=postgres
 postgresql_admin_password=<set your own>
@@ -53,14 +53,14 @@ registry_password=<your RHN password>
 redis_mode=standalone
 
 # {GatewayStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-gateway-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#platform-gateway-variables
 # -----------------------------------------------------
 gateway_admin_password=<set your own>
 gateway_pg_host=aap.example.org
 gateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-controller-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#controller-variables
 # -----------------------------------------------------
 controller_admin_password=<set your own>
 controller_pg_host=aap.example.org
@@ -68,7 +68,7 @@ controller_pg_password=<set your own>
 controller_percent_memory_capacity=0.5
 
 # {HubNameStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-hub-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#hub-variables
 # -----------------------------------------------------
 hub_admin_password=<set your own>
 hub_pg_host=aap.example.org
@@ -76,7 +76,7 @@ hub_pg_password=<set your own>
 hub_seed_collections=false
 
 # {EDAcontroller}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLContainerizedInstall}/appendix-inventory-files-vars#event-driven-ansible-variables
 # -----------------------------------------------------
 eda_admin_password=<set your own>
 eda_pg_host=aap.example.org

--- a/downstream/snippets/inventory-cont-b-env-a.adoc
+++ b/downstream/snippets/inventory-cont-b-env-a.adoc
@@ -50,7 +50,7 @@ eda2.example.org
 [all:vars]
 
 # Common variables
-# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#general-variables
 # -----------------------------------------------------
 postgresql_admin_username=<set your own>
 postgresql_admin_password=<set your own>
@@ -58,7 +58,7 @@ registry_username=<your RHN username>
 registry_password=<your RHN password>
 
 # {GatewayStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-gateway-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#platform-gateway-variables
 # -----------------------------------------------------
 gateway_admin_password=<set your own>
 gateway_pg_host=externaldb.example.org
@@ -67,7 +67,7 @@ gateway_pg_username=<set your own>
 gateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-controller-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#controller-variables
 # -----------------------------------------------------
 controller_admin_password=<set your own>
 controller_pg_host=externaldb.example.org
@@ -76,7 +76,7 @@ controller_pg_username=<set your own>
 controller_pg_password=<set your own>
 
 # {HubNameStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#ref-hub-variables
+# {URLContainerizedInstall}/appendix-inventory-files-vars#hub-variables
 # -----------------------------------------------------
 hub_admin_password=<set your own>
 hub_pg_host=externaldb.example.org
@@ -85,7 +85,7 @@ hub_pg_username=<set your own>
 hub_pg_password=<set your own>
 
 # {EDAcontroller}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLContainerizedInstall}/appendix-inventory-files-vars#event-driven-ansible-variables
 # -----------------------------------------------------
 eda_admin_password=<set your own>
 eda_pg_host=externaldb.example.org

--- a/downstream/snippets/inventory-rpm-a-env-a.adoc
+++ b/downstream/snippets/inventory-rpm-a-env-a.adoc
@@ -47,7 +47,7 @@ db.example.org
 [all:vars]
 
 # Common variables
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#general-variables
 # -----------------------------------------------------
 registry_username=<your RHN username>
 registry_password=<your RHN password>
@@ -55,28 +55,28 @@ registry_password=<your RHN password>
 redis_mode=standalone
 
 # {GatewayStart}
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-gateway-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#platform-gateway-variables
 # -----------------------------------------------------
 automationgateway_admin_password=<set your own>
 automationgateway_pg_host=db.example.org
 automationgateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-controller-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#controller-variables
 # -----------------------------------------------------
 admin_password=<set your own>
 pg_host=db.example.org
 pg_password=<set your own>
 
 # {HubNameStart}
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-hub-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#hub-variables
 # -----------------------------------------------------
 automationhub_admin_password=<set your own>
 automationhub_pg_host=db.example.org
 automationhub_pg_password=<set your own>
 
 # {EDAcontroller}
-# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-variables
 # -----------------------------------------------------
 automationedacontroller_admin_password=<set your own>
 automationedacontroller_pg_host=db.example.org

--- a/downstream/snippets/inventory-rpm-a-env-b.adoc
+++ b/downstream/snippets/inventory-rpm-a-env-b.adoc
@@ -28,7 +28,7 @@ db.example.org
 [all:vars]
 
 # Common variables
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#general-variables
 # -----------------------------------------------------
 registry_username=<your RHN username>
 registry_password=<your RHN password>
@@ -36,14 +36,14 @@ registry_password=<your RHN password>
 redis_mode=standalone
 
 # {GatewayStart}
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-gateway-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#platform-gateway-variables
 # -----------------------------------------------------
 automationgateway_admin_password=<set your own>
 automationgateway_pg_host=db.example.org
 automationgateway_pg_password=<set your own>
 
 # {EDAcontroller}
-# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-variables
 # -----------------------------------------------------
 automationedacontroller_admin_password=<set your own>
 automationedacontroller_pg_host=db.example.org

--- a/downstream/snippets/inventory-rpm-b-env-a.adoc
+++ b/downstream/snippets/inventory-rpm-b-env-a.adoc
@@ -51,13 +51,13 @@ eda2.example.org
 
 [all:vars]
 # Common variables
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#general-variables
 # -----------------------------------------------------
 registry_username=<your RHN username>
 registry_password=<your RHN password>
 
 # {GatewayStart}
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-gateway-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#platform-gateway-variables
 # -----------------------------------------------------
 automationgateway_admin_password=<set your own>
 automationgateway_pg_host=<set your own>
@@ -66,7 +66,7 @@ automationgateway_pg_username=<set your own>
 automationgateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-controller-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#controller-variables
 # -----------------------------------------------------
 admin_password=<set your own>
 pg_host=<set your own>
@@ -75,7 +75,7 @@ pg_username=<set your own>
 pg_password=<set your own>
 
 # {HubNameStart}
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-hub-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#hub-variables
 # -----------------------------------------------------
 automationhub_admin_password=<set your own>
 automationhub_pg_host=<set your own>
@@ -84,7 +84,7 @@ automationhub_pg_username=<set your own>
 automationhub_pg_password=<set your own>
 
 # {EDAcontroller}
-# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-variables
 # -----------------------------------------------------
 automationedacontroller_admin_password=<set your own>
 automationedacontroller_pg_host=<set your own>

--- a/downstream/snippets/inventory-rpm-b-env-b.adoc
+++ b/downstream/snippets/inventory-rpm-b-env-b.adoc
@@ -31,13 +31,13 @@ eda3.example.org
 
 [all:vars]
 # Common variables
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-general-inventory-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#general-variables
 # -----------------------------------------------------
 registry_username=<your RHN username>
 registry_password=<your RHN password>
 
 # {GatewayStart}
-# {URLInstallationGuide}/appendix-inventory-files-vars#ref-gateway-variables
+# {URLInstallationGuide}/appendix-inventory-files-vars#platform-gateway-variables
 # -----------------------------------------------------
 automationgateway_admin_password=<set your own>
 automationgateway_pg_host=<set your own>
@@ -46,7 +46,7 @@ automationgateway_pg_username=<set your own>
 automationgateway_pg_password=<set your own>
 
 # {EDAcontroller}
-# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-controller
+# {URLInstallationGuide}/appendix-inventory-files-vars#event-driven-ansible-variables
 # -----------------------------------------------------
 automationedacontroller_admin_password=<set your own>
 automationedacontroller_pg_host=<set your own>


### PR DESCRIPTION
Backports #3521 from main to 2.5

Updating the assembly-appendix-inventory-file-vars.adoc and associated modules to adhere to modular docs best practices

Containerized installation - Assembly - Inventory file variables

https://issues.redhat.com/browse/AAP-45911