### PR TITLE
[Backport] AAP-42977 - Add service account details to Settings and Subscriptions content (#3545)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-activate.adoc
+++ b/downstream/assemblies/platform/assembly-aap-activate.adoc
@@ -6,9 +6,19 @@ ifdef::context[:parent-context: {context}]
 :context: activate-aap
 
 [role="_abstract"]
+
+Ansible subscriptions require a service account from {Console}. You must link:{BaseURL}/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[create a service account] and use the client ID and client secret to activate your subscription.  
+
+[NOTE]
+====
+If you enter your client ID and client secret but cannot locate your subscription, you might not have the correct permissions set on your service account. For more information and troubleshooting guidance for service accounts, see link:https://access.redhat.com/articles/7112649[Configure Ansible Automation Platform to authenticate through service account credentials].
+====
+
+For Red Hat Satellite, input your Satellite username and Satellite password in the fields below. 
+
 {PlatformName} uses available subscriptions or a subscription manifest to authorize the use of {PlatformNameShort}. To obtain a subscription, you can do either of the following:
 
-. Use your Red Hat customer or Satellite credentials when you launch {PlatformNameShort}.
+. Use your Red Hat service account or Satellite credentials when you launch {PlatformNameShort}.
 . Upload a subscriptions manifest file either using the {PlatformName} interface or manually in an Ansible playbook.
 
 ifndef::operationG[]

--- a/downstream/modules/platform/proc-aap-activate-with-credentials.adoc
+++ b/downstream/modules/platform/proc-aap-activate-with-credentials.adoc
@@ -3,7 +3,7 @@
 
 = Activate with credentials
 
-When {PlatformNameShort} launches for the first time, the {PlatformNameShort} Subscription screen automatically displays. You can use your Red Hat credentials to retrieve and import your subscription directly into {PlatformNameShort}.
+When {PlatformNameShort} launches for the first time, the {PlatformNameShort} Subscription screen automatically displays. You can use your Red Hat service account to retrieve and import your subscription directly into {PlatformNameShort}.
 
 [NOTE]
 ====
@@ -16,8 +16,8 @@ You are opted in for {Analytics} by default when you activate the platform on fi
 
 .Procedure
 . Log in to {PlatformName}.
-. Select *Username / password*.
-. Enter your Red Hat username and password.
+. Select *Service Account / Red Hat Satellite*.
+. Enter your *Client ID / Satellite username* and *Client secret / Satellite password*.
 . Select your subscription from the *Subscription* list.
 +
 [NOTE]

--- a/downstream/modules/platform/proc-controller-configure-subscriptions.adoc
+++ b/downstream/modules/platform/proc-controller-configure-subscriptions.adoc
@@ -4,12 +4,21 @@
 
 You can use the *Subscription* menu to view the details of your subscription, such as compliance, host-related statistics, or expiry, or you can apply a new subscription.
 
+Ansible subscriptions require a service account from {Console}. You must link:{BaseURL}/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[create a service account] and use the client ID and client secret to activate your subscription.  
+
+[NOTE]
+====
+If you enter your client ID and client secret but cannot locate your subscription, you might not have the correct permissions set on your service account. For more information and troubleshooting guidance for service accounts, see link:https://access.redhat.com/articles/7112649[Configure Ansible Automation Platform to authenticate through service account credentials].
+====
+
+For Red Hat Satellite, input your Satellite username and Satellite password in the fields below. 
+
 .Procedure
 . From the navigation panel, select {MenuSetSubscription}. The *Subscription* page is displayed.
 //[ddacosta] - Removing images but they can be added back if requested.
 //image::settings_subscription_page.png[Initial subscriptions page]
 . Click btn:[Edit subscription].
-. You can either enter your Red Hat Username and Password, or attach a current Subscription Manifest in the *Welcome* page.
+. You can either enter your service account or Satellite credentials, or attach a current Subscription Manifest in the *Welcome* page.
 //[ddacosta] - Removing images but they can be added back if requested.
 //image::subscriptions_first-page.png[Suscriptions page for password or manifest]
 . Click btn:[Next] and agree to the terms of the license agreement.


### PR DESCRIPTION
This PR backports the changes from #3545 to the 2.5 branch and includes the following:

* AAP-42977 - Add service account details to Settings and Subscriptions content

* AAP-42977 - add peer review suggestions