### PR TITLE
AAP-46576 mod docs update Chapter 1 Planning guide (#3559)

### DIFF
--- a/downstream/assemblies/platform/assembly-planning-installation.adoc
+++ b/downstream/assemblies/platform/assembly-planning-installation.adoc
@@ -1,9 +1,9 @@
-
-ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 
 [id="planning-installation"]
-= Planning your {PlatformName} installation
+ifdef::context[:parent-context: {context}]
 
+= Planning your {PlatformName} installation
 
 :context: planning
 


### PR DESCRIPTION
2.5 backport of https://github.com/ansible/aap-docs/pull/3559

https://issues.redhat.com/browse/AAP-46576

Mod docs updates for Chapter 1 Planning your installation

Files modified:
- assembly-planning-installation.adoc