### PR TITLE
Updating controller link in 2.4 planning guide

### DIFF
--- a/downstream/modules/platform/ref-postgresql-requirements.adoc
+++ b/downstream/modules/platform/ref-postgresql-requirements.adoc
@@ -38,12 +38,12 @@ For example, a playbook run every hour (24 times a day) across 250 hosts, with 2
 [NOTE]
 ====
 PostgreSQL versions older than v10 might not have ICU support. 
-You must build your PostgreSQL server with ICU support or you may encounter unexpected errors.
+You must build your PostgreSQL server with ICU support or you might meet unexpected errors.
 ====
 
 .PostgreSQL configurations
 
-Optionally, you can configure the PostgreSQL database as separate nodes that are not managed by the {PlatformName} installer. When the {PlatformNameShort} installer manages the database server, it configures the server with defaults that are generally recommended for most workloads. For more information about the settings you can use to improve database performance, see link:https://docs.ansible.com/automation-controller/latest/html/administration/performance.html#database-settings[Database Settings].
+Optionally, you can configure the PostgreSQL database as separate nodes that are not managed by the {PlatformName} installer. When the {PlatformNameShort} installer manages the database server, it configures the server with defaults that are generally recommended for most workloads. For more information about the settings you can use to improve database performance, see link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref-controller-database-settings[PostgreSQL database configuration and maintenance for automation controller].
 //-----
 //max_connections == 1024
 //shared_buffers == ansible_memtotal_mb*0.3


### PR DESCRIPTION
Dead link for database tuning in AAP 2.4 docs

https://issues.redhat.com/browse/AAP-46466

Affects `titles/aap-planning-guide`