### PR TITLE
Update Using custom TLS certs

### DIFF
--- a/downstream/modules/platform/ref-using-custom-tls-certificates.adoc
+++ b/downstream/modules/platform/ref-using-custom-tls-certificates.adoc
@@ -74,7 +74,7 @@ If any of the TLS certificates you manually provide are signed by a custom CA, y
 custom_ca_cert=<path_to_custom_ca_certificate>
 ----
 
-This is necessary for {PlatformNameShort} to trust the connections secured by these certificates, such as when configuring LDAP authentication.
+This is necessary for {PlatformNameShort} to trust the connections secured by these certificates, such as when configuring LDAPS (LDAP with TLS enabled) authentication.
 
 If you have more than one CA certificate (for example a root CA and one or more intermediate certificates), combine them into a single file.  
 


### PR DESCRIPTION
- Update "Providing a custom CA certificate" in Using custom TLS certificates to add LDAP authentication as an example use case.
- Add context about ordering of cert concat.

Affected title: /titles/aap-containerized-install

LDAPS documentation for containerized AAP

https://issues.redhat.com/browse/AAP-45940