### PR TITLE
2.5 Add assembly-gateway-licensing.adoc to Containerized installation gui…

### DIFF
--- a/downstream/titles/aap-containerized-install/master.adoc
+++ b/downstream/titles/aap-containerized-install/master.adoc
@@ -10,6 +10,8 @@ include::attributes/attributes.adoc[]
 
 include::{Boilerplate}[]
 
+include::platform/assembly-gateway-licensing.adoc[leveloffset=+1]
+
 include::platform/assembly-aap-containerized-installation.adoc[leveloffset=+1]
 
 include::platform/assembly-horizontal-scaling.adoc[leveloffset=+1]


### PR DESCRIPTION
…de (#3580)

Backports #3580 from main to 2.5

Add licensing topics to containerized install guide

https://issues.redhat.com/browse/AAP-46320