### PR TITLE
Removing incorrect formatting from controller UG

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-login.adoc
+++ b/downstream/assemblies/platform/assembly-controller-login.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type:ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 [id="assembly-controller-login"]
 
 ifdef::controller-GS[]

--- a/downstream/assemblies/platform/assembly-controller-search.adoc
+++ b/downstream/assemblies/platform/assembly-controller-search.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type:ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 
 ifdef::context[:parent-context: {context}]
 

--- a/downstream/assemblies/platform/assembly-controller-user-interface.adoc
+++ b/downstream/assemblies/platform/assembly-controller-user-interface.adoc
@@ -11,11 +11,11 @@ Access your user profile, the *About* page, view related documentation, or log o
 The navigation panel provides quick access to {ControllerName} resources, such as *Jobs*, *Templates*, *Schedules*, *Projects*, *Infrastructure*, and *Administration*.
 
 
-* xref:controller-jobs[Jobs]
-* xref:controller-job-templates[Job templates]
-* xref:controller-workflow-job-templates[Workflow job templates]
-* xref:controller-schedules[Schedules]
-* xref:controller-projects[Projects]
+* link:{URLControllerUserGuide}/controller-jobs[Jobs]
+* link:{URLControllerUserGuide}/controller-job-templates[Job templates]
+* link:{URLControllerUserGuide}/controller-workflow-job-templates[Workflow job templates]
+* link:{URLControllerUserGuide}/controller-schedules[Schedules]
+* link:{URLControllerUserGuide}/controller-projects[Projects]
 
 //You can view the activity stream for that user by clicking the btn:[Activity Stream] image:activitystream.png[activitystream,15,15] icon.
 

--- a/downstream/modules/platform/con-controller-administration.adoc
+++ b/downstream/modules/platform/con-controller-administration.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type:CONCEPT
+:_mod-docs-content-type: CONCEPT
 
 [id="con-controller-administration"]
 
@@ -8,9 +8,9 @@ The *Administration* menu provides access to the administrative options of {Cont
 From here, you can create, view, and edit:
 
 //activity stream is an unconnected procedure. It needs a home.
-* xref:assembly-controller-activity-stream[Activity Stream]
-* xref:controller-approval-nodes[Workflow Approvals]
-* xref:controller-notifications[Notifiers]
+* link:{URLControllerUserGuide}/assembly-controller-activity-stream[Activity Stream]
+* link:{URLControllerUserGuide}/controller-workflow-job-templates#controller-approval-nodes[Workflow Approvals]
+* link:{URLControllerUserGuide}/controller-notifications[Notifiers]
 * link:{URLControllerAdminGuide}/assembly-controller-management-jobs[Management Jobs]
 
 

--- a/downstream/modules/platform/con-controller-infrastructure.adoc
+++ b/downstream/modules/platform/con-controller-infrastructure.adoc
@@ -1,16 +1,16 @@
-:_mod-docs-content-type:CONCEPT
+:_mod-docs-content-type: CONCEPT
 
 [id="con-controller-infrastructure"]
 
 = Infrastructure menu
 
-The *Infrastucture* menu provides quick access to the following {ControllerName} resources:
+The *Infrastructure* menu provides quick access to the following {ControllerName} resources:
 
-* xref:assembly-controller-topology-viewer[Topology View]
-* xref:controller-inventories[Inventories]
-* xref:assembly-controller-hosts[Hosts]
-* xref:controller-instance-groups[Instance Groups]
-* xref:assembly-controller-instances[Instances]
-* xref:assembly-controller-execution-environments[Execution Environments]
-* xref:controller-credentials[Credentials]
-* xref:ref-controller-credential-types[Credential Types]
+* link:{URLControllerUserGuide}/assembly-controller-topology-viewer[Topology View]
+* link:{URLControllerUserGuide}/controller-inventories[Inventories]
+* link:{URLControllerUserGuide}/assembly-controller-hosts[Hosts]
+* link:{URLControllerUserGuide}/controller-instance-groups[Instance Groups]
+* link:{URLControllerUserGuide}/assembly-controller-instances[Instances]
+* link:{URLControllerUserGuide}/assembly-controller-execution-environments[Execution Environments]
+* link:{URLControllerUserGuide}/controller-credentials[Credentials]
+* link:{URLControllerUserGuide}/controller-credentials#ref-controller-credential-types[Credential Types]

--- a/downstream/modules/platform/con-controller-settings.adoc
+++ b/downstream/modules/platform/con-controller-settings.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type:CONCEPT
+:_mod-docs-content-type: CONCEPT
 
 [id="con-controller-settings"]
 

--- a/downstream/modules/platform/ref-controller-other-search-considerations.adoc
+++ b/downstream/modules/platform/ref-controller-other-search-considerations.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type:REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="ref-controller-other-search-considerations"]
 

--- a/downstream/modules/platform/ref-controller-search-sort.adoc
+++ b/downstream/modules/platform/ref-controller-search-sort.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type:REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="ref-controller-search-sort"]
 

--- a/downstream/modules/platform/ref-controller-search-tips.adoc
+++ b/downstream/modules/platform/ref-controller-search-tips.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type:REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="ref-controller-search-tips"]
 

--- a/downstream/modules/platform/ref-controller-search-values-related-fields.adoc
+++ b/downstream/modules/platform/ref-controller-search-values-related-fields.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type:REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="ref-controller-search-values-related-fields"]
 

--- a/downstream/modules/platform/ref-controller-values-for-search-fields.adoc
+++ b/downstream/modules/platform/ref-controller-values-for-search-fields.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type:REFERENCE
+:_mod-docs-content-type: REFERENCE
 
 [id="ref-controller-values-for-search-fields"]
 


### PR DESCRIPTION
Removing incorrect use of ":_mod-docs-content-type:"

https://issues.redhat.com/browse/AAP-46762

Affects `titles/controller-user-guide`