### PR TITLE
2.5 Update Using custom TLS certs (#3579)

### DIFF
--- a/downstream/modules/platform/ref-using-custom-tls-certificates.adoc
+++ b/downstream/modules/platform/ref-using-custom-tls-certificates.adoc
@@ -68,10 +68,16 @@ Use this method if your organization manages TLS certificates outside of {Platfo
 
 *Providing a custom CA certificate*
 
-If any of the TLS certificates you manually provided are signed by a custom CA, you must specify the CA certificate by using the following variable in your inventory file:
+If any of the TLS certificates you manually provide are signed by a custom CA, you must specify the path to the CA certificate file by using the following variable in your inventory file:
 
 ----
 custom_ca_cert=<path_to_custom_ca_certificate>
 ----
 
-If you have more than one CA certificate, combine them into a single file and reference the combined certificate with the `custom_ca_cert` variable.
+This is necessary for {PlatformNameShort} to trust the connections secured by these certificates, such as when configuring LDAPS (LDAP with TLS enabled) authentication.
+
+If you have more than one CA certificate (for example a root CA and one or more intermediate certificates), combine them into a single file.  
+
+Ensure the certificates are concatenated in the correct order, starting with the root CA followed by any intermediate CAs. 
+
+Provide the absolute path to this combined certificate file by using the `custom_ca_cert` variable.


### PR DESCRIPTION
Backports #3579 from main to 2.5
 
* Update Using custom TLS certs

- Update "Providing a custom CA certificate" in Using custom TLS certificates to add LDAP authentication as an example use case.
- Add context about ordering of cert concat.

Affected title: /titles/aap-containerized-install

LDAPS documentation for containerized AAP

https://issues.redhat.com/browse/AAP-45940

* updates based on SME feedback