### PR TITLE
AAP-45517: AAP-45517: Corrected the version no. in upgrade doc

### DIFF
--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -22,7 +22,7 @@ When upgrading from {PlatformNameShort} 2.4 to 2.5, the API endpoints for the {C
 * Verify that you have a valid subscription before upgrading from a previous version of {PlatformNameShort}. Existing subscriptions are carried over during the upgrade process. 
 * Ensure you have a backup of an {PlatformNameShort} 2.4 environment before upgrading in case any issues occur. See link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] and link:{LinkOperatorBackup} for the specific topology of the environment.
 * Ensure you capture your inventory or instance group details before upgrading.
-* Ensure you have upgraded to the latest version of {PlatformNameShort} 2.4 before upgrading your Red Hat Ansible Automation Platform.
+* Ensure you have upgraded to the latest version of {PlatformNameShort} 2.4 before upgrading your {PlatformName}.
 * Upgrades of {EDAName} version 2.4 to 2.5 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.5 are not compatible. For more information, see xref:upgrade-controller-hub-eda-unified-ui_aap-upgrading-platform[{ControllerName} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades].
 +
 If you are currently running {EDAcontroller} 2.5, it is recommended that you disable all {EDAName} activations before upgrading to ensure that only new activations run after the upgrade process is complete.

--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -22,7 +22,7 @@ When upgrading from {PlatformNameShort} 2.4 to 2.5, the API endpoints for the {C
 * Verify that you have a valid subscription before upgrading from a previous version of {PlatformNameShort}. Existing subscriptions are carried over during the upgrade process. 
 * Ensure you have a backup of an {PlatformNameShort} 2.4 environment before upgrading in case any issues occur. See link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] and link:{LinkOperatorBackup} for the specific topology of the environment.
 * Ensure you capture your inventory or instance group details before upgrading.
-* Ensure you have upgraded to {ControllerName} 2.5 or later before upgrading your {PlatformName}.  
+* Ensure you have upgraded to the latest version of {PlatformNameShort} 2.4 before upgrading your Red Hat Ansible Automation Platform.
 * Upgrades of {EDAName} version 2.4 to 2.5 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.5 are not compatible. For more information, see xref:upgrade-controller-hub-eda-unified-ui_aap-upgrading-platform[{ControllerName} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades].
 +
 If you are currently running {EDAcontroller} 2.5, it is recommended that you disable all {EDAName} activations before upgrading to ensure that only new activations run after the upgrade process is complete.

--- a/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
+++ b/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
@@ -36,7 +36,7 @@ Supported topologies described in this document assume that:
 DO NOT upgrade {EDAName} and the unified UI ({Gateway}) to the latest version of {PlatformNameShort} 2.5 without first upgrading the individual services ({ControllerName} and {HubName}) to the initial version of {PlatformNameShort} 2.5.
 ====
 
-* Ensure you have upgraded to {ControllerName} 2.5 or later before upgrading your {PlatformName}.
+* Ensure you have upgraded to the latest version of {PlatformNameShort} 2.4 before upgrading your Red Hat Ansible Automation Platform.
 
 .Procedure
 

--- a/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
+++ b/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
@@ -36,7 +36,7 @@ Supported topologies described in this document assume that:
 DO NOT upgrade {EDAName} and the unified UI ({Gateway}) to the latest version of {PlatformNameShort} 2.5 without first upgrading the individual services ({ControllerName} and {HubName}) to the initial version of {PlatformNameShort} 2.5.
 ====
 
-* Ensure you have upgraded to the latest version of {PlatformNameShort} 2.4 before upgrading your Red Hat Ansible Automation Platform.
+* Ensure you have upgraded to the latest version of {PlatformNameShort} 2.4 before upgrading your {PlatformName}.
 
 .Procedure
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-45517. 

Changes made:

- Changed "Ensure you have upgraded to automation controller 2.5 or later before upgrading your Red Hat Ansible Automation Platform." to "Ensure you have upgraded to the latest version of Ansible Automation Platform 2.4 before upgrading your Red Hat Ansible Automation Platform." in all instances. 