### PR TITLE
Add troubleshooting SSL proc to Troubleshooting guide (#3600)

### DIFF
--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-networking.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-networking.adoc
@@ -6,3 +6,5 @@
 Troubleshoot networking issues.
 
 include::troubleshooting-aap/proc-troubleshoot-subnet-conflict.adoc[leveloffset=+1]
+
+include::troubleshooting-aap/proc-troubleshoot-ssl-tls-issues.adoc[leveloffset=+1]

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-ssl-tls-issues.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-ssl-tls-issues.adoc
@@ -1,0 +1,42 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="troubleshooting-ssl-tls-issues"]
+
+= Troubleshooting SSL/TLS issues
+
+To troubleshoot issues with SSL/TLS, verify the certificate chain, use the correct certificates, and confirm that a trusted Certificate Authority (CA) signed the certificate. 
+
+.Procedure
+
+. Check if the server is reachable over SSL/TLS.
+.. Run the following command to confirm whether the server is reachable over SSL/TLS and to see the full certificate chain:
++
+----
+# true | openssl s_client -showcerts -connect <fqdn_or_ip>:<port>
+----
++
+.. Replace `<fqdn_or_ip>` and `<port>` with suitable values.
+. Verify the certificate details.
+.. Run the following command to view the details of a certificate:
++
+----
+# openssl x509 -in <path_to_certificate> -noout -text
+----
++
+. Replace `<path_to_certificate>` with the path to the certificate file you want to inspect.
++
+The result of the command shows information such as:
+
+* Subject - The entity the certificate has been issued to.
+* Issuer - The CA that issued the certificate.
+* Validity "Not Before" - The date the certificate was issued.
+* Validity "Not After" - The date the certificate expires.
++
+. Verify a trusted CA signed the certificate.
+.. Run the following command to verify that a specific certificate is valid and was signed by a trusted CA:
++
+----
+openssl verify -CAfile <path_to_ca_public_certificate> <path_to_server_certificate_file_to_verify>
+----
++
+.. If the command returns `OK`, it means the certificate file is valid and signed by a trusted CA.

--- a/downstream/titles/troubleshooting-aap/master.adoc
+++ b/downstream/titles/troubleshooting-aap/master.adoc
@@ -13,15 +13,25 @@ Use the Troubleshooting {PlatformNameShort} guide to troubleshoot your {Platform
 include::{Boilerplate}[]
 
 include::troubleshooting-aap/assembly-diagnosing-the-problem.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/assembly-troubleshoot-controller.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/assembly-troubleshoot-backup-recovery.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/assembly-troubleshoot-execution-environments.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/assembly-troubleshoot-installation.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/assembly-troubleshoot-jobs.adoc[leveloffset=+1]
+
 // Michelle - commenting out as it refers to controller UI which should no longer be accessed
 //include::troubleshooting-aap/assembly-troubleshoot-login.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/assembly-troubleshoot-networking.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/assembly-troubleshoot-playbooks.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/assembly-troubleshoot-upgrade.adoc[leveloffset=+1]
+
 // Michelle - commenting out for now as this content doesn't appear to exist anymore in a published doc
 //include::troubleshooting-aap/assembly-troubleshoot-subscriptions.adoc[leveloffset=+1]


### PR DESCRIPTION
Backports #3600 from main to 2.5 

* Add troubleshooting SSL proc to Troubleshooting guide

Adds a new procedure to the Troubleshooting guide entitled "Troubleshooting SSL/TLS issues"

Affected title: `titles/troubleshooting-aap`

Add information about troubleshooting SSL issues

https://issues.redhat.com/browse/AAP-26513

* updates based on peer review feedback