### PR TITLE
AAP-47179 (AAP-44414) Removed various screen shots from Using automation decisions guide

### DIFF
--- a/downstream/modules/eda/con-eda-rulebook-activation-list-view.adoc
+++ b/downstream/modules/eda/con-eda-rulebook-activation-list-view.adoc
@@ -8,7 +8,7 @@ If the *Status* is *Running*, it means that the rulebook activation is running i
 
 You can view more details by selecting the activation from the *Rulebook Activations* list view.
 
-//Replace this screen shot with current view
-image::eda-rulebook-activations-list-view.png[Rulebook activation][width=25px]
+//[JMSelf] Remove this image for now
+//image::eda-rulebook-activations-list-view.png[Rulebook activation][width=25px]
 
 For all activations that have run, you can view the *Details* and *History* tabs to get more information about what happened.

--- a/downstream/modules/eda/proc-eda-check-rule-audit-event-stream.adoc
+++ b/downstream/modules/eda/proc-eda-check-rule-audit-event-stream.adoc
@@ -8,6 +8,6 @@ When events have been sent and received by {EDAcontroller}, you can confirm that
 . Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuADRuleAudit}. 
 +
-If your rulebook activation received the event data from the event stream type you selected, the Rule Audit page displays the results similar to this image. 
-+
-image:eda-rule-audit-event-streams.png[Rule audit - Event stream]
+If your rulebook activation received the event data from the event stream type you selected, the Rule Audit page displays the results for *Status*, *Rulebook activation*, and the *Last fired date* fields. 
+//[JMSelf]Remove screen shot for now
+//image:eda-rule-audit-event-streams.png[Rule audit - Event stream]

--- a/downstream/modules/eda/proc-eda-set-up-credential-types.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-credential-types.adoc
@@ -77,11 +77,10 @@ The following configuration in JSON format shows each field and how they are use
 
 . Click btn:[Create credential type].
 +
-Your newly created credential type is displayed in the list of credential types:
-
+Your newly created credential type is displayed in the list of credential types.
 +
-image:credential-types-new-listed.png[New credential type]
-//[JMS] Replace image with EDA version
+//[JMS] Hide images for now
+//image:credential-types-new-listed.png[New credential type]
 
 . Click the btn:[Edit credential type] image:leftpencil.png[Edit,15,15] icon to modify the credential type options.
 +
@@ -93,10 +92,11 @@ If the *Delete* option is disabled, this means that the credential type is being
 
 .Verification
 
-* Verify that the newly created credential type can be selected from the *Credential Type* selection window when creating a new credential:
-+
-image:credential-types-new-listed-verify.png[Verify new credential type]
-//[JMS] Replace this image with up to date one, maybe?
+* Verify that the newly created credential type can be selected from the *Credential Type* list when creating a new credential.
+//[JMS] Hide images for now; outdated
+//+
+//image:credential-types-new-listed-verify.png[Verify new credential type]
+
 
 .Additional resources
 

--- a/downstream/modules/eda/proc-eda-verify-event-streams-work.adoc
+++ b/downstream/modules/eda/proc-eda-verify-event-streams-work.adoc
@@ -7,16 +7,19 @@ Verify that you can use your event stream to connect to a remote system and rece
 . Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuADEventStreams}.
 . Select the event stream that you created to validate connectivity and ensure that the event stream sends data to the rulebook activation. 
-. Verify that the events were received.You can see in the *Events received* field that the event was received. You can also see the header for the event stream that contains details about the event.
+. Verify that the events were received. The number of *Events received* is displayed along with a header that contains details about the event.
 +
+//[JMS] Replace this image with one that shows a number for the Events received field.
 image:eda-verify-event-streams.png[Verify event streams work]
 +
 If you scroll down in the UI, you can also see the body of the payload with more information about the webhook. 
 +
-image:eda-payload-body-event-streams.png[Payload body]
+The *Header* and *Body* sections for the event stream are displayed on the Details page. They differ based on the vendor who is sending the event. The header and body can be used to check the attributes in the event payload, which will help you in writing conditions in your rulebook. 
 +
-
-The *Header* and *Body* sections for the event stream are displayed on the Details page. They differ based on the vendor who is sending the event. The header and body can be used to check the attributes in the event payload,  which will help you in writing conditions in your rulebook. For example:
+//[JMSelf] Hide or maybe replace this image for now.
+//+
+//image:eda-payload-body-event-streams.png[Payload body]
++
 
 . Toggle the *Forward events to rulebook activation* option to  enable you to push your events to a rulebook activation.
 This moves the event stream to production mode and makes it easy to attach to rulebook activations.

--- a/downstream/modules/eda/proc-eda-view-activation-output.adoc
+++ b/downstream/modules/eda/proc-eda-view-activation-output.adoc
@@ -7,9 +7,9 @@ You can view the output of the activations in the *History* tab.
 .Procedure
 . Select the *History* tab to access the list of all the activation instances.
 An activation instance represents a single execution of the activation.
-. Then select the activation instance in question, this shows you the *Output* produced by that specific execution.
+. Then select the activation instance you want to view. The *Output* for the activation instance is displayed.
 
-//Replace this screenshot with current view
-image::eda-rulebook-activation-history.png[Rulebook activation history]
+//[JMSelf] Remove this screenshot due to outdated view.
+//image::eda-rulebook-activation-history.png[Rulebook activation history]
 
 To view events that came in and triggered an action, you can use the xref:eda-rule-audit[Rule Audit] section in the {EDAcontroller} Dashboard.

--- a/downstream/modules/eda/proc-eda-view-rule-audit-details.adoc
+++ b/downstream/modules/eda/proc-eda-view-rule-audit-details.adoc
@@ -4,7 +4,8 @@
 
 From the *Rule Audit* list view you can check the event that triggered specific actions.
 
-image::eda-rule-audit-list-view.png[Rule audit list view]
+//[JMSelf] Remove outdated image.
+//image::eda-rule-audit-list-view.png[Rule audit list view]
 
 .Procedure
 . From the navigation panel select *{MenuADRuleAudit}*.

--- a/downstream/modules/eda/proc-eda-view-rule-audit-events.adoc
+++ b/downstream/modules/eda/proc-eda-view-rule-audit-events.adoc
@@ -9,4 +9,5 @@
 This shows you the event that triggered actions.
 . Select an event to view the *Event log*, along with the *Source type* and *Timestamp*.
 
-image::eda-event-details.png[Event details]
+//[JMSelf] Hide/remove images and preapre for UI changes. The content should be clear without the image.
+//image::eda-event-details.png[Event details]


### PR DESCRIPTION
Removed screen shots that are outdated or might be impacted by future DEV/UI/UX changes in the following sections: 

- [Creating a new credential type](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-set-up-new-credential-types)
- [Verifying your event streams work](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-verify-event-streams) 
- [Check the Rule Audit for events on your new event stream](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-check-rule-audit-event-stream)
- [Rulebook activation list view](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-rulebook-activation-list-view)
- [Viewing activation output](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-view-activations-output)
- [Viewing rule audit details](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-view-rule-audit-details)
- [Viewing rule audit events](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-view-rule-audit-events)