### PR TITLE
Add VMware-ESXi to inventory plugin types. (#3588)

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-inventories.adoc
+++ b/downstream/assemblies/platform/assembly-controller-inventories.adoc
@@ -70,47 +70,73 @@ inventory's groups and hosts.
 
 //Smart inventories are deprecated.
 include::platform/ref-controller-smart-inventories.adoc[leveloffset=+1]
+
 include::platform/ref-controller-smart-host-filter.adoc[leveloffset=+2]
+
 //include::platform/proc-controller-define-filter-with-facts.adoc[leveloffset=+2]
+
 include::platform/ref-controller-constructed-inventories.adoc[leveloffset=+1]
 
 include::platform/ref-controller-group-name-vars-filtering.adoc[leveloffset=+2]
+
 include::platform/ref-controller-inv-debugging-tips.adoc[leveloffset=+2]
+
 include::platform/ref-controller-inv-nested-groups.adoc[leveloffset=+2]
+
 include::platform/ref-controller-inv-ansible-facts.adoc[leveloffset=+2]
+
 include::platform/ref-controller-filter-environ-variables.adoc[leveloffset=+3]
+
 include::platform/ref-controller-filter-hosts-cpu-type.adoc[leveloffset=+3]
 
 include::platform/ref-controller-inventory-plugins.adoc[leveloffset=+1]
 
 include::platform/proc-controller-adding-new-inventory.adoc[leveloffset=+1]
+
 include::platform/proc-controller-adding-inv-permissions.adoc[leveloffset=+2]
+
 include::platform/proc-controller-add-groups.adoc[leveloffset=+2]
 
 include::platform/proc-controller-add-groups-to-groups.adoc[leveloffset=+3]
+
 include::platform/ref-controller-view-edit-inv-groups.adoc[leveloffset=+3]
 
 include::platform/proc-controller-add-hosts.adoc[leveloffset=+2]
+
 include::platform/proc-controller-add-source.adoc[leveloffset=+2]
 
 include::platform/ref-controller-inventory-sources.adoc[leveloffset=+3]
+
 include::platform/proc-controller-sourced-from-project.adoc[leveloffset=+4]
+
 include::platform/proc-controller-amazon-ec2.adoc[leveloffset=+4]
+
 include::platform/proc-controller-inv-source-gce.adoc[leveloffset=+4]
+
 include::platform/proc-controller-azure-resource-manager.adoc[leveloffset=+4]
+
 include::platform/proc-controller-inv-source-vm-vcenter.adoc[leveloffset=+4]
+
+include::platform/proc-controller-inv-source-vm-esxi.adoc[leveloffset=+4]
+
 include::platform/proc-controller-inv-source-satellite.adoc[leveloffset=+4]
+
 include::platform/proc-controller-inv-source-insights.adoc[leveloffset=+4]
+
 include::platform/proc-controller-inv-source-openstack.adoc[leveloffset=+4]
+
 include::platform/proc-controller-inv-source-rh-virt.adoc[leveloffset=+4]
+
 include::platform/proc-controller-inv-source-aap.adoc[leveloffset=+4]
-//The following Terraform module is for 2.5 only:
+
 include::platform/proc-controller-inv-source-terraform.adoc[leveloffset=+4]
+
 include::platform/proc-controller-inv-source-open-shift-virt.adoc[leveloffset=+4]
 
 include::platform/ref-controller-export-old-scripts.adoc[leveloffset=+3]
 
 include::platform/ref-controller-view-completed-jobs.adoc[leveloffset=+1]
+
 include::platform/proc-controller-run-ad-hoc-commands.adoc[leveloffset=+1]
 
 //endif::controller-UG[]

--- a/downstream/assemblies/platform/assembly-controller-inventory-templates.adoc
+++ b/downstream/assemblies/platform/assembly-controller-inventory-templates.adoc
@@ -6,11 +6,11 @@ After upgrade to 4.x, existing configurations are migrated to the new format tha
 Use the following templates to aid in migrating your inventories to the new style inventory plugin output.
 
 * link:{URLControllerUserGuide}/controller-inventory-templates#controller-amazon-web-services[Amazon Web Services EC2]
-* link:{URLControllerUserGuide}/controller-inventory-templates#ccontroller-google-compute[Google Compute Engine]
+* link:{URLControllerUserGuide}/controller-inventory-templates#controller-google-compute[Google Compute Engine] 
 * link:{URLControllerUserGuide}/controller-inventory-templates#controller-microsoft-azure[Microsoft Azure Resource Manager]
 * link:{URLControllerUserGuide}/controller-inventory-templates#controller-vmware-vcenter[VMware vCenter]
-//Placemarker for VMWare ESXI
-//* link:{URLControllerUserGuide}/controller-inventory-templates#controller-vmware-esxi[VMware ESXI]
+//This is an xref because for some bizzare reason, if I use a link, all these links go to existing documentation, not within this local build. [AAP-41239-esxi]
+* xref:ref-controller-vmware-esxi[VMware ESXI]
 * link:{URLControllerUserGuide}/controller-inventory-templates#controller-rh-satellite[Red Hat Satellite 6]
 * link:{URLControllerUserGuide}/controller-inventory-templates#controller-openstack[OpenStack]
 * link:{URLControllerUserGuide}/controller-inventory-templates#controller-rh-virtualization[Red Hat Virtualization]
@@ -24,8 +24,7 @@ include::platform/ref-controller-microsoft-azure.adoc[leveloffset=+1]
 
 include::platform/ref-controller-vmware-vcenter.adoc[leveloffset=+1]
 
-//Placemarker for VMWare ESXI
-//include::platform/ref-controller-vmware-esxi.adoc[leveloffset=+1]
+include::platform/ref-controller-vmware-esxi.adoc[leveloffset=+1]
 
 include::platform/ref-controller-rh-satellite.adoc[leveloffset=+1]
 

--- a/downstream/modules/platform/proc-controller-add-source.adoc
+++ b/downstream/modules/platform/proc-controller-add-source.adoc
@@ -30,6 +30,9 @@ For more information about sources, and supplying the appropriate information, s
 . Use the *Host filter* field to specify only matching host names to be imported into {ControllerName}.
 . In the *Enabled variable* field, specify that {ControllerName} retrieves the enabled state from the dictionary of host variables.
 You can specify the enabled variable by using dot notation as 'foo.bar', in which case the lookup searches nested dictionaries, equivalent to: `from_dict.get('foo', {}).get('bar', default)`.
++
+The *Enabled value* field is ignored unless you set the *Enabled variable* field. If the enabled variable matches this value, the host is enabled on import.
+
 . If you specified a dictionary of host variables in the *Enabled variable* field, you can give a value to enable on import.
 For example, for `enabled_var='status.power_state'` and `'enabled_value='powered_on'` in the following host variables, the host is marked `enabled`:
 +
@@ -77,6 +80,7 @@ cache timeout rules) before the inventory update starts.
 +
 You can create a job template that uses an inventory that sources from the same project that the template uses.
 In such a case, the project updates and then the inventory updates (if updates are not already in progress, or if the cache timeout has not already expired).
+
 . Review your entries and selections.
 This enables you to configure additional details, such as schedules and notifications.
 . To configure schedules associated with this inventory source, click the *Schedules* tab:

--- a/downstream/modules/platform/proc-controller-inv-source-vm-esxi.adoc
+++ b/downstream/modules/platform/proc-controller-inv-source-vm-esxi.adoc
@@ -1,0 +1,32 @@
+[id="proc-controller-inv-source-vm-esxi"]
+
+= VMware ESXi
+
+Use the following procedure to configure a VMWare-ESXI sourced inventory.
+
+.Procedure
+. From the navigation panel, select {MenuInfrastructureInventories}.
+. Select the inventory name you want to add a source to, and click the *Sources* tab.
+. Click btn:[Create source].
+. Enter a *Name* for the source (required).
+. In the *Create source* page, select *VMware ESXi* from the *Source* list.
+. The *Create source* window expands with additional fields.
+Enter the following details:
+
+* *Credential*: Choose from an existing VMware credential.
+For more information, see xref:controller-credentials[Managing user credentials].
+
+. Use the *Verbosity* menu to select the level of output on any inventory source's update jobs.
+. Optional: You can specify the host filter, enabled variables or values, and update options as described in xref:proc-controller-add-source[Adding a source].
+. Use the *Source Variables* field to override variables used by the `vmware_inventory` inventory plugin.
+Enter variables by using either JSON or YAML syntax.
+Use the radio button to toggle between the two.
+
+The VMware ESxi plugin is supplied link:https://github.com/ansible-collections/vmware.vmware/blob/main/plugins/inventory/esxi_hosts.py[here].
+
+[NOTE]
+====
+VMWare properties have changed from lower case to camel case. 
+{ControllerNameStart} provides aliases for the top-level keys, but lower case keys in nested properties have been discontinued. 
+For a list of valid and supported properties, see link:https://docs.ansible.com/ansible/4/scenario_guides/vmware_scenarios/vmware_inventory_vm_attributes.html[Using Virtual machine attributes in VMware dynamic inventory plugin].
+====

--- a/downstream/modules/platform/ref-controller-inventory-plugins.adoc
+++ b/downstream/modules/platform/ref-controller-inventory-plugins.adoc
@@ -9,6 +9,7 @@ In {Controllername} v4.4, you can provide the inventory plugin configuration dir
 * xref:proc-controller-inv-source-gce[Google Compute Engine]
 * xref:proc-controller-azure-resource-manager[{Azure} Resource Manager]
 * xref:proc-controller-inv-source-vm-vcenter[VMware vCenter]
+* xref:proc-controller-inv-source-vm-esxi[VMWare ESXI]
 * xref:proc-controller-inv-source-satellite[Red Hat Satellite 6]
 * xref:proc-controller-inv-source-insights[Red Hat Insights]
 * xref:proc-controller-inv-source-openstack[OpenStack]

--- a/downstream/modules/platform/ref-controller-inventory-sources.adoc
+++ b/downstream/modules/platform/ref-controller-inventory-sources.adoc
@@ -9,6 +9,7 @@ Choose a source which matches the inventory type against which a host can be ent
 * xref:proc-controller-inv-source-gce[Google Compute Engine]
 * xref:proc-controller-azure-resource-manager[{Azure} Resource Manager]
 * xref:proc-controller-inv-source-vm-vcenter[VMware vCenter]
+* xref:proc-controller-inv-source-vm-esxi[VMware ESXi]
 * xref:proc-controller-inv-source-satellite[Red Hat Satellite 6]
 * xref:proc-controller-inv-source-insights[Red Hat Insights]
 * xref:proc-controller-inv-source-openstack[OpenStack]


### PR DESCRIPTION
* Add VMware-ESXi to inventory plugin types.

Docs : Update AAP core docs on inventory plugins

https://issues.redhat.com/browse/AAP-41239

* Add VMware-ESXi to inventory plugin types

Corrections from tech review

Docs : Update AAP core docs on inventory plugins

https://issues.redhat.com/browse/AAP-41239

* Add VMware-ESXi to inventory plugin types

Corrections

Docs : Update AAP core docs on inventory plugins

https://issues.redhat.com/browse/AAP-41239

* Add VMware-ESXi to inventory plugins

Correction

Docs : Update AAP core docs on inventory plugins

https://issues.redhat.com/browse/AAP-41239

* Add VMware-ESXi to inventory plugins

Correction to link/xref

Docs : Update AAP core docs on inventory plugins

https://issues.redhat.com/browse/AAP-41239

* Add VMware-ESXi to inventory plugin types

Corrections

Docs : Update AAP core docs on inventory plugins

https://issues.redhat.com/browse/AAP-41239