### PR TITLE
Backport-2.5-3614 Fixed broken links in Using automation decisions guide 

### DIFF
--- a/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
+++ b/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
@@ -11,7 +11,7 @@ To change this behavior, you must change the default maximum number of running r
 [NOTE]
 ====
 * The value for `MAX_RUNNING_ACTIVATIONS` does not change when you modify the instance size, so it needs to be adjusted manually.
-* If you are installing {EDAName} on {OCPShort}, the 12 rulebook activations per node is a global value since there is no concept of worker nodes when installing {EDAName} on {OCPShort}. For more information, see link:{URLOperatorInstallation}/operator-install-planning#modifying_the_number_of_simultaneous_rulebook_activations_during_or_after_event_driven_ansible_controller_installation[Modifying the number of simultaneous rulebook activations during or after {EDAcontroller} installation] in link:{LinkOperatorInstallation}.
+* If you are installing {EDAName} on {OCPShort}, the 12 rulebook activations per node is a global value since there is no concept of worker nodes when installing {EDAName} on {OCPShort}. For more information, see link:{URLOperatorInstallation}/operator-install-operator_operator-platform-doc#modifying_the_number_of_simultaneous_rulebook_activations_during_or_after_event_driven_ansible_controller_installation[Modifying the number of simultaneous rulebook activations during or after {EDAcontroller} installation] in link:{LinkOperatorInstallation}.
 ====
 
 include::proc-modifying-activations-during-install.adoc[leveloffset=+1]
@@ -19,5 +19,4 @@ include::proc-modifying-activations-after-install.adoc[leveloffset=+1]
 
 .Additional Resources 
 * For more information about rulebook activations, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/event-driven_ansible_controller_user_guide/index#eda-rulebook-activations[Rulebook activations].
-* For more information about modifying simultaneous rulebook activations during or after {EDAName} on {OCPShort}, see link:{URLOperatorInstallation}/appendix-operator-crs_performance-considerations#eda_max_running_activations[EDA_MAX_RUNNING_ACTIVATIONS].
-
+* For more information about modifying simultaneous rulebook activations during or after {EDAName} on {OCPShort}, see the example in link:{URLOperatorInstallation}/appendix-operator-crs_appendix-operator-crs#eda_max_running_activations_yml[eda_max_running_activations_yml].


### PR DESCRIPTION
Per [AAP-47128](https://issues.redhat.com/browse/AAP-47128), fixed broken links here:

- [Modifying the number of simultaneous rulebook activations](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-performance-tuning#modifying-simultaneous-activations), specifically the link in the note pointing [here](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_on_openshift_container_platform/operator-install-operator_operator-platform-doc#modifying_the_number_of_simultaneous_rulebook_activations_during_or_after_event_driven_ansible_controller_installation).
- [Modifying the number of simultaneous rulebook activations during or after Event-Driven Ansible controller installation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_on_openshift_container_platform/operator-install-operator_operator-platform-doc#modifying_the_number_of_simultaneous_rulebook_activations_during_or_after_event_driven_ansible_controller_installation), specifically the link to the [eda_max_running_activations_yml](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_on_openshift_container_platform/appendix-operator-crs_appendix-operator-crs#eda_max_running_activations_yml) example