### PR TITLE
Backport to 2.5: AAP-39301: Adds domain of interest info to getting started with AAP guide

### DIFF
--- a/downstream/assemblies/platform/assembly-gs-auto-dev.adoc
+++ b/downstream/assemblies/platform/assembly-gs-auto-dev.adoc
@@ -24,33 +24,61 @@ This guide will walk you through the basic steps to get set up as an automation 
 * Create and use job templates
 
 include::platform/con-gs-setting-up-dev-env.adoc[leveloffset=+1]
+
 include::platform/con-gs-create-automation-content.adoc[leveloffset=+1]
+
 include::platform/con-gs-define-events-rulebooks.adoc[leveloffset=+1]
+
 include::platform/con-gs-ansible-roles.adoc[leveloffset=+1]
+
 include::platform/proc-creating-ansible-role.adoc[leveloffset=+2]
+
 include::platform/con-gs-learn-about-collections.adoc[leveloffset=+1]
+
 include::platform/proc-gs-publish-to-a-collection.adoc[leveloffset=+1]
+
 include::platform/proc-gs-upload-collection.adoc[leveloffset=+2]
+
 include::platform/con-gs-execution-env.adoc[leveloffset=+1]
+
 include::platform/proc-gs-use-base-execution-env.adoc[leveloffset=+2]
+
 include::platform/proc-gs-add-ee-to-job-template.adoc[leveloffset=+2]
+
 include::platform/con-gs-build-decision-env.adoc[leveloffset=+1]
+
 include::platform/proc-gs-auto-dev-set-up-decision-env.adoc[leveloffset=+2]
+
 include::platform/proc-gs-auto-dev-create-automation-execution-proj.adoc[leveloffset=+1]
+
 include::platform/proc-gs-auto-dev-create-automation-decision-proj.adoc[leveloffset=+1]
+
 include::platform/con-gs-auto-dev-about-inv.adoc[leveloffset=+1]
 // [hherbly] this repeats module above include::platform/proc-controller-create-inventory.adoc[leveloffset=+2]
+
 include::platform/con-gs-auto-dev-job-templates.adoc[leveloffset=+1]
+
 include::platform/proc-controller-getting-started-with-job-templates.adoc[leveloffset=+2]
+
+include::platform/proc-set-domain-of-interest.adoc[leveloffset=+2]
+
 include::platform/proc-gs-auto-dev-create-template.adoc[leveloffset=+2]
 // [hherbly] incomplete module? include::platform/proc-gs-auto-dev-run-template.adoc[leveloffset=+2]
+
 include::platform/proc-controller-edit-job-template.adoc[leveloffset=+2]
+
 include::platform/con-gs-rulebook-activations.adoc[leveloffset=+1]
+
 include::platform/proc-gs-eda-set-up-rulebook-activation.adoc[leveloffset=+2]
+
 include::eda/con-eda-rulebook-activation-list-view.adoc[leveloffset=+3]
+
 include::eda/proc-eda-enable-rulebook-activations.adoc[leveloffset=+2]
+
 include::eda/proc-eda-restart-rulebook-activations.adoc[leveloffset=+2]
+
 include::eda/proc-eda-delete-rulebook-activations.adoc[leveloffset=+2]
+
 include::eda/proc-eda-activate-webhook.adoc[leveloffset=+2]
 
 ifdef::parent-context-of-assembly-gs-auto-dev[:context: {parent-context-of-assembly-gs-auto-dev}]

--- a/downstream/assemblies/platform/assembly-gs-key-functionality.adoc
+++ b/downstream/assemblies/platform/assembly-gs-key-functionality.adoc
@@ -18,16 +18,25 @@ With {PlatformNameShort}, you can create, manage, and scale automation for your 
 The release of {PlatformNameShort} {PlatformVers} introduces an updated, unified user interface (UI) that allows you to interact with and manage each part of the platform.
 
 include::snippets/snip-gateway-component-description.adoc[leveloffset=+1] 
+
 include::platform/con-gw-activity-stream.adoc[leveloffset=+1] 
 
 include::platform/con-gs-automation-execution.adoc[leveloffset=+1]
+
 include::platform/con-gs-automation-content.adoc[leveloffset=+1]
+
 include::platform/con-gs-automation-decisions.adoc[leveloffset=+1]
+
 include::platform/con-gs-automation-mesh.adoc[leveloffset=+1]
+
 include::platform/con-gs-ansible-lightspeed.adoc[leveloffset=+1]
+
 include::platform/con-gs-developer-tools.adoc[leveloffset=+1]
+
 include::platform/ref-gs-install-config.adoc[leveloffset=+1]
+
 include::platform/con-gs-dashboard-components.adoc[leveloffset=+1]
+
 include::platform/con-gs-final-set-up.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-assembly-gs-key-functionality[:context: {parent-context-of-assembly-gs-key-functionality}]

--- a/downstream/modules/platform/proc-set-domain-of-interest.adoc
+++ b/downstream/modules/platform/proc-set-domain-of-interest.adoc
@@ -1,0 +1,23 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-06-04
+:_mod-docs-content-type: PROCEDURE
+
+[id="set-domain-of-interest_{context}"]
+= Set your domains of interest
+
+With domain filtering, you can customize the content displayed in the *Jobs* and *Templates* sub-sections of Automation Execution. Jobs and templates are linked to descriptive labels. When you select a label, you can filter out less-relevant resources, giving you easy access to the resources relevant to your area of interest. 
+
+.Procedure
+
+. From the navigation panel, select {MenuAEJobs} or {MenuAETemplates}.
+. Beneath the page heading, next to *Domains*, is a list of topic-related labels. Select a label to filter jobs and job templates so that only content related to the labels is shown. You can choose more than one label. 
+. To clear your selection, click the *X*. 
+. To customize your domain options, select the image:wrench.png[Wrench,15,15] icon. In the modal that appears, select *Add Domain* to add new domains to filter with. 
+
+[NOTE]
+
+====
+
+You can add labels to your individual job templates to make the templates appear as resources when you filter with the related domain label. Navigate to {MenuAETemplates}, select your job template, and click btn:[Edit template]. On the editing screen, enter the label you want to use in the *Labels* field and click btn:[Save job template].
+
+====


### PR DESCRIPTION
This PR ports the changes from [PR 3593](https://github.com/ansible/aap-docs/pull/3593) to the 2.5 branch. This work is being tracked in [AAP-39301](https://issues.redhat.com/browse/AAP-39301).