### PR TITLE
AAP-47046: Added info. about ansible-lint error in multitask prompts

### DIFF
--- a/lightspeed/modules/proc_multi-task-recs.adoc
+++ b/lightspeed/modules/proc_multi-task-recs.adoc
@@ -21,6 +21,11 @@ For better readability, you can split your multitask inline prompts over multipl
 
 The Ansible Lightspeed service reads the text, interacts with the {ibmwatsonxcodeassistant} model, and generates the code recommendations.
 
+[NOTE]
+====
+While entering a multitask prompt, the Ansible VS Code extension might display a warning if you have long lines in your prompt based on your ansible-lint settings. This warning is a minor readability error and does not impact the quality of your code recommendation output. To resolve the error, you can either ignore it or fix it by splitting your multitask inline prompt over multiple lines.
+====
+
 .Prerequisites
 
 * You meet *one* of the following requirements:


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-47046. 

Changes made:
- Added info. about ansible-lint warning when entering multitask prompts. 