### PR TITLE
2.5 Update hub_shared_data_path to add req format (#3635)

### DIFF
--- a/downstream/modules/platform/proc-cont-aap-hub-storage.adoc
+++ b/downstream/modules/platform/proc-cont-aap-hub-storage.adoc
@@ -63,4 +63,6 @@ NFS is a type of shared storage that is supported in containerized installations
 hub_shared_data_path=<path_to_nfs_share>
 ----
 
+* The value must match the format `host:dir`, for example `nfs-server.example.com:/exports/hub`.
+
 * To change the mount options for your NFS share, use the `hub_shared_data_mount_opts` variable. This variable is optional and the default value is `rw,sync,hard`.

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -413,7 +413,7 @@ For more information about the list of parameters, see link:https://django-stora
 
 | 
 | `hub_shared_data_path` 
-| Path to the Network File System (NFS) share with read, write, and execute (RWX) access.
+| Path to the Network File System (NFS) share with read, write, and execute (RWX) access. The value must match the format `host:dir`, for example `nfs-server.example.com:/exports/hub`.
 | Required if installing more than one instance of {HubName} with a `file` storage backend. When installing a single instance of {HubName}, it is optional.
 |
 


### PR DESCRIPTION
Backports #3635  from main to 2.5.

Add the formatting requirements for hub_shared_data_path.

Affected title: titles/aap-containerized-install

Containerized installation - update hub_shared_data_path to show example format

https://issues.redhat.com/browse/AAP-43903