### PR TITLE
AAP-47091: Corrected a hyperlink to point to 2.4 docs

### DIFF
--- a/downstream/modules/platform/con-aap-upgrades.adoc
+++ b/downstream/modules/platform/con-aap-upgrades.adoc
@@ -20,7 +20,7 @@ h|Supported upgrade path h| Steps to upgrade
 
 xref:editing-inventory-file-for-updates_aap-upgrading-platform[Set up your inventory file] to match your installation environment. See link:{LinkTopologies} for a list of example inventory files.
 
-xref:con-backup-aap_aap-upgrading-platform[Back up your {PlatformNameShort} instance].
+link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index#con-backup-aap_upgrading-to-ees[Back up your {PlatformNameShort} instance].
 
 xref:proc-running-setup-script-for-updates[Run the 2.5 installation program] over your current {PlatformNameShort} instance.
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-47091.

Changes made:
Corrected a hyperlink to point to 2.4 backup instructions instead of 2.5 topic. 