### PR TITLE
Add link to ocp-b.env-a CR

### DIFF
--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -80,9 +80,9 @@ a|
 | s3 storage | HTTPS only accessible through AWS Role assigned to {HubName} SA at runtime by using AWS Pod Identity
 |====
 
-// == Example custom resource file 
+== Example custom resource file 
 
-// Use the following example custom resource (CR) to add your {PlatformNameShort} instance to your project:
+For example CR files for this topology, see the link:https://github.com/ansible/test-topologies/blob/aap-2.5/ocp-b.env-a/README.md[ocp-b.env-a] directory in the `test-topologies` GitHub repository.
 
 == Nonfunctional requirements
 


### PR DESCRIPTION
Adds a link to the test-topologies GitHub repo for ocp-b.env-a CR files

OCP Enterprise environment missing yaml example

https://issues.redhat.com/browse/AAP-41747