### PR TITLE
AAP-45856-A Updated metrics-utility content (2) (#3660)

### DIFF
--- a/downstream/modules/platform/proc-configure-a-config-map.adoc
+++ b/downstream/modules/platform/proc-configure-a-config-map.adoc
@@ -2,6 +2,8 @@
 
 = Create a ConfigMap in the OpenShift UI YAML view 
 
+To inject the `metrics-utility` cronjobs with configuration data, use the following procedure to create a ConfigMap in the OpenShift UI YAML view:
+
 .Prerequisites:
 * A running OpenShift cluster
 * An operator-based installation of {PlatformNameShort} on {OCPShort}. 

--- a/downstream/modules/platform/proc-controller-metrics-utility-ocp.adoc
+++ b/downstream/modules/platform/proc-controller-metrics-utility-ocp.adoc
@@ -2,9 +2,9 @@
 
 [id="controller-metrics-utility-ocp"]
 
-= On {OCPShort} from the {PlatformNameShort} operator
+= Configuring metrics-utility on {OCPShort} from the {PlatformNameShort} operator
 
-Metrics-utility is included in the {OCPShort} image beginning with version 4.12. 
+`metrics-utility` is included in the {OCPShort} image beginning with version 4.12, 4.512, and 4.6. 
 If your system does not have `metrics-utility` installed, update your OpenShift image to the latest version. 
 
-Complete the following steps to configure the run schedule for `metrics-utility` on {OCPShort} using the {PlatformNameShort} operator.
+Complete the following steps to configure the run schedule for `metrics-utility` on {OCPShort} using the {PlatformNameShort} operator:

--- a/downstream/modules/platform/proc-controller-metrics-utility-rhel.adoc
+++ b/downstream/modules/platform/proc-controller-metrics-utility-rhel.adoc
@@ -2,7 +2,7 @@
 
 [id="controller-metrics-utility-rhel"]
 
-= On {RHEL} 
+= Configuring metrics-utility on {RHEL} 
 
 .Prerequisites:
 
@@ -15,26 +15,33 @@ See link:https://www.redhat.com/sysadmin/linux-cron-command[How to schedule jobs
 
 .Procedure
 
-. In the cron file, set the following variables to ensure `metrics-utility` gathers the relevant data. To open the cron file for editing, run: 
+. Create two scripts in your user's home director in order to set correct variables to ensure that `metrics-utility` gathers all relevant data.
+.. In `/home/my-user/cron-gather`:
 +
 [source, ]
 ----
-crontab -e
-----
-+
-. Specify the following variables to indicate where the report is deposited in your file system:
-+
-[source, ]
-----
+#!/bin/sh
+
+# Specify the following variables to indicate where the report is deposited in your file system
 export METRICS_UTILITY_SHIP_TARGET=directory
 export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
+
+# Run the following command to gather and store the data in the provided SHIP_PATH directory:
+metrics-utility gather_automation_controller_billing_data --ship --until=10m
 ----
 +
-. Set these variables to generate a report: 
+.. In `/home/my-user/cron-report`:
 +
 [source, ]
 ----
-export METRICS_UTILITY_REPORT_TYPE=CCSP
+#!/bin/sh
+
+# Specify the following variables to indicate where the report is deposited in your file system
+export METRICS_UTILITY_SHIP_TARGET=directory
+export METRICS_UTILITY_SHIP_PATH=/awx_devel/awx-dev/metrics-utility/shipped_data/billing
+
+# Set these variables to generate a report:
+export METRICS_UTILITY_REPORT_TYPE=CCSPv2
 export METRICS_UTILITY_PRICE_PER_NODE=11.55 # in USD
 export METRICS_UTILITY_REPORT_SKU=MCT3752MO
 export METRICS_UTILITY_REPORT_SKU_DESCRIPTION="EX: Red Hat Ansible Automation Platform, Full Support (1 Managed Node, Dedicated, Monthly)"
@@ -44,21 +51,31 @@ export METRICS_UTILITY_REPORT_EMAIL="email@email.com"
 export METRICS_UTILITY_REPORT_RHN_LOGIN="test_login"
 export METRICS_UTILITY_REPORT_COMPANY_BUSINESS_LEADER="BUSINESS LEADER"
 export METRICS_UTILITY_REPORT_COMPANY_PROCUREMENT_LEADER="PROCUREMENT LEADER"
+
+# Build the report
+metrics-utility build_report
 ----
 +
-. Run the following command to gather and store the data in the provided `SHIP_PATH` directory:
-+
-[source, ]
-----
-metrics-utility gather_automation_controller_billing_data --ship --until=10m
-----
-+
-. To configure the run schedule, add the following parameters to the end of the file and specify how often you want `metrics-utility` to gather information and build a report using link:https://www.redhat.com/sysadmin/linux-cron-command[cron syntax]. In the following example, the `gather` command is configured to run every hour at 00 minutes. The `build_report` command is configured to run every second day of each month at 4:00 AM. 
+. To ensure that these files are executable, run: 
 +
 [source, ]
 ----
-0 */1 * * * metrics-utility gather_automation_controller_billing_data --ship --until=10m
-0 4 2 * *  metrics-utility build_report
+chmod a+x /home/my-user/cron-gather /home/my-user/cron-report
+----
++
+. To open the cron file for editing, run:
++
+[source, ]
+----
+crontab -e
+----
++
+. To configure the run schedule, add the following parameters to the end of the file and specify how often you want `metrics-utility` to gather information and build a report using link:https://www.redhat.com/sysadmin/linux-cron-command[cron syntax]. In the following example, the `gather` command is configured to run every hour at 00 minutes. The `build_report` command is configured to run on the second day of each month at 4:00 AM. 
++
+[source, ]
+----
+0 */1 * * * /home/my-user/cron-gather
+0 4 2 * * /home/my-user/cron-report
 ----
 +
 . Save and close the file.
@@ -69,7 +86,7 @@ metrics-utility gather_automation_controller_billing_data --ship --until=10m
 crontab -l
 ----
 +
-. You can also check the logs to ensure that data is being collected. Run: 
+. To ensure that data is being collected, run: 
 +
 [source, ]
 ----
@@ -90,11 +107,5 @@ May  8 09:46:03 ip-10-0-6-23 CROND[51669]: (root) CMDEND (metrics-utility gather
 May  8 09:46:26 ip-10-0-6-23 crontab[51659]: (root) END EDIT (root)
 ----
 +
-. Run the following command to build a report for the previous month:
-+
-[source, ]
-----
-metrics-utility build_report
-----
-+
-The generated report will have the default name CCSP-<YEAR>-<MONTH>.xlsx and will be deposited in the ship path that you specified in step 2.
+
+The generated report will have the default name CCSP-<YEAR>-<MONTH>.xlsx and will be deposited in the ship path that you specified in step 3.

--- a/downstream/modules/platform/proc-deploy-controller.adoc
+++ b/downstream/modules/platform/proc-deploy-controller.adoc
@@ -4,7 +4,7 @@
 
 = Deploy {ControllerName} 
 
-Deploy {ControllerName} and specify variables for how often `metrics-utility` gathers usage information and generates a report.
+To deploy {ControllerName} and specify variables for how often metrics-utility gathers usage information and generates a report, use the following procedure:
 
 .Procedure
 

--- a/downstream/modules/platform/proc-modifying-the-run-schedule.adoc
+++ b/downstream/modules/platform/proc-modifying-the-run-schedule.adoc
@@ -4,9 +4,11 @@
 
 [id="modifying-the-run-schedule_{context}"]
 
-= Modifying the run schedule on {RHEL}
+= Modifying the run schedule
 
-You can configure `metrics-utility` to run at specified times and intervals. Run frequency is expressed in cronjobs. See link:https://www.redhat.com/sysadmin/linux-cron-command[How to schedule jobs using the Linux ‘Cron’ utility] for more information. 
+You can configure `metrics-utility` to run at specified times and intervals. Run frequency is expressed in cronjobs. For more information on the cron utility, see link:https://www.redhat.com/sysadmin/linux-cron-command[How to schedule jobs using the Linux ‘Cron’ utility]. 
+
+To modify the run schedule on {RHEL} and on {OCPShort}, use one of the following procedures:
 
 .Procedure
  

--- a/downstream/modules/platform/ref-fetching-a-monthly-report.adoc
+++ b/downstream/modules/platform/ref-fetching-a-monthly-report.adoc
@@ -2,15 +2,20 @@
 
 = Fetching a monthly report 
 
-== On {RHEL} 
+Fetch a monthly report from {PlatformNameShort} to gather usage metrics and create a consumption-based billing report. To fetch a monthly report on {RHEL} or on {OCPShort}, use the following procedures:
 
-To fetch a monthly report on RHEL, run:
+== Fetching a monthly report on {RHEL} 
 
+Use the following procedure to fetch a monthly report on {RHEL}:
+
+.Procedure 
+
+. Run:
 `scp -r username@controller_host:$METRICS_UTILITY_SHIP_PATH/data/<YYYY>/<MM>/ /local/directory/`
 
 The system saves the generated report as `CCSP-<YEAR>-<MONTH>.xlsx` in the ship path that you specified.
 
-== On {OCPShort} from the {PlatformNameShort} Operator 
+== Fetching a monthly report on {OCPShort} from the {PlatformNameShort} Operator 
 
 Use the following playbook to fetch a monthly consumption report for {PlatformNameShort} on {OCPShort}:
 


### PR DESCRIPTION
2.5 backport of https://github.com/ansible/aap-docs/pull/3660

[AAP-45856](https://issues.redhat.com/browse/AAP-45856) [Doc] Update published subscription and metrics-utility content in configuring automation execution

Files modified:
- proc-configure-a-config-map.adoc
- proc-controller-metrics-utility-ocp.adoc
- proc-controller-metrics-utility-rhel.adoc
- proc-deploy-controller.adoc
- proc-modifying-the-run-schedule.adoc
- ref-fetching-a-monthly-report.adoc

Title:
- controller-admin-guide