### PR TITLE
Bp to 2.5: AAP-47754: updates attribute for policy settings

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -311,7 +311,7 @@
 :MenuSetJob: menu:{MenuAEAdminSettings}[Automation Execution > Job]
 :MenuSetLogging: menu:{MenuAEAdminSettings}[Automation Execution > Logging]
 :MenuSetTroubleshooting: menu:{MenuAEAdminSettings}[Automation Execution > Troubleshooting]
-:MenuSetPolicy: menu:{MenuAEAdminSettings}[Policy]
+:MenuSetPolicy: menu:{MenuAEAdminSettings}[Automation Execution > Policy]
 // Not yet implemented but look to be in the future scope 2.5-next plan
 //:MenuSetLogin: {MenuAEAdminSettings}[Log In Settings]
 //:MenuSetUI: {MenuAEAdminSettings}[User Interface Settings]


### PR DESCRIPTION
This PR ports the changes from [PR 3683](https://github.com/ansible/aap-docs/pull/3683) to the 2.5 branch. This work is being tracked in [AAP-47754](https://issues.redhat.com/browse/AAP-47754).