### PR TITLE
Backport-2.5-3688 Fixes broken link in a note in the Using automation decisions guide

### DIFF
--- a/downstream/modules/eda/proc-eda-activation-stuck-pending.adoc
+++ b/downstream/modules/eda/proc-eda-activation-stuck-pending.adoc
@@ -19,7 +19,7 @@ These logs reveal the source of the issue, such as an exception thrown by the co
 +
 [NOTE]
 ====
-To adjust the maximum number of simultaneous activations for {OperatorPlatformNameShort} on {OCPShort} deployments, see link:{URLOperatorInstallation}/operator-install-planning#modifying_the_number_of_simultaneous_rulebook_activations_during_or_after_event_driven_ansible_controller_installation[Modifying the number of simultaneous rulebook activations during or after {EDAcontroller} installation] in link:{LinkOperatorInstallation}.
+To adjust the maximum number of simultaneous activations for {OperatorPlatformNameShort} on {OCPShort} deployments, see link:{URLOperatorInstallation}/operator-install-operator_operator-platform-doc#modifying_the_number_of_simultaneous_rulebook_activations_during_or_after_event_driven_ansible_controller_installation[Modifying the number of simultaneous rulebook activations during or after {EDAcontroller} installation] in link:{LinkOperatorInstallation}.
 ====
 
 


### PR DESCRIPTION
Per broken link report, updated the link in [Chapter 8.1 Activation stuck in Pending state](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rulebook-troubleshooting#eda-activation-stuck-pending) in the note that follows step 1., iii.