### PR TITLE
backport to 2.5 AAP-47553: PaC docs add reminder to configure global and resource settings

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-pac.adoc
+++ b/downstream/assemblies/platform/assembly-controller-pac.adoc
@@ -27,6 +27,8 @@ Before you can implement policy enforcement in your {PlatformNameShort} instance
 * Configured {PlatformNameShort} with settings required for authenticating to your OPA server.
 * Some familiarity with OPA and the Rego language, which is the language policies are written in.
 
+For policy enforcement to work correctly, you must both configure the OPA server in your policy settings, and associate a specific policy with a particular resource (for example, a particular organization, inventory, or job template). 
+
 [NOTE]
 ====
 OPA API V1 is the only version currently supported in {PlatformNameShort}.

--- a/downstream/modules/platform/proc-configure-pac-enforcement.adoc
+++ b/downstream/modules/platform/proc-configure-pac-enforcement.adoc
@@ -12,3 +12,11 @@ You can associate a policy with a job template, an inventory, or an organization
 Organization:: Jobs launched from a template owned by an organization will fail if the policy is violated. This configuration provides broad control over automation within organizational boundaries.
 Inventory:: Jobs using an inventory associated with a policy fail if the policy is violated. This configuration allows you to control access to specific infrastructure resources. 
 Job template:: Jobs launched from a template associated with a policy fail if the job violates the associated policy. This configuration provides granular control over specific automation tasks. 
+
+[NOTE]
+
+====
+
+If you do not associate a policy with a resource, policy evaluation will not occur when you run the related job.
+
+====

--- a/downstream/modules/platform/proc-configure-pac-settings.adoc
+++ b/downstream/modules/platform/proc-configure-pac-settings.adoc
@@ -7,6 +7,17 @@
 
 You can specify how your {PlatformNameShort} instance interacts with OPA by modifying your global settings.
 
+.Prerequisites
+* To configure policy enforcement, you must have administrative privileges.
+
+[NOTE]
+
+====
+
+If you do not configure the OPA server in your policy settings, policy evaluation will not occur when you run the job.
+
+====
+
 .Procedure
 . From the navigation panel, select {MenuSetPolicy}.
 . Click *Edit policy settings*.
@@ -15,7 +26,7 @@ You can specify how your {PlatformNameShort} instance interacts with OPA by modi
 OPA Server hostname:: Enter the name of the host that connects to the OPA service.
 OPA server port:: Enter the port that connects to the OPA service.
 OPA authentication type:: Select the OPA authentication type.
-OPA custom authentication header:: Enter a custom header to be appended to request headers for OPA authentication.
+OPA custom authentication header:: Enter a custom header to append to request headers for OPA authentication.
 OPA request timeout:: Enter the number of seconds until the connection times out.
 OPA request retry count:: Enter a figure for the number of times a request can attempt to connect to the OPA service before failing.
 +

--- a/downstream/modules/platform/proc-controller-find-subscription.adoc
+++ b/downstream/modules/platform/proc-controller-find-subscription.adoc
@@ -8,7 +8,7 @@ If you have already added your subscription, you can update your subscription de
 
 .Prerequisite
 
-* You have link:https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[created a service account] and saved the client ID and client secret. 
+* You have link:https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[created a service account] and saved the client ID and client secret.
 
 .Procedure
 


### PR DESCRIPTION
This PR ports the changes from [PR 3664](https://github.com/ansible/aap-docs/pull/3664) to the 2.5 branch. This work is being tracked in [AAP-47553](https://issues.redhat.com/browse/AAP-47553). 