### PR TITLE
Bp to 2.5: AAP-47884: updates requirements for using service account to add subscription

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-activate.adoc
+++ b/downstream/assemblies/platform/assembly-aap-activate.adoc
@@ -7,7 +7,9 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-Ansible subscriptions require a service account from {Console}. You must link:{BaseURL}/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[create a service account] and use the client ID and client secret to activate your subscription.  
+If you are an organization administrator, Ansible subscriptions require a service account from {Console}. You must link:{BaseURL}/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[create a service account] and use the client ID and client secret to activate your subscription.
+
+If you do not have administrative access, you can enter your Red Hat username and password in the Client ID and Client secret fields, respectively, to locate and add your subscription to your {PlatformNameShort} instance.
 
 [NOTE]
 ====
@@ -18,7 +20,7 @@ For Red Hat Satellite, input your Satellite username and Satellite password in t
 
 {PlatformName} uses available subscriptions or a subscription manifest to authorize the use of {PlatformNameShort}. To obtain a subscription, you can do either of the following:
 
-. Use your Red Hat service account or Satellite credentials when you launch {PlatformNameShort}.
+. Use your Red Hat username and password, service account credentials, or Satellite credentials when you launch {PlatformNameShort}.
 . Upload a subscriptions manifest file either using the {PlatformName} interface or manually in an Ansible playbook.
 
 ifndef::operationG[]

--- a/downstream/modules/platform/proc-aap-activate-with-credentials.adoc
+++ b/downstream/modules/platform/proc-aap-activate-with-credentials.adoc
@@ -3,7 +3,9 @@
 
 = Activate with credentials
 
-When {PlatformNameShort} launches for the first time, the {PlatformNameShort} Subscription screen automatically displays. You can use your Red Hat service account to retrieve and import your subscription directly into {PlatformNameShort}.
+When {PlatformNameShort} launches for the first time, the {PlatformNameShort} Subscription screen automatically displays. If you are an organization administrator, you can use your Red Hat service account to retrieve and import your subscription directly into {PlatformNameShort}.
+
+If you do not have administrative access, you can enter your Red Hat username and password in the Client ID and Client secret fields, respectively, to locate and add your subscription to your {PlatformNameShort} instance.
 
 [NOTE]
 ====

--- a/downstream/modules/platform/proc-controller-find-subscription.adoc
+++ b/downstream/modules/platform/proc-controller-find-subscription.adoc
@@ -6,9 +6,18 @@ When you log in to {PlatformNameShort} for the first time, you must add your sub
 
 If you have already added your subscription, you can update your subscription details in the platform by going to {MenuSetSubscription} → btn:[Edit subscription].
 
-.Prerequisite
+.Prerequisites
 
-* You have link:https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[created a service account] and saved the client ID and client secret.
+* You are an organization administrator.
+* You have link:https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/proc-ciam-svc-acct-overview-creating-service-acct#proc-ciam-svc-acct-create-creating-service-acct[created a service account] and saved the client ID and client secret. 
+
+
+[NOTE]
+
+====
+
+If you do not have administrative access, you can enter your Red Hat username and password in the Client ID and Client secret fields, respectively, to locate and add your subscription to your {PlatformNameShort} instance.
+====
 
 .Procedure
 


### PR DESCRIPTION
This PR ports the changes from[ PR 3686 ](https://github.com/ansible/aap-docs/pull/3686)to the 2.5 branch. This work is being tracked in [AAP-47884](https://issues.redhat.com/browse/AAP-47884).