### PR TITLE
Update default backup dir location

### DIFF
--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -57,4 +57,4 @@ This backs up the important data deployed by the containerized installer such as
 * Configuration files
 * Data files
 
-By default, the backup directory is set to `~/backups`. You can change this by using the `backup_dir` variable in your `inventory` file.
+By default, the backup directory is set to `./backups`. You can change this by using the `backup_dir` variable in your `inventory` file.

--- a/downstream/modules/platform/proc-restore-aap-container.adoc
+++ b/downstream/modules/platform/proc-restore-aap-container.adoc
@@ -26,4 +26,4 @@ This restores the important data deployed by the containerized installer such as
 * Configuration files
 * Data files
 
-By default, the backup directory is set to `~/backups`. You can change this by using the `backup_dir` variable in your `inventory` file.
+By default, the backup directory is set to `./backups`. You can change this by using the `backup_dir` variable in your `inventory` file.


### PR DESCRIPTION
Default backup/restore directory is "~/backups" instead of "./backups"

https://issues.redhat.com/browse/AAP-47250