### PR TITLE
Correct broken link in Containerized installation

### DIFF
--- a/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
+++ b/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
@@ -56,4 +56,4 @@ If performing a bundled installation of the {GrowthTopology} with `hub_seed_coll
 [role="_additional-resources"]
 .Additional resources
 * For more information about the scope of coverage for each variety of database, see link:https://access.redhat.com/articles/4010491[{PlatformName} Database Scope of Coverage].
-* For more information about setting up an external database, see link:{URLContainerizedInstall}/aap-containerized-installation#proc-setup-postgresql-ext-database-containerized[Setting up a customer provided (external) database].
+* For more information about setting up an external database, see link:{URLContainerizedInstall}/aap-containerized-installation#setting-up-a-customer-provided-external-database[Setting up a customer provided (external) database].


### PR DESCRIPTION
Corrects a broken link in the system requirements section of Containerized installation

https://issues.redhat.com/browse/DOCS-2807