### PR TITLE
AAP-46216 Modular and migration compliance for Using automation decisions, chapter 3

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-credential-types.adoc
+++ b/downstream/assemblies/eda/assembly-eda-credential-types.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: <ASSEMBLY>
 [id="eda-credential-types"]
 
 = Credential types
@@ -11,5 +12,10 @@ For more information, see xref:eda-custom-credential-types[Custom credential typ
 
 
 include::eda/con-custom-credential-types.adoc[leveloffset=+1]
+
+include::eda/con-credential-types-input-config.adoc[leveloffset=+2]
+
+include::eda/con-credential-types-injector-config.adoc[leveloffset=+2]
+
 include::eda/proc-eda-set-up-credential-types.adoc[leveloffset=+1]
 

--- a/downstream/modules/eda/con-credential-types-injector-config.adoc
+++ b/downstream/modules/eda/con-credential-types-injector-config.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: <CONCEPT>
+[id="eda-cred-types-injector-config"]
+
+= Injector Configuration
+
+You can use Injector configuration to extract information from Input configuration fields and map them into injector types that can be sent to ansible-rulebook when running a rulebook activation. {EDAName} supports the following types of injectors: 
+
+* Environment variables (`env`) - Used in source plugins for the underlying package or shared library.
+* Ansible extra variables (`extra_vars`) - Used for substitution in the rulebook conditions, actions or source plugin parameters.
+* File-based templating (`file`) - Used to create file contents from the credential inputs such as certificates and keys, which might be required by source plugins. File injectors provide a way to deliver these certificates and keys to ansible-rulebook at runtime without having to store them in decision environments. As a result, ansible-rulebook creates temporary files and the file names can be accessed using `eda.filename` variables, which are automatically created for you after the files have been created (for instance,  "{{eda.filename.my_cert}}”).
+
+[IMPORTANT]
+====
+When creating `extra_vars` in rulebook activations and credential type injectors, avoid using `eda` or `ansible` as key names since that conflicts with internal usage and might cause failure in both rulebook activations and credential type creation.
+====
+
+Injectors enable you to adjust the fields so that they can be injected into a rulebook as one of the above-mentioned injector types, which cannot have duplicate keys at the top level. If you have two sources in a rulebook that both require parameters such as username and password, the injectors, along with the rulebook, help you adapt the arguments for each source.
+
+To view a sample injector and input, see the following GitHub gists, respectively:
+
+* link:https://gist.github.com/mkanoor/f080648917377da870bb002d4563294d[credential injectors]
+* link:https://gist.github.com/mkanoor/04c32b20addb7898af299a9254a46e61#file-gssapi-input-credential-type[gssapi input credential type]

--- a/downstream/modules/eda/con-credential-types-input-config.adoc
+++ b/downstream/modules/eda/con-credential-types-input-config.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: <CONCEPT>
+[id="eda-cred-types-input-config"]
+
+= Input Configuration
+
+The Input configuration has two attributes:
+
+* fields - a collection of properties for a credential type.
+* required - a list of required fields.
+
+Fields can have multiple properties, depending on the credential type you select.
+
+.Input Configuration Field Properties
+[cols="a,a,a"]
+|===
+| Fields | Description | Mandatory (Y/N)
+
+h| id | Unique id of the field; must be a string type and stores the variable name | Yes
+
+h| type | Can be string or boolean type | No, default is string
+
+h| label | Used by the UI when rendering the UI element | Yes
+
+h| secret | Will be encrypted | No, default false
+
+h| multiline | If the field contains data from a file the multiline can be set to True | No, default false
+
+h| help_text | The help text associated with this field | No
+
+|===

--- a/downstream/modules/eda/con-custom-credential-types.adoc
+++ b/downstream/modules/eda/con-custom-credential-types.adoc
@@ -4,9 +4,11 @@
 
 As a system administrator, you can define a custom credential type that works in ways similar to existing credential types in a standard format using a YAML or JSON-like definition. 
 
-Each credential type displays its own unique configurations in the Input Configuration field and the Injector Configuration field, if applicable. Custom credentials support Ansible extra variables as a means of injecting their authentication information. 
+Each credential type displays its own unique configurations in the *Input Configuration* and the *Injector Configuration* fields, if applicable. Both YAML and JSON formats are supported in the configuration fields. 
 
-You can attach one or more cloud, vault, and {PlatformName} credentials to a rulebook activation. 
+Custom credentials support Ansible extra variables as a means of injecting their authentication information. 
+
+You can attach one or more cloud, vault, and {PlatformName} credential types to a rulebook activation. 
 
 [NOTE]
 ====
@@ -15,57 +17,5 @@ You can attach one or more cloud, vault, and {PlatformName} credentials to a rul
 * You must have System administrator (superuser) permissions to be able to create and edit a credential type and to be able to view the *Injector configuration* field.
 ====
 
-When you customize your own credential types, they will display on the Credential Types page along with a list of built-in credential types.
+When you customize your own credential types, they display on the Credential Types page along with a list of built-in credential types.
 
-Each credential type displays its own unique configurations in the Input Configuration and the Injector Configuration fields, if applicable. Both YAML and JSON formats are supported in the configuration fields.
-//Note from J. Self: REVIEWERS, please confirm the Note above along with the paragraph about attachning one SSH and multiple clouds to a job template. I copied this from automation controller content, but not entirely sure it's relevant to EDA.
-
-[discrete]
-== Input Configuration
-
-The Input configuration has two attributes:
-
-* fields - a collection of properties for a credential type.
-* required - a list of required fields.
-
-Fields can have multiple properties, depending on the credential type you select.
-
-.Input Configuration Field Properties
-[cols="a,a,a"]
-|===
-| Fields | Description | Mandatory (Y/N)
-
-h| id | Unique id of the field; must be a string type and stores the variable name | Yes
-
-h| type | Can be string or boolean type | No, default is string
-
-h| label | Used by the UI when rendering the UI element | Yes
-
-h| secret | Will be encrypted | No, default false
-
-h| multiline | If the field contains data from a file the multiline can be set to True | No, default false
-
-h| help_text | The help text associated with this field | No
-
-|===
-
-[discrete]
-== Injector Configuration
-
-You can use Injector configuration to extract information from Input configuration fields and map them into injector types that can be sent to ansible-rulebook when running a rulebook activation. {EDAName} supports the following types of injectors: 
-
-* Environment variables (`env`) - Used in source plugins for the underlying package or shared library.
-* Ansible extra variables (`extra_vars`) - Used for substitution in the rulebook conditions, actions or source plugin parameters.
-* File-based templating (`file`) - Used to create file contents from the credential inputs such as certificates and keys, which might be required by source plugins. File injectors provide a way to deliver these certificates and keys to ansible-rulebook at runtime without having to store them in decision environments. As a result, ansible-rulebook creates temporary files and the file names can be accessed using `eda.filename` variables, which are automatically created for you after the files have been created (for instance,  "{{eda.filename.my_cert}}”).
-
-[IMPORTANT]
-====
-When creating `extra_vars` in rulebook activations and credential type injectors, avoid using `eda` or `ansible` as key names since that conflicts with internal usage and might cause failure in both rulebook activations and credential type creation.
-====
-
-Injectors enable you to adjust the fields so that they can be injected into a rulebook as one of the above-mentioned injector types, which cannot have duplicate keys at the top level. If you have two sources in a rulebook that both require parameters such as username and password, the injectors, along with the rulebook, help you adapt the arguments for each source.
-
-To view a sample injector and input, see the following GitHub gists, respectively:
-
-* link:https://gist.github.com/mkanoor/f080648917377da870bb002d4563294d[credential injectors]
-* link:https://gist.github.com/mkanoor/04c32b20addb7898af299a9254a46e61#file-gssapi-input-credential-type[gssapi input credential type]

--- a/downstream/modules/eda/con-custom-credential-types.adoc
+++ b/downstream/modules/eda/con-custom-credential-types.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: <CONCEPT>
 [id="eda-custom-credential-types"]
 
 = Custom credential types

--- a/downstream/modules/eda/proc-eda-set-up-credential-types.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-credential-types.adoc
@@ -1,9 +1,9 @@
+:_mod-docs-content-type: <PROCEDURE>
 [id="eda-set-up-new-credential-types"]
 
 = Creating a new credential type
 
 You can create a credential type to use with a source plugin that you select based on the supported, default credential types. You can make your credential type available to a team or individuals.
-
 
 .Procedure
 
@@ -83,12 +83,6 @@ Your newly created credential type is displayed in the list of credential types.
 //image:credential-types-new-listed.png[New credential type]
 
 . Click the btn:[Edit credential type] image:leftpencil.png[Edit,15,15] icon to modify the credential type options.
-+
-[NOTE]
-====
-On the *Edit* page, you can modify the details or delete the credential.
-If the *Delete* option is disabled, this means that the credential type is being used by a credential, and you must delete the credential type from all the credentials that use it before you can delete it. 
-====
 
 .Verification
 
@@ -97,6 +91,9 @@ If the *Delete* option is disabled, this means that the credential type is being
 //+
 //image:credential-types-new-listed-verify.png[Verify new credential type]
 
+.Next steps
+* On the *Edit* page, you can modify the details or delete the credential.
+* If the *Delete* option is disabled, this means that the credential type is being used by a credential, and you must delete the credential type from all the credentials that use it before you can delete it.
 
 .Additional resources
 


### PR DESCRIPTION
Prepped [Chapter 3. Credential types](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credential-types) in the Using automation decisions guide for migration compliance. 

- Includes removing the **Input configuration** and **Injector configuration** discrete headings from the conceptual topic and adding the content to two new conceptual modules that align 1 level beneath the "Custom credential types" topic.