### PR TITLE
2.5 Correct inventory var typo (#3735)

### DIFF
--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -144,7 +144,7 @@
 | `eda_pg_port` 
 | Port number for the PostgreSQL database used by {EDAName}.
 | Optional
-| `5342`
+| `5432`
 
 | `automationedacontroller_pg_sslmode` 
 | `eda_pg_sslmode` 


### PR DESCRIPTION
Backports #3735  from main to 2.5

[DOC]Request to fix "A.5. Event-Driven Ansible controller variables" section

https://issues.redhat.com/browse/AAP-48479