### PR TITLE
2.5 Update ansible-core version reqs for containerized AAP (#3676)

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -8,9 +8,9 @@
 :CentralAuth: central authentication
 :PlatformVers: 2.5
 :PostgresVers: PostgreSQL 15
-//The Ansible-core version required to install AAP
-:CoreInstVers: 2.16
-//The Ansible-core version used by the AAP control plane and EEs
+//The ansible-core version used to install AAP
+:CoreInstVers: 2.14
+//The ansible-core version used by the AAP control plane and EEs
 :CoreUseVers: 2.16
 :PlatformDownloadUrl: https://access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.5/x86_64/product-software
 :BaseURL: https://docs.redhat.com/en/documentation

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -20,7 +20,7 @@ a|
 * {RHEL} 8.8 or later minor versions of {RHEL} 8
 * {RHEL} 9.2 or later minor versions of {RHEL} 9 | {PlatformName} are also supported on OpenShift, see link:{LinkOperatorInstallation} for more information.
 h| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power) |
-h| Ansible-core | Ansible-core version {CoreInstVers} or later | {PlatformNameShort} uses the system-wide ansible-core package to install the platform, but uses ansible-core {CoreUseVers} for both its control plane and built-in execution environments.
+h| Ansible-core | Ansible-core version {CoreUseVers} or later | {PlatformNameShort} uses the system-wide ansible-core package to install the platform, but uses ansible-core {CoreUseVers} for both its control plane and built-in execution environments.
 h| Browser | A currently supported version of Mozilla Firefox or Google Chrome. |
 h| Database | {PostgresVers} | {PlatformName} {PlatformVers} requires the external (customer supported) databases to have ICU support.
 |====
@@ -71,5 +71,5 @@ The following are necessary for you to work with project updates and collections
 [NOTE]
 ====
 You must use Ansible-core, which is installed via dnf.
-Ansible-core version {CoreInstVers} is required for versions {PlatformVers} and later.
+Ansible-core version {CoreUseVers} is required for versions {PlatformVers} and later.
 ====

--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -53,7 +53,7 @@ a|
 * Version: 4.14
 * num_of_control_nodes: 1
 * num_of_worker_nodes: 1 
-| Ansible-core | Ansible-core version {CoreInstVers} or later
+| Ansible-core | Ansible-core version {CoreUseVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome.
 | Database | {PostgresVers}
 |====

--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -51,7 +51,7 @@ Red{nbsp}Hat has tested the following configurations to install and run {Platfor
 a| 
 * Red Hat OpenShift on AWS Hosted Control Planes 4.15.16
 ** 2 worker nodes in different availability zones (AZs) at t3.xlarge
-| Ansible-core | Ansible-core version {CoreInstVers} or later
+| Ansible-core | Ansible-core version {CoreUseVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome.
 | AWS RDS PostgreSQL service 
 a|

--- a/downstream/snippets/cont-tested-system-config.adoc
+++ b/downstream/snippets/cont-tested-system-config.adoc
@@ -2,14 +2,35 @@
 .System configuration
 [options="header"]
 |====
-| Type | Description 
+| Type | Description | Notes
 | Subscription 
 a| 
 * Valid {PlatformName} subscription
 * Valid {RHEL} subscription (to consume the BaseOS and AppStream repositories)
-| Operating system | {RHEL} 9.2 or later minor versions of {RHEL} 9
-| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
-| Ansible-core | Ansible-core version {CoreInstVers} or later
-| Browser | A currently supported version of Mozilla Firefox or Google Chrome.
-| Database | {PostgresVers}
+|
+
+| Operating system 
+| {RHEL} 9.2 or later minor versions of {RHEL} 9
+| 
+
+| CPU architecture 
+| x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
+|
+
+| `ansible-core` 
+a| 
+* For the installation: `ansible-core` version {CoreInstVers}. 
+* For {PlatformNameShort} operation: `ansible-core` version {CoreUseVers}.
+a| 
+* The installation program uses the `ansible-core` {CoreInstVers} package from the RHEL 9 AppStream repository. 
+* {PlatformNameShort} bundles `ansible-core` version {CoreUseVers} for its operation, so you do not need to install it manually.
+
+| Browser 
+| A currently supported version of Mozilla Firefox or Google Chrome.
+|
+
+| Database 
+| {PostgresVers}
+|
+
 |====

--- a/downstream/snippets/rpm-env-a-tested-system-config.adoc
+++ b/downstream/snippets/rpm-env-a-tested-system-config.adoc
@@ -9,7 +9,7 @@ a|
 * {RHEL} 8.8 or later minor versions of {RHEL} 8. 
 * {RHEL} 9.2 or later minor versions of {RHEL} 9.
 | CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power)
-| Ansible-core | Ansible-core version {CoreInstVers} or later
+| Ansible-core | Ansible-core version {CoreUseVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}
 |====

--- a/downstream/snippets/rpm-env-b-tested-system-config.adoc
+++ b/downstream/snippets/rpm-env-b-tested-system-config.adoc
@@ -9,7 +9,7 @@ a|
 * {RHEL} 8.8 or later minor versions of {RHEL} 8. 
 * {RHEL} 9.2 or later minor versions of {RHEL} 9.
 | CPU architecture | x86_64, AArch64
-| Ansible-core | Ansible-core version {CoreInstVers} or later
+| Ansible-core | Ansible-core version {CoreUseVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome
 | Database | {PostgresVers}
 |====


### PR DESCRIPTION
Backports #3676 from main to 2.5

* Update ansible-core version reqs for containerized AAP

Add clarity about the ansible-core version requirements in Containerized installation.

Affected title: titles/aap-containerized-install

[Docs]Documentation gives mixed messages about ansible-core version for install

https://issues.redhat.com/browse/AAP-47449

* Updates based on SME feedback