### PR TITLE
Bp to 2.5: AAP-48159: fixes incorrect module reference in include statement (#3752)

### DIFF
--- a/downstream/assemblies/platform/assembly-gs-auto-dev.adoc
+++ b/downstream/assemblies/platform/assembly-gs-auto-dev.adoc
@@ -47,7 +47,7 @@ include::platform/con-gs-about-builder.adoc[leveloffset=+2]
 
 include::platform/proc-gs-add-ee-to-job-template.adoc[leveloffset=+2]
 
-include::platform/proc-gs-about-container-registries.adoc[leveloffset=+2]
+include::platform/ref-gs-about-container-registries.adoc[leveloffset=+2]
 
 include::platform/con-gs-build-decision-env.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR ports the change from PR 3752 to the 2.5 branch. This work is being tracked in [AAP-48159](https://issues.redhat.com/browse/AAP-48159).