### PR TITLE
2.5 Update CONT RHEL requirements (#3746)

### DIFF
--- a/downstream/snippets/cont-tested-system-config.adoc
+++ b/downstream/snippets/cont-tested-system-config.adoc
@@ -10,7 +10,10 @@ a|
 |
 
 | Operating system 
-| {RHEL} 9.2 or later minor versions of {RHEL} 9
+
+a| 
+* {RHEL} 9.2 or later minor versions of {RHEL} 9.
+* {RHEL} 10 or later minor versions of {RHEL} 10 for enterprise topologies.
 | 
 
 | CPU architecture 

--- a/downstream/titles/release-notes/async/aap-25-20250702.adoc
+++ b/downstream/titles/release-notes/async/aap-25-20250702.adoc
@@ -153,6 +153,8 @@ With this update, the following CVEs have been addressed:
 
 * Validate that nodes are configured with at least 16G of RAM.(AAP-47542)
 
+* Containerized {PlatformNameShort} now supports RHEL 10 for enterprise topologies.(AAP-47083)
+
 === Bug Fixes
 
 * Fixed an issue where the TLS Certificate Authority (CA) certificate for Receptor mesh configuration when providing TLS certificates were not signed by the internal CA.(AAP-48065)


### PR DESCRIPTION
Backports #3746  from main to 2.5 

Update the Operating system section of system requirements for the Containerized installer for RHEL 10

Update containerized AAP 2.5 documentation for RHEL 10 support

https://issues.redhat.com/browse/AAP-47083

add release note entry