### PR TITLE
2.5 Correct broken link in Troubleshooting AAP (#3755)

### DIFF
--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-backup-recovery.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-backup-recovery.adoc
@@ -5,4 +5,4 @@
 
 * For information about performing a backup and recovery of {PlatformNameShort}, see link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] in _{TitleControllerAdminGuide}_.
 
-* For information about troubleshooting backup and recovery for installations of {OperatorPlatformNameShort} on {OCPShort}, see the link:{URLOperatorBackup}/aap-troubleshoot-backup-recover[Troubleshooting] section in _{TitleOperatorBackup}_.
+* For information about troubleshooting backup and recovery for installations of {OperatorPlatformNameShort} on {OCPShort}, see the link:{URLOperatorBackup}/assembly-aap-troubleshoot-backup-recover[Troubleshooting] section in _{TitleOperatorBackup}_.


### PR DESCRIPTION
Backports #3755 from main to 2.5

Corrects broken link in Backup and recovery section of Troubleshooting AAP guide

Broken links report June 23 2025

https://issues.redhat.com/browse/AAP-48710