### PR TITLE
bp to 2.5: AAP-45907: removes mentions of feature flag from PaC docs (#3654)

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-pac.adoc
+++ b/downstream/assemblies/platform/assembly-controller-pac.adoc
@@ -22,7 +22,7 @@ OPA, or link:https://www.openpolicyagent.org/docs/latest/[Open Policy Agent], is
 
 Before you can implement policy enforcement in your {PlatformNameShort} instance, you must have: 
 
-* An {PlatformNameShort} 2.5 deployment with the `FEATURE_POLICY_AS_CODE_ENABLED` feature flag set to `TRUE`.
+// * An {PlatformNameShort} 2.5 deployment with the `FEATURE_POLICY_AS_CODE_ENABLED` feature flag set to `TRUE`.
 * Access to an OPA server that is reachable from your {PlatformNameShort} deployment.
 * Configured {PlatformNameShort} with settings required for authenticating to your OPA server.
 * Some familiarity with OPA and the Rego language, which is the language policies are written in.
@@ -34,7 +34,7 @@ For policy enforcement to work correctly, you must both configure the OPA server
 OPA API V1 is the only version currently supported in {PlatformNameShort}.
 ====
 
-include::platform/proc-enable-pac.adoc[leveloffset=+1]
+// include::platform/proc-enable-pac.adoc[leveloffset=+1]
 
 include::platform/proc-configure-pac-settings.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR ports the changes from [PR 3654](https://github.com/ansible/aap-docs/pull/3654) to the 2.5 branch. This work is being tracked in [AAP-45907](https://issues.redhat.com/browse/AAP-45907).