### PR TITLE
2.5 AAP-47431 Devtools pre-migration updates (#3796)

### DIFF
--- a/downstream/assemblies/devtools/assembly-creating-playbook-project.adoc
+++ b/downstream/assemblies/devtools/assembly-creating-playbook-project.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="creating-playbook-project"]
 
 = Creating a playbook project

--- a/downstream/assemblies/devtools/assembly-developer-workflow.adoc
+++ b/downstream/assemblies/devtools/assembly-developer-workflow.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="developer-workflow"]
 
 = Workflow for developing automation content

--- a/downstream/assemblies/devtools/assembly-devtools-create-roles-collection.adoc
+++ b/downstream/assemblies/devtools/assembly-devtools-create-roles-collection.adoc
@@ -31,18 +31,23 @@ You can add existing standalone roles to a collection, or add new roles to it.
 Push the collection to source control and configure credentials for the repository in {PlatformNameShort}. 
 
 include::devtools/con-devtools-plan-roles-collection.adoc[leveloffset=+1]
+
 include::devtools/con-devtools-roles-collection-prerequisites.adoc[leveloffset=+1]
 
 include::devtools/proc-devtools-scaffold-roles-collection.adoc[leveloffset=+1]
 
 include::devtools/proc-devtools-migrate-existing-roles-collection.adoc[leveloffset=+1]
+
 include::devtools/proc-devtools-create-new-role-in-collection.adoc[leveloffset=+1]
+
 include::devtools/proc-devtools-docs-roles-collection.adoc[leveloffset=+1]
 
 // include::devtools/proc-devtools-run-roles-collection.adoc[leveloffset=+1]
+
 // include::devtools/proc-devtools-molecule-test-roles-collection.adoc[leveloffset=+1]
 
 include::devtools/proc-devtools-publish-roles-collection-pah.adoc[leveloffset=+1]
+
 include::devtools/proc-devtools-use-roles-collections-aap.adoc[leveloffset=+2]
 
 ifdef::parent-context-of-devtools-create-roles-collection[:context: {parent-context-of-devtools-create-roles-collection}]

--- a/downstream/assemblies/devtools/assembly-devtools-install.adoc
+++ b/downstream/assemblies/devtools/assembly-devtools-install.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-assembly-devtools-install: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="installing-devtools"]
 
 = Installing {ToolsName}
@@ -13,12 +14,19 @@ You can install this option on MacOS, Windows, and Linux systems.
 * Installation on your local RHEL system using an RPM (Red Hat Package Manager) package.
 
 include::devtools/con-devtools-requirements.adoc[leveloffset=+1]
+
 include::devtools/proc-devtools-install-podman-desktop-wsl.adoc[leveloffset=+2]
+
 include::devtools/proc-devtools-setup-registry-redhat-io.adoc[leveloffset=+2]
+
 include::devtools/proc-devtools-install-vsc.adoc[leveloffset=+2]
+
 include::devtools/proc-devtools-install-vscode-extension.adoc[leveloffset=+2]
+
 include::devtools/proc-devtools-extension-settings.adoc[leveloffset=+2]
+
 include::devtools/proc-devtools-extension-set-language.adoc[leveloffset=+2]
+
 include::devtools/proc-devtools-ms-dev-containers-ext.adoc[leveloffset=+2]
 
 include::devtools/proc-devtools-install-container.adoc[leveloffset=+1]

--- a/downstream/assemblies/devtools/assembly-devtools-intro.adoc
+++ b/downstream/assemblies/devtools/assembly-devtools-intro.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="devtools-intro"]
 
 = {ToolsName}

--- a/downstream/assemblies/devtools/assembly-publishing-playbook-collection-aap.adoc
+++ b/downstream/assemblies/devtools/assembly-publishing-playbook-collection-aap.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="publishing-playbook-collection-aap"]
 
 = Publishing and running your playbooks in {PlatformNameShort}
@@ -10,6 +11,7 @@ ifdef::context[:parent-context: {context}]
 The following procedures describe how to deploy your new playbooks in your instance of {PlatformNameShort} so that you can use them to run automation jobs.
 
 include::devtools/proc-devtools-save-scm.adoc[leveloffset=+1]
+
 include::devtools/proc-devtools-create-aap-job.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/devtools/assembly-rhdh-example.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-example.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-example_{context}"]
 
 = Example: Automate Red Hat Enterprise Linux firewall configuration
@@ -12,9 +13,13 @@ As an infrastructure engineer new to Ansible, you have been tasked to create a p
 The following procedures show you how to use the Ansible plug-ins and Dev Spaces to develop a playbook.
 
 include::devtools/proc-rhdh-firewall-example-learn.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-firewall-example-discover.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-firewall-example-create-playbook.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-firewall-example-new-playbook.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-firewall-example-edit.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/devtools/assembly-rhdh-feedback.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-feedback.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-feedback_{context}"]
 
 = Providing feedback in the Ansible plug-ins

--- a/downstream/assemblies/devtools/assembly-rhdh-install-ocp-helm.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-install-ocp-helm.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-rhdh-install-ocp-helm: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-install-ocp-helm_{context}"]
 
 = Installing the Ansible plug-ins with a Helm chart on {OCPShort}
@@ -23,18 +24,25 @@ You do not have to make all the changes to these files in a single session.
 ====
 
 include::devtools/con-rhdh-install-ocp-prereqs.adoc[leveloffset=+1]
+
 include::devtools/con-rhdh-recommended-preconfig.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-download-plugins.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-create-plugin-registry.adoc[leveloffset=+1]
+
 
 // Required config
 include::assembly-rhdh-ocp-required-installation.adoc[leveloffset=+1]
+
 //
 // Optional config 
 include::assembly-rhdh-ocp-configure-optional.adoc[leveloffset=+1]
+
 //
 // Full example configuration
 include::assembly-rhdh-ocp-full-examples.adoc[leveloffset=+1]
+
 //
 
 ifdef::parent-context-of-rhdh-install-ocp-helm[:context: {parent-context-of-rhdh-install-ocp-helm}]

--- a/downstream/assemblies/devtools/assembly-rhdh-install-ocp-operator.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-install-ocp-operator.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-rhdh-install-ocp-operator: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-install-ocp-operator_{context}"]
 
 = Installing the {AAPRHDHShort} with the Operator on {OCPShort}
@@ -8,6 +9,7 @@ ifdef::context[:parent-context-of-rhdh-install-ocp-operator: {context}]
 The following procedures describe how to install {AAPRHDHShort} in {RHDH} instances on {OCP} using the Operator.
 
 include::devtools/con-rhdh-install-ocp-prereqs.adoc[leveloffset=+1]
+
 include::devtools/con-rhdh-recommended-preconfig.adoc[leveloffset=+1]
 
 // Add sidecar container to the base configmap of for the rhdh deployment
@@ -15,24 +17,32 @@ include::devtools/proc-rhdh-operator-add-sidecar-container.adoc[leveloffset=+1]
 
 // Plug-in registry
 include::devtools/proc-rhdh-download-plugins.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-create-plugin-registry.adoc[leveloffset=+1]
 
 // Install the dynamic plug-ins
 include::devtools/proc-rhdh-install-dynamic-plugins-operator.adoc[leveloffset=+1]
+
 //
 // Add dynamic plug-ins to rhaap-dynamic-plugins-config
 // Replace the following to reuse Helm config:
 // include::devtools/proc-rhdh-operator-install-add-plugins-app-config.adoc[leveloffset=+1]
 
 include::devtools/proc-rhdh-add-custom-configmap.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-configure-devtools-server.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-configure-aap-details.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-add-plugin-software-templates.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-configure-rbac.adoc[leveloffset=+1]
+
 include::assembly-rhdh-ocp-configure-optional.adoc[leveloffset=+1]
 
 // Full example configuration
 include::devtools/ref-rhdh-full-aap-configmap-example.adoc[leveloffset=+1]
+
 //
 
 ifdef::parent-context-of-rhdh-install-ocp-operator[:context: {parent-context-of-rhdh-install-ocp-operator}]

--- a/downstream/assemblies/devtools/assembly-rhdh-intro.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-intro.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-intro_{context}"]
 
 = {AAPRHDH}
@@ -7,8 +8,11 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 
 include::devtools/ref-rhdh-about-rhdh.adoc[leveloffset=+1]
+
 include::devtools/ref-rhdh-about-plugins.adoc[leveloffset=+1]
+
 include::devtools/ref-rhdh-architecture.adoc[leveloffset=+1]
+
 // include::devtools/ref-devtools-components.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/devtools/assembly-rhdh-ocp-configure-optional.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-ocp-configure-optional.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-rhdh-ocp-configure-optional: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-ocp-configure-optional_{context}"]
 
 = Optional configuration for Ansible plug-ins
@@ -7,8 +8,11 @@ ifdef::context[:parent-context-of-rhdh-ocp-configure-optional: {context}]
 [role="_abstract"]
 
 include::devtools/proc-rhdh-enable-rhdh-authentication.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-configure-optional-integrations.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-configure-devspaces.adoc[leveloffset=+2]
+
 include::devtools/proc-rhdh-configure-pah-url.adoc[leveloffset=+2]
 
 ifdef::parent-context-of-rhdh-ocp-configure-optional[:context: {parent-context-of-rhdh-ocp-configure-optional}]

--- a/downstream/assemblies/devtools/assembly-rhdh-ocp-full-examples.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-ocp-full-examples.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-rhdh-ocp-full-examples: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-ocp-full-examples_{context}"]
 
 = Full examples
@@ -8,6 +9,7 @@ ifdef::context[:parent-context-of-rhdh-ocp-full-examples: {context}]
 
 
 include::devtools/ref-rhdh-full-aap-configmap-example.adoc[leveloffset=+1]
+
 include::devtools/ref-rhdh-full-helm-chart-ansible-plugins.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-rhdh-ocp-full-examples[:context: {parent-context-of-rhdh-ocp-full-examples}]

--- a/downstream/assemblies/devtools/assembly-rhdh-ocp-required-installation.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-ocp-required-installation.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-rhdh-ocp-required-installation: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-ocp-required-installation_{context}"]
 
 = Required configuration
@@ -7,14 +8,23 @@ ifdef::context[:parent-context-of-rhdh-ocp-required-installation: {context}]
 [role="_abstract"]
 
 include::devtools/proc-rhdh-add-plugin-config.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-devtools-sidecar.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-add-pull-secret-helm.adoc[leveloffset=+2]
+
 include::devtools/proc-rhdh-add-devtools-container.adoc[leveloffset=+2]
+
 include::devtools/proc-rhdh-add-custom-configmap.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-configure-devtools-server.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-configure-aap-details.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-configure-showcase-location.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-add-plugin-software-templates.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-configure-rbac.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-rhdh-ocp-required-installation[:context: {parent-context-of-rhdh-ocp-required-installation}]

--- a/downstream/assemblies/devtools/assembly-rhdh-subscription-warnings.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-subscription-warnings.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-rhdh-subscription-warnings: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-subscription-warnings_{context}"]
 
 = Ansible plug-ins subscription warning messages
@@ -15,9 +16,13 @@ The Ansible plug-ins display a subscription warning banner in the user interface
 * xref:rhdh-warning-invalid-aap-subscription_rhdh-subscription-warnings[Invalid Ansible Automation Platform subscription]
 
 include::devtools/proc-rhdh-warning-unable-connect-aap.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-warning-unable-authenticate-aap.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-warning-invalid-aap-config.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-warning-aap-ooc.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-warning-invalid-aap-subscription.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-rhdh-subscription-warnings[:context: {parent-context-of-rhdh-subscription-warnings}]

--- a/downstream/assemblies/devtools/assembly-rhdh-telemetry-capturing.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-telemetry-capturing.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-rhdh-telemetry-capturing: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-configure-telemetry_{context}"]
 
 = {RHDH} data telemetry capturing

--- a/downstream/assemblies/devtools/assembly-rhdh-uninstall-ocp-helm.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-uninstall-ocp-helm.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-assembly-rhdh-uninstall-ocp-helm: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-uninstall-ocp-helm_{context}"]
 
 = Uninstalling the Ansible plug-ins from a Helm installation on {OCPShort}

--- a/downstream/assemblies/devtools/assembly-rhdh-uninstall-ocp-operator.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-uninstall-ocp-operator.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-assembly-rhdh-uninstall-ocp-operator: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-uninstall-ocp-operator{context}"]
 
 = Uninstalling an Operator installation on {OCPShort}

--- a/downstream/assemblies/devtools/assembly-rhdh-upgrade-ocp-helm.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-upgrade-ocp-helm.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-assembly-rhdh-upgrade-ocp-helm: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-upgrade-ocp-helm_{context}"]
 
 = Upgrading the Ansible plug-ins on a Helm installation on {OCPShort}
@@ -9,7 +10,9 @@ ifdef::context[:parent-context-of-assembly-rhdh-upgrade-ocp-helm: {context}]
 To upgrade the Ansible plug-ins, you must update the `plugin-registry` application with the latest Ansible plug-ins files.
 
 include::devtools/proc-rhdh-download-plugins.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-update-plugin-registry.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-update-plugins-helm-version-numbers.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-assembly-rhdh-upgrade-ocp-helm[:context: {parent-context-of-assembly-rhdh-upgrade-ocp-helm}]

--- a/downstream/assemblies/devtools/assembly-rhdh-upgrade-ocp-operator.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-upgrade-ocp-operator.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context-of-assembly-rhdh-upgrade-ocp-operator: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-upgrade-ocp-operator_{context}"]
 
 = Upgrading the Ansible plug-ins on an Operator installation on {OCPShort}
@@ -9,7 +10,9 @@ ifdef::context[:parent-context-of-assembly-rhdh-upgrade-ocp-operator: {context}]
 To upgrade the Ansible plug-ins, you must update the `plugin-registry` application with the latest Ansible plug-ins files.
 
 include::devtools/proc-rhdh-download-plugins.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-update-plugin-registry.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-update-plugins-operator-version-numbers.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-assembly-rhdh-upgrade-ocp-operator[:context: {parent-context-of-assembly-rhdh-upgrade-ocp-operator}]

--- a/downstream/assemblies/devtools/assembly-rhdh-using.adoc
+++ b/downstream/assemblies/devtools/assembly-rhdh-using.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="rhdh-using_{context}"]
 
 = Using the Ansible plug-ins
@@ -19,13 +20,21 @@ link:https://developers.redhat.com/learn[developers.redhat.com/learn].
 To access the Learning Paths, you must have a Red{nbsp}Hat account and you must be able to log in to link:https://developers.redhat.com[developers.redhat.com].
 
 include::devtools/ref-rhdh-dashboard.adoc[leveloffset=+1]
+
 include::devtools/ref-rhdh-learning.adoc[leveloffset=+1]
+
 include::devtools/ref-rhdh-discover-collections.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-create.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-view.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-develop-projects.adoc[leveloffset=+1]
+
 include::devtools/proc-rhdh-develop-projects-devspaces.adoc[leveloffset=+2]
+
 include::devtools/proc-rhdh-execute-automation-devspaces.adoc[leveloffset=+2]
+
 include::devtools/proc-rhdh-set-up-controller-project.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/devtools/assembly-self-service-accessing-deployment.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-accessing-deployment.adoc
@@ -17,7 +17,9 @@ endif::[]
 :context: self-service-accessing-deployment
 
 include::devtools/proc-self-service-add-deployment-url-oauth-app.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-sign-in.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-sync-frequency.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-accessing-deployment[:context: {parent-context-of-self-service-accessing-deployment}]

--- a/downstream/assemblies/devtools/assembly-self-service-create-ocp-registry.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-create-ocp-registry.adoc
@@ -17,6 +17,7 @@ endif::[]
 :context: self-service-create-ocp-registry
 
 include::devtools/proc-self-service-download-tar.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-setup-registry-image.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-create-ocp-registry[:context: {parent-context-of-self-service-create-ocp-registry}]

--- a/downstream/assemblies/devtools/assembly-self-service-create-ocp-secrets.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-create-ocp-secrets.adoc
@@ -20,7 +20,9 @@ Before installing the chart, you must create a set of secrets in your OpenShift 
 The {SelfServiceShort} Helm chart fetches environment variables from OpenShift secrets. 
 
 include::devtools/proc-self-service-create-ocp-auth-secrets.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-create-scm-secrets.adoc[leveloffset=+1]
+
 
 ifdef::parent-context-of-self-service-create-ocp-secrets[:context: {parent-context-of-self-service-create-ocp-secrets}]
 ifndef::parent-context-of-self-service-create-ocp-secrets[:!context:]

--- a/downstream/assemblies/devtools/assembly-self-service-deregister-templates.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-deregister-templates.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="self-service-deregister-templates{context}"]
 
 = Deregistering templates
@@ -6,6 +7,7 @@ ifdef::context[:parent-context: {context}]
 :context: self-service-deregister-templates
 
 include::devtools/proc-self-service-deregister-dynamic-templates.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-deregister-preinstalled-templates.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/devtools/assembly-self-service-feedback.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-feedback.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="self-service-feedback_{context}"]
 
 = Providing feedback in {SelfServiceShort}

--- a/downstream/assemblies/devtools/assembly-self-service-generate-scm-tokens.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-generate-scm-tokens.adoc
@@ -17,6 +17,7 @@ endif::[]
 :context: self-service-generate-scm-tokens
 
 include::devtools/proc-self-service-create-gh-pat.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-create-gl-pat.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-generate-scm-tokens[:context: {parent-context-of-self-service-generate-scm-tokens}]

--- a/downstream/assemblies/devtools/assembly-self-service-helm-install.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-helm-install.adoc
@@ -17,7 +17,9 @@ endif::[]
 :context: self-service-helm-install
 
 include::devtools/proc-self-service-install-helm-from-catalog.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-install-verify.adoc[leveloffset=+1]
+
 // include::devtools/zzz[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-helm-install[:context: {parent-context-of-self-service-helm-install}]

--- a/downstream/assemblies/devtools/assembly-self-service-ocp-project.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-ocp-project.adoc
@@ -24,6 +24,7 @@ Alternatively, you can create the project in the {OCPShort} console.
 For more about {OCPShort} projects, see the _link:{BaseURL}/openshift_container_platform/{OCPLatest}/html/building_applications/projects#working-with-projects[Building applications]_ guide in the {OCPShort} documentation.
 
 include::devtools/proc-self-service-ocp-project-setup.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-ocp-project-setup-ui.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-new-ocp-project[:context: {parent-context-of-self-service-new-ocp-project}]

--- a/downstream/assemblies/devtools/assembly-self-service-preinstall-config.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-preinstall-config.adoc
@@ -17,11 +17,17 @@ endif::[]
 :context: self-service-preinstall-config
 
 include::devtools/proc-self-service-create-oauth-app.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-generate-oauth-token.adoc[leveloffset=+1]
+
 include::assembly-self-service-generate-scm-tokens.adoc[leveloffset=+1]
+
 include::assembly-self-service-ocp-project.adoc[leveloffset=+1]
+
 include::assembly-self-service-create-ocp-registry.adoc[leveloffset=+1]
+
 include::assembly-self-service-create-ocp-secrets.adoc[leveloffset=+1]
+
 // include::devtools/zzz[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-preinstall-config[:context: {parent-context-of-self-service-preinstall-config}]

--- a/downstream/assemblies/devtools/assembly-self-service-rbac.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-rbac.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="self-service-rbac_{context}"]
 
 = Working with RBAC
@@ -6,6 +7,7 @@ ifdef::context[:parent-context: {context}]
 :context: self-service-rbac
 
 include::devtools/proc-self-service-set-up-rbac.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-verify-rbac.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/devtools/assembly-self-service-scm-credentials-private-repos.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-scm-credentials-private-repos.adoc
@@ -27,6 +27,7 @@ See _link:{LinkSelfServiceInstall}_ for more information.
 ====
 
 include::devtools/proc-self-service-add-scm-credentials-aap.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-share-credentials-aap.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-using-scm-credentials-private-repos[:context: {parent-context-of-self-service-using-scm-credentials-private-repos}]

--- a/downstream/assemblies/devtools/assembly-self-service-using-repo-setup.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-using-repo-setup.adoc
@@ -17,7 +17,9 @@ endif::[]
 :context: self-service-using-repo-setup
 
 include::devtools/proc-self-service-export-collection-pah.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-create-collection-repo.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-create-pattern-loader-repo.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-using-repo-setup[:context: {parent-context-of-self-service-using-repo-setup}]

--- a/downstream/assemblies/devtools/assembly-self-service-view-deployment.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-view-deployment.adoc
@@ -19,7 +19,9 @@ endif::[]
 You can inspect the deployment logs and ConfigMap on the OpenShift UI to verify that the deployment conforms with the settings in your Helm chart.
 
 include::devtools/proc-self-service-view-deployment-logs.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-view-configmap.adoc[leveloffset=+1]
+
 // include::devtools/zzz[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-view-deployment[:context: {parent-context-of-self-service-view-deployment}]

--- a/downstream/assemblies/devtools/assembly-self-service-working-templates.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-working-templates.adoc
@@ -17,6 +17,7 @@ endif::[]
 :context: self-service-working-templates
 
 include::devtools/proc-self-service-add-template.adoc[leveloffset=+1]
+
 include::devtools/proc-self-service-launch-template.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-self-service-working-templates[:context: {parent-context-of-self-service-working-templates}]

--- a/downstream/assemblies/devtools/assembly-writing-running-playbook.adoc
+++ b/downstream/assemblies/devtools/assembly-writing-running-playbook.adoc
@@ -1,4 +1,5 @@
 ifdef::context[:parent-context_of_writing-running-playbook: {context}]
+:_mod-docs-content-type: ASSEMBLY
 [id="writing-running-playbook_{context}"]
 
 = Writing and running a playbook with {ToolsName}
@@ -7,14 +8,23 @@ ifdef::context[:parent-context_of_writing-running-playbook: {context}]
 [role="_abstract"]
 
 include::devtools/proc-devtools-set-up-ansible-config.adoc[leveloffset=+1]
+
 include::devtools/proc-devtools-writing-first-playbook.adoc[leveloffset=+1]
+
 include::devtools/proc-devtools-inspect-playbook.adoc[leveloffset=+1]
-include::devtools/proc-devtools-run-playbook-extension.adoc[leveloffset=+1]
-include::devtools/proc-devtools-extension-run-ansible-playbook.adoc[leveloffset=+2]
-include::devtools/proc-devtools-extension-run-ansible-navigator.adoc[leveloffset=+2]
-include::devtools/proc-devtools-working-with-ee.adoc[leveloffset=+2]
+
 include::devtools/proc-debugging-playbook.adoc[leveloffset=+1]
+
+include::devtools/proc-devtools-run-playbook-extension.adoc[leveloffset=+1]
+
+include::devtools/proc-devtools-extension-run-ansible-playbook.adoc[leveloffset=+2]
+
+include::devtools/proc-devtools-extension-run-ansible-navigator.adoc[leveloffset=+2]
+
+include::devtools/proc-devtools-working-with-ee.adoc[leveloffset=+2]
+
 include::devtools/proc-devtools-testing-playbook.adoc[leveloffset=+1]
+
 
 ifdef::parent-context_of_writing-running-playbook[:context: {parent-context_of_writing-running-playbook}]
 ifndef::parent-context_of_writing-running-playbook[:!context:]

--- a/downstream/modules/devtools/con-devtools-requirements.adoc
+++ b/downstream/modules/devtools/con-devtools-requirements.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: CONCEPT
+
 [id="devtools-requirements_{context}"]
 
 = Requirements
@@ -16,7 +18,7 @@ xref:devtools-ms-dev-containers-ext_installing-devtools[Installing and configuri
 [NOTE]
 ====
 The installation procedure for {ToolsName} on Windows covers the use of Podman Desktop only.
-See xref:devtools-install-podman-desktop-wsl_installing-devtools#installing_podman_desktop_on_a_windows_machine[Installing Podman Desktop on a Windows machine].
+See link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/developing_automation_content/index#devtools-install-podman-desktop-wsl_installing-devtools[Requirements for Ansible development tools on Windows].
 ====
 * You have a Red Hat account and you can log in to the Red Hat container registry at `registry.redhat.io`.
 For information about logging in to `registry.redhat.io`, see

--- a/downstream/modules/devtools/proc-debugging-playbook.adoc
+++ b/downstream/modules/devtools/proc-debugging-playbook.adoc
@@ -1,11 +1,12 @@
 [id="debugging-playbook_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Debugging your playbook
 
-== Error messages
+Learn how to use {VSCode} to identify and understand error messages in playbooks.
 
-The following playbook contains multiple errors:
-
+. The following playbook contains multiple errors. Copy and paste it into a new file in {VSCode}.
++
 ----
 - name:
   hosts: localhost 
@@ -13,16 +14,16 @@ The following playbook contains multiple errors:
    - name: 
      ansible.builtin.ping:
 ----
-
++
 The errors are indicated with a wavy underline in {VSCode}.
-Hover your mouse over an error to view the details:
-
+. Hover your mouse over an error to view the details:
++
 image::ansible-lint-errors.png[Popup message explaining a playbook error]
-
-The errors are listed in the *Problems* tab of the {VSCode} terminal.
-Playbook files that contain errors are indicated with a number in the *Explorer* pane:
-
+. Playbook files that contain errors are indicated with a number in the *Explorer* pane.
+. Select the *Problems* tab of the {VSCode} terminal to view a list of the errors.
++
 image::ansible-lint-errors-explorer.png[Playbook errors shown in Problems tab and explorer list]
++
+`$[0].tasks[0].name None is not of type 'string'` indicates that the playbook does not have a label. 
 
-`$[0].tasks[0].name None is not of type 'string'` indicates that the playbook does not have a label.  
 

--- a/downstream/modules/devtools/proc-devtools-create-aap-job.adoc
+++ b/downstream/modules/devtools/proc-devtools-create-aap-job.adoc
@@ -1,4 +1,5 @@
 [id="create-aap-job_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Running your playbook in {PlatformNameShort}
 

--- a/downstream/modules/devtools/proc-devtools-docs-roles-collection.adoc
+++ b/downstream/modules/devtools/proc-devtools-docs-roles-collection.adoc
@@ -3,35 +3,30 @@
 [id="devtools-docs-roles-collection_{context}"]
 = Adding documentation for your roles collection
 
-It is important to provide documentation for your roles so that other users understand what your roles do and how to use them. 
+It is important to provide documentation for your roles and roles collection, so that other users understand what your roles do and how to use them. 
 
-== Documenting your roles
-
-When you scaffolded your collection directory, a `README.md` file was added in the role directory.
-Add your documentation for your role in this file.
-Provide the following information in the `README.md` files for every role in your collection:
-
-* Role description: A brief summary of what the role does
-* Requirements: List the collections, libraries, and required installations
-* Dependencies 
-* Role variables: Provide the following information about the variables your role uses.
-**  Description
-**  Defaults
-**  Example values
-**  Required variables
-* Example playbook: Show an example of a playbook that uses your role.
+. To add documentation for a role, navigate to the role directory.
+. Open the `README.md` file in an editor.
+This file was added in the role directory when you scaffolded your collection directory.
+. Provide the following information in the `README.md` files for every role in your collection:
+** Role description: A brief summary of what the role does
+** Requirements: List the collections, libraries, and required installations
+** Dependencies 
+** Role variables: Provide the following information about the variables your role uses.
+***  Description
+***  Defaults
+***  Example values
+***  Required variables
+** Example playbook: Show an example of a playbook that uses your role.
 Use comments in the playbook to help users understand where to set variables.
-
-The `README.md` file in link:https://github.com/redhat-cop/controller_configuration/tree/devel/roles/ad_hoc_command_cancel[`controller_configuration.ad_hoc_command_cancel`] is an example of a role with standard documentation:
-
-== Documenting your collection
-
-In the `README.md` file for your collection, provide the following information:
-
-* Collection description: Describe what the collection does.
-* Requirements: List required collections.
-* List the roles as a component of the collection.
-* Using the collection: Describe how to run the components of the collection.
-* Add a troubleshooting section.
-* Versioning: Describe the release cycle of your collection.
++
+The `README.md` file in link:https://github.com/redhat-cop/controller_configuration/tree/devel/roles/ad_hoc_command_cancel[`controller_configuration.ad_hoc_command_cancel`] is an example of a role with standard documentation.
+. To add documentation for your roles collection, navigate to the collection directory.
+. In the `README.md` file for your collection, provide the following information:
+** Collection description: Describe what the collection does.
+** Requirements: List required collections.
+** List the roles as a component of the collection.
+** Using the collection: Describe how to run the components of the collection.
+** Add a troubleshooting section.
+** Versioning: Describe the release cycle of your collection.
 

--- a/downstream/modules/devtools/proc-devtools-extension-run-ansible-navigator.adoc
+++ b/downstream/modules/devtools/proc-devtools-extension-run-ansible-navigator.adoc
@@ -1,4 +1,5 @@
 [id="extension-run-ansible-navigator_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Running your playbook with `ansible-navigator`
 

--- a/downstream/modules/devtools/proc-devtools-extension-run-ansible-playbook.adoc
+++ b/downstream/modules/devtools/proc-devtools-extension-run-ansible-playbook.adoc
@@ -1,4 +1,5 @@
 [id="extension-run-ansible-playbook_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Running your playbook with `ansible-playbook`
 

--- a/downstream/modules/devtools/proc-devtools-extension-set-language.adoc
+++ b/downstream/modules/devtools/proc-devtools-extension-set-language.adoc
@@ -1,4 +1,5 @@
 [id="devtools-extension-set-language_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Associating the Ansible language to YAML files
 

--- a/downstream/modules/devtools/proc-devtools-extension-settings.adoc
+++ b/downstream/modules/devtools/proc-devtools-extension-settings.adoc
@@ -1,4 +1,5 @@
 [id="devtools-extension-settings_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Configuring Ansible extension settings
 

--- a/downstream/modules/devtools/proc-devtools-inspect-playbook.adoc
+++ b/downstream/modules/devtools/proc-devtools-inspect-playbook.adoc
@@ -1,24 +1,16 @@
 [id="inspect-playbook_context_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Inspecting your playbook
 
 [role="_abstract"]
-The Ansible {VSCode} extension provides syntax highlighting and assists you with indentation in `.yml` files.
+The Ansible {VSCode} extension provides inline help, syntax highlighting, and assists you with indentation in `.yml` files.
 
-The following rules apply for playbook files:
-
-* Every playbook file must finish with a blank line.
-* Trailing spaces at the end of lines are not allowed.
-* Every playbook and every play require an identifier (name).
-
-== Inline help
-
-The Ansible extension also provides inline help when you are editing your playbook file.
-
-* If you hover your mouse over a keyword or a module name, the Ansible extension provides documentation:
+. Open a playbook in {VSCode}.
+. Hover your mouse over a keyword or a module name: the Ansible extension provides documentation:
 +
 image::ansible-lint-keyword-help.png[Ansible-lint showing no errors in a playbook]
-* If you begin to type the name of a module, for example `ansible.builtin.ping`, the extension provides a list of suggestions.
+. If you begin to type the name of a module, for example `ansible.builtin.ping`, the extension provides a list of suggestions.
 +
 Select one of the suggestions to autocomplete the line.
 +

--- a/downstream/modules/devtools/proc-devtools-install-container.adoc
+++ b/downstream/modules/devtools/proc-devtools-install-container.adoc
@@ -1,4 +1,5 @@
 [id="devtools-install-container_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Installing {ToolsName} on a container inside {VSCode}
 

--- a/downstream/modules/devtools/proc-devtools-install-podman-desktop-wsl.adoc
+++ b/downstream/modules/devtools/proc-devtools-install-podman-desktop-wsl.adoc
@@ -1,4 +1,5 @@
 [id="devtools-install-podman-desktop-wsl_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Requirements for {ToolsName} on Windows
 
@@ -8,7 +9,7 @@ If you are installing {ToolsName} on a container in {VSCode} on Windows, there a
 * Windows Subsystem for Linux(WSL2)
 * Podman Desktop
 
-== Installing WSL
+.Procedure
 
 . Install WSL2 without a distribution:
 +
@@ -23,9 +24,6 @@ Edit the `%USERPROFILE%/wsl.conf` file and add the following lines to force `cgr
 [wsl2]
 kernelCommandLine = cgroup_no_v1="all"
 ----
-
-== Installing Podman Desktop on a Windows machine
-
 . Install Podman Desktop. Follow the instructions in
 link:https://podman-desktop.io/docs/installation/windows-install[Installing Podman Desktop and Podman on Windows]
 in the Podman Desktop documentation.
@@ -41,10 +39,8 @@ $ podman info | findstr cgroup
 ----
 $ podman run hello
 ----
-
-== Configuring settings for Podman Desktop
-
-. Add a `%USERPROFILE%\bin\docker.bat` file with the following content:
+. Configure the settings for Podman Desktop.
+Add a `%USERPROFILE%\bin\docker.bat` file with the following content:
 +
 ----
 @echo off
@@ -52,50 +48,9 @@ podman %*
 ----
 +
 This avoids having to install Docker as required by the {VSCode} `Dev Container` extension.
-. Add the `%USERPROFILE%\bin` directory to the `PATH`.
+. Add the `%USERPROFILE%\bin` directory to the `PATH`:
 .. Select *Settings* and search for "Edit environment variables for your account" to display all of the user environment variables.
 .. Highlight "Path" in the top user variables box, click btn:[Edit] and add the path.
 .. Click btn:[Save] to set the path for any new console that you open.
 
-
-// https://podman-desktop.io/docs/installation/windows-install
-
-// Moved to general requirements section 
-// == Configuring the `Dev Containers` extension
-// 
-// . Replace docker with podman in the `Dev Containers` extension settings:
-// .. In {VSCode}, open the settings editor.
-// .. Search for `@ext:ms-vscode-remote.remote-containers`.
-// +
-// Alternatively, click the *Extensions* icon in the activity bar and click the gear icon for the `Dev Containers` extension.
-// . Set `Dev > Containers:Docker Path` to `podman`.
-// . Set `Dev > Containers:Docker Compose Path` to `podman-compose`.
-
-// == Adding the .devcontainer file
-// 
-// . Click the `Remote` (image:vscode-remote-icon.png[Remote,15,15]) icon.
-// + In the dropdown menu that appears, select the option to connect to the WSL machine.
-// . Open a terminal window  in {VSCode}.
-// . Create a .devcontainer directory:
-// +
-// ----
-// $  mkdir .devcontainer
-// ----
-// . Create a `devcontainer.json` file:
-// +
-// ----
-// $ touch .devcontainer/devcontainer.json
-// ----
-// . Add the following code to the `.devcontainer/devcontainer.json` file:
-// +
-// include::snippets/podman-devcontainer.json[]
-// . Log in to the Red Hat registry:
-// ----
-// $ podman login registry.redhat.io
-// ----
-// . Click the `Remote` (image:vscode-remote-icon.png[Remote,15,15]) icon. In the dropdown menu that appears, select *Reopen in Container*.
-// 
-// .Verification
-// 
-// When the directory reopens in a container, the *Remote ()* status displays `Dev Container: ansible-dev-container`.
 

--- a/downstream/modules/devtools/proc-devtools-install-rpm.adoc
+++ b/downstream/modules/devtools/proc-devtools-install-rpm.adoc
@@ -1,4 +1,5 @@
 [id="devtools-install_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Installing {ToolsName} from a package on RHEL
 

--- a/downstream/modules/devtools/proc-devtools-install-vsc.adoc
+++ b/downstream/modules/devtools/proc-devtools-install-vsc.adoc
@@ -1,4 +1,5 @@
 [id="devtools-install-vsc_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Installing {VScode}
 

--- a/downstream/modules/devtools/proc-devtools-install-vscode-extension.adoc
+++ b/downstream/modules/devtools/proc-devtools-install-vscode-extension.adoc
@@ -1,4 +1,5 @@
 [id="devtools-install-extension_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Installing the {VSCode} Ansible extension
 

--- a/downstream/modules/devtools/proc-devtools-ms-dev-containers-ext.adoc
+++ b/downstream/modules/devtools/proc-devtools-ms-dev-containers-ext.adoc
@@ -1,4 +1,5 @@
 [id="devtools-ms-dev-containers-ext_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Installing and configuring the `Dev Containers` extension
 

--- a/downstream/modules/devtools/proc-devtools-run-playbook-extension.adoc
+++ b/downstream/modules/devtools/proc-devtools-run-playbook-extension.adoc
@@ -1,4 +1,5 @@
 [id="running-playbook-extension_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Running your playbook
 

--- a/downstream/modules/devtools/proc-devtools-save-scm.adoc
+++ b/downstream/modules/devtools/proc-devtools-save-scm.adoc
@@ -1,4 +1,5 @@
 [id="devtools-save-scm_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Saving your project in SCM
 

--- a/downstream/modules/devtools/proc-devtools-set-up-ansible-config.adoc
+++ b/downstream/modules/devtools/proc-devtools-set-up-ansible-config.adoc
@@ -1,4 +1,5 @@
 [id="devtools-set-up-ansible-config_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Setting up the Ansible configuration file for your playbook project
 

--- a/downstream/modules/devtools/proc-devtools-setup-registry-redhat-io.adoc
+++ b/downstream/modules/devtools/proc-devtools-setup-registry-redhat-io.adoc
@@ -1,4 +1,5 @@
 [id="devtools-setup-registry-redhat-io_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Authenticating with the Red Hat container registry
 

--- a/downstream/modules/devtools/proc-devtools-testing-playbook.adoc
+++ b/downstream/modules/devtools/proc-devtools-testing-playbook.adoc
@@ -1,4 +1,5 @@
 [id="test-playbook_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Testing your playbooks
 

--- a/downstream/modules/devtools/proc-devtools-working-with-ee.adoc
+++ b/downstream/modules/devtools/proc-devtools-working-with-ee.adoc
@@ -1,4 +1,5 @@
 [id="working-with-ee_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Working with execution environments
 

--- a/downstream/modules/devtools/proc-devtools-writing-first-playbook.adoc
+++ b/downstream/modules/devtools/proc-devtools-writing-first-playbook.adoc
@@ -1,9 +1,10 @@
 [id="writing-playbook_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Writing your first playbook
 
 [role="_abstract"]
-The instructions below describe how {ToolsName} help you to create and run your first playbook in {VSCode}.
+{ToolsName} help you to create and run playbooks in {VSCode}.
 
 .Prerequisites
 
@@ -31,5 +32,9 @@ The playbook consists of a single play that executes a `ping` to your local mach
 There are no errors in this playbook:
 +
 image::ansible-lint-no-errors.png[Ansible-lint showing no errors in a playbook]
+. If you want to add new content to the playbook, use the following rules:
+** Every playbook file must finish with a blank line.
+** Trailing spaces at the end of lines are not allowed.
+** Every playbook and every play require an identifier (name).
 . Save your playbook file.
 

--- a/downstream/modules/devtools/proc-rhdh-warning-aap-ooc.adoc
+++ b/downstream/modules/devtools/proc-rhdh-warning-aap-ooc.adoc
@@ -13,9 +13,6 @@ Contact your Red Hat account team to obtain a new subscription entitlement.
 Learn more about account compliance.
 ----
 
-[discrete]
-== Remediation steps
-
 . Contact your Red Hat account team to obtain a new subscription entitlement.
 . Learn more about link:https://access.redhat.com/solutions/6988859[account compliance].
 . When the subscription is in compliance, restart the {RHDH} pod to initiate a new subscription query.

--- a/downstream/modules/devtools/proc-rhdh-warning-invalid-aap-config.adoc
+++ b/downstream/modules/devtools/proc-rhdh-warning-invalid-aap-config.adoc
@@ -11,9 +11,6 @@ Verify that the resource url for Ansible Automation Platform are correctly confi
 For help, please refer to the Ansible plug-ins installation guide.
 ----
 
-[discrete]
-== Remediation steps
-
 . Verify that the `rhaap` section of the Ansible plug-ins ConfigMap is correctly configured and contains all the necessary entries.
 For more information, refer to xref:rhdh-configure-aap-details_rhdh-ocp-required-installation[Configuring Ansible Automation Platform details].
 . After correcting the configuration, restart the {RHDH} pod to initiate a subscription query.

--- a/downstream/modules/devtools/proc-rhdh-warning-invalid-aap-subscription.adoc
+++ b/downstream/modules/devtools/proc-rhdh-warning-invalid-aap-subscription.adoc
@@ -12,9 +12,6 @@ The connected Ansible Automation Platform subscription is invalid.
 Contact your Red Hat account team, or start an Ansible Automation Platform trial.
 ----
 
-[discrete]
-== Remediation steps
-
 . Contact your Red Hat account team to obtain a new subscription entitlement or link:http://red.ht/aap-rhdh-plugins-start-trial[start an {PlatformNameShort} trial].
 . When you have updated the subscription, restart the {RHDH} pod to initiate a new subscription query.
 

--- a/downstream/modules/devtools/proc-rhdh-warning-unable-authenticate-aap.adoc
+++ b/downstream/modules/devtools/proc-rhdh-warning-unable-authenticate-aap.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="rhdh-warning-unable-authenticate-aap_{context}"]
-= Unable to authenticate to Ansible Automation Platform
+= Unable to authenticate to {PlatformNameShort}
 
 The following warning indicates that the Ansible plug-ins were not able to authenticate with {PlatformNameShort} to query the subscription status.
 
@@ -10,9 +10,6 @@ Unable to authenticate to Ansible Automation Platform
 Verify that the authentication details for Ansible Automation Platform are correctly configured in the Ansible plug-ins.
 For help, please refer to the Ansible plug-ins installation guide.
 ----
-
-[discrete]
-== Remediation steps
 
 . Verify that the automation controller Personal Access Token (PAT) configured in the Ansible plug-ins is correct.
 For more information, refer to the

--- a/downstream/modules/devtools/proc-rhdh-warning-unable-connect-aap.adoc
+++ b/downstream/modules/devtools/proc-rhdh-warning-unable-connect-aap.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="rhdh-warning-unable-connect-aap_{context}"]
-= Unable to connect to Ansible Automation Platform
+= Unable to connect to {PlatformNameShort}
 
 The following warning indicates that the automation controller details are not configured, or the controller instance API is unreachable to query the subscription status.
 
@@ -10,9 +10,6 @@ Unable to connect to Ansible Automation Platform
 Verify that Ansible Automation Platform is reachable and correctly configured in the Ansible plug-ins.
 To get help, please refer to the Ansible plug-ins installation guide.
 ----
-
-[discrete]
-== Remediation steps
 
 . Verify that {PlatformNameShort} is reachable and correctly configured in the `rhaap` section of the ConfigMap.
 . Ensure the `checkSSL` key is correctly set for your environment.

--- a/downstream/modules/devtools/proc-scaffolding-playbook-project.adoc
+++ b/downstream/modules/devtools/proc-scaffolding-playbook-project.adoc
@@ -1,4 +1,5 @@
 [id="scaffolding-playbook-project_{context}"]
+:_mod-docs-content-type: PROCEDURE
 
 = Scaffolding a playbook project
 

--- a/downstream/modules/devtools/ref-devtools-components.adoc
+++ b/downstream/modules/devtools/ref-devtools-components.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: REFERENCE
+
 [id="devtools-components_{context}"]
 
 = {ToolsName} components

--- a/downstream/modules/devtools/ref-devtools-workflow.adoc
+++ b/downstream/modules/devtools/ref-devtools-workflow.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: REFERENCE
+
 [id="devtools-workflow_{context}"]
 
 = Workflow

--- a/downstream/titles/aap-plugin-rhdh-install/master.adoc
+++ b/downstream/titles/aap-plugin-rhdh-install/master.adoc
@@ -20,6 +20,7 @@ include::{Boilerplate}[]
 // ==== 
 // {AAPRHDH} is a Technology Preview feature only.
 // include::snippets/technology-preview.adoc[]
+
 // ==== 
 
 include::devtools/assembly-rhdh-intro.adoc[leveloffset=+1]
@@ -27,18 +28,25 @@ include::devtools/assembly-rhdh-intro.adoc[leveloffset=+1]
 
 // Installation
 include::devtools/assembly-rhdh-install-ocp-helm.adoc[leveloffset=+1]
+
 include::devtools/assembly-rhdh-install-ocp-operator.adoc[leveloffset=+1]
+
 //
 // Subscription warnings
 include::devtools/assembly-rhdh-subscription-warnings.adoc[leveloffset=+1]
+
 //
 // Upgrade
 include::devtools/assembly-rhdh-upgrade-ocp-helm.adoc[leveloffset=+1]
+
 include::devtools/assembly-rhdh-upgrade-ocp-operator.adoc[leveloffset=+1]
+
 //
 // Uninstall
 include::devtools/assembly-rhdh-uninstall-ocp-helm.adoc[leveloffset=+1]
+
 include::devtools/assembly-rhdh-uninstall-ocp-operator.adoc[leveloffset=+1]
+
 //
 // Telemetry
 include::devtools/assembly-rhdh-telemetry-capturing.adoc[leveloffset=+1]

--- a/downstream/titles/aap-plugin-rhdh-using/master.adoc
+++ b/downstream/titles/aap-plugin-rhdh-using/master.adoc
@@ -20,8 +20,12 @@ include::{Boilerplate}[]
 // ====
 // {AAPRHDH} is a Technology Preview feature only.
 // include::snippets/technology-preview.adoc[]
+
 // ====
 
 include::devtools/assembly-rhdh-using.adoc[leveloffset=+1]
+
 include::devtools/assembly-rhdh-feedback.adoc[leveloffset=+1]
+
 include::devtools/assembly-rhdh-example.adoc[leveloffset=+1]
+

--- a/downstream/titles/develop-automation-content/master.adoc
+++ b/downstream/titles/develop-automation-content/master.adoc
@@ -17,16 +17,25 @@ This document has been updated to include information for the latest release of 
 include::{Boilerplate}[]
 
 include::devtools/assembly-devtools-intro.adoc[leveloffset=+1]
+
 include::devtools/assembly-developer-workflow.adoc[leveloffset=+1]
+
 include::devtools/assembly-devtools-install.adoc[leveloffset=+1]
+
 // ----- include::devtools/assembly-devtools-setup.adoc[leveloffset=+1]
+
 include::devtools/assembly-creating-playbook-project.adoc[leveloffset=+1]
+
 include::devtools/assembly-writing-running-playbook.adoc[leveloffset=+1]
+
 // ----- include::devtools/assembly-testing-playbooks.adoc[leveloffset=+1]
+
 include::devtools/assembly-publishing-playbook-collection-aap.adoc[leveloffset=+1]
+
 
 // Roles collections
 
 include::devtools/assembly-devtools-develop-collections.adoc[leveloffset=+1]
+
 include::devtools/assembly-devtools-create-roles-collection.adoc[leveloffset=+1]
 

--- a/downstream/titles/self-service-using/master.adoc
+++ b/downstream/titles/self-service-using/master.adoc
@@ -24,16 +24,22 @@ include::{Boilerplate}[]
 {SelfService} is a Technology Preview feature only.
 
 include::snippets/technology-preview.adoc[]
+
 ==== 
 
 include::devtools/assembly-self-service-using-overview.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-using-prereqs.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-using-repo-setup.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-scm-credentials-private-repos.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-working-templates.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-rbac.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-deregister-templates.adoc[leveloffset=+1]
-// include::devtools/zzz[leveloffset=+1]
 
 include::devtools/assembly-self-service-feedback.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Update the Devtools content to comply with dita rules for migration to the adobe tooling.