### PR TITLE
Remove unnecessary parameter

### DIFF
--- a/downstream/modules/platform/ref-controller-analytics-gathering.adoc
+++ b/downstream/modules/platform/ref-controller-analytics-gathering.adoc
@@ -4,19 +4,12 @@
 
 Use this command to gather analytics on-demand outside of the predefined window (the default is 4 hours):
 
-[literal, options="nowrap" subs="+attributes"]
-----
-$ awx-manage gather_analytics --ship
-----
+`$ awx-manage gather_analytics --ship`
 
-For customers with disconnected environments who want to collect usage information about unique hosts automated across a time period, use this
-command:
+For customers with disconnected environments who want to collect usage information about unique hosts automated across a time period, use this command:
 
-[literal, options="nowrap" subs="+attributes"]
-----
-awx-manage host_metric --since YYYY-MM-DD --until YYYY-MM-DD --json
-----
+`awx-manage host_metric --since YYYY-MM-DD --json`
 
-The parameters `--since` and `--until` specify date ranges and are optional, but one of them has to be present. 
+The `--since` parameter is optional. 
 
 The `--json` flag specifies the output format and is optional.


### PR DESCRIPTION
Remove non-existing "--until" command-line option from host_metric documentation

https://issues.redhat.com/browse/AAP-49089