### PR TITLE
AAP-48959: Removed Matrix feedback note from Lightspeed docs

### DIFF
--- a/lightspeed/modules/proc_provide-feedback.adoc
+++ b/lightspeed/modules/proc_provide-feedback.adoc
@@ -14,8 +14,6 @@ IMPORTANT: Red Hat Support cannot assist with the suggestion quality reports. Co
 
 * From the link:access.redhat.com[Red Hat customer portal]: Use this method to log bug reports and service disruption incidents, and feature requests.
 
-NOTE: On the login screen of the link:https://c.ai.ansible.redhat.com/[Ansible Lightspeed Portal], there is a *Chat* link that redirects you to a Matrix channel. Use the Matrix channel to ask questions pertaining to your Ansible Lightspeed experience and request help to troubleshoot your issues. However, the Matrix channel is not an official Support channel, and issues raised in the Matrix chat would not be tracked through Red Hat Service Level Agreement (SLA). To raise a bug or a feature request, contact link:https://access.redhat.com/support[Red Hat Support] and open a support ticket.  
-
 .Prerequisites
 
 Ensure that you meet *one* of the following requirements:


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-48959.

Changes made:
The note to use Matrix channel for providing feedback was removed, as Matrix channel was deprecated sometime along the way. 