### PR TITLE
2.5 Update cont system requirements (#3816)

### DIFF
--- a/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
+++ b/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
@@ -3,9 +3,10 @@
 [id="system-requirements"]
 
 = System requirements
+
 Use this information when planning your installation of containerized {PlatformNameShort}.
 
-*Prerequisites*
+== Prerequisites
 
 * Ensure a dedicated non-root user is configured on the {RHEL} host. 
 ** This user requires `sudo` or other Ansible supported privilege escalation (`sudo` is recommended) to perform administrative tasks during the installation. 
@@ -31,12 +32,10 @@ For more information, see link:https://www.redhat.com/en/blog/rootless-podman-nf
 
 Your system must meet the following minimum system requirements to install and run {PlatformName}. 
 
-.Base system requirements
 include::snippets/cont-tested-system-config.adoc[]
 
 Each virtual machine (VM) has the following system requirements:
 
-.Virtual machine requirements
 include::snippets/cont-tested-vm-config.adoc[]
 
 [NOTE]
@@ -55,5 +54,7 @@ If performing a bundled installation of the {GrowthTopology} with `hub_seed_coll
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about the scope of coverage for each variety of database, see link:https://access.redhat.com/articles/4010491[{PlatformName} Database Scope of Coverage].
-* For more information about setting up an external database, see link:{URLContainerizedInstall}/aap-containerized-installation#setting-up-a-customer-provided-external-database[Setting up a customer provided (external) database].
+
+* link:https://access.redhat.com/articles/4010491[{PlatformName} Database Scope of Coverage]
+
+* link:{URLContainerizedInstall}/aap-containerized-installation#setting-up-a-customer-provided-external-database[Setting up a customer provided (external) database]

--- a/downstream/snippets/cont-tested-vm-config.adoc
+++ b/downstream/snippets/cont-tested-vm-config.adoc
@@ -10,8 +10,12 @@
 | 4 
 
 | Local disk  
-a| * 60 GB
-* Minimum of 15 GB dedicated to the installation directory if it is in a dedicated partition.
+a| 
+* Total available disk space: 60 GB
+* Installation directory: 15 GB (if on a dedicated partition)
+* `/var/tmp` for online installations: 1 GB
+* `/var/tmp` for offline or bundled installations: 3 GB
+* Temporary directory (defaults to `/tmp`) for offline or bundled installations: 10GB
 
 | Disk IOPS   
 | 3000   


### PR DESCRIPTION
Backports #3816 from main to 2.5

Update the virtual machine requirements for Containerized installation to ensure local disk information is available.

AAP 2.5 containerized installation failed with disk space issue

https://issues.redhat.com/browse/AAP-36584