### PR TITLE
AAP-48687: Added info. about disk space for /var/backups

### DIFF
--- a/downstream/modules/platform/ref-controller-backup-restore-considerations.adoc
+++ b/downstream/modules/platform/ref-controller-backup-restore-considerations.adoc
@@ -11,6 +11,11 @@ Disk space:: Review your disk space requirements to ensure you have enough room 
 System credentials:: Confirm you have the required system credentials when working with a local database or a remote database. 
 On local systems, you might need `root` or `sudo` access, depending on how credentials are set up. 
 On remote systems, you might need different credentials to grant you access to the remote system you are trying to backup or restore.
++
+[NOTE]
+====
+The {PlatformNameShort} database backups are staged on each node at `/var/backups/automation-platform` through the variable `backup_dir`. You might need to mount a new volume to `/var/backups` or change the staging location with the variable `backup_dir` to prevent issues with disk space before running the `./setup.sh -b` script.
+====
 
 Version:: You must always use the most recent minor version of a release to backup or restore your {PlatformNameShort} installation version. 
 For example, if the current platform version you are on is 2.0.x, only use the latest 2.0 installer.

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -66,6 +66,8 @@ The following are necessary for you to work with project updates and collections
 
 .Additional notes for {PlatformName} requirements
 
+* The {PlatformNameShort} database backups are staged on each node at `/var/backups/automation-platform` through the variable `backup_dir`. You might need to mount a new volume to `/var/backups` or change the staging location with the variable `backup_dir` to prevent issues with disk space before running the `./setup.sh -b` script.
+
 * If performing a bundled {PlatformNameShort} installation, the installation setup.sh script attempts to install ansible-core (and its dependencies) from the bundle for you.
 
 * If you have installed Ansible-core manually, the {PlatformNameShort} installation setup.sh script detects that Ansible has been installed and does not attempt to reinstall it.


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-48687. 

Changes made:
Added note about disk space for /var/backups in RPM install guide. 

Pending: Checking the appropriate location for doc update in 'Configuring automation execution' guide authors. 