### PR TITLE
2.5 Ansible DITA readiness (#3818)

### DIFF
--- a/downstream/assemblies/platform/assembly-appendix-troubleshoot-rpm-aap.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-troubleshoot-rpm-aap.adoc
@@ -3,6 +3,6 @@
 [id="appendix-troubleshoot-rpm-aap"]
 = Troubleshooting RPM installation of {PlatformNameShort}
 
-Use this information to troubleshoot your RPM installation of {PlatformNameShort}.
+Use this information to troubleshoot your RPM-based installation of {PlatformNameShort}.
 
-include::platform/ref-rpm-troubleshoot-generating-logs.adoc[leveloffset=+1]
+include::platform/proc-rpm-troubleshoot-generating-logs.adoc[leveloffset=+1]

--- a/downstream/assemblies/troubleshooting-aap/assembly-diagnosing-the-problem.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-diagnosing-the-problem.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 
 [id="diagnosing-the-problem"]
 
@@ -6,4 +7,5 @@
 To start troubleshooting {PlatformNameShort}, use the `must-gather` command on {OCPShort} or the `sos` utility on a {VMBase} to collect configuration and diagnostic information. You can attach the output of these utilities to your support case.
 
 include::troubleshooting-aap/proc-troubleshoot-must-gather.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/proc-troubleshoot-sosreport.adoc[leveloffset=+1]

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-jobs.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-jobs.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 
 [id="troubleshoot-jobs"]
 
@@ -8,6 +9,9 @@ Troubleshoot issues with jobs.
 // Michelle - commenting out for now as it refers to upgrade info
 // include::troubleshooting-aap/proc-troubleshoot-job-localhost.adoc[leveloffset=+1]
 include::troubleshooting-aap/proc-troubleshoot-job-resolve-module.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/proc-troubleshoot-job-timeout.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/proc-troubleshoot-job-pending.adoc[leveloffset=+1]
+
 include::troubleshooting-aap/proc-troubleshoot-job-permissions.adoc[leveloffset=+1]

--- a/downstream/modules/aap-migration/proc-ocp-target-import.adoc
+++ b/downstream/modules/aap-migration/proc-ocp-target-import.adoc
@@ -206,9 +206,9 @@ tar xf artifact.tar && cd artifact && sha256sum --check sha256sum.txt
 Example output:
 +
 ----
-./controller/controller.pgc: OK
-./gateway/gateway.pgc: OK
-./hub/hub.pgc: OK
+ ./controller/controller.pgc: OK
+ ./gateway/gateway.pgc: OK
+ ./hub/hub.pgc: OK
 ----
 +
 Drop the {ControllerName} database:

--- a/downstream/modules/platform/con-certs-per-service-considerations.adoc
+++ b/downstream/modules/platform/con-certs-per-service-considerations.adoc
@@ -11,4 +11,4 @@ When providing custom TLS certificates for each individual service, consider the
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about using TLS certificates, see link:{BaseURL}/red_hat_enterprise_linux/9/html/securing_networks/index[Securing networks].
+* link:{BaseURL}/red_hat_enterprise_linux/9/html/securing_networks/index[Securing networks]

--- a/downstream/modules/platform/con-hs-eda-controller.adoc
+++ b/downstream/modules/platform/con-hs-eda-controller.adoc
@@ -1,5 +1,4 @@
 :_mod-docs-content-type: CONCEPT
-
 [id="con-hs-eda-controller"]
 
 = Horizontal scaling in {EDAcontroller} 

--- a/downstream/modules/platform/con-hs-eda-sizing-scaling.adoc
+++ b/downstream/modules/platform/con-hs-eda-sizing-scaling.adoc
@@ -4,10 +4,8 @@
 
 = Sizing and scaling guidelines
 
-API nodes process user requests (interactions with the UI or API) while worker nodes process the activations and other background tasks required for {EDAName} to function properly. The number of API nodes you require correlates to the desired number of users of the application and the number of worker nodes correlates to the desired number of activations you want to run.
+API nodes process user requests (interactions with the UI or API) while worker nodes process the activations and other background tasks required for {EDAName} to function properly. The number of API nodes you require correlates to the required number of users of the application and the number of worker nodes correlates to the required number of activations you want to run.
 
 Since activations are variable and controlled by worker nodes, the supported approach for scaling is to use separate API and worker nodes instead of hybrid nodes due to the efficient allocation of hardware resources by worker nodes. By separating the nodes, you can scale each type independently based on specific needs, leading to better resource utilization and cost efficiency.
 
 An example of an instance in which you might consider scaling up your node deployment is when you want to deploy {EDAName} for a small group of users who will run a large number of activations. In this case, one API node is adequate, but if you require more, you can scale up to three additional worker nodes. 
-
-To set up a multi-node deployment, follow the procedure in xref:proc-hs-eda-setup[Setting up horizontal scaling for {EDAcontroller}].

--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -59,4 +59,4 @@ This backs up the important data deployed by the containerized installer such as
 * Configuration files
 * Data files
 
-By default, the backup directory is set to `./backups`. You can change this by using the `backup_dir` variable in your `inventory` file.
+. By default, the backup directory is set to `./backups`. You can change this by using the `backup_dir` variable in your `inventory` file.

--- a/downstream/modules/platform/proc-configure-hub-azure-storage.adoc
+++ b/downstream/modules/platform/proc-configure-hub-azure-storage.adoc
@@ -27,4 +27,4 @@ hub_azure_extra_settings:
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about the list of parameters, see link:https://django-storages.readthedocs.io/en/latest/backends/azure.html#settings[django-storages documentation - Azure Storage].
+* link:https://django-storages.readthedocs.io/en/latest/backends/azure.html#settings[django-storages documentation - Azure Storage]

--- a/downstream/modules/platform/proc-configure-hub-s3-storage.adoc
+++ b/downstream/modules/platform/proc-configure-hub-s3-storage.adoc
@@ -27,4 +27,4 @@ hub_s3_extra_settings:
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about the list of parameters, see link:https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings[django-storages documentation - Amazon S3].
+* link:https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings[django-storages documentation - Amazon S3]

--- a/downstream/modules/platform/proc-containerized-troubleshoot-gathering-logs.adoc
+++ b/downstream/modules/platform/proc-containerized-troubleshoot-gathering-logs.adoc
@@ -54,4 +54,4 @@ $ ansible-playbook -i <path_to_inventory_file> ansible.containerized_installer.l
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the `sos` report tool, see link:https://access.redhat.com/solutions/3592[What is an sos report and how to create one in {RHEL}?]
+* link:https://access.redhat.com/solutions/3592[What is an sos report and how to create one in {RHEL}?]

--- a/downstream/modules/platform/proc-downloading-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-downloading-containerized-aap.adoc
@@ -48,4 +48,4 @@ $ tar xfvz ansible-automation-platform-containerized-setup-bundle-<version>-<arc
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about using `scp`, see link:https://man7.org/linux/man-pages/man1/scp.1.html[scp(1) - Linux manual page].
+* link:https://man7.org/linux/man-pages/man1/scp.1.html[scp(1) - Linux manual page]

--- a/downstream/modules/platform/proc-enabling-automation-hub-collection-and-container-signing.adoc
+++ b/downstream/modules/platform/proc-enabling-automation-hub-collection-and-container-signing.adoc
@@ -1,6 +1,3 @@
-:_newdoc-version: 2.15.1
-:_template-generated: 2024-01-12
-
 :_mod-docs-content-type: PROCEDURE
 
 [id="enabling-automation-hub-collection-and-container-signing_{context}"]
@@ -152,4 +149,4 @@ hub_container_signing_pass=<password>
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on working with signed containers following an installation, see link:{URLHubManagingContent}/managing-containers-hub#working-with-signed-containers[Working with signed containers] in the {TitleHubManagingContent} guide.
+* link:{URLHubManagingContent}/managing-containers-hub#working-with-signed-containers[Working with signed containers]

--- a/downstream/modules/platform/proc-hs-eda-setup.adoc
+++ b/downstream/modules/platform/proc-hs-eda-setup.adoc
@@ -1,5 +1,4 @@
 :_mod-docs-content-type: PROCEDURE
-
 [id="proc-hs-eda-setup"]
 
 = Setting up horizontal scaling for {EDAcontroller}

--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -10,68 +10,72 @@ After you prepare the {RHEL} host, download {PlatformNameShort}, and configure t
 
 You have done the following:
 
-* xref:preparing-the-rhel-host-for-containerized-installation[Prepared the {RHEL} host]
-* xref:preparing-the-managed-nodes-for-containerized-installation[Prepared the managed nodes]
-* xref:downloading-ansible-automation-platform[Downloaded {PlatformNameShort}]
-* xref:configuring-inventory-file[Configured the inventory file]
+* link:{URLContainerizedInstall}/aap-containerized-installation#preparing-the-rhel-host-for-containerized-installation[Prepared the {RHEL} host]
+* link:{URLContainerizedInstall}/aap-containerized-installation#preparing-the-managed-nodes-for-containerized-installation[Prepared the managed nodes]
+* link:{URLContainerizedInstall}/aap-containerized-installation#downloading-ansible-automation-platform[Downloaded {PlatformNameShort}]
+* link:{URLContainerizedInstall}/aap-containerized-installation#configuring-inventory-file[Configured the inventory file]
 * Logged in to the {RHEL} host as your non-root user
 
 .Procedure
 
 * Go to the installation directory on your {RHEL} host.
 * Run the `install` playbook:
++
 ----
 ansible-playbook -i <inventory_file_name> ansible.containerized_installer.install
 ----
-
++
 For example:
++
 ----
 ansible-playbook -i inventory ansible.containerized_installer.install
 ----
-
++
 You can add additional parameters to the installation command as needed:
++
 ----
 ansible-playbook -i <inventory_file_name> -e @<vault_file_name> --ask-vault-pass -K -v ansible.containerized_installer.install
 ----
-
++
 For example:
++
 ----
 ansible-playbook -i inventory -e @vault.yml --ask-vault-pass -K -v  ansible.containerized_installer.install
 ----
 
-* `-i <inventory_file_name>` - The inventory file to use for the installation.
-* `-e @<vault_file_name> --ask-vault-pass` - (Optional) If you are using a vault to store sensitive variables, add this to the installation command.
-* `-K` - (Optional) If your privilege escalation requires you to enter a password, add this to the installation command. You are then prompted for the BECOME password.
-* `-v` - (Optional) You can use increasing verbosity, up to 4 v’s (`-vvvv`) to see the details of the installation process. However, it is important to note that this can significantly increase installation time, so use it only as needed or requested by Red Hat support.
+** `-i <inventory_file_name>` - The inventory file to use for the installation.
+** `-e @<vault_file_name> --ask-vault-pass` - (Optional) If you are using a vault to store sensitive variables, add this to the installation command.
+** `-K` - (Optional) If your privilege escalation requires you to enter a password, add this to the installation command. You are then prompted for the BECOME password.
+** `-v` - (Optional) You can use increasing verbosity, up to 4 v’s (`-vvvv`) to see the details of the installation process. However, it is important to note that this can significantly increase installation time, so use it only as needed or requested by Red Hat support.
 
-The installation of containerized {PlatformNameShort} begins.
+* The installation of containerized {PlatformNameShort} begins.
 
 .Verification
 
 * After the installation completes, verify that you can access the platform UI which is available by default at the following URL:
-
++
 ----
 https://<gateway_node>:443
 ----
-
-Log in as the admin user with the credentials you created for `gateway_admin_username` and `gateway_admin_password`.
-
-The default ports and protocols used for {PlatformNameShort} are 80 (HTTP) and 443 (HTTPS). You can customize the ports with the following variables:
-
++
+* Log in as the admin user with the credentials you created for `gateway_admin_username` and `gateway_admin_password`.
++
+* The default ports and protocols used for {PlatformNameShort} are 80 (HTTP) and 443 (HTTPS). You can customize the ports with the following variables:
++
 ----
 envoy_http_port=80
 envoy_https_port=443
 ----
-
-If you want to disable HTTPS, set `envoy_disable_https` to `true`:
-
++
+* If you want to disable HTTPS, set `envoy_disable_https` to `true`:
++
 ----
 envoy_disable_https: true
 ----
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about privilege escalation, see link:https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_privilege_escalation.html[Understanding privilege escalation: become].
-* For more information about securing sensitive variables, see link:{URLHardening}/hardening-aap#ref-sensitive-variables-install-inventory_hardening-aap[Sensitive variables in the installation inventory] in _{TitleHardening}_.
-* For more information about post installation instructions see link:{LinkGettingStarted}
-* For more information about troubleshooting your containerized {PlatformNameShort} installation, see link:{URLContainerizedInstall}/troubleshooting-containerized-ansible-automation-platform[Troubleshooting containerized {PlatformNameShort}].
+* link:https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_privilege_escalation.html[Understanding privilege escalation: become]
+* link:{URLHardening}/hardening-aap#ref-sensitive-variables-install-inventory_hardening-aap[Sensitive variables in the installation inventory]
+* link:{URLGettingStarted}[Getting started with {PlatformNameShort}]
+* link:{URLContainerizedInstall}/troubleshooting-containerized-ansible-automation-platform[Troubleshooting containerized {PlatformNameShort}]

--- a/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
@@ -10,9 +10,9 @@ To ensure a consistent and secure setup of containerized {PlatformNameShort}, cr
 
 Once configured, you can define the dedicated user for each host by adding `ansible_user=<username>` in your inventory file, for example: `aap.example.org ansible_user=aap`.
 
-.Procedure
-
 Complete the following steps for each host:
+
+.Procedure
 
 . Log in to the host as the root user.
 . Create a new user. Replace `<username>` with the username you want, for example `aap`.

--- a/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
@@ -68,7 +68,7 @@ sudo dnf install -y wget git-core rsync vim
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about registering your {RHEL} host and attaching a subscription, see link:{URLCentralAuth}/assembly-gateway-licensing#proc-attaching-subscriptions[Attaching your {PlatformName} Subscription].
-* For information about configuring unbound DNS, see link:{BaseURL}/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/assembly_setting-up-an-unbound-dns-server_networking-infrastructure-services[Setting up an unbound DNS server].
-* For information about configuring DNS using BIND, see link:{BaseURL}/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/assembly_setting-up-and-configuring-a-bind-dns-server_networking-infrastructure-services[Setting up and configuring a BIND DNS server].
-* For more information about `ansible-core`, see link:https://docs.ansible.com/ansible/latest/[Ansible Core Documentation].
+* link:{URLCentralAuth}/assembly-gateway-licensing#proc-attaching-subscriptions[Attaching your {PlatformName} Subscription]
+* link:{BaseURL}/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/assembly_setting-up-an-unbound-dns-server_networking-infrastructure-services[Setting up an unbound DNS server]
+* link:{BaseURL}/red_hat_enterprise_linux/9/html/managing_networking_infrastructure_services/assembly_setting-up-and-configuring-a-bind-dns-server_networking-infrastructure-services[Setting up and configuring a BIND DNS server]
+* link:https://docs.ansible.com/ansible/latest/[Ansible Core Documentation]

--- a/downstream/modules/platform/proc-rpm-troubleshoot-generating-logs.adoc
+++ b/downstream/modules/platform/proc-rpm-troubleshoot-generating-logs.adoc
@@ -1,16 +1,16 @@
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: PROCEDURE
 
-[id="ref-rpm-troubleshoot-generating-logs"]
+[id="rpm-troubleshoot-generating-logs"]
 
 = Gathering {PlatformNameShort} logs
 
 With the `sos` utility, you can collect configuration, diagnostic, and troubleshooting data, and provide those files to Red Hat Technical Support. An `sos` report is a common starting point for Red Hat technical support engineers when performing analysis of a service request for the {PlatformNameShort}. 
 
-As part of the troubleshooting with Red Hat Support, you can collect the `sos` report for each node in your RPM installation of {PlatformNameShort} using the installation inventory and the installer.
+As part of the troubleshooting with Red Hat Support, you can collect the `sos` report for each node in your RPM-based installation of {PlatformNameShort} using the installation inventory and the installation program.
 
 .Procedure
 
-. Access the installer folder with the inventory file and run the installer setup script the following command:
+. Access the installation program folder with the inventory file and run the installation program setup script the following command:
 +
 `$ ./setup.sh -s`
 +
@@ -56,8 +56,4 @@ $ ./setup.sh -e 'case_number=0000000' -e 'clean=true' -e 'upload=true' -s
 `upload`| Automatically uploads the `sos` report data to Red Hat. | `false` |
 |===
 
-To know more about the `sos` report tool, see the KCS article: link:https://access.redhat.com/solutions/3592[What is an sos report and how to create one in Red Hat Enterprise Linux?] 
-
-
-
-
+To know more about the `sos` report tool, see the KCS article: link:https://access.redhat.com/solutions/3592[What is an sos report and how to create one in {RHEL}?] 

--- a/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
@@ -49,4 +49,3 @@ To keep PostgreSQL databases, set the `postgresql_keep_databases` parameter to `
 ----
 $ ansible-playbook -i inventory ansible.containerized_installer.uninstall -e postgresql_keep_databases=true
 ----
-

--- a/downstream/modules/platform/proc-update-aap-container.adoc
+++ b/downstream/modules/platform/proc-update-aap-container.adoc
@@ -1,5 +1,4 @@
 :_mod-docs-content-type: PROCEDURE
-
 [id="updating-containerized-ansible-automation-platform"]
 
 = Updating containerized {PlatformNameShort}
@@ -14,7 +13,7 @@ You have done the following:
 
 * Reviewed the release notes for the associated patch release. For more information, see the link:{URLReleaseNotes}[{PlatformNameShort} {TitleReleaseNotes}].
 
-* Created a backup of your {PlatformNameShort} deployment. For more information, see xref:backing-up-containerized-ansible-automation-platform[Backing up container-based {PlatformNameShort}].
+* Created a backup of your {PlatformNameShort} deployment. For more information, see link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backing up container-based {PlatformNameShort}]
 
 * Logged in to the {RHEL} host as your dedicated non-root user.
 
@@ -32,5 +31,4 @@ $ ansible-playbook -i inventory ansible.containerized_installer.install
 +
 * If your privilege escalation requires a password to be entered, append `-K` to the command. You will then be prompted for the `BECOME` password.
 * You can use increasing verbosity, up to 4 v’s (`-vvvv`) to see the details of the installation process. However it is important to note that this can significantly increase installation time, so it is recommended that you use it only as needed or requested by Red Hat support.
-
-The update begins.
+* The update begins.

--- a/downstream/modules/platform/ref-configuring-inventory-file.adoc
+++ b/downstream/modules/platform/ref-configuring-inventory-file.adoc
@@ -29,7 +29,7 @@ include::snippets/inventory-cont-a-env-a.adoc[]
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about the container {GrowthTopology} (all-in-one), see link:{URLTopologies}/container-topologies#infrastructure_topology_5[Container {GrowthTopology}] in _{TitleTopologies}_.
+* link:{URLTopologies}/container-topologies#infrastructure_topology_5[Container {GrowthTopology}]
 
 == Inventory file for online installation for containerized {EnterpriseTopology}
 
@@ -39,8 +39,8 @@ include::snippets/inventory-cont-b-env-a.adoc[]
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about the container {EnterpriseTopology}, see link:{URLTopologies}/container-topologies#infrastructure_topology_6[Container {EnterpriseTopology}] in _{TitleTopologies}_.
-* For more information about Redis, see link:{URLPlanningGuide}/ha-redis_planning[Caching and queueing system] in _{TitlePlanningGuide}_.
+* link:{URLTopologies}/container-topologies#infrastructure_topology_6[Container {EnterpriseTopology}]
+* link:{URLPlanningGuide}/ha-redis_planning[Caching and queueing system]
 
 
 == Performing an offline or bundled installation

--- a/downstream/modules/platform/ref-containerized-troubleshoot-ref.adoc
+++ b/downstream/modules/platform/ref-containerized-troubleshoot-ref.adoc
@@ -1,5 +1,6 @@
 :_mod-docs-content-type: REFERENCE
-[id="containerized-ansible-automation-platform-reference_{context}"]
+
+[id="containerized-ansible-automation-platform-reference"]
 
 = Containerized {PlatformNameShort} reference
 
@@ -39,19 +40,19 @@ The installation program adds the following files to the filesystem where you ru
 
 ----
 $ tree -L 1
-.
-├── aap_install.log
-├── ansible.cfg
-├── collections
-├── galaxy.yml
-├── inventory
-├── LICENSE
-├── meta
-├── playbooks
-├── plugins
-├── README.md
-├── requirements.yml
-├── roles
+    .
+    ├── aap_install.log
+    ├── ansible.cfg
+    ├── collections
+    ├── galaxy.yml
+    ├── inventory
+    ├── LICENSE
+    ├── meta
+    ├── playbooks
+    ├── plugins
+    ├── README.md
+    ├── requirements.yml
+    ├── roles
 ----
 
 The installation root directory includes other containerized services that make use of Podman volumes. 
@@ -61,62 +62,62 @@ Here are some examples for further reference:
 The `containers` directory includes some of the Podman specifics used and installed for the execution plane:
 
 ----
-containers/
-├── podman
-├── storage
-│   ├── defaultNetworkBackend
-│   ├── libpod
-│   ├── networks
-│   ├── overlay
-│   ├── overlay-containers
-│   ├── overlay-images
-│   ├── overlay-layers
-│   ├── storage.lock
-│   └── userns.lock
-└── storage.conf
+    containers/
+    ├── podman
+    ├── storage
+    │   ├── defaultNetworkBackend
+    │   ├── libpod
+    │   ├── networks
+    │   ├── overlay
+    │   ├── overlay-containers
+    │   ├── overlay-images
+    │   ├── overlay-layers
+    │   ├── storage.lock
+    │   └── userns.lock
+    └── storage.conf
 ----
 
 The `controller` directory has some of the installed configuration and runtime data points:
 
 ----
-controller/
-├── data
-│   ├── job_execution
-│   ├── projects
-│   └── rsyslog
-├── etc
-│   ├── conf.d
-│   ├── launch_awx_task.sh
-│   ├── settings.py
-│   ├── tower.cert
-│   └── tower.key
-├── nginx
-│   └── etc
-├── rsyslog
-│   └── run
-└── supervisor
-    └── run
+    controller/
+    ├── data
+    │   ├── job_execution
+    │   ├── projects
+    │   └── rsyslog
+    ├── etc
+    │   ├── conf.d
+    │   ├── launch_awx_task.sh
+    │   ├── settings.py
+    │   ├── tower.cert
+    │   └── tower.key
+    ├── nginx
+    │   └── etc
+    ├── rsyslog
+    │   └── run
+    └── supervisor
+        └── run
 ----
 
 The `receptor` directory has the {AutomationMesh} configuration:
 
 ----
-receptor/
-├── etc
-│   └── receptor.conf
-└── run
-    ├── receptor.sock
-    └── receptor.sock.lock
+    receptor/
+    ├── etc
+    │   └── receptor.conf
+    └── run
+        ├── receptor.sock
+        └── receptor.sock.lock
 ----
 
 After installation, you will also find other files in the local user's `/home` directory such as the `.cache` directory:
 
 ----
-.cache/
-├── containers
-│   └── short-name-aliases.conf.lock
-└── rhsm
-    └── rhsm.log
+    .cache/
+    ├── containers
+    │   └── short-name-aliases.conf.lock
+    └── rhsm
+        └── rhsm.log
 ----
 
 As services are run using rootless Podman by default, you can use other services such as running `systemd` as non-privileged users. Under `systemd` you can see some of the component service controls available:
@@ -124,24 +125,24 @@ As services are run using rootless Podman by default, you can use other services
 The `.config` directory:
 
 ----
-.config/
-├── cni
-│   └── net.d
-│       └── cni.lock
-├── containers
-│   ├── auth.json
-│   └── containers.conf
-└── systemd
-    └── user
-        ├── automation-controller-rsyslog.service
-        ├── automation-controller-task.service
-        ├── automation-controller-web.service
-        ├── default.target.wants
-        ├── podman.service.d
-        ├── postgresql.service
-        ├── receptor.service
-        ├── redis.service
-        └── sockets.target.wants
+    .config/
+    ├── cni
+    │   └── net.d
+    │       └── cni.lock
+    ├── containers
+    │   ├── auth.json
+    │   └── containers.conf
+    └── systemd
+        └── user
+            ├── automation-controller-rsyslog.service
+            ├── automation-controller-task.service
+            ├── automation-controller-web.service
+            ├── default.target.wants
+            ├── podman.service.d
+            ├── postgresql.service
+            ├── receptor.service
+            ├── redis.service
+            └── sockets.target.wants
 ----
 
 This is specific to Podman and conforms to the Open Container Initiative (OCI) specifications. When you run Podman as the root user `/var/lib/containers` is used by default. For standard users the hierarchy under `$HOME/.local` is used.
@@ -149,12 +150,12 @@ This is specific to Podman and conforms to the Open Container Initiative (OCI) s
 The `.local` directory:
 
 ----
-.local/
-└── share
-    └── containers
-        ├── cache
-        ├── podman
-        └── storage
+    .local/
+    └── share
+        └── containers
+            ├── cache
+            ├── podman
+            └── storage
 ----
 
 As an example `.local/storage/volumes` contains what the output from `podman volume ls` provides:

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -22,8 +22,8 @@
 
 | `postgres_max_connections` 
 | `postgresql_max_connections` 
-| Maximum number of concurrent connections to the database if you are using an installer-managed database. +
-See link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref-controller-database-settings[PostgreSQL database configuration and maintenance for {ControllerName}] for help selecting a value.
+| Maximum number of concurrent connections to the database if you are using an installer-managed database. 
+For more information see link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref-controller-database-settings[PostgreSQL database configuration and maintenance for {ControllerName}].
 | Optional
 | `1024`
 
@@ -53,15 +53,15 @@ See link:{URLControllerAdminGuide}/assembly-controller-improving-performance#ref
 
 | 
 | `postgresql_admin_password` 
-| Password for the PostgreSQL admin user. +
-When used, the installation program creates each component’s database and credentials.
+| Password for the PostgreSQL admin user. 
+When used, the installation program creates each component's database and credentials.
 | Required if using `postgresql_admin_username`.
 |
 
 | 
 | `postgresql_admin_username` 
-|  Username for the PostgreSQL admin user. +
-When used, the installation program creates each component’s database and credentials.
+|  Username for the PostgreSQL admin user. 
+When used, the installation program creates each component's database and credentials.
 | Optional
 | `postgres`
 
@@ -73,8 +73,8 @@ When used, the installation program creates each component’s database and cred
 
 | 
 | `postgresql_keep_databases` 
-| Controls whether or not to keep databases during uninstall. +
-This variable applies to databases managed by the installation program only, and not external (customer-managed) databases. +
+| Controls whether or not to keep databases during uninstall. 
+This variable applies to databases managed by the installation program only, and not external (customer-managed) databases. 
 Set to `true` to keep databases during uninstall.
 | Optional
 | `false`

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -10,28 +10,28 @@
 
 | `automationhub_admin_password` 
 | `hub_admin_password` 
-| {HubNameStart} administrator password. +
+| {HubNameStart} administrator password. 
 Use of special characters for this variable is limited. The password can include any printable ASCII character except `/`, `”`, or `@`.
 | Required 
 | 
 
 | `automationhub_api_token`
 |
-| Set the existing token for the installation program. +
+| Set the existing token for the installation program. 
 For example, a regenerated token in the {HubName} UI will invalidate an existing token. Use this variable to set that token in the installation program the next time you run the installation program.
 | Optional
 |
 
 | `automationhub_auto_sign_collections` 
 | `hub_collection_auto_sign` 
-| If a collection signing service is enabled, collections are not signed automatically by default. +
+| If a collection signing service is enabled, collections are not signed automatically by default. 
 Set this variable to `true` to sign collections by default.
 | Optional
 | `false`
 
 | `automationhub_backup_collections` 
 | 
-| {HubNameMain} provides artifacts in `/var/lib/pulp`. These artifacts are automatically backed up by default. +
+| {HubNameMain} provides artifacts in `/var/lib/pulp`. These artifacts are automatically backed up by default. 
 Set this variable to `false` to prevent backup or restore of `/var/lib/pulp`.
 | Optional
 | `true`
@@ -50,7 +50,7 @@ Set this variable to `false` to prevent backup or restore of `/var/lib/pulp`.
 
 | `automationhub_collection_seed_repository`
 | 
-| Controls the type of content to upload when `hub_seed_collections` is set to `true`. +
+| Controls the type of content to upload when `hub_seed_collections` is set to `true`. 
 Valid options include: `certified`, `validated`
 | Optional
 | Both certified and validated are enabled by default.
@@ -88,36 +88,36 @@ Valid options include: `true`, `false`, `auto`
 
 | `automationhub_disable_hsts` 
 | `hub_nginx_disable_hsts` 
-| Controls whether HTTP Strict Transport Security (HSTS) is enabled or disabled for {HubName}. +
+| Controls whether HTTP Strict Transport Security (HSTS) is enabled or disabled for {HubName}. 
 Set this variable to `true` to disable HSTS.
 | Optional
 | `false`
 
 | `automationhub_disable_https` 
 | `hub_nginx_disable_https` 
-| Controls whether HTTPS is enabled or disabled for {HubName}. +
+| Controls whether HTTPS is enabled or disabled for {HubName}. 
 Set this variable to `true` to disable HTTPS.
 | Optional
 | `false`
 
 | `automationhub_enable_api_access_log` 
 |  
-| Controls whether logging is enabled or disabled at `/var/log/galaxy_api_access.log`. +
-The file logs all user actions made to the platform, including username and IP address. +
+| Controls whether logging is enabled or disabled at `/var/log/galaxy_api_access.log`. 
+The file logs all user actions made to the platform, including username and IP address. 
 Set this variable to `true` to enable this logging.
 | Optional
 | `false`
 
 | `automationhub_enable_unauthenticated_collection_access` 
 |  
-| Controls whether read-only access is enabled or disabled for unauthorized users viewing collections or namespaces for {HubName}. +
+| Controls whether read-only access is enabled or disabled for unauthorized users viewing collections or namespaces for {HubName}. 
 Set this variable to `true` to enable read-only access.
 | Optional
 | `false`
 
 | `automationhub_enable_unauthenticated_collection_download` 
 | 
-| Controls whether or not unauthorized users can download read-only collections from {HubName}. +
+| Controls whether or not unauthorized users can download read-only collections from {HubName}. 
 Set this variable to `true` to enable download of read-only collections.
 | Optional
 | `false`
@@ -137,7 +137,7 @@ Set to `true` to require the user to change the default administrator password d
 
 | `automationhub_importer_settings` 
 | `hub_galaxy_importer` 
-|  Dictionary of settings to pass to the `galaxy-importer.cfg` configuration file. These settings control how the `galaxy-importer` service processes and validates Ansible content. +
+|  Dictionary of settings to pass to the `galaxy-importer.cfg` configuration file. These settings control how the `galaxy-importer` service processes and validates Ansible content. 
 Example values include: `ansible-doc`, `ansible-lint`, and `flake8`.
 | Optional
 |
@@ -150,7 +150,7 @@ Example values include: `ansible-doc`, `ansible-lint`, and `flake8`.
 
 | `automationhub_pg_cert_auth` 
 | `hub_pg_cert_auth` 
-| Controls whether client certificate authentication is enabled or disabled on the {HubName} PostgreSQL database. +
+| Controls whether client certificate authentication is enabled or disabled on the {HubName} PostgreSQL database. 
 Set this variable to `true` to enable client certificate authentication.
 | Optional
 | `false`
@@ -159,19 +159,18 @@ Set this variable to `true` to enable client certificate authentication.
 | `hub_pg_database` 
 | Name of the PostgreSQL database used by {HubName}.
 | Optional
-| RPM = `automationhub` +
+| RPM = `automationhub`.
 Container = `pulp`
 
 | `automationhub_pg_host` 
 | `hub_pg_host` 
 | Hostname of the PostgreSQL database used by {HubName}.
 | Required
-| RPM = `127.0.0.1` +
-Container = 
+| RPM = `127.0.0.1`. Container = no default.
 
 | `automationhub_pg_password` 
 | `hub_pg_password` 
-| Password for the {HubName} PostgreSQL database user. +
+| Password for the {HubName} PostgreSQL database user.
 Use of special characters for this variable is limited. The `!`, `#`, `0` and `@` characters are supported. Use of other special characters can cause the setup to fail.
 | Optional
 |
@@ -184,7 +183,7 @@ Use of special characters for this variable is limited. The `!`, `#`, `0` and `@
 
 | `automationhub_pg_sslmode` 
 | `hub_pg_sslmode` 
-| Controls the SSL/TLS mode to use when {HubName} connects to the PostgreSQL database. +
+| Controls the SSL/TLS mode to use when {HubName} connects to the PostgreSQL database. 
 Valid options include `verify-full`, `verify-ca`, `require`, `prefer`, `allow`, `disable`.
 | Optional
 | `prefer`
@@ -193,8 +192,7 @@ Valid options include `verify-full`, `verify-ca`, `require`, `prefer`, `allow`, 
 | `hub_pg_username` 
 | Username for the {HubName} PostgreSQL database user.
 | Optional
-| RPM = `automationhub` +
-Container = `pulp`
+| RPM = `automationhub`. Container = `pulp`.
 
 | `automationhub_pgclient_sslcert` 
 | `hub_pg_tls_cert` 
@@ -217,24 +215,24 @@ Container = `pulp`
 
 | `automationhub_require_content_approval` 
 | 
-| Controls whether content signing is enabled or disabled for {HubName}. +
-By default when you upload collections to {HubName}, an administrator must approve it before they are made available to users. +
+| Controls whether content signing is enabled or disabled for {HubName}. 
+By default when you upload collections to {HubName}, an administrator must approve it before they are made available to users. 
 To disable the content approval flow, set the variable to `false`.
 | Optional
 | `true`
 
 | `automationhub_restore_signing_keys`
 |
-| Controls whether or not existing signing keys should be restored from a backup. +
+| Controls whether or not existing signing keys should be restored from a backup. 
 Set to `false` to disable restoration of existing signing keys.
 | Optional
 | `true`
 
 | `automationhub_seed_collections` 
 | `hub_seed_collections` 
-| Controls whether or not pre-loading of collections is enabled. +
-When you run the bundle installer, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository. By default, certified content and validated content are both uploaded. +
-If you do not want to pre-load content, set this variable to `false`. +
+| Controls whether or not pre-loading of collections is enabled. 
+When you run the bundle installer, validated content is uploaded to the `validated` repository, and certified content is uploaded to the `rh-certified` repository. By default, certified content and validated content are both uploaded. 
+If you do not want to pre-load content, set this variable to `false`. 
 For the RPM-based installer, if you only want one type of content, set this variable to `true` and set the `automationhub_collection_seed_repository` variable to the type of content you want to include.
 | Optional
 | `true`
@@ -277,7 +275,7 @@ For the RPM-based installer, if you only want one type of content, set this vari
 
 |`generate_automationhub_token` 
 | 
-| Controls whether or not a token is generated for {HubName} during installation. By default, a token is automatically generated during a fresh installation. +
+| Controls whether or not a token is generated for {HubName} during installation. By default, a token is automatically generated during a fresh installation. 
 If set to `true`, a token is regenerated during installation.
 | Optional
 | `false`
@@ -327,7 +325,7 @@ hub_extra_settings:
 
 | 
 | `hub_azure_extra_settings` 
-| Defines extra parameters for the Azure blob storage backend. +
+| Defines extra parameters for the Azure blob storage backend. 
 For more information about the list of parameters, see link:https://django-storages.readthedocs.io/en/latest/backends/azure.html#settings[django-storages documentation - Azure Storage].
 | Optional
 | `{}`
@@ -394,7 +392,7 @@ For more information about the list of parameters, see link:https://django-stora
 
 | 
 | `hub_s3_extra_settings` 
-| Used to define extra parameters for the AWS S3 storage backend. +
+| Used to define extra parameters for the AWS S3 storage backend. 
 For more information about the list of parameters, see link:https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings[django-storages documentation - Amazon S3].
 | Optional
 | `{}`
@@ -419,7 +417,7 @@ For more information about the list of parameters, see link:https://django-stora
 
 |  
 | `hub_storage_backend` 
-| {HubNameStart} storage backend type. +
+| {HubNameStart} storage backend type. 
 Possible values include: `azure`, `file`, `s3`.
 | Optional
 | `file`

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -10,8 +10,8 @@
 
 | `receptor_datadir`
 | 
-| The directory where receptor stores its runtime data and local artifacts. +
-The target directory must be accessible to *awx* users. +
+| The directory where receptor stores its runtime data and local artifacts. 
+The target directory must be accessible to *awx* users. 
 If the target directory is a temporary file system *tmpfs*, ensure it is remounted correctly after a reboot. Failure to do so results in the receptor no longer having a working directory.
 | Optional
 | `/tmp/receptor`
@@ -30,7 +30,7 @@ If the target directory is a temporary file system *tmpfs*, ensure it is remount
 
 | `receptor_log_level`
 | `receptor_log_level` 
-| Controls the verbosity of logging for receptor. +
+| Controls the verbosity of logging for receptor. 
 Valid options include: `error`, `warning`, `info`, or `debug`.
 | Optional
 | `info`
@@ -55,7 +55,7 @@ For the `[execution_nodes]` group the two options are:
 * `receptor_type=hop` - The node forwards jobs to an execution node.
 * `receptor_type=execution` - The node can run jobs.
 | Optional
-| For the `[automationcontroller]` group: `hybrid`. +
+| For the `[automationcontroller]` group: `hybrid`. 
 For the `[execution_nodes]` group: `execution`.
 
 | See `peers` for the RPM equivalent variable 
@@ -75,14 +75,14 @@ endif::container-install[]
 
 | 
 | `receptor_disable_signing` 
-| Controls whether signing of communications between receptor nodes is enabled or disabled. +
+| Controls whether signing of communications between receptor nodes is enabled or disabled. 
 Set this variable to `true` to disable communication signing.
 | Optional
 | `false`
 
 | 
 | `receptor_disable_tls` 
-| Controls whether TLS is enabled or disabled for receptor. +
+| Controls whether TLS is enabled or disabled for receptor. 
 Set this variable to `true` to disable TLS.
 | Optional
 | `false`
@@ -95,7 +95,7 @@ Set this variable to `true` to disable TLS.
 
 |
 | `receptor_mintls13` 
-| Controls whether or not receptor only accepts connections that use TLS 1.3 or higher. +
+| Controls whether or not receptor only accepts connections that use TLS 1.3 or higher. 
 Set to `true` to only accept connections that use TLS 1.3 or higher.
 | Optional
 | `false`

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-permissions.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-permissions.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="troubleshoot-job-permissions"]
 = Issue - Jobs in {PrivateHubName} are failing with "denied: requested access to the resource is denied, unauthorized: Insufficient permissions" error message
 
@@ -16,4 +17,4 @@ This issue happens when your {PrivateHubName} is protected with a password or to
 [role="_additional-resources"]
 .Additional resources
 
-* For information about creating new credentials in {ControllerName}, see link:{URLControllerUserGuide}/controller-credentials#controller-create-credential[Creating new credentials] in _{TitleControllerUserGuide}_.
+* link:{URLControllerUserGuide}/controller-credentials#controller-create-credential[Creating new credentials]

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-resolve-module.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-resolve-module.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: PROCEDURE
+
 [id="troubleshoot-job-resolve-module"]
 = Issue - Jobs are failing with “ERROR! couldn’t resolve module/action” error message
 
@@ -21,4 +23,3 @@ collections:
 - _<collection_name>_
 ----
 +
-

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-timeout.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-timeout.adoc
@@ -1,9 +1,11 @@
+:_mod-docs-content-type: PROCEDURE
+
 [id="troubleshoot-job-timeout"]
 = Issue - Jobs are failing with “Timeout (12s) waiting for privilege escalation prompt” error message
 
 This error can happen when the timeout value is too small, causing the job to stop before completion. The default timeout value for connection plugins is `10`. 
 
-To resolve the issue, increase the timeout value by completing one of the following procedures. 
+To resolve the issue, increase the timeout value by completing one of the following methods. 
 
 [NOTE]
 ====
@@ -49,6 +51,4 @@ timeout = 60
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the `DEFAULT_TIMEOUT` configuration setting, see link:https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-timeout[DEFAULT_TIMEOUT] in the Ansible Community Documentation.
-
-
+* link:https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-timeout[DEFAULT_TIMEOUT]

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: PROCEDURE
+
 [id="troubleshoot-must-gather"]
 = Troubleshooting {PlatformNameShort} on {OCPShort} by using the must-gather command
 
@@ -55,6 +57,6 @@ $ tar cvaf must-gather.tar.gz _<must-gather.local.5421342344627712289/>_
 [role="_additional-resources"]
 .Additional resources
 
-* For information about installing the OpenShift CLI (`oc`), see link:https://docs.openshift.com/container-platform/{OCPLatest}/cli_reference/openshift_cli/getting-started-cli.html[Installing the OpenShift CLI] in the {OCPShort} Documentation.
+* link:https://docs.openshift.com/container-platform/{OCPLatest}/cli_reference/openshift_cli/getting-started-cli.html[Installing the OpenShift CLI]
 
-* For information about running the `oc adm inspect` command, see the link:https://docs.openshift.com/container-platform/{OCPLatest}/cli_reference/openshift_cli/administrator-cli-commands.html#oc-adm-inspect[ocm adm inspect] section in the {OCPShort} Documentation.
+* link:https://docs.openshift.com/container-platform/{OCPLatest}/cli_reference/openshift_cli/administrator-cli-commands.html#oc-adm-inspect[ocm adm inspect]


### PR DESCRIPTION
Backports #3818 from main to 2.5

Correcting issues flagged by the asciidoctor-dita-vale tool.

Affected titles:
- `titles/aap-containerized-install`
- `titles/troubleshooting-aap`
- `titles/aap-migration`

Ansible DITA readiness (2025-07-09) - Michelle

https://issues.redhat.com/browse/AAP-49393