### PR TITLE
2.5 Add prereq to restore containerized AAP (#3838)

### DIFF
--- a/downstream/modules/platform/proc-restore-aap-container.adoc
+++ b/downstream/modules/platform/proc-restore-aap-container.adoc
@@ -9,6 +9,7 @@ Restore your {ContainerBase} of {PlatformNameShort} from a backup, or to a diffe
 * You have logged in to the {RHEL} host as your dedicated non-root user.
 * You have a backup of your {PlatformNameShort} deployment. For more information, see link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backing up container-based {PlatformNameShort}].
 * If restoring to a different environment with the same hostnames, you have performed a fresh installation on the target environment with the same topology as the original (source) environment.
+* You have ensured that the administrator credentials on the target environment match the administrator credentials from the source environment.
 
 .Procedure
 . Go to the installation directory on your {RHEL} host.


### PR DESCRIPTION
Backports #3838 from main to 2.5

Containerized restores to another environment fails to authenticate with APIs and database

https://issues.redhat.com/browse/AAP-45445