### PR TITLE
AAP-49654 Corrected the link to the Custom domain section

### DIFF
--- a/stories/topics/con-saas-customer-access.adoc
+++ b/stories/topics/con-saas-customer-access.adoc
@@ -16,6 +16,6 @@ If you need help accessing your deployment, submit a support request through lin
 
 [NOTE]
 =====
-You can provide a custom URL for your {SaaSonAWSShort} by using a domain name that you own. To request a custom domain name for your deployment, you can submit a customer support request to initiate the configuration process. The Red Hat SRE team will engage the support ticket for collaboration on next steps. Refer to the link:https://docs.redhat.com/en/documentation/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_service_on_aws/saas-service-definition#con-saas-custom-domain.adoc[Custom Domain] section for configuration information.
+You can provide a custom URL for your {SaaSonAWSShort} by using a domain name that you own. To request a custom domain name for your deployment, you can submit a customer support request to initiate the configuration process. The Red Hat SRE team will engage the support ticket for collaboration on next steps. Refer to the link:https://docs.redhat.com/en/documentation/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_service_on_aws/saas-service-definition#con-saas-custom-domain[Custom Domain] section for configuration information.
 =====
 //[Jameria Self] Added a link to the Custom Domain section to the note. To be confirmed after publishing.


### PR DESCRIPTION
Corrected the link from the [Customer access](https://docs.redhat.com/en/documentation/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_service_on_aws/saas-service-definition#con-saas-customer-access) topic to the [Custom domain](https://docs.redhat.com/en/documentation/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_service_on_aws/saas-service-definition#con-saas-custom-domain) section in the published doc.