### PR TITLE
Backport to 2.5: AAP-45978: DITA migration task: update content type statement

### DIFF
--- a/downstream/assemblies/hub/assembly-collection-import-export.adoc
+++ b/downstream/assemblies/hub/assembly-collection-import-export.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 [id="export-import-collections"]

--- a/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
+++ b/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="assembly-collections-and-content-signing-in-pah"]
 
 = Collections and content signing in {PrivateHubName}

--- a/downstream/assemblies/hub/assembly-container-user-access.adoc
+++ b/downstream/assemblies/hub/assembly-container-user-access.adoc
@@ -1,4 +1,4 @@
-
+:_mod-docs-content-type: ASSEMBLY
 
 ifdef::context[:parent-context: {context}]
 

--- a/downstream/assemblies/hub/assembly-delete-container.adoc
+++ b/downstream/assemblies/hub/assembly-delete-container.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 [id="delete-container"]

--- a/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
+++ b/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 [id="managing-cert-valid-content"]

--- a/downstream/assemblies/hub/assembly-managing-collections-hub.adoc
+++ b/downstream/assemblies/hub/assembly-managing-collections-hub.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 [id="managing-collections-hub"]

--- a/downstream/assemblies/hub/assembly-managing-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-managing-container-registry.adoc
@@ -1,4 +1,4 @@
-
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 

--- a/downstream/assemblies/hub/assembly-managing-containers-hub.adoc
+++ b/downstream/assemblies/hub/assembly-managing-containers-hub.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 [id="managing-containers-hub"]

--- a/downstream/assemblies/hub/assembly-managing-private-collections.adoc
+++ b/downstream/assemblies/hub/assembly-managing-private-collections.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="assembly-managing-private-collections"]
 
 = Managing the publication process of internal collections in Automation Hub

--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -1,4 +1,4 @@
-
+:_mod-docs-content-type: ASSEMBLY
 
 ifdef::context[:parent-context: {context}]
 

--- a/downstream/assemblies/hub/assembly-pull-image.adoc
+++ b/downstream/assemblies/hub/assembly-pull-image.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 [id="pulling-images-container-repository"]

--- a/downstream/assemblies/hub/assembly-remote-management.adoc
+++ b/downstream/assemblies/hub/assembly-remote-management.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 [id="remote-management"]

--- a/downstream/assemblies/hub/assembly-repo-management.adoc
+++ b/downstream/assemblies/hub/assembly-repo-management.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 [id="repo-management"]

--- a/downstream/assemblies/hub/assembly-repo-sync.adoc
+++ b/downstream/assemblies/hub/assembly-repo-sync.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 [id="repository-sync"]

--- a/downstream/assemblies/hub/assembly-setup-container-repository.adoc
+++ b/downstream/assemblies/hub/assembly-setup-container-repository.adoc
@@ -1,4 +1,4 @@
-
+:_mod-docs-content-type: ASSEMBLY
 
 ifdef::context[:parent-context: {context}]
 

--- a/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
+++ b/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="assembly-creating-tokens-in-automation-hub"]
 = Configuring {HubNameMain} remote repositories to synchronize content
 

--- a/downstream/assemblies/hub/assembly-synclists.adoc
+++ b/downstream/assemblies/hub/assembly-synclists.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="assembly-synclists"]
 = Synchronizing Ansible Content Collections in {HubName}
 

--- a/downstream/assemblies/hub/assembly-validated-content.adoc
+++ b/downstream/assemblies/hub/assembly-validated-content.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="assembly-validated-content"]
 = {Valid}
 

--- a/downstream/assemblies/hub/assembly-working-with-namespaces.adoc
+++ b/downstream/assemblies/hub/assembly-working-with-namespaces.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="assembly-working-with-namespaces"]
 
 = Using namespaces to manage collections in {HubName}

--- a/downstream/assemblies/hub/assembly-working-with-signed-containers.adoc
+++ b/downstream/assemblies/hub/assembly-working-with-signed-containers.adoc
@@ -1,4 +1,4 @@
-
+:_mod-docs-content-type: ASSEMBLY
 ifdef::context[:parent-context: {context}]
 
 

--- a/downstream/modules/hub/con-approval-pipeline.adoc
+++ b/downstream/modules/hub/con-approval-pipeline.adoc
@@ -1,6 +1,4 @@
-// Module included in the following assemblies:
-// assembly-repo-management.adoc
-
+:_mod-docs-content-type: CONCEPT
 
 [id="con-approval-pipeline"]
 

--- a/downstream/modules/hub/con-approval.adoc
+++ b/downstream/modules/hub/con-approval.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: CONCEPT
 [id="con-approval"]
 
 = About Approval

--- a/downstream/modules/hub/con-container-registry.adoc
+++ b/downstream/modules/hub/con-container-registry.adoc
@@ -1,4 +1,4 @@
-
+:_mod-docs-content-type: CONCEPT
 
 [id="container-registries"]
 

--- a/downstream/modules/hub/con-repo-rbac.adoc
+++ b/downstream/modules/hub/con-repo-rbac.adoc
@@ -1,5 +1,4 @@
-// Module included in the following assemblies:
-// assembly-repo-management.adoc
+:_mod-docs-content-type: CONCEPT
 
 
 [id="con-repo-rbac"]

--- a/downstream/modules/hub/proc-add-container-readme.adoc
+++ b/downstream/modules/hub/proc-add-container-readme.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 
 = Adding a README to your container repository
 

--- a/downstream/modules/hub/proc-add-group-to-container-repo.adoc
+++ b/downstream/modules/hub/proc-add-group-to-container-repo.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="providing-access-to-containers"]
 
 = Providing access to your {ExecEnvName}

--- a/downstream/modules/hub/proc-adding-an-execution-environment.adoc
+++ b/downstream/modules/hub/proc-adding-an-execution-environment.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="adding-an-execution-environment"]
 
 = Adding and signing an {ExecEnvShort}

--- a/downstream/modules/hub/proc-adding-collections-repository.adoc
+++ b/downstream/modules/hub/proc-adding-collections-repository.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-adding-collections-repository"]
 
 = Adding collections to an {HubName} repository

--- a/downstream/modules/hub/proc-adding-containers-remotely-to-the-automation-hub.adoc
+++ b/downstream/modules/hub/proc-adding-containers-remotely-to-the-automation-hub.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="adding-containers-remotely-to-the-automation-hub"]
 
 = Adding containers remotely to {HubName}

--- a/downstream/modules/hub/proc-approve-collection.adoc
+++ b/downstream/modules/hub/proc-approve-collection.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-approve-collection"]
 
 = Approving collections for internal publication

--- a/downstream/modules/hub/proc-basic-repo-sync.adoc
+++ b/downstream/modules/hub/proc-basic-repo-sync.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-basic-repo-sync"]
 
 = Synchronizing repositories in {HubName}

--- a/downstream/modules/hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-configure-ansible-galaxy-cli-verify"]
 
 = Configuring Ansible-Galaxy CLI to verify collections

--- a/downstream/modules/hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/hub/proc-configure-content-signing-on-pah.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-configure-content-signing-on-pah"]
 
 = Configuring content signing on {PrivateHubName}

--- a/downstream/modules/hub/proc-configuring-the-client-to-verify-signatures.adoc
+++ b/downstream/modules/hub/proc-configuring-the-client-to-verify-signatures.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-the-client-to-verify-signatures"]
 
 = Configuring the client to verify signatures

--- a/downstream/modules/hub/proc-create-api-token-pah.adoc
+++ b/downstream/modules/hub/proc-create-api-token-pah.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-create-api-token-pah_{context}"]
 = Creating the API token in {PrivateHubName}
 

--- a/downstream/modules/hub/proc-create-api-token.adoc
+++ b/downstream/modules/hub/proc-create-api-token.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-create-api-token_{context}"]
 = Creating the offline token in {HubName}
 

--- a/downstream/modules/hub/proc-create-content-developers.adoc
+++ b/downstream/modules/hub/proc-create-content-developers.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-create-content-developers"]
 
 = Creating a new team for content curators

--- a/downstream/modules/hub/proc-create-credential.adoc
+++ b/downstream/modules/hub/proc-create-credential.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-create-credential"]
 
 = Creating a credential

--- a/downstream/modules/hub/proc-create-namespace.adoc
+++ b/downstream/modules/hub/proc-create-namespace.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-create-namespace"]
 
 = Creating a namespace

--- a/downstream/modules/hub/proc-create-remote.adoc
+++ b/downstream/modules/hub/proc-create-remote.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-create-remote_{context}"]
 
 = Creating a remote configuration in {HubName}

--- a/downstream/modules/hub/proc-create-repository.adoc
+++ b/downstream/modules/hub/proc-create-repository.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-create-repository"]
 
 = Creating a custom repository in {HubName}

--- a/downstream/modules/hub/proc-create-synclist.adoc
+++ b/downstream/modules/hub/proc-create-synclist.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-create-synclist"]
 
 = Syncing Ansible content collections

--- a/downstream/modules/hub/proc-delete-collection.adoc
+++ b/downstream/modules/hub/proc-delete-collection.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="delete-collection"]
 
 = Deleting a collection

--- a/downstream/modules/hub/proc-delete-namespace.adoc
+++ b/downstream/modules/hub/proc-delete-namespace.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-delete-namespace"]
 
 = Deleting a namespace

--- a/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
+++ b/downstream/modules/hub/proc-deploying-your-system-for-container-signing.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="deploying-your-system-for-container-signing"]
 
 = Deploying your system for container signing

--- a/downstream/modules/hub/proc-downloading-signature-public-keys.adoc
+++ b/downstream/modules/hub/proc-downloading-signature-public-keys.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-downloading-signature-public-keys"]
 
 = Downloading signature public keys

--- a/downstream/modules/hub/proc-edit-namespace.adoc
+++ b/downstream/modules/hub/proc-edit-namespace.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-edit-namespace"]
 
 = Adding additional information and resources to a namespace

--- a/downstream/modules/hub/proc-export-collection.adoc
+++ b/downstream/modules/hub/proc-export-collection.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-export-collection"]
 
 = Exporting an automation content collection in {HubName}

--- a/downstream/modules/hub/proc-import-collection.adoc
+++ b/downstream/modules/hub/proc-import-collection.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-import-collection"]
 
 = Importing an automation content collection in {HubName}

--- a/downstream/modules/hub/proc-obtain-images.adoc
+++ b/downstream/modules/hub/proc-obtain-images.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="obtain-images"]
 = Pulling {ExecEnvShort}s for use in {HubName}
 

--- a/downstream/modules/hub/proc-offline-token-active.adoc
+++ b/downstream/modules/hub/proc-offline-token-active.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="con-offline-token-active_{context}"]
 
 = Keeping your offline token active

--- a/downstream/modules/hub/proc-provide-remote-access.adoc
+++ b/downstream/modules/hub/proc-provide-remote-access.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-provide-remote-access_{context}"]
 
 = Providing access to a remote configuration

--- a/downstream/modules/hub/proc-provide-repository-access.adoc
+++ b/downstream/modules/hub/proc-provide-repository-access.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-provide-repository-access"]
 
 = Providing access to a custom {HubName} repository

--- a/downstream/modules/hub/proc-pull-image.adoc
+++ b/downstream/modules/hub/proc-pull-image.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="pulling-image"]
 
 = Pulling an image

--- a/downstream/modules/hub/proc-push-container.adoc
+++ b/downstream/modules/hub/proc-push-container.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="push-containers"]
 
 

--- a/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
+++ b/downstream/modules/hub/proc-pushing-container-images-from-your-local.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="pushing-container-images-from-your-local"]
 
 = Pushing container images from your local environment

--- a/downstream/modules/hub/proc-reject-collections.adoc
+++ b/downstream/modules/hub/proc-reject-collections.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-reject-collections"]
 
 = Rejecting collections uploaded for review

--- a/downstream/modules/hub/proc-revert-repository-version.adoc
+++ b/downstream/modules/hub/proc-revert-repository-version.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-revert-repository-version"]
 
 = Revert to a different {HubName} repository version

--- a/downstream/modules/hub/proc-review-collection-imports.adoc
+++ b/downstream/modules/hub/proc-review-collection-imports.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-review-collection-imports"]
 = Reviewing your namespace import logs
 

--- a/downstream/modules/hub/proc-set-community-remote.adoc
+++ b/downstream/modules/hub/proc-set-community-remote.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-set-community-remote"]
 ifndef::operationG[]
 = Configuring the community remote repository to sync {Galaxy} collections

--- a/downstream/modules/hub/proc-set-rhcertified-remote.adoc
+++ b/downstream/modules/hub/proc-set-rhcertified-remote.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-set-rhcertified-remote_{context}"]
 = Configuring the rh-certified remote repository to sync {CertifiedName}
 

--- a/downstream/modules/hub/proc-tag-image.adoc
+++ b/downstream/modules/hub/proc-tag-image.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-tag-image"]
 
 = Tagging container images

--- a/downstream/modules/hub/proc-tag-pulled-image.adoc
+++ b/downstream/modules/hub/proc-tag-pulled-image.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="tag-pulled-images"]
 
 

--- a/downstream/modules/hub/proc-uploading-collections.adoc
+++ b/downstream/modules/hub/proc-uploading-collections.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-uploading-collections"]
 
 = Uploading collections to your namespaces

--- a/downstream/modules/hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/hub/proc-using-content-signing-services-in-pah.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="proc-using-content-signing-services-in-pah"]
 
 = Using content signing services in {PrivateHubName}

--- a/downstream/modules/hub/proc-using-podman-ensure-image-signed.adoc
+++ b/downstream/modules/hub/proc-using-podman-ensure-image-signed.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="using-podman-ensure-image-signed"]
 = Using podman to ensure an image is signed by a specific signature
 To ensure an {ExecEnvShort} is signed by specific signatures, the signatures must first be on your local environment.

--- a/downstream/modules/hub/proc-using-policies-with-signed-images.adoc
+++ b/downstream/modules/hub/proc-using-policies-with-signed-images.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="using-policies-with-signed-images_{context}"]
 
 = Policies with signed images

--- a/downstream/modules/hub/ref-container-permissions.adoc
+++ b/downstream/modules/hub/ref-container-permissions.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <REFERENCE>
+:_mod-docs-content-type: REFERENCE
 [id="container-registry-group-permissions"]
 
 = Remote registry team permissions


### PR DESCRIPTION
This PR ports the changes from [PR 3846](https://github.com/ansible/aap-docs/pull/3846) to the 2.5 branch. This work is being tracked in [AAP-49578](https://issues.redhat.com/browse/AAP-49578).