### PR TITLE
AAP-49578: DITA conversion, xrefs to links in Managing automation content guide

### DIFF
--- a/downstream/archive/archived-assemblies/hub/assembly-hub-create-api-token.adoc
+++ b/downstream/archive/archived-assemblies/hub/assembly-hub-create-api-token.adoc
@@ -10,15 +10,17 @@ Before you can interact with {HubName} by uploading or downloading collections, 
 
 Your method for creating the API token differs according to the type of {HubName} that you are using:
 
-* {HubNameStart} uses offline token management. See xref:proc-create-api-token_api-token[Creating the offline token in {HubName}].
+* {HubNameStart} uses offline token management. See link:{URLHubManagingContent}/managing-cert-valid-content#proc-create-api-token_cloud-sync[Creating the offline token in {HubName}].
 
-* {PrivateHubNameStart} uses API token management. See xref:proc-create-api-token-pah_api-token[Creating the API token in {PrivateHubName}].
+* {PrivateHubNameStart} uses API token management. See link:{URLHubManagingContent}/managing-cert-valid-content#proc-create-api-token-pah_cloud-sync[Creating the API token in {PrivateHubName}].
 
-* If you are using Keycloak to authenticate your {PrivateHubName}, follow the procedure for xref:proc-create-api-token_api-token[Creating the offline token in {HubName}].
+* If you are using Keycloak to authenticate your {PrivateHubName}, follow the procedure for link:{URLHubManagingContent}/managing-cert-valid-content#proc-create-api-token_cloud-sync[Creating the offline token in {HubName}].
 
 
 include::hub/proc-create-api-token.adoc[leveloffset=+1]
+
 include::hub/proc-create-api-token-pah.adoc[leveloffset=+1]
+
 include::hub/con-offline-token-active.adoc[leveloffset=+1]
 
 

--- a/downstream/archive/archived-assemblies/hub/assembly_ppah-installation.adoc
+++ b/downstream/archive/archived-assemblies/hub/assembly_ppah-installation.adoc
@@ -35,12 +35,19 @@ Your system must meet the following minimum system requirements to install and r
 |======================
 
 include::hub/proc_ppah-prepare-rhel-host.adoc[leveloffset=+1]
+
 include::hub/proc_ppah-install-ansible-core.adoc[leveloffset=+1]
+
 include::hub/proc_ppah-download-aap.adoc[leveloffset=+1]
+
 include::hub/proc_ppah-online-offline-install.adoc[leveloffset=+1]
+
 include::hub/proc_ppah-install-dev.adoc[leveloffset=+1]
+
 include::hub/proc_ppah-install-ha.adoc[leveloffset=+1]
+
 //include::hub/ref_ppah-config.adoc[leveloffset=+1]
+
 include::hub/ref_ppah-access.adoc[leveloffset=+1]
 
 

--- a/downstream/assemblies/hub/assembly-collection-import-export.adoc
+++ b/downstream/assemblies/hub/assembly-collection-import-export.adoc
@@ -12,6 +12,7 @@ ifdef::context[:parent-context: {context}]
 Collections are stored as .tar files that can be imported and exported. This storage format ensures that the collection you are importing to a new repository is the same one that was originally created and exported.
 
 include::hub/proc-export-collection.adoc[leveloffset=+1]
+
 include::hub/proc-import-collection.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/hub/assembly-container-user-access.adoc
+++ b/downstream/assemblies/hub/assembly-container-user-access.adoc
@@ -12,6 +12,7 @@ ifdef::context[:parent-context: {context}]
 To determine who can access and manage {ExecEnvShort}s in your {PlatformNameShort}, you must configure user access for container repositories in your {PrivateHubName}.
 
 include::hub/ref-container-permissions.adoc[leveloffset=+1]
+
 include::hub/proc-create-groups.adoc[leveloffset=+1]
 // [hherbly]: proc-assigning-permissions seems to repeat proc-create-groups.adoc include::hub/proc-assigning-permissions.adoc[leveloffset=+1]
 
@@ -19,7 +20,6 @@ include::hub/proc-create-groups.adoc[leveloffset=+1]
 
 // [hherbly] LINK SHOULD BE REPLACED when we find a better one * See <<container-registry-group-permissions, Container registry team permissions>> to learn more about specific permissions.
 
-// [hherbly]: this module also seems redundant include::hub/proc-add-user-to-group.adoc[leveloffset=+1]
 
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
+++ b/downstream/assemblies/hub/assembly-managing-cert-valid-content.adoc
@@ -2,7 +2,7 @@
 ifdef::context[:parent-context: {context}]
 
 [id="managing-cert-valid-content"]
-= Red Hat Certified, validated, and Ansible Galaxy content in automation hub
+= Red Hat Certified, validated, and Ansible Galaxy content in {HubName}
 
 :context: cloud-sync
 
@@ -14,7 +14,7 @@ Red Hat Ansible content contains two types of content:
 * {CertifiedName}
 * {Valid} collections
 
-You can use both {CertifiedName} or {Valid} collections to build your automation library. For more information on the differences between {CertifiedName} and {Valid} collections, see the Knowledgebase article link:https://access.redhat.com/support/articles/ansible-automation-platform-certified-content[{CertifiedName} and {Valid}], or xref:assembly-validated-content[{Valid}] in this guide.
+You can use both {CertifiedName} or {Valid} collections to build your automation library. For more information on the differences between {CertifiedName} and {Valid} collections, see the Knowledgebase article link:https://access.redhat.com/support/articles/ansible-automation-platform-certified-content[{CertifiedName} and {Valid}], or link:{URLHubManagingContent}/managing-cert-valid-content#assembly-validated-content[{Valid}] in this guide.
 
 // hherbly--removed, see aap-20548  
 // Ansible validated collections are available in your {PrivateHubName} through the platform installer.
@@ -22,7 +22,7 @@ You can use both {CertifiedName} or {Valid} collections to build your automation
 
 // If you are not using the bundle installer, you can use a Red Hat supplied Ansible playbook to install validated content.
 
-// For further information, see xref:assembly-validated-content[{Valid}].
+// For further information, see link:{URLHubManagingContent}/managing-cert-valid-content#assembly-validated-content[{Valid}].
 
 You can update these collections manually by downloading their packages.
 
@@ -64,9 +64,9 @@ You can use {HubNameMain} to distribute the relevant {CertifiedColl}s to your us
 
 Before you can use a requirements file to install content, you must: 
 
-. xref:token-management-hub_cloud-sync[Obtain an automation hub API token]
-. xref:proc-set-rhcertified-remote_cloud-sync[Use the API token to configure a remote repository in your local hub]
-. Then, xref:create-requirements-file_cloud-sync[Create a requirements file].
+. link:{URLHubManagingContent}/managing-cert-valid-content#token-management-hub_cloud-sync[Obtain an {HubName} API token]
+. link:{URLHubManagingContent}/managing-cert-valid-content#proc-set-rhcertified-remote_cloud-sync[Use the API token to configure a remote repository in your local hub]
+. Then, link:{URLHubManagingContent}/managing-cert-valid-content#create-requirements-file_cloud-sync[Create a requirements file].
 
 
 

--- a/downstream/assemblies/hub/assembly-populate-container-registry.adoc
+++ b/downstream/assemblies/hub/assembly-populate-container-registry.adoc
@@ -50,7 +50,9 @@ Ensure that the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[Net
 ====
 
 include::hub/proc-obtain-images.adoc[leveloffset=+1]
+
 include::hub/proc-tag-pulled-image.adoc[leveloffset=+1]
+
 include::hub/proc-push-container.adoc[leveloffset=+1]
 
 

--- a/downstream/assemblies/hub/assembly-pull-image.adoc
+++ b/downstream/assemblies/hub/assembly-pull-image.adoc
@@ -12,6 +12,7 @@ Pull {ExecEnvName} from the {HubName} remote registry to make a copy to your loc
 You can copy and paste this command into your terminal, or use `podman pull` to copy an {ExecEnvName} based on an {ExecEnvName} tag.
 
 include::hub/proc-pull-image.adoc[leveloffset=+1]
+
 include::hub/proc-sync-image.adoc[leveloffset=+1]
 
 

--- a/downstream/assemblies/hub/assembly-remote-management.adoc
+++ b/downstream/assemblies/hub/assembly-remote-management.adoc
@@ -10,6 +10,7 @@ ifdef::context[:parent-context: {context}]
 You can set up remote configurations to any server that is running {HubName}. Remote configurations allow you to sync content to your custom repositories from an external collection source.
 
 include::hub/proc-create-remote.adoc[leveloffset=+1]
+
 include::hub/proc-provide-remote-access.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/downstream/assemblies/hub/assembly-repo-management.adoc
+++ b/downstream/assemblies/hub/assembly-repo-management.adoc
@@ -9,7 +9,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 As a platform administrator, you can create, edit, delete, and move automation content collections between repositories.
 
-== Types of repositories in automation hub
+== Types of repositories in {HubName}
 
 In {HubName} you can publish collections to two types of repositories, depending on whether you want your collection to be verified:
 
@@ -17,13 +17,18 @@ Staging repositories:: Any user with permission to upload to a namespace can pub
 
 Custom repositories:: Any user with write permissions on the repository can publish collections to these repositories. Custom repositories can be public where all users can see them, or private where only users with view permissions can see them. These repositories are not displayed on the approval dashboard. If the repository owner enables search, the collection can appear in search results.
 
-By default, {HubName} includes one staging repository that is automatically used when a repository is not specified for uploading collections. Users can create new staging repositories during xref:proc-create-repository[repository creation].
+By default, {HubName} includes one staging repository that is automatically used when a repository is not specified for uploading collections. Users can create new staging repositories during link:{URLHubManagingContent}/managing-collections-hub#proc-create-repository[repository creation].
 
 include::hub/con-approval-pipeline.adoc[leveloffset=+1]
+
 include::hub/con-repo-rbac.adoc[leveloffset=+1]
+
 include::hub/proc-create-repository.adoc[leveloffset=+1]
+
 include::hub/proc-provide-repository-access.adoc[leveloffset=+1]
+
 include::hub/proc-adding-collections-repository.adoc[leveloffset=+1]
+
 include::hub/proc-revert-repository-version.adoc[leveloffset=+1]
 
 

--- a/downstream/assemblies/hub/assembly-setup-container-repository.adoc
+++ b/downstream/assemblies/hub/assembly-setup-container-repository.adoc
@@ -20,8 +20,11 @@ When you set up your container repository, you must add a description, include a
 
 
 include::hub/proc-add-container-readme.adoc[leveloffset=+1]
+
 include::hub/proc-add-group-to-container-repo.adoc[leveloffset=+1]
+
 include::hub/proc-tag-image.adoc[leveloffset=+1]
+
 include::hub/proc-create-credential.adoc[leveloffset=+1]
 
 

--- a/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
+++ b/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
@@ -9,8 +9,7 @@ Use remote configurations to configure your {PrivateHubName} to synchronize with
 Each remote configuration located in {MenuACAdminRemotes} provides information for both the *community* and *rh-certified* repository about when the repository was *last updated*.
 You can add new content to {HubNameMain} at any time using the *Edit* and *Sync* features included on the {MenuACAdminRepositories} page.
 
-[discrete]
-== What's the difference between {Galaxy} and {HubNameMain}?
+*What's the difference between {Galaxy} and {HubNameMain}?*
 
 Collections published to {Galaxy} are the latest content published by the Ansible community and have no joint support claims associated with them. 
 {Galaxy} is the recommended frontend directory for the Ansible community to access content.
@@ -19,8 +18,7 @@ Collections published to {HubNameMain} are targeted to joint customers of Red Ha
 Customers need an Ansible subscription to access and download collections on {HubNameMain}. 
 A certified collection means that Red Hat and partners have a strategic relationship in place and are ready to support joint customers, and that the collections may have had additional testing and validation done against them.
 
-[discrete]
-== How do I request a namespace on {Galaxy}?
+*How do I request a namespace on {Galaxy}?*
 
 To request a namespace through an {Galaxy} GitHub issue, follow these steps:
 
@@ -31,8 +29,7 @@ You must have logged in at least once for the system to validate.
 
 After users are added as administrators of the namespace, you can use the self-serve process to add more administrators.
 
-[discrete]
-== Are there any restrictions for {Galaxy} namespace naming?
+*Are there any restrictions for {Galaxy} namespace naming?*
 
 Collection namespaces must follow Python module name convention. 
 This means collections should have short, all lowercase names. 

--- a/downstream/assemblies/hub/assembly-synclists.adoc
+++ b/downstream/assemblies/hub/assembly-synclists.adoc
@@ -6,4 +6,5 @@ To synchronize content, create and upload a requirements file to the appropriate
 Remotes are configurations that enable you to synchronize content to your custom repositories from an external collection source.
 
 // include::hub/con-rh-certified-synclist.adoc[leveloffset=+1]
+
 include::hub/proc-create-synclist.adoc[leveloffset=+1]


### PR DESCRIPTION
This work is being tracked in [AAP-49578](https://issues.redhat.com/browse/AAP-49578)

Changes include:
- changes xrefs to links in all assemblies in managing automation content
- Adds spaces between include statements in assemblies
- removes discrete headings from assemblies