### PR TITLE
Adding callback URL field info to OIDC auth section

### DIFF
--- a/downstream/modules/platform/proc-controller-set-up-generic-oidc.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-generic-oidc.adoc
@@ -28,6 +28,10 @@ include::snippets/snip-gw-authentication-auto-migrate.adoc[]
 * *Access Token URL*
 * *Access Token Method*
 * *Authorization URL*
+* *Callback URL* - The OIDC *Callback URL* field registers the service as a service provider (SP) with each OIDC provider (IdP) you have configured. 
+Leave this field blank. 
+After you save this authentication method, it is auto generated. 
+This field must match the *Redirect Endpoint URL* setting in your IdP.
 * *ID Key*
 * *ID Token Issuer*
 * *JWKS URI*


### PR DESCRIPTION
[DOCS] Generic OIDC Authenticator Does Not Provide a Callback URL

https://issues.redhat.com/browse/AAP-49860

Affects `titles/central-auth`