### PR TITLE
2.6 Update Containerized installation for AAP 2.6 (#3906)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -10,13 +10,6 @@ ifdef::context[:parent-context: {context}]
 
 This guide helps you to understand the installation requirements and processes behind the containerized version of {PlatformNameShort}. 
 
-[NOTE]
-====
-
-include::snippets/container-upgrades.adoc[]
-
-====
-
 == Tested deployment models
 
 Red Hat tests {PlatformNameShort} {PlatformVers} with a defined set of topologies to give you opinionated deployment options. The supported topologies include infrastructure topology diagrams, tested system configurations, example inventory files, and network ports information.

--- a/downstream/modules/platform/proc-downloading-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-downloading-containerized-aap.adoc
@@ -36,13 +36,13 @@ scp -i <path_to_private_key> ansible-automation-platform-containerized-setup-<ve
 .. To unpack the online installer:
 +
 ----
-$ tar xfvz ansible-automation-platform-containerized-setup-<version>.tar.gz
+$ tar xfvz ansible-automation-platform-containerized-setup-<version_number>.tar.gz
 ----
 +
 .. To unpack the offline or bundled installer:
 +
 ----
-$ tar xfvz ansible-automation-platform-containerized-setup-bundle-<version>-<arch_name>.tar.gz
+$ tar xfvz ansible-automation-platform-containerized-setup-bundle-<version_number>-<arch_name>.tar.gz
 ----
 
 [role="_additional-resources"]

--- a/downstream/modules/platform/proc-enabling-automation-hub-collection-and-container-signing.adoc
+++ b/downstream/modules/platform/proc-enabling-automation-hub-collection-and-container-signing.adoc
@@ -38,7 +38,7 @@ The algorithm and cipher used is the responsibility of the customer.
 
 .Procedure
 
-. On a RHEL9 server run the following command to create a new key pair for collection signing:
+. On a RHEL server run the following command to create a new key pair for collection signing:
 +
 ----
 gpg --gen-key

--- a/downstream/modules/platform/proc-restore-aap-container.adoc
+++ b/downstream/modules/platform/proc-restore-aap-container.adoc
@@ -39,7 +39,7 @@ Restoring to a different environment with different hostnames is not recommended
 For example:
 +
 ----
-$ cd ansible-automation-platform-containerized-setup-2.5-XX/backups
+$ cd ansible-automation-platform-containerized-setup-<version_number>/backups
 ----
 +
 ----
@@ -53,7 +53,7 @@ $ tar tvf gateway_env1-gateway-node1.tar.gz | grep db
 For example:
 +
 ----
-$ cd ansible-automation-platform-containerized-setup-2.5-XX/backups
+$ cd ansible-automation-platform-containerized-setup-<version_number>/backups
 ----
 +
 ----
@@ -64,7 +64,7 @@ $ mv gateway_env1-gateway-node1.tar.gz gateway_env2-gateway-node1.tar.gz
 For example:
 +
 ----
-$ cd ansible-automation-platform-containerized-setup-2.5-XX
+$ cd ansible-automation-platform-containerized-setup-<version_number>
 ----
 +
 ----

--- a/downstream/modules/platform/proc-update-aap-container.adoc
+++ b/downstream/modules/platform/proc-update-aap-container.adoc
@@ -3,9 +3,7 @@
 
 = Updating containerized {PlatformNameShort}
 
-Perform a patch update for a {ContainerBase} of {PlatformNameShort} from 2.5 to 2.5.x.
-
-include::snippets/container-upgrades.adoc[]
+Perform an upgrade of containerized {PlatformNameShort}. 
 
 .Prerequisites
 

--- a/downstream/modules/platform/ref-containerized-troubleshoot-ref.adoc
+++ b/downstream/modules/platform/ref-containerized-troubleshoot-ref.adoc
@@ -8,31 +8,9 @@
 
 We use as much of the underlying native {RHEL} technology as possible. Podman is used for the container runtime and management of services. 
 
-Use `podman ps` to list the running containers on the system:
+Use `podman ps` to list the running containers on the system.
 
-----
-$ podman ps
-
-CONTAINER ID  IMAGE                                                                        COMMAND               CREATED         STATUS         PORTS       NAMES
-88ed40495117  registry.redhat.io/rhel8/postgresql-13:latest                                run-postgresql        48 minutes ago  Up 47 minutes              postgresql
-8f55ba612f04  registry.redhat.io/rhel8/redis-6:latest                                      run-redis             47 minutes ago  Up 47 minutes              redis
-56c40445c590  registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel8:latest  /usr/bin/receptor...  47 minutes ago  Up 47 minutes              receptor
-f346f05d56ee  registry.redhat.io/ansible-automation-platform-24/controller-rhel8:latest    /usr/bin/launch_a...  47 minutes ago  Up 45 minutes              automation-controller-rsyslog
-26e3221963e3  registry.redhat.io/ansible-automation-platform-24/controller-rhel8:latest    /usr/bin/launch_a...  46 minutes ago  Up 45 minutes              automation-controller-task
-c7ac92a1e8a1  registry.redhat.io/ansible-automation-platform-24/controller-rhel8:latest    /usr/bin/launch_a...  46 minutes ago  Up 28 minutes              automation-controller-web
-----
-
-Use `podman images` to display information about locally stored images:
-
-----
-$ podman images
-
-REPOSITORY                                                            TAG         IMAGE ID      CREATED      SIZE
-registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel8  latest      b497bdbee59e  10 days ago  3.16 GB
-registry.redhat.io/ansible-automation-platform-24/controller-rhel8    latest      ed8ebb1c1baa  10 days ago  1.48 GB
-registry.redhat.io/rhel8/redis-6                                      latest      78905519bb05  2 weeks ago  357 MB
-registry.redhat.io/rhel8/postgresql-13                                latest      9b65bc3d0413  2 weeks ago  765 MB
-----
+Use `podman images` to display information about locally stored images.
 
 Containerized {PlatformNameShort} runs as rootless containers for enhanced security by default. This means you can install containerized {PlatformNameShort} by using any local unprivileged user account. Privilege escalation is only needed for certain root level tasks, and by default is not needed to use root directly.
 

--- a/downstream/modules/platform/ref-images-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-images-inventory-variables.adoc
@@ -18,7 +18,7 @@
 | `controller_image` 
 | Container image for {ControllerName}.
 | Optional
-| `controller-rhel8:latest`
+| `controller-rhel9:latest`
 
 |
 | `de_extra_images` 
@@ -30,19 +30,19 @@
 | `de_supported_image` 
 | Supported decision environment container image.
 | Optional
-| `de-supported-rhel8:latest`
+| `de-supported-rhel9:latest`
 
 | 
 | `eda_image` 
 | Backend container image for {EDAName}. 
 | Optional
-| `eda-controller-rhel8:latest`
+| `eda-controller-rhel9:latest`
 
 | 
 | `eda_web_image` 
 | Front-end container image for {EDAName}.
 | Optional
-| `eda-controller-ui-rhel8:latest`
+| `eda-controller-ui-rhel9:latest`
 
 | 
 | `ee_extra_images` 
@@ -54,37 +54,37 @@
 | `ee_minimal_image` 
 | Minimal {ExecEnvShort} container image. 
 | Optional
-| `ee-minimal-rhel8:latest`
+| `ee-minimal-rhel9:latest`
 
 | 
 | `ee_supported_image` 
 | Supported {ExecEnvShort} container image.
 | Optional
-| `ee-supported-rhel8:latest`
+| `ee-supported-rhel9:latest`
 
 |
 | `gateway_image`
 | Container image for {Gateway}.
 | Optional
-| `gateway-rhel8:latest`
+| `gateway-rhel9:latest`
 
 |
 | `gateway_proxy_image`
 | Container image for {Gateway} proxy.
 | Optional
-| `gateway-proxy-rhel8:latest`
+| `gateway-proxy-rhel9:latest`
 
 | 
 | `hub_image` 
 | Backend container image for {HubName}.
 | Optional
-| `hub-rhel8:latest`
+| `hub-rhel9:latest`
 
 |
 | `hub_web_image`
 | Front-end container image for {HubName}.
 | Optional
-| `hub-web-rhel8:latest`
+| `hub-web-rhel9:latest`
 
 |
 | `pcp_image`
@@ -102,7 +102,7 @@
 | `receptor_image`
 | Container image for receptor.
 | Optional
-| `receptor-rhel8:latest`
+| `receptor-rhel9:latest`
 
 |
 | `redis_image`

--- a/downstream/snippets/cont-tested-system-config.adoc
+++ b/downstream/snippets/cont-tested-system-config.adoc
@@ -12,7 +12,7 @@ a|
 | Operating system 
 
 a| 
-* {RHEL} 9.2 or later minor versions of {RHEL} 9.
+* {RHEL} 9.4 or later minor versions of {RHEL} 9.
 * {RHEL} 10 or later minor versions of {RHEL} 10 for enterprise topologies.
 | 
 
@@ -33,7 +33,11 @@ a|
 |
 
 | Database 
-| {PostgresVers}
-| External (customer supported) databases require ICU support.
+a| 
+* For {PlatformNameShort} managed databases: {PostgresVers}
+* For customer provided (external) databases: {PostgresVers}, 16, or 17.
+a| 
+* External (customer supported) databases require ICU support.
+* External databases using PostgreSQL 16 or 17 must rely on external backup and restore processes. Backup and restore functionality is dependent on utilities provided with {PostgresVers}.
 
 |====

--- a/downstream/snippets/inventory-cont-a-env-a.adoc
+++ b/downstream/snippets/inventory-cont-a-env-a.adoc
@@ -5,12 +5,12 @@
 # This is the {PlatformNameShort} installer inventory file intended for the container growth deployment topology.
 # This inventory file expects to be run from the host where {PlatformNameShort} will be installed.
 # Consult the {PlatformNameShort} product documentation about this topology's tested hardware configuration.
-# {URLTopologies}/container-topologies
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/tested_deployment_models/container-topologies
 #
 # Consult the docs if you are unsure what to add
 # For all optional variables consult the included README.md
 # or the {PlatformNameShort} documentation:
-# {URLContainerizedInstall}
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation
 
 # This section is for your {Gateway} hosts
 # -----------------------------------------------------
@@ -42,7 +42,7 @@ aap.example.org
 ansible_connection=local
 
 # Common variables
-# {URLContainerizedInstall}/appendix-inventory-files-vars#general-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#general-variables
 # -----------------------------------------------------
 postgresql_admin_username=postgres
 postgresql_admin_password=<set your own>
@@ -53,14 +53,14 @@ registry_password=<your RHN password>
 redis_mode=standalone
 
 # {GatewayStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#platform-gateway-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#platform-gateway-variables
 # -----------------------------------------------------
 gateway_admin_password=<set your own>
 gateway_pg_host=aap.example.org
 gateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#controller-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#controller-variables
 # -----------------------------------------------------
 controller_admin_password=<set your own>
 controller_pg_host=aap.example.org
@@ -68,7 +68,7 @@ controller_pg_password=<set your own>
 controller_percent_memory_capacity=0.5
 
 # {HubNameStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#hub-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#hub-variables
 # -----------------------------------------------------
 hub_admin_password=<set your own>
 hub_pg_host=aap.example.org
@@ -76,7 +76,7 @@ hub_pg_password=<set your own>
 hub_seed_collections=false
 
 # {EDAcontroller}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#event-driven-ansible-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#event-driven-ansible-variables
 # -----------------------------------------------------
 eda_admin_password=<set your own>
 eda_pg_host=aap.example.org

--- a/downstream/snippets/inventory-cont-b-env-a.adoc
+++ b/downstream/snippets/inventory-cont-b-env-a.adoc
@@ -6,7 +6,7 @@
 # Consult the docs if you are unsure what to add
 # For all optional variables consult the included README.md
 # or the Red Hat documentation:
-# {URLContainerizedInstall}
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation
 
 # This section is for your {Gateway} hosts
 # -----------------------------------------------------
@@ -50,7 +50,7 @@ eda2.example.org
 [all:vars]
 
 # Common variables
-# {URLContainerizedInstall}/appendix-inventory-files-vars#general-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#general-variables
 # -----------------------------------------------------
 postgresql_admin_username=<set your own>
 postgresql_admin_password=<set your own>
@@ -58,7 +58,7 @@ registry_username=<your RHN username>
 registry_password=<your RHN password>
 
 # {GatewayStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#platform-gateway-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#platform-gateway-variables
 # -----------------------------------------------------
 gateway_admin_password=<set your own>
 gateway_pg_host=externaldb.example.org
@@ -67,7 +67,7 @@ gateway_pg_username=<set your own>
 gateway_pg_password=<set your own>
 
 # {ControllerNameStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#controller-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#controller-variables
 # -----------------------------------------------------
 controller_admin_password=<set your own>
 controller_pg_host=externaldb.example.org
@@ -76,7 +76,7 @@ controller_pg_username=<set your own>
 controller_pg_password=<set your own>
 
 # {HubNameStart}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#hub-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#hub-variables
 # -----------------------------------------------------
 hub_admin_password=<set your own>
 hub_pg_host=externaldb.example.org
@@ -85,7 +85,7 @@ hub_pg_username=<set your own>
 hub_pg_password=<set your own>
 
 # {EDAcontroller}
-# {URLContainerizedInstall}/appendix-inventory-files-vars#event-driven-ansible-variables
+# https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/appendix-inventory-files-vars#event-driven-ansible-variables
 # -----------------------------------------------------
 eda_admin_password=<set your own>
 eda_pg_host=externaldb.example.org


### PR DESCRIPTION
Backports #3906 from main to 2.6 

Update Containerized installation for AAP 2.6

https://issues.redhat.com/browse/AAP-48592