### PR TITLE
Fixing table headers in crsf section of OCP guide

### DIFF
--- a/downstream/modules/platform/proc-operator-config-csrf-gateway.adoc
+++ b/downstream/modules/platform/proc-operator-config-csrf-gateway.adoc
@@ -33,7 +33,7 @@ spec:
 
 {OCP} creates the pods. This may take a few minutes. You can view the progress by navigating to menu:Workloads[Pods] and locating the newly created instance. Verify that the following operator pods provided by the {OperatorPlatformName} installation from {Gateway} are running:
 
-[cols="a,a,a,a,a"]
+[cols="a,a,a,a,a", options="header", subs=+attributes]
 |===
 | Operator manager controllers pods | {ControllerNameStart} pods |{HubNameStart} pods |{EDAName} (EDA) pods |{Gateway} pods
 

--- a/downstream/modules/platform/ref-operator-ocp-version.adoc
+++ b/downstream/modules/platform/ref-operator-ocp-version.adoc
@@ -10,4 +10,4 @@ The {OperatorPlatformNameShort} to install {PlatformNameShort} {PlatformVers} is
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle].
+* link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[Red Hat Ansible Automation Platform Life Cycle]


### PR DESCRIPTION
Just fixing an issue where the heading in my table didn't recognise the attribute. Confirmed fix after building. 

Also removed a full stop after a link that was causing an issue. 