### PR TITLE
2.6 Update backup/restore note (#3918)

### DIFF
--- a/downstream/assemblies/platform/assembly-ag-controller-backup-and-restore.adoc
+++ b/downstream/assemblies/platform/assembly-ag-controller-backup-and-restore.adoc
@@ -10,12 +10,12 @@ For more information, see the link:{URLControllerAdminGuide}/index#controller-ba
 
 [NOTE]
 ====
-Ensure that you restore to the same version from which it was backed up.
-However, you must use the most recent minor version of a release to backup or restore your {PlatformNameShort} installation version.
-For example, if the current {PlatformNameShort} version you are on is 2.0.x, use only the latest 2.0 installer.
+When backing up {PlatformNameShort}, use the installation program that matches your currently installed version of {PlatformNameShort}.
 
-Backup and restore only works on PostgreSQL versions supported by your current platform version. 
-For more information, see link:{URLPlanningGuide}/platform-system-requirements[System requirements] in the _{TitlePlanningGuide}_.
+When restoring {PlatformNameShort}, use the latest installation program available at the time of the restore. For example, if you are restoring a backup taken from version `2.6-1`, use the latest `2.6-x` installation program available at the time of the restore.
+
+Backup and restore functionality only works with the PostgreSQL versions supported by your current {PlatformNameShort} version. 
+For more information, see link:{URLPlanningGuide}/platform-system-requirements[System requirements] in _{TitlePlanningGuide}_.
 ====
 
 The {PlatformNameShort} setup playbook is invoked as `setup.sh` from the path where you unpacked the platform installer tarball. 


### PR DESCRIPTION
Backports #3918 from main to 2.6

Configuring automation execution - Update backup and restore note to ensure clarity regarding the latest version prerequisite

https://issues.redhat.com/browse/AAP-46263