### PR TITLE
Bp to 2.5: AAP-45952: adds PaC info to getting started guide intro (#3922)

### DIFF
--- a/downstream/modules/platform/con-gs-automation-execution.adoc
+++ b/downstream/modules/platform/con-gs-automation-execution.adoc
@@ -14,3 +14,7 @@ In the automation execution environment, you can use {ControllerName} tasks to b
 An inventory is a single file, usually in INI or YAML format, containing a list of hosts and groups that can be acted upon using Ansible commands and playbooks. 
 You can use an inventory file to specify your installation scenario and describe host deployments to Ansible. 
 You can also use an inventory file to organize managed nodes in centralized files that give Ansible with system information and network locations. 
+
+== Policy enforcement
+
+Policy enforcement at automation runtime is a feature that uses encoded rules to define, manage, and enforce policies that govern how your users interact with your {PlatformNameShort} instance. Policy enforcement automates policy management, improving security, compliance, and efficiency. Policy enforcement points can be configured at the level of the inventory, job template, or organization. For more, see link:{URLControllerAdminGuide}/controller-pac[Implementing policy enforcement] in the {TitleControllerAdminGuide} guide.


### PR DESCRIPTION
This PR ports the changes from [PR 3922](https://github.com/ansible/aap-docs/pull/3922) to the 2.5 branch. This work is being tracked in [AAP-45942](https://issues.redhat.com/browse/AAP-45942).