### PR TITLE
2.6 Add backup/restore note to Containerized installation (#3946)

### DIFF
--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -4,7 +4,16 @@
 
 = Backing up containerized {PlatformNameShort}
 
+[role="_abstract"]
 Perform a backup of your {ContainerBase} of {PlatformNameShort}.
+
+[NOTE]
+====
+When backing up {PlatformNameShort}, use the installation program that matches your currently installed version of {PlatformNameShort}.
+
+Backup functionality only works with the PostgreSQL versions supported by your current {PlatformNameShort} version. 
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/aap-containerized-installation#system-requirements[System requirements].
+====
 
 .Prerequisites
 

--- a/downstream/modules/platform/proc-restore-aap-container.adoc
+++ b/downstream/modules/platform/proc-restore-aap-container.adoc
@@ -3,11 +3,20 @@
 [id="proc-restore-aap-container"]
 = Restoring containerized {PlatformNameShort}
 
+[role="_abstract"]
 Restore your {ContainerBase} of {PlatformNameShort} from a backup, or to a different environment.
+
+[NOTE]
+====
+When restoring {PlatformNameShort}, use the latest installation program available at the time of the restore. For example, if you are restoring a backup taken from version `2.6-1`, use the latest `2.6-x` installation program available at the time of the restore.
+
+Restore functionality only works with the PostgreSQL versions supported by your current {PlatformNameShort} version. 
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/aap-containerized-installation#system-requirements[System requirements].
+====
 
 .Prerequisites
 * You have logged in to the {RHEL} host as your dedicated non-root user.
-* You have a backup of your {PlatformNameShort} deployment. For more information, see link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backing up container-based {PlatformNameShort}].
+* You have a backup of your {PlatformNameShort} deployment. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/containerized_installation/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backing up containerized {PlatformNameShort}].
 * If restoring to a different environment with the same hostnames, you have performed a fresh installation on the target environment with the same topology as the original (source) environment.
 * You have ensured that the administrator credentials on the target environment match the administrator credentials from the source environment.
 


### PR DESCRIPTION
Backports #3946 from main to 2.6

Containerized installation - Update backup & restore procedures to ensure clarity regarding the latest version prerequisite

https://issues.redhat.com/browse/AAP-46266