### PR TITLE
Add reference to AWS (#3957)

### DIFF
--- a/downstream/assemblies/platform/assembly-planning-mesh.adoc
+++ b/downstream/assemblies/platform/assembly-planning-mesh.adoc
@@ -19,7 +19,7 @@ Simple to complex topology examples are included to illustrate the various ways 
 endif::mesh-VM[]
 ifdef::operator-mesh[]
 The following topics contain information to help plan an {AutomationMesh} deployment in your operator-based {PlatformName} environment. 
-The document covers the setting up of {AutomationMesh} on operator-based deployments, such as {OCPShort} and {PlatformNameShort} on {Azure} managed application. 
+The document covers the setting up of {AutomationMesh} on operator-based deployments, such as {OCPShort} and {PlatformNameShort} on {AWS} (AWS) and {Azure} managed applications. 
 endif::operator-mesh[]
 
 include::platform/con-about-automation-mesh.adoc[leveloffset=+1]


### PR DESCRIPTION
Include specific reference to AWS Managed coverage within automation mesh docs for operator-based envs.

https://issues.redhat.com/browse/AAP-50358