### PR TITLE
2.6 Update docs for mod docs (#3956)

### DIFF
--- a/downstream/assemblies/aap-migration/assembly-migration-artifact.adoc
+++ b/downstream/assemblies/aap-migration/assembly-migration-artifact.adoc
@@ -3,6 +3,7 @@
 [id="migration-artifact"]
 = Migration artifact structure and verification
 
+[role="_abstract"]
 The migration artifact is a critical component for successfully transferring your {PlatformNameShort} deployment. It packages all necessary data and configurations from your source environment.
 
 This section details the structure of the migration artifact and includes a migration checklist for artifact verification.

--- a/downstream/assemblies/aap-migration/assembly-migration-prerequisites.adoc
+++ b/downstream/assemblies/aap-migration/assembly-migration-prerequisites.adoc
@@ -3,6 +3,7 @@
 [id="migration-prerequisites"]
 = Migration prerequisites 
 
+[role="_abstract"]
 Prerequisites for migrating your {PlatformNameShort} deployment. For your specific migration path, ensure that you meet all necessary conditions before proceeding.
 
 include::aap-migration/con-rpm-to-containerized-prerequisites.adoc[leveloffset=+1]

--- a/downstream/assemblies/aap-migration/assembly-source-containerized.adoc
+++ b/downstream/assemblies/aap-migration/assembly-source-containerized.adoc
@@ -3,6 +3,7 @@
 [id="source-containerized"]
 = Container-based {PlatformNameShort}
 
+[role="_abstract"]
 Prepare and export data from your container-based {PlatformNameShort} deployment.
 
 include::aap-migration/proc-containerized-source-environment-preparation-assessment.adoc[leveloffset=+1]

--- a/downstream/assemblies/aap-migration/assembly-source-rpm.adoc
+++ b/downstream/assemblies/aap-migration/assembly-source-rpm.adoc
@@ -3,6 +3,7 @@
 [id="source-rpm"]
 = RPM-based {PlatformNameShort}
 
+[role="_abstract"]
 Prepare and export data from your RPM-based {PlatformNameShort} deployment.
 
 include::aap-migration/proc-rpm-environment-source-prep.adoc[leveloffset=+1]

--- a/downstream/assemblies/aap-migration/assembly-target-containerized.adoc
+++ b/downstream/assemblies/aap-migration/assembly-target-containerized.adoc
@@ -3,6 +3,7 @@
 [id="target-containerized"]
 = Container-based {PlatformNameShort}
 
+[role="_abstract"]
 Prepare and assess your target container-based {PlatformNameShort} environment, and import and reconcile your migrated content.
 
 include::aap-migration/proc-containerized-target-prep.adoc[leveloffset=+1]

--- a/downstream/assemblies/aap-migration/assembly-target-managed-aap.adoc
+++ b/downstream/assemblies/aap-migration/assembly-target-managed-aap.adoc
@@ -3,6 +3,7 @@
 [id="target-managed-aap"]
 = Managed {PlatformNameShort}
 
+[role="_abstract"]
 Prepare and migrate your source environment to a Managed {PlatformNameShort} deployment, and reconcile the target environment post-migration.
 
 include::aap-migration/proc-managed-target-migration.adoc[leveloffset=+1]

--- a/downstream/assemblies/aap-migration/assembly-target-ocp.adoc
+++ b/downstream/assemblies/aap-migration/assembly-target-ocp.adoc
@@ -3,6 +3,7 @@
 [id="target-ocp"]
 = {OCPShort}
 
+[role="_abstract"]
 Prepare and assess your target {OCPShort} environment, and import and reconcile your migrated content.
 
 include::aap-migration/proc-ocp-target-prep.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-installation.adoc
@@ -6,6 +6,7 @@ ifdef::context[:parent-context: {context}]
 
 :context: aap-containerized-installation
 
+[role="_abstract"]
 {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
 This guide helps you to understand the installation requirements and processes behind the containerized version of {PlatformNameShort}. 

--- a/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-inventory-file-vars.adoc
@@ -3,7 +3,7 @@
 [id="appendix-inventory-files-vars"]
 = Inventory file variables
 
-
+[role="_abstract"]
 The following tables contain information about the variables used in {PlatformNameShort}'s installation `inventory` files. The tables include the variables that you can use for RPM-based installation and {ContainerBase}.
 
 include::platform/ref-ansible-inventory-variables.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-appendix-troubleshoot-containerized-aap.adoc
+++ b/downstream/assemblies/platform/assembly-appendix-troubleshoot-containerized-aap.adoc
@@ -7,6 +7,7 @@ ifdef::context[:parent-context: {context}]
 
 :context: troubleshooting-containerized-aap
 
+[role="_abstract"]
 Use this information to troubleshoot your containerized {PlatformNameShort} installation.
 
 include::platform/proc-containerized-troubleshoot-gathering-logs.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-configure-hub-storage.adoc
+++ b/downstream/assemblies/platform/assembly-configure-hub-storage.adoc
@@ -5,6 +5,7 @@ ifdef::context[:parent-context: {context}]
 
 = Configuring storage for {HubName}
 
+[role="_abstract"]
 Configure storage backends for {HubName} including Amazon S3, Azure Blob Storage, and Network File System (NFS) storage.
 
 include::platform/proc-configure-hub-s3-storage.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-setup-postgresql-ext-database.adoc
+++ b/downstream/assemblies/platform/assembly-setup-postgresql-ext-database.adoc
@@ -5,6 +5,12 @@ ifdef::context[:parent-context: {context}]
 
 = Setting up a customer provided (external) database
 
+[role="_abstract"]
+There are two possible scenarios for setting up an external database:
+
+. An external database with PostgreSQL admin credentials
+. An external database without PostgreSQL admin credentials
+
 [IMPORTANT]
 ====
 * When using an external database with {PlatformNameShort}, you must create and maintain that database. Ensure that you clear your external database when uninstalling {PlatformNameShort}.
@@ -13,11 +19,6 @@ ifdef::context[:parent-context: {context}]
 
 * During configuration of an external database, you must check the external database coverage. For more information, see link:https://access.redhat.com/articles/4010491[{PlatformName} Database Scope of Coverage].
 ====
-
-There are two possible scenarios for setting up an external database:
-
-. An external database with PostgreSQL admin credentials
-. An external database without PostgreSQL admin credentials
 
 include::platform/proc-setup-ext-db-with-admin-creds.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-using-custom-tls-certificates.adoc
+++ b/downstream/assemblies/platform/assembly-using-custom-tls-certificates.adoc
@@ -5,6 +5,7 @@ ifdef::context[:parent-context: {context}]
 
 = Using custom TLS certificates
 
+[role="_abstract"]
 {PlatformName} uses X.509 certificate and key pairs to secure traffic both internally between {PlatformNameShort} components and externally for public UI and API connections. 
 
 There are two primary ways to manage TLS certificates for your {PlatformNameShort} deployment: 

--- a/downstream/assemblies/topologies/assembly-appendix-topology-resources.adoc
+++ b/downstream/assemblies/topologies/assembly-appendix-topology-resources.adoc
@@ -1,6 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="appendix-topology-resources"]
 = Additional resources for tested deployment models
 
+[role="_abstract"]
 This appendix provides a reference for the additional resources relevant to the tested deployment models outlined in {TitleTopologies}.
 
 * For additional information about each of the tested topologies described in this document, see the link:https://github.com/ansible/test-topologies/[test-topologies GitHub repo].

--- a/downstream/assemblies/topologies/assembly-container-topologies.adoc
+++ b/downstream/assemblies/topologies/assembly-container-topologies.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="container-topologies"]
 
 = Container topologies
 
+[role="_abstract"]
 The containerized installer deploys {PlatformNameShort} on {RHEL} by using Podman which runs the platform in containers on host machines. Customers manage the product and infrastructure lifecycle.
 
 //Container growth topology

--- a/downstream/assemblies/topologies/assembly-ocp-topologies.adoc
+++ b/downstream/assemblies/topologies/assembly-ocp-topologies.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="ocp-topologies"]
 
 = Operator topologies
 
+[role="_abstract"]
 The {OperatorPlatformNameShort} uses Red Hat OpenShift Operators to deploy {PlatformNameShort} within Red Hat OpenShift. Customers manage the product and infrastructure lifecycle.
 
 [IMPORTANT]

--- a/downstream/assemblies/topologies/assembly-overview-tested-deployment-models.adoc
+++ b/downstream/assemblies/topologies/assembly-overview-tested-deployment-models.adoc
@@ -1,7 +1,10 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="overview-tested-deployment-models"]
 
 = Overview of tested deployment models
 
+[role="_abstract"]
 Red Hat tests {PlatformNameShort} {PlatformVers} with a defined set of topologies to give you opinionated deployment options. Deploy all components of {PlatformNameShort} so that all features and capabilities are available for use without the need to take further action.
 
 Red Hat tests the installation of {PlatformNameShort} {PlatformVers} based on a defined set of infrastructure topologies or reference architectures. Enterprise organizations can use one of the {EnterpriseTopologyPlural} for production deployments to ensure the highest level of uptime, performance, and continued scalability. Organizations or deployments that are resource constrained can use a {GrowthTopology}.

--- a/downstream/assemblies/topologies/assembly-rpm-topologies.adoc
+++ b/downstream/assemblies/topologies/assembly-rpm-topologies.adoc
@@ -3,6 +3,7 @@
 
 = RPM topologies
 
+[role="_abstract"]
 The RPM installer deploys {PlatformNameShort} on {RHEL} by using RPMs to install the platform on host machines. Customers manage the product and infrastructure lifecycle.
 
 //RPM growth topology

--- a/downstream/assemblies/troubleshooting-aap/assembly-diagnosing-the-problem.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-diagnosing-the-problem.adoc
@@ -4,6 +4,7 @@
 
 = Diagnosing the problem
 
+[role="_abstract"]
 To start troubleshooting {PlatformNameShort}, use the `must-gather` command on {OCPShort} or the `sos` utility on a {VMBase} to collect configuration and diagnostic information. You can attach the output of these utilities to your support case.
 
 include::troubleshooting-aap/proc-troubleshoot-must-gather.adoc[leveloffset=+1]

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-backup-recovery.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-backup-recovery.adoc
@@ -1,7 +1,10 @@
-
+:_mod-docs-content-type: ASSEMBLY
 [id="troubleshoot-backup-recovery"]
 
 = Backup and recovery
+
+[role="_abstract"]
+Use this information to troubleshoot backup and recovery.
 
 * For information about performing a backup and recovery of {PlatformNameShort}, see link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] in _{TitleControllerAdminGuide}_.
 

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-controller.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-controller.adoc
@@ -1,7 +1,10 @@
-
+:_mod-docs-content-type: ASSEMBLY
 [id="troubleshoot-controller"]
 
 = Resources for troubleshooting {ControllerName}
+
+[role="_abstract"]
+Use the following resources to troubleshoot {ControllerName}.
 
 * For information about troubleshooting {ControllerName}, see link:{URLControllerAdminGuide}/controller-troubleshooting[Troubleshooting {ControllerName}] in _{TitleControllerAdminGuide}_.
 

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-execution-environments.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-execution-environments.adoc
@@ -1,8 +1,9 @@
-
+:_mod-docs-content-type: ASSEMBLY
 [id="troubleshoot-execution-environments"]
 
 = Execution environments
 
+[role="_abstract"]
 Troubleshoot issues with execution environments.
 
 include::troubleshooting-aap/proc-troubleshoot-use-in-controller.adoc[leveloffset=+1]

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-installation.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-installation.adoc
@@ -1,8 +1,9 @@
-
+:_mod-docs-content-type: ASSEMBLY
 [id="troubleshoot-installation"]
 
 = Installation
 
+[role="_abstract"]
 Troubleshoot issues with your installation.
 
 include::troubleshooting-aap/proc-troubleshoot-aap-packages.adoc[leveloffset=+1]

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-jobs.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-jobs.adoc
@@ -4,6 +4,7 @@
 
 = Jobs
 
+[role="_abstract"]
 Troubleshoot issues with jobs.
 
 // Michelle - commenting out for now as it refers to upgrade info

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-networking.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-networking.adoc
@@ -1,8 +1,9 @@
-
+:_mod-docs-content-type: ASSEMBLY
 [id="troubleshoot-networking"]
 
 = Networking
 
+[role="_abstract"]
 Troubleshoot networking issues.
 
 include::troubleshooting-aap/proc-troubleshoot-subnet-conflict.adoc[leveloffset=+1]

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-playbooks.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-playbooks.adoc
@@ -1,9 +1,11 @@
-
+:_mod-docs-content-type: ASSEMBLY
 [id="troubleshoot-playbooks"]
 
 = Playbooks
 
+[role="_abstract"]
 You can use {Navigator} to interactively troubleshoot your playbook.
+
 For more information about troubleshooting a playbook with {Navigator}, see
 link:{URLNavigatorGuide}/assembly-troubleshooting-navigator_ansible-navigator[Troubleshooting Ansible content with {Navigator}]
 in the _{TitleNavigatorGuide}_ Guide.

--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-upgrade.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-upgrade.adoc
@@ -1,8 +1,9 @@
-
+:_mod-docs-content-type: ASSEMBLY
 [id="troubleshoot-upgrade"]
 
 = Upgrading
 
-Troubleshoot issues when upgrading to {PlatformNameShort} 2.5.
+[role="_abstract"]
+Troubleshoot issues when upgrading to {PlatformNameShort} {PlatformVers}.
 
 include::troubleshooting-aap/proc-troubleshoot-upgrade-issues.adoc[leveloffset=+1]

--- a/downstream/modules/aap-migration/con-artifact-structure.adoc
+++ b/downstream/modules/aap-migration/con-artifact-structure.adoc
@@ -3,6 +3,7 @@
 [id="artifact-structure"]
 = Artifact structure
 
+[role="_abstract"]
 The migration artifact serves as a comprehensive package containing all necessary components to successfully transfer your {PlatformNameShort} deployment. 
 
 Structure the artifact as follows:

--- a/downstream/modules/aap-migration/con-containerized-to-managed-prerequisites.adoc
+++ b/downstream/modules/aap-migration/con-containerized-to-managed-prerequisites.adoc
@@ -3,6 +3,7 @@
 [id="containerized-to-managed-prerequisites"]
 = Prerequisites for migrating from a container-based deployment to a Managed {PlatformNameShort} deployment
 
+[role="_abstract"]
 Before migrating from a container-based deployment to a Managed {PlatformNameShort} deployment, ensure that you meet the following prerequisites:
 
 * You have a source container-based deployment of {PlatformNameShort}.

--- a/downstream/modules/aap-migration/con-containerized-to-ocp-prerequisites.adoc
+++ b/downstream/modules/aap-migration/con-containerized-to-ocp-prerequisites.adoc
@@ -3,6 +3,7 @@
 [id="containerized-to-ocp-prerequisites"]
 = Prerequisites for migrating from a container-based deployment to an {OCPShort} deployment
 
+[role="_abstract"]
 Before migrating from a container-based deployment to an {OCPShort} deployment, ensure that you meet the following prerequisites:
 
 * You have a source container-based deployment of {PlatformNameShort}.

--- a/downstream/modules/aap-migration/con-introduction-and-objectives.adoc
+++ b/downstream/modules/aap-migration/con-introduction-and-objectives.adoc
@@ -3,6 +3,7 @@
 [id="introduction-and-objectives"]
 = Introduction and objectives
 
+[role="_abstract"]
 This document outlines the necessary steps and considerations for migrating between different {PlatformNameShort} deployment types for {PlatformNameShort} {PlatformVers}. Specifically, it focuses on these migration paths:
 
 [options="header"]

--- a/downstream/modules/aap-migration/con-manifest-file.adoc
+++ b/downstream/modules/aap-migration/con-manifest-file.adoc
@@ -3,6 +3,7 @@
 [id="manifest-file"]
 = Manifest file
 
+[role="_abstract"]
 The `manifest.yml` file serves as the primary metadata document for the migration artifact, containing critical versioning and component information from your source environment. 
 
 Structure the manifest as follows:

--- a/downstream/modules/aap-migration/con-migration-process-overview.adoc
+++ b/downstream/modules/aap-migration/con-migration-process-overview.adoc
@@ -8,6 +8,7 @@
 You can only migrate to a different installation type of the same {PlatformNameShort} version. For example you can migrate from RPM version {PlatformVers} to containerized {PlatformVers}, but not from RPM version 2.4 to containerized {PlatformVers}.
 ====
 
+[role="_abstract"]
 The migration between {PlatformNameShort} installation types follows this general workflow:
 
 . Prepare and assess the source environment - Prepare and assess the existing source environment for migration.

--- a/downstream/modules/aap-migration/con-out-of-scope.adoc
+++ b/downstream/modules/aap-migration/con-out-of-scope.adoc
@@ -3,6 +3,7 @@
 [id="out-of-scope"]
 = Out of scope
 
+[role="_abstract"]
 This guide is focused on the core components of {PlatformNameShort}. The following items are currently out of scope for the migration processes described in this document:
 
 * {EDAName}: Configuration and content for {EDAName} must be manually recreated in the target environment.

--- a/downstream/modules/aap-migration/con-rpm-to-containerized-prerequisites.adoc
+++ b/downstream/modules/aap-migration/con-rpm-to-containerized-prerequisites.adoc
@@ -3,6 +3,7 @@
 [id="rpm-to-containerized-prerequisites"]
 = Prerequisites for migrating from an RPM deployment to a containerized deployment
 
+[role="_abstract"]
 Before migrating from an RPM-based deployment to a container-based deployment, ensure you meet the following prerequisites:
 
 * You have a source RPM-based deployment of {PlatformNameShort}.

--- a/downstream/modules/aap-migration/con-rpm-to-managed-prerequisites.adoc
+++ b/downstream/modules/aap-migration/con-rpm-to-managed-prerequisites.adoc
@@ -3,6 +3,7 @@
 [id="rpm-to-managed-prerequisites"]
 = Prerequisites for migrating from an RPM-based deployment to a Managed {PlatformNameShort} deployment
 
+[role="_abstract"]
 Before migrating from an RPM-based deployment to a Managed {PlatformNameShort} deployment, ensure you meet the following prerequisites:
 
 * You have a source RPM-based deployment of {PlatformNameShort}.

--- a/downstream/modules/aap-migration/con-rpm-to-ocp-prerequisites.adoc
+++ b/downstream/modules/aap-migration/con-rpm-to-ocp-prerequisites.adoc
@@ -3,6 +3,7 @@
 [id="rpm-to-ocp-prerequisites"]
 = Prerequisites for migrating from an RPM-based deployment to an {OCPShort} deployment
 
+[role="_abstract"]
 Before migrating from an RPM-based deployment to an {OCPShort} deployment, ensure you meet the following prerequisites:
 
 * You have a source RPM-based deployment of {PlatformNameShort}.

--- a/downstream/modules/aap-migration/con-secrets-file.adoc
+++ b/downstream/modules/aap-migration/con-secrets-file.adoc
@@ -3,6 +3,7 @@
 [id="secrets-file"]
 = Secrets file
 
+[role="_abstract"]
 The `secrets.yml` file in the migration artifact includes essential Django `SECRET_KEY` values and other sensitive data required for authentication between services. 
 
 Structure the secrets file as follows:

--- a/downstream/modules/aap-migration/proc-containerized-post-import.adoc
+++ b/downstream/modules/aap-migration/proc-containerized-post-import.adoc
@@ -3,6 +3,7 @@
 [id="containerized-post-import"]
 = Reconciling the target environment post-import
 
+[role="_abstract"]
 Perform the following post-import reconciliation steps to ensure your target environment is fully functional and correctly configured.
 
 .Procedure

--- a/downstream/modules/aap-migration/proc-containerized-target-import.adoc
+++ b/downstream/modules/aap-migration/proc-containerized-target-import.adoc
@@ -3,6 +3,7 @@
 [id="containerized-target-import"]
 = Importing the migration content to the target environment
 
+[role="_abstract"]
 To import your migration content into the target environment, stop the containerized services, import the database dumps, and then restart the services.
 
 .Procedure

--- a/downstream/modules/aap-migration/proc-containerized-target-prep.adoc
+++ b/downstream/modules/aap-migration/proc-containerized-target-prep.adoc
@@ -3,6 +3,7 @@
 [id="containerized-target-prep"]
 = Preparing and assessing the target environment
 
+[role="_abstract"]
 To prepare your target environment, perform the following steps.
 
 .Procedure

--- a/downstream/modules/aap-migration/proc-containerized-validation.adoc
+++ b/downstream/modules/aap-migration/proc-containerized-validation.adoc
@@ -3,6 +3,7 @@
 [id="containerized-validation"]
 = Validating the target environment
 
+[role="_abstract"]
 After completing the migration, validate your target environment to ensure all components are functional and operating as expected.
 
 .Procedure

--- a/downstream/modules/aap-migration/proc-managed-post-import.adoc
+++ b/downstream/modules/aap-migration/proc-managed-post-import.adoc
@@ -3,6 +3,7 @@
 [id="managed-post-import"]
 = Reconciling the target environment post-migration
 
+[role="_abstract"]
 After a successful migration, perform the following tasks:
 
 .Procedure

--- a/downstream/modules/aap-migration/proc-managed-target-migration.adoc
+++ b/downstream/modules/aap-migration/proc-managed-target-migration.adoc
@@ -3,6 +3,9 @@
 [id="managed-target-migration"]
 = Migrating to Managed {PlatformNameShort}
 
+[role="_abstract"]
+Follow this procedure to migrate to Managed {PlatformNameShort}.
+
 .Prerequisites
 * You have a migration artifact from your source environment.
 

--- a/downstream/modules/aap-migration/proc-ocp-post-import.adoc
+++ b/downstream/modules/aap-migration/proc-ocp-post-import.adoc
@@ -3,6 +3,7 @@
 [id="ocp-post-import"]
 = Reconciling the target environment post-import
 
+[role="_abstract"]
 After importing your migration artifact, perform the following steps to reconcile your target environment.
 
 .Procedure

--- a/downstream/modules/aap-migration/proc-ocp-target-import.adoc
+++ b/downstream/modules/aap-migration/proc-ocp-target-import.adoc
@@ -3,6 +3,7 @@
 [id="ocp-target-import"]
 = Importing the migration content to the target environment
 
+[role="_abstract"]
 To import your environment, scale down {PlatformNameShort} components, restore databases, replace encryption secrets, and scale services back up.
 
 [NOTE]

--- a/downstream/modules/aap-migration/proc-ocp-target-prep.adoc
+++ b/downstream/modules/aap-migration/proc-ocp-target-prep.adoc
@@ -3,6 +3,7 @@
 [id="ocp-target-prep"]
 = Preparing and assessing the target environment
 
+[role="_abstract"]
 To prepare and assess your target environment, perform the following steps.
 
 .Procedure

--- a/downstream/modules/aap-migration/proc-ocp-validation.adoc
+++ b/downstream/modules/aap-migration/proc-ocp-validation.adoc
@@ -3,6 +3,7 @@
 [id="ocp-validation"]
 = Validating the target environment
 
+[role="_abstract"]
 To validate your migrated environment, perform the following steps.
 
 .Procedure

--- a/downstream/modules/aap-migration/proc-rpm-environment-source-prep.adoc
+++ b/downstream/modules/aap-migration/proc-rpm-environment-source-prep.adoc
@@ -3,6 +3,7 @@
 [id="rpm-environment-source-prep"]
 = Preparing and assessing the source environment
 
+[role="_abstract"]
 Before beginning your migration, document your current RPM deployment. This documentation serves as a reference throughout the migration process and is critical for properly configuring your target environment.
 
 .Procedure

--- a/downstream/modules/aap-migration/proc-rpm-source-environment-export.adoc
+++ b/downstream/modules/aap-migration/proc-rpm-source-environment-export.adoc
@@ -3,6 +3,7 @@
 [id="rpm-source-environment-export"]
 = Exporting the source environment
 
+[role="_abstract"]
 From your source environment, export the data and configurations needed for migration.
 
 .Procedure

--- a/downstream/modules/aap-migration/ref-migration-artifact-checklist.adoc
+++ b/downstream/modules/aap-migration/ref-migration-artifact-checklist.adoc
@@ -3,6 +3,7 @@
 [id="migration-artifact-checklist"]
 = Migration artifact creation checklist
 
+[role="_abstract"]
 Use this checklist to verify the migration artifact.
 
 * Database dumps: Include complete database dumps for each component.

--- a/downstream/modules/platform/con-certs-per-service-considerations.adoc
+++ b/downstream/modules/platform/con-certs-per-service-considerations.adoc
@@ -3,6 +3,7 @@
 [id="certs-per-service-considerations"]
 = Considerations for certificates provided per service
 
+[role="_abstract"]
 When providing custom TLS certificates for each individual service, consider the following:
 
 * It is possible to provide unique certificates per host. This requires defining the specific `_tls_cert` and `_tls_key` variables in your inventory file as shown in the earlier inventory file example.

--- a/downstream/modules/platform/con-installer-generated-certs.adoc
+++ b/downstream/modules/platform/con-installer-generated-certs.adoc
@@ -3,6 +3,7 @@
 [id="installer-generated-certificates"]
 = {PlatformNameShort} generated certificates
 
+[role="_abstract"]
 By default, the installation program creates a self-signed Certificate Authority (CA) and uses it to generate self-signed TLS certificates for all {PlatformNameShort} services. The self-signed CA certificate and key are generated on one node under the `~/aap/tls/` directory and copied to the same location on all other nodes. This CA is valid for 10 years after the initial creation date.
 
 Self-signed certificates are not part of any public chain of trust. The installation program creates a certificate truststore that includes the self-signed CA certificate under `~/aap/tls/extracted/` and bind-mounts that directory to each {PlatformNameShort} service container under `/etc/pki/ca-trust/extracted/`. This allows each {PlatformNameShort} component to validate the self-signed certificates of the other {PlatformNameShort} services. The CA certificate can also be added to the truststore of other systems or browsers as needed.

--- a/downstream/modules/platform/con-receptor-cert-considerations.adoc
+++ b/downstream/modules/platform/con-receptor-cert-considerations.adoc
@@ -3,6 +3,7 @@
 [id="receptor-certificate-considerations"]
 = Receptor certificate considerations
 
+[role="_abstract"]
 When using a custom certificate for Receptor nodes, the certificate requires the `otherName` field specified in the Subject Alternative Name (SAN) of the certificate with the value `1.3.6.1.4.1.2312.19.1`. For more information, see link:https://ansible.readthedocs.io/projects/receptor/en/latest/user_guide/tls.html#above-the-mesh-tls[Above the mesh TLS].
 
 Receptor does not support the usage of wildcard certificates. Additionally, each Receptor certificate must have the host FQDN specified in its SAN for TLS hostname validation to be correctly performed.

--- a/downstream/modules/platform/proc-add-eda-safe-plugin-var.adoc
+++ b/downstream/modules/platform/proc-add-eda-safe-plugin-var.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: PROCEDURE
 
-
 [id="proc-add-eda-safe-plugin-var"]
 
 = Adding a safe plugin variable to {EDAcontroller}
 
+[role="_abstract"]
 When using `redhat.insights_eda` or similar plugins to run rulebook activations in {EDAcontroller}, you must add a safe plugin variable to a directory in {PlatformNameShort}. This ensures connection between {EDAcontroller} and the source plugin, and displays port mappings correctly. 
 
 .Procedure

--- a/downstream/modules/platform/proc-configure-ext-db-mtls.adoc
+++ b/downstream/modules/platform/proc-configure-ext-db-mtls.adoc
@@ -3,6 +3,7 @@
 [id="configure-ext-db-mtls"]
 = Optional: configuring mutual TLS (mTLS) authentication for an external database
 
+[role="_abstract"]
 mTLS authentication is disabled by default. To configure each component's database with mTLS authentication, add the following variables to your inventory file under the `[all:vars]` group and ensure each component has a different TLS certificate and key:
 
 .Procedure

--- a/downstream/modules/platform/proc-configure-haproxy-load-balancer.adoc
+++ b/downstream/modules/platform/proc-configure-haproxy-load-balancer.adoc
@@ -3,6 +3,7 @@
 [id="configuring-haproxy-load-balancer"]
 = Configuring a HAProxy load balancer
 
+[role="_abstract"]
 To configure a HAProxy load balancer in front of {Gateway} with a custom CA cert, set the following inventory file variables under the `[all:vars]` group:
 
 ----

--- a/downstream/modules/platform/proc-configure-hub-azure-storage.adoc
+++ b/downstream/modules/platform/proc-configure-hub-azure-storage.adoc
@@ -3,6 +3,7 @@
 [id="configure-hub-azure-storage"]
 = Configuring Azure Blob Storage for {HubName}
 
+[role="_abstract"]
 Azure Blob storage is a type of object storage that is supported in containerized installations. When using an Azure blob storage backend, set `hub_storage_backend` to `azure`. The Azure container needs to exist before running the installation program.
 
 .Procedure

--- a/downstream/modules/platform/proc-configure-hub-nfs-storage.adoc
+++ b/downstream/modules/platform/proc-configure-hub-nfs-storage.adoc
@@ -3,6 +3,7 @@
 [id="configure-hub-nfs-storage"]
 = Configuring Network File System (NFS) storage for {HubName}
 
+[role="_abstract"]
 NFS is a type of shared storage that is supported in containerized installations. Shared storage is required when installing more than one instance of {HubName} with a `file` storage backend. When installing a single instance of the {HubName}, shared storage is optional.
 
 .Procedure

--- a/downstream/modules/platform/proc-configure-hub-s3-storage.adoc
+++ b/downstream/modules/platform/proc-configure-hub-s3-storage.adoc
@@ -3,6 +3,7 @@
 [id="configure-hub-s3-storage"]
 = Configuring Amazon S3 storage for {HubName}
 
+[role="_abstract"]
 Amazon S3 storage is a type of object storage that is supported in containerized installations. When using an AWS S3 storage backend, set `hub_storage_backend` to `s3`. The AWS S3 bucket needs to exist before running the installation program.
 
 .Procedure

--- a/downstream/modules/platform/proc-containerized-troubleshoot-gathering-logs.adoc
+++ b/downstream/modules/platform/proc-containerized-troubleshoot-gathering-logs.adoc
@@ -3,6 +3,7 @@
 
 = Gathering {PlatformNameShort} logs
 
+[role="_abstract"]
 With the `sos` utility, you can collect configuration, diagnostic, and troubleshooting data, and give those files to Red Hat Technical Support. An `sos` report is a common starting point for Red Hat technical support engineers when performing analysis of a service request for {PlatformNameShort}. 
 
 You can collect an `sos` report for each host in your containerized {PlatformNameShort} deployment by running the `log_gathering` playbook with the appropriate parameters.
@@ -31,19 +32,15 @@ $ ansible-playbook -i <path_to_inventory_file> ansible.containerized_installer.l
 [options="header"]
 |====
 | Parameter name | Description | Default 
-
 | `target_sos_directory`
 | Used to change the default location for the `sos` report files. 
 | `/tmp` directory of the current server.
-
 | `case_number`
 | Specifies the support case number if relevant to the log gathering.
 |
-
 | `clean`
 | Obfuscates sensitive data that might be present on the `sos` report.
 | `false`
-
 | `upload`
 | Automatically uploads the `sos` report data to Red Hat.
 | `false`

--- a/downstream/modules/platform/proc-downloading-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-downloading-containerized-aap.adoc
@@ -4,6 +4,7 @@
 
 = Downloading {PlatformNameShort}
 
+[role="_abstract"]
 Choose the installation program you need based on your {RHEL} environment internet connectivity and download the installation program to your {RHEL} host.
 
 .Prerequisites

--- a/downstream/modules/platform/proc-enable-hstore-extension.adoc
+++ b/downstream/modules/platform/proc-enable-hstore-extension.adoc
@@ -4,6 +4,7 @@
 
 = Enabling the hstore extension for the {HubName} PostgreSQL database
 
+[role="_abstract"]
 The database migration script uses `hstore` fields to store information, therefore the `hstore` extension must be enabled in the {HubName} PostgreSQL database.
 
 This process is automatic when using the {PlatformNameShort} installer and a managed PostgreSQL server.

--- a/downstream/modules/platform/proc-enabling-automation-hub-collection-and-container-signing.adoc
+++ b/downstream/modules/platform/proc-enabling-automation-hub-collection-and-container-signing.adoc
@@ -3,6 +3,7 @@
 [id="enabling-automation-hub-collection-and-container-signing_{context}"]
 = Enabling automation content collection and container signing
 
+[role="_abstract"]
 Automation content signing is disabled by default. To enable it, the following installation variables are required in the inventory file:
 
 [source,yaml]

--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -4,6 +4,7 @@
 
 = Installing containerized {PlatformNameShort}
 
+[role="_abstract"]
 After you prepare the {RHEL} host, download {PlatformNameShort}, and configure the inventory file, run the `install` playbook to install containerized {PlatformNameShort}.
 
 .Prerequisites

--- a/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
@@ -4,6 +4,7 @@
 
 = Preparing the managed nodes for containerized installation
 
+[role="_abstract"]
 Managed nodes, also referred to as hosts, are the devices that {PlatformNameShort} is configured to manage.
 
 To ensure a consistent and secure setup of containerized {PlatformNameShort}, create a dedicated user on each host. {PlatformNameShort} connects as this user to run tasks on the host.

--- a/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
@@ -4,6 +4,7 @@
 
 = Preparing the {RHEL} host for containerized installation
 
+[role="_abstract"]
 Containerized {PlatformNameShort} runs the component services as Podman based containers on top of a {RHEL} host. Prepare the {RHEL} host to ensure a successful installation. 
 
 .Procedure

--- a/downstream/modules/platform/proc-provide-custom-ca-cert.adoc
+++ b/downstream/modules/platform/proc-provide-custom-ca-cert.adoc
@@ -3,6 +3,7 @@
 [id="providing-a-custom-ca-certificate"]
 = Providing a custom CA certificate
 
+[role="_abstract"]
 When you manually provide TLS certificates, those certificates might be signed by a custom CA. Provide a custom CA certificate to ensure proper authentication and secure communication within your environment. If you have multiple custom CA certificates, you must merge them into a single file.
 
 .Procedure

--- a/downstream/modules/platform/proc-provide-custom-tls-certs-per-service.adoc
+++ b/downstream/modules/platform/proc-provide-custom-tls-certs-per-service.adoc
@@ -3,6 +3,7 @@
 [id="proc-provide-custom-tls-certs-per-service"]
 = Providing custom TLS certificates for each service
 
+[role="_abstract"]
 Use this method if your organization manages TLS certificates outside of {PlatformNameShort} and requires manual provisioning.
 
 .Procedure

--- a/downstream/modules/platform/proc-reinstalling-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-reinstalling-containerized-aap.adoc
@@ -4,7 +4,6 @@
 = Reinstalling containerized {PlatformNameShort}
 
 [role="_abstract"]
-
 To reinstall a containerized deployment after uninstalling and preserving the database, follow the steps in link:{URLContainerizedInstall}/aap-containerized-installation#installing-containerized-aap[Installing containerized {PlatformNameShort}] and include the existing secret key value in the playbook command:
 
 ----

--- a/downstream/modules/platform/proc-set-registry-username-password.adoc
+++ b/downstream/modules/platform/proc-set-registry-username-password.adoc
@@ -4,6 +4,7 @@
 
 = Setting registry_username and registry_password
 
+[role="_abstract"]
 When using the `registry_username` and `registry_password` variables for an online non-bundled installation, you need to create a new registry service account.
 
 Registry service accounts are named tokens that can be used in environments where credentials will be shared, such as deployment systems.

--- a/downstream/modules/platform/proc-setup-ext-db-with-admin-creds.adoc
+++ b/downstream/modules/platform/proc-setup-ext-db-with-admin-creds.adoc
@@ -3,6 +3,7 @@
 [id="setup-ext-db-with-admin-creds"]
 = Setting up an external database with PostgreSQL admin credentials
 
+[role="_abstract"]
 If you have PostgreSQL admin credentials, you can supply them in the inventory file and the installation program creates the PostgreSQL users and databases for each component for you. The PostgreSQL admin account must have `SUPERUSER` privileges.
 
 .Procedure

--- a/downstream/modules/platform/proc-setup-ext-db-without-admin-creds.adoc
+++ b/downstream/modules/platform/proc-setup-ext-db-without-admin-creds.adoc
@@ -3,6 +3,7 @@
 [id="setup-ext-db-without-admin-creds"]
 = Setting up an external database without PostgreSQL admin credentials
 
+[role="_abstract"]
 If you do not have PostgreSQL admin credentials, then PostgreSQL users and databases need to be created for each component ({Gateway}, {ControllerName}, {HubName}, and {EDAName}) before running the installation program.
 
 .Procedure

--- a/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
@@ -3,6 +3,7 @@
 [id="uninstalling-containerized-aap"]
 = Uninstalling containerized {PlatformNameShort}
 
+[role="_abstract"]
 Uninstall your {ContainerBase} of {PlatformNameShort}.
 
 .Prerequisites

--- a/downstream/modules/platform/proc-update-aap-container.adoc
+++ b/downstream/modules/platform/proc-update-aap-container.adoc
@@ -3,6 +3,7 @@
 
 = Updating containerized {PlatformNameShort}
 
+[role="_abstract"]
 Perform an upgrade of containerized {PlatformNameShort}. 
 
 .Prerequisites

--- a/downstream/modules/platform/proc-use-custom-ca-certs.adoc
+++ b/downstream/modules/platform/proc-use-custom-ca-certs.adoc
@@ -3,6 +3,7 @@
 [id="use-custom-ca-certs"]
 = Using a custom CA to generate all TLS certificates
 
+[role="_abstract"]
 Use this method when you want {PlatformNameShort} to generate all of the certificates, but you want them signed by a custom CA rather than the default self-signed certificates.
 
 .Procedure

--- a/downstream/modules/platform/ref-adding-execution-nodes.adoc
+++ b/downstream/modules/platform/ref-adding-execution-nodes.adoc
@@ -1,11 +1,9 @@
-:_newdoc-version: 2.15.1
-:_template-generated: 2024-01-12
-
 :_mod-docs-content-type: REFERENCE
 
 [id="adding-execution-nodes_{context}"]
 = Adding execution nodes
 
+[role="_abstract"]
 Containerized {PlatformNameShort} can deploy remote execution nodes. 
 
 You can define remote execution nodes in the `[execution_nodes]` group of your inventory file:

--- a/downstream/modules/platform/ref-ansible-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-ansible-inventory-variables.adoc
@@ -4,6 +4,7 @@
 
 = Ansible variables
 
+[role="_abstract"]
 The following variables control how {PlatformNameShort} interacts with remote hosts.
 
 .Ansible variables

--- a/downstream/modules/platform/ref-configuring-inventory-file.adoc
+++ b/downstream/modules/platform/ref-configuring-inventory-file.adoc
@@ -3,6 +3,7 @@
 [id="configuring-inventory-file"]
 = Configuring the inventory file
 
+[role="_abstract"]
 You can control the installation of {PlatformNameShort} with inventory files. Inventory files define the information needed to customize the installation. For example, host details, certificate details, and various component-specific settings. 
 
 Example inventory files are available in this document that you can copy and change to quickly get started.

--- a/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
+++ b/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
@@ -4,6 +4,7 @@
 
 = System requirements
 
+[role="_abstract"]
 Use this information when planning your installation of containerized {PlatformNameShort}.
 
 == Prerequisites

--- a/downstream/modules/platform/ref-containerized-troubleshoot-config.adoc
+++ b/downstream/modules/platform/ref-containerized-troubleshoot-config.adoc
@@ -3,6 +3,9 @@
 
 = Troubleshooting containerized {PlatformNameShort} configuration
 
+[role="_abstract"]
+Use this information to troubleshoot your containerized {PlatformNameShort} configuration.
+
 *Sometimes the post install for seeding my {PlatformNameShort} content errors out* 
 
 This could manifest itself as output similar to this:

--- a/downstream/modules/platform/ref-containerized-troubleshoot-diagnosing.adoc
+++ b/downstream/modules/platform/ref-containerized-troubleshoot-diagnosing.adoc
@@ -3,6 +3,7 @@
 
 = Diagnosing the problem
 
+[role="_abstract"]
 For general container-based troubleshooting, you can inspect the container logs for any running service to help troubleshoot underlying issues.
 
 *Identifying the running containers*

--- a/downstream/modules/platform/ref-containerized-troubleshoot-install.adoc
+++ b/downstream/modules/platform/ref-containerized-troubleshoot-install.adoc
@@ -3,6 +3,9 @@
 
 = Troubleshooting containerized {PlatformNameShort} installation
 
+[role="_abstract"]
+Use this information to troubleshoot your containerized installation of {PlatformNameShort}.
+
 *The installation takes a long time, or has errors, what should I check?*
 
 . Ensure your system meets the minimum requirements as outlined in link:{URLContainerizedInstall}/aap-containerized-installation#system-requirements[System requirements]. Factors such as improper storage choices and high latency when distributing across many hosts will all have an impact on installation time.

--- a/downstream/modules/platform/ref-containerized-troubleshoot-ref.adoc
+++ b/downstream/modules/platform/ref-containerized-troubleshoot-ref.adoc
@@ -4,6 +4,9 @@
 
 = Containerized {PlatformNameShort} reference
 
+[role="_abstract"]
+Use this information to understand the architecture for your containerized {PlatformNameShort} deployment.
+
 *Can you give details of the architecture for the {PlatformNameShort} containerized design?*
 
 We use as much of the underlying native {RHEL} technology as possible. Podman is used for the container runtime and management of services. 

--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -4,6 +4,9 @@
 
 = {ControllerNameStart} variables
 
+[role="_abstract"]
+Inventory file variables for {ControllerName}.
+
 [cols="25%,25%,30%,10%,10%",options="header"]
 |===
 | RPM variable name | Container variable name | Description | Required or optional | Default

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -4,6 +4,9 @@
 
 = Database variables
 
+[role="_abstract"]
+Inventory file variables for the database used with {PlatformNameShort}.
+
 [cols="25%,25%,30%,10%,10%",options="header"]
 |===
 | RPM variable name | Container variable name | Description | Required or optional | Default

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -4,6 +4,9 @@
 
 = {EDAcontroller} variables
 
+[role="_abstract"]
+Inventory file variables for {EDAcontroller}.
+
 [cols="25%,25%,30%,10%,10%",options="header"]
 |===
 | RPM variable name | Container variable name | Description | Required or optional | Default

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="platform-gateway-variables"]
-
 = {GatewayStart} variables
+
+[role="_abstract"]
+Inventory file variables for {Gateway}.
 
 [cols="25%,25%,30%,10%,10%",options="header"]
 |===

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -4,6 +4,9 @@
 
 = General variables
 
+[role="_abstract"]
+General inventory file variables for {PlatformNameShort}.
+
 [cols="25%,25%,30%,10%,10%",options="header"]
 |===
 | RPM variable name | Container variable name | Description | Required or optional | Default

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -4,6 +4,9 @@
 
 = {HubNameStart} variables
 
+[role="_abstract"]
+Inventory file variables for {HubName}.
+
 [cols="25%,25%,30%,10%,10%",options="header"]
 |===
 | RPM variable name | Container variable name | Description | Required or optional | Default

--- a/downstream/modules/platform/ref-images-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-images-inventory-variables.adoc
@@ -4,6 +4,9 @@
 
 = Image variables
 
+[role="_abstract"]
+Inventory file variables for images.
+
 [cols="25%,25%,30%,10%,10%",options="header"]
 |===
 | RPM variable name | Container variable name | Description | Required or optional | Default

--- a/downstream/modules/platform/ref-receptor-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-receptor-inventory-variables.adoc
@@ -4,6 +4,9 @@
 
 = Receptor variables
 
+[role="_abstract"]
+Inventory file variables for Receptor.
+
 [cols="25%,25%,30%,10%,10%",options="header"]
 |===
 | RPM variable name | Container variable name | Description | Required or optional | Default

--- a/downstream/modules/platform/ref-redis-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-redis-inventory-variables.adoc
@@ -4,6 +4,9 @@
 
 = Redis variables
 
+[role="_abstract"]
+Inventory file variables for Redis.
+
 [cols="25%,25%,30%,10%,10%",options="header"]
 |===
 | RPM variable name | Container variable name | Description | Required or optional | Default

--- a/downstream/modules/topologies/ref-cont-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-a-env-a.adoc
@@ -2,6 +2,7 @@
 [id="cont-a-env-a"]
 = Container {GrowthTopology}
 
+[role="_abstract"]
 include::snippets/growth-topologies.adoc[]
 
 == Infrastructure topology

--- a/downstream/modules/topologies/ref-cont-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-cont-b-env-a.adoc
@@ -2,6 +2,7 @@
 [id="cont-b-env-a"]
 = Container {EnterpriseTopology}
 
+[role="_abstract"]
 include::snippets/enterprise-topologies.adoc[]
 
 == Infrastructure topology

--- a/downstream/modules/topologies/ref-installation-deployment-models.adoc
+++ b/downstream/modules/topologies/ref-installation-deployment-models.adoc
@@ -3,6 +3,7 @@
 
 = Installation and deployment models
 
+[role="_abstract"]
 The following table outlines the different ways to install or deploy {PlatformNameShort}:
 
 .{PlatformNameShort} installation and deployment models

--- a/downstream/modules/topologies/ref-mesh-nodes.adoc
+++ b/downstream/modules/topologies/ref-mesh-nodes.adoc
@@ -1,6 +1,8 @@
+:_mod-docs-content-type: REFERENCE
 [id="mesh-nodes"]
 = {AutomationMeshStart} nodes
 
+[role="_abstract"]
 {AutomationMeshStart} is an overlay network intended to ease the distribution of work across a large and dispersed collection of workers. This is done through nodes that establish peer-to-peer connections with each other by using existing networks. 
 
 == Tested system configurations

--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -1,6 +1,8 @@
+:_mod-docs-content-type: REFERENCE
 [id="ocp-a-env-a"]
 = Operator {GrowthTopology}
 
+[role="_abstract"]
 include::snippets/growth-topologies.adoc[]
 
 == Infrastructure topology

--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -1,6 +1,8 @@
+:_mod-docs-content-type: REFERENCE
 [id="ocp-b-env-a"]
 = Operator {EnterpriseTopology}
 
+[role="_abstract"]
 include::snippets/enterprise-topologies.adoc[]
 
 == Infrastructure topology

--- a/downstream/modules/topologies/ref-rpm-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-a-env-a.adoc
@@ -2,6 +2,7 @@
 [id="rpm-a-env-a"]
 = RPM {GrowthTopology}
 
+[role="_abstract"]
 include::snippets/growth-topologies.adoc[]
 
 == Infrastructure topology

--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -2,6 +2,7 @@
 [id="rpm-b-env-a"]
 = RPM {EnterpriseTopology}
 
+[role="_abstract"]
 include::snippets/enterprise-topologies.adoc[]
 
 == Infrastructure topology

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-aap-packages.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-aap-packages.adoc
@@ -1,6 +1,8 @@
+:_mod-docs-content-type: PROCEDURE
 [id="troubleshoot-aap-packages"]
 = Issue - Cannot locate certain packages that come bundled with the {PlatformNameShort} installer
 
+[role="_abstract"]
 You cannot locate certain packages that come bundled with the {PlatformNameShort} installer, or you are seeing a "Repositories disabled by configuration" message.
 
 To resolve this issue, enable the repository by using the `subscription-manager` command in the command line. For more information about resolving this issue, see the _Troubleshooting_ section of link:{URLCentralAuth}/assembly-gateway-licensing#proc-attaching-subscriptions[Attaching your {PlatformName} subscription] in _{TitleCentralAuth}_.

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-pending.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-pending.adoc
@@ -1,6 +1,8 @@
+:_mod-docs-content-type: PROCEDURE
 [id="troubleshoot-job-pending"]
 = Issue - Jobs in {ControllerName} are stuck in a pending state
 
+[role="_abstract"]
 After launching jobs in {ControllerName}, the jobs stay in a pending state and do not start.
 
 There are a few reasons jobs can become stuck in a pending state. For more information about troubleshooting this issue, see link:{URLControllerAdminGuide}/controller-troubleshooting#controller-playbook-pending[Playbook stays in pending] in _{TitleControllerAdminGuide}_

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-permissions.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-permissions.adoc
@@ -2,6 +2,7 @@
 [id="troubleshoot-job-permissions"]
 = Issue - Jobs in {PrivateHubName} are failing with "denied: requested access to the resource is denied, unauthorized: Insufficient permissions" error message
 
+[role="_abstract"]
 Jobs are failing with the error message "denied: requested access to the resource is denied, unauthorized: Insufficient permissions" when using an {ExecEnvShort} in {PrivateHubName}.
 
 This issue happens when your {PrivateHubName} is protected with a password or token and the registry credential is not assigned to the {ExecEnvShort}.

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-resolve-module.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-resolve-module.adoc
@@ -3,6 +3,7 @@
 [id="troubleshoot-job-resolve-module"]
 = Issue - Jobs are failing with “ERROR! couldn’t resolve module/action” error message
 
+[role="_abstract"]
 Jobs are failing with the error message “ERROR! couldn't resolve module/action 'module name'. This often indicates a misspelling, missing collection, or incorrect module path”.
 
 This error can happen when the collection associated with the module is missing from the {ExecEnvShort}.

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-timeout.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-job-timeout.adoc
@@ -3,6 +3,7 @@
 [id="troubleshoot-job-timeout"]
 = Issue - Jobs are failing with “Timeout (12s) waiting for privilege escalation prompt” error message
 
+[role="_abstract"]
 This error can happen when the timeout value is too small, causing the job to stop before completion. The default timeout value for connection plugins is `10`. 
 
 To resolve the issue, increase the timeout value by completing one of the following methods. 

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
@@ -3,6 +3,7 @@
 [id="troubleshoot-must-gather"]
 = Troubleshooting {PlatformNameShort} on {OCPShort} by using the must-gather command
 
+[role="_abstract"]
 The `oc adm must-gather` command line interface (CLI) command collects information from your {PlatformNameShort} installation deployed on {OCPShort}. It gathers information that is often needed for debugging issues, including resource definitions and service logs.
 
 Running the `oc adm must-gather` CLI command creates a new directory containing the collected data that you can use to troubleshoot or attach to your support case.

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-sosreport.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-sosreport.adoc
@@ -1,6 +1,8 @@
+:_mod-docs-content-type: PROCEDURE
 [id="troubleshoot-sosreport"]
 = Troubleshooting {PlatformNameShort} on VM-based installations by generating an sos report
 
+[role="_abstract"]
 The `sos` utility collects configuration, diagnostic, and troubleshooting data from your {PlatformNameShort} on a {VMBase}.
 
 For more information about installing and using the `sos` utility, see link:{BaseURL}/red_hat_enterprise_linux/9/html-single/getting_the_most_from_your_support_experience/index#generating-an-sos-report-for-technical-support_getting-the-most-from-your-support-experience[Generating an sos report for technical support].

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-ssl-tls-issues.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-ssl-tls-issues.adoc
@@ -4,6 +4,7 @@
 
 = Troubleshooting SSL/TLS issues
 
+[role="_abstract"]
 To troubleshoot issues with SSL/TLS, verify the certificate chain, use the correct certificates, and confirm that a trusted Certificate Authority (CA) signed the certificate. 
 
 .Procedure

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-subnet-conflict.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-subnet-conflict.adoc
@@ -1,6 +1,8 @@
+:_mod-docs-content-type: PROCEDURE
 [id="troubleshoot-subnet-conflict"]
 = Issue - The default subnet used in {PlatformNameShort} containers conflicts with the internal network
 
+[role="_abstract"]
 The default subnet used in {PlatformNameShort} containers conflicts with the internal network resulting in "No route to host" errors.
 
 To resolve this issue, update the default classless inter-domain routing (CIDR) value so it does not conflict with the CIDR used by the default Podman networking plugin.

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-use-in-controller.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-use-in-controller.adoc
@@ -1,6 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="troubleshoot-use-in-controller"]
+
 = Issue - Cannot select the "Use in Controller" option for {ExecEnvShort} image on {PrivateHubName}
 
+[role="_abstract"]
 You cannot use the *Use in Controller* option for an {ExecEnvShort} image on {PrivateHubName}. You also receive the error message: “No Controllers available”.
 
 To resolve this issue, connect {ControllerName} to your {PrivateHubName} instance.
@@ -44,10 +47,6 @@ CONNECTED_ANSIBLE_CONTROLLERS = ['_<https://my.controller.node1>_', '_<https://m
 ----
 +
 
-
 .Verification
 * Verify that you can now use the *Use in Controller* option in {PrivateHubName}.
-
-
-
 


### PR DESCRIPTION
Backports #3956 from main to 2.6

Affected titles:
- `titles/aap-containerized-install`
- `titles/topologies`
- `titles/aap-migration`
- `titles/troubleshooting-aap`

Ansible DITA readiness (2025-07-09) - Michelle

https://issues.redhat.com/browse/AAP-49393