### PR TITLE
AAP-50126: Updated PG 13 to PG 15 references

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -91,7 +91,7 @@ Use of other special characters can cause the setup to fail.
 
 NOTE
 
-You no longer have to provide a `pg_hashed_password` in your inventory file at the time of installation because PostgreSQL 13 can now store user passwords more securely.
+You no longer have to provide a `pg_hashed_password` in your inventory file at the time of installation because PostgreSQL can now store user passwords more securely.
 
 When you supply `pg_password` in the inventory file for the installer, PostgreSQL uses the SCRAM-SHA-256 hash to secure that password as part of the installation process.
 | *`pg_port`* | The postgreSQL port to use.

--- a/downstream/modules/platform/ref-postgresql-requirements.adoc
+++ b/downstream/modules/platform/ref-postgresql-requirements.adoc
@@ -2,7 +2,7 @@
 
 = PostgreSQL requirements
 
-{PlatformName} uses PostgreSQL 13. PostgreSQL user passwords are hashed with SCRAM-SHA-256 secure hashing algorithm before storing in the database.
+{PlatformName} uses PostgreSQL 15. PostgreSQL user passwords are hashed with SCRAM-SHA-256 secure hashing algorithm before storing in the database.
 
 To determine if your {ControllerName} instance has access to the database, you can do so with the command, `awx-manage check_db` command.
 
@@ -53,4 +53,8 @@ Optionally, you can configure the PostgreSQL database as separate nodes that are
 
 [role="_additional-resources"]
 .Additional resources
-For more information about tuning your PostgreSQL server, see the link:https://wiki.postgresql.org/wiki/Main_Page[PostgreSQL documentation].
+
+* link:https://wiki.postgresql.org/wiki/Main_Page[PostgreSQL documentation]
+* link:https://access.redhat.com/articles/7128116[Ansible Automation Platform 2.4 - Adoption of PostgreSQL 15]
+
+

--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -22,7 +22,7 @@ h| Python | 3.9 or later |
 
 h| Browser | A currently supported version of Mozilla FireFox or Google Chrome |
 
-h| Database | PostgreSQL version 13 |
+h| Database | PostgreSQL version 15 |
 |===
 
 The following are necessary for you to work with project updates and collections:


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-50126. Update applies to RPM install guide 2.4 only, so no backport needed. 

Changes made:
- Updated references of PostgreSQL 13 to PostgreSQL 15.
- Added cross-reference to relevant KCS article. 