### PR TITLE
Removing LDAP referrals are disabled by default (#3909)

### DIFF
--- a/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
@@ -87,7 +87,12 @@ If this setting has a value it will be used instead of the *LDAP User Search* se
 +
 include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
 +
-. Enter any *LDAP Connection Options* to set for the LDAP connection. LDAP referrals are disabled by default (to prevent certain LDAP queries from hanging with Active Directory). Option names should be strings as shown in the following example:
+. Enter any *LDAP Connection Options* to set for the LDAP connection. 
+// Temporarily commenting out the following statement for [AAP-50041]:
+//LDAP referrals are disabled by default (to prevent certain LDAP queries from hanging with Active Directory). 
+LDAP referrals are not disabled by default. 
+Disable this setting to prevent login flow timeouts and ensure successful user logins.
+Option names should be strings as shown in the following example:
 +
 ----
 OPT_REFERRALS: 0


### PR DESCRIPTION
* Removing LDAP referrals are disabled by default

[Doc] AAP 2.5 documentation for LDAP configuration is misleading

https://issues.redhat.com/browse/AAP-50041

Affects `titles/central-auth`

* Tech review edits