### PR TITLE
Bp to 2.5: fixes menu formatting in one module (#3969)

### DIFF
--- a/downstream/modules/platform/proc-controller-review-organizations.adoc
+++ b/downstream/modules/platform/proc-controller-review-organizations.adoc
@@ -8,7 +8,7 @@ The *Organizations* page displays the existing organizations for your installati
 
 .Procedure
 
-. From the navigation panel, select menu:{MenuAMOrganizations}.
+. From the navigation panel, select {MenuAMOrganizations}.
 . In the Search bar, enter an appropriate keyword for the organization you want to search for and click the arrow icon.
 . From the menu bar, you can sort the list of organizations by using the arrows for *Name* to toggle your sorting preference.
 . You can also sort the list by selecting *Name*, *Created* or *Last modified* from the *Sort* list.


### PR DESCRIPTION
This PR ports the change from [PR 3969](https://github.com/ansible/aap-docs/pull/3969) to the 2.5 branch. 