### PR TITLE
AAP-45594: Removes references to component tabs in RBAC docs

### DIFF
--- a/downstream/modules/platform/proc-controller-add-organization-user.adoc
+++ b/downstream/modules/platform/proc-controller-add-organization-user.adoc
@@ -18,7 +18,7 @@ New user memberships to an organization must be added at the platform level.
 .Procedure
 . From the navigation panel, select {MenuAMOrganizations}.
 . From the *Organizations* list view, select the organization to which you want to add a user. 
-. Click the *Users* tab to add users.
+. Click the *Users* tab, then btn:[Assign Users] to add users.
 // . Select the *{PlatformNameShort}* tab and click btn:[Add users] to add user access to the team, or select the *Automation Execution* tab to view or remove user access from the team.
 . Select one or more users from the list by clicking the checkbox next to the name to add them as members.
 . Click btn:[Next].

--- a/downstream/modules/platform/proc-controller-add-organization-user.adoc
+++ b/downstream/modules/platform/proc-controller-add-organization-user.adoc
@@ -7,11 +7,11 @@
 You can provide a user with access to an organization by adding them to the organization and managing the roles associated with the user. To add a user to an organization, the user must already exist. For more information, see xref:proc-controller-creating-a-user[Creating a user]. 
 To add roles for a user, the role must already exist. See xref:proc-gw-create-roles[Creating a role] for more information.
 
-The following tab selections are available when adding users to an organization. When user accounts from the {ControllerName} organization have been migrated to {PlatformNameShort} 2.5 during the upgrade process, the *Automation Execution* tab shows content based on whether the users were added to the organization prior to migration.  
+// [[hherbly] removed for 2.6] The following tab selections are available when adding users to an organization. When user accounts from the {ControllerName} organization have been migrated to {PlatformNameShort} 2.5 during the upgrade process, the *Automation Execution* tab shows content based on whether the users were added to the organization prior to migration.  
 
-{PlatformNameShort}:: Reflects all users added to the organization at the platform level. From this tab, you can add users as organization members and, optionally provide specific organization level roles.
+// {PlatformNameShort}:: Reflects all users added to the organization at the platform level. From this tab, you can add users as organization members and, optionally provide specific organization level roles.
 
-Automation Execution:: Reflects users that were added directly to the {ControllerName} organization prior to an upgrade and migration. From this tab, you can only view existing memberships in {ControllerName} and remove those memberships but not you can not add new memberships. 
+// Automation Execution:: Reflects users that were added directly to the {ControllerName} organization prior to an upgrade and migration. From this tab, you can only view existing memberships in {ControllerName} and remove those memberships but not you can not add new memberships. 
 
 New user memberships to an organization must be added at the platform level.
 
@@ -19,7 +19,7 @@ New user memberships to an organization must be added at the platform level.
 . From the navigation panel, select {MenuAMOrganizations}.
 . From the *Organizations* list view, select the organization to which you want to add a user. 
 . Click the *Users* tab to add users.
-. Select the *{PlatformNameShort}* tab and click btn:[Add users] to add user access to the team, or select the *Automation Execution* tab to view or remove user access from the team.
+// . Select the *{PlatformNameShort}* tab and click btn:[Add users] to add user access to the team, or select the *Automation Execution* tab to view or remove user access from the team.
 . Select one or more users from the list by clicking the checkbox next to the name to add them as members.
 . Click btn:[Next].
 . Select the roles you want the selected user to have. Scroll down for a complete list of roles.

--- a/downstream/modules/platform/proc-gw-create-roles.adoc
+++ b/downstream/modules/platform/proc-gw-create-roles.adoc
@@ -9,12 +9,12 @@
 .Procedure
 
 . From the navigation panel, select {MenuAMRoles}.
-. Select a tab for the component resource for which you want to create custom roles.
+// [[hherbly]This may need to be replaced with updated steps for 2.6.]. Select a tab for the component resource for which you want to create custom roles.
 +
-include::snippets/snip-gw-roles-note-multiple-components.adoc[]
+// include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Click btn:[Create role].
 . Provide a *Name* and optionally include a *Description* for the role.
 . Select a *Content Type*.
-. Select the *Permissions* you want assigned to this role.
+. Select the *Permissions* you want assigned to this role from the drop-down menu.
 . Click btn:[Create role] to create your new role.

--- a/downstream/modules/platform/proc-gw-delete-roles.adoc
+++ b/downstream/modules/platform/proc-gw-delete-roles.adoc
@@ -9,9 +9,9 @@ Built in roles can not be deleted, however, you can delete custom roles from the
 .Procedure
 
 . From the navigation panel, select {MenuAMRoles}.
-. Select a tab for the component resource for which you want to create custom roles.
+// [[hherbly]This may need to be replaced with updated steps for 2.6.]. Select a tab for the component resource for which you want to create custom roles.
 +
-include::snippets/snip-gw-roles-note-multiple-components.adoc[]
+// include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Click the *More Actions* icon *{MoreActionsIcon}* next to the role you want and select *Delete role*.
 . To delete roles in bulk, select the roles you want to delete from the *Roles* list view, click the *More Actions* icon *{MoreActionsIcon}*, and select *Delete roles*.

--- a/downstream/modules/platform/proc-gw-edit-roles.adoc
+++ b/downstream/modules/platform/proc-gw-edit-roles.adoc
@@ -9,9 +9,9 @@ Built in roles can not be changed, however, you can modify custom roles from the
 .Procedure
 
 . From the navigation panel, select {MenuAMRoles}.
-. Select a tab for the component resource for which you want to modify a custom role.
+// [[hherbly]This may need to be replaced with updated steps for 2.6.]. Select a tab for the component resource for which you want to modify a custom role.
 +
-include::snippets/snip-gw-roles-note-multiple-components.adoc[]
+// include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
 . Click the *Edit role* icon image:leftpencil.png[Edit,15,15] next to the role you want and modify the role settings as needed.
 . Click btn:[Save role] to save your changes.

--- a/downstream/modules/platform/proc-gw-editing-a-user.adoc
+++ b/downstream/modules/platform/proc-gw-editing-a-user.adoc
@@ -6,13 +6,13 @@
 
 You can modify the properties of a user account after it is created.
 
-In upgrade scenarios, there might be pre-existing user accounts from {ControllerName} or {HubName} services. When editing these user accounts, the *User type* checkboxes indicate whether the account had one of the following service level administrator privileges: 
+// [[hherbly] removed for 2.6] In upgrade scenarios, there might be pre-existing user accounts from {ControllerName} or {HubName} services. When editing these user accounts, the *User type* checkboxes indicate whether the account had one of the following service level administrator privileges: 
 
-Automation Execution Administrator:: A previously defined {ControllerName} administrator with full read and write privileges over automation execution resources only.
-Automation Decisions Administrator:: A previously defined {EDAName} administrator with full read and write privileges over automation decision resources only.
-Automation Content Administrator:: A previously defined {HubName} administrator with full read and write privileges over automation content resources only.
+// Automation Execution Administrator:: A previously defined {ControllerName} administrator with full read and write privileges over automation execution resources only.
+// Automation Decisions Administrator:: A previously defined {EDAName} administrator with full read and write privileges over automation decision resources only.
+// Automation Content Administrator:: A previously defined {HubName} administrator with full read and write privileges over automation content resources only.
 
-Platform administrators can revoke or assign administrator permissions for the individual services and designate the user as either an *{PlatformNameShort} Administrator*, *{PlatformNameShort} Auditor* or normal user. Assigning administrator privileges to all of the individual services automatically designates the user as an *{PlatformNameShort} Administrator*. See xref:proc-controller-creating-a-user[Creating a user] for more information about user types.
+// Platform administrators can revoke or assign administrator permissions for the individual services and designate the user as either an *{PlatformNameShort} Administrator*, *{PlatformNameShort} Auditor* or normal user. Assigning administrator privileges to all of the individual services automatically designates the user as an *{PlatformNameShort} Administrator*. See xref:proc-controller-creating-a-user[Creating a user] for more information about user types.
 
 To see whether a user had service level auditor privileges, you must refer to the API.
 
@@ -31,9 +31,9 @@ Users previously designated as {ControllerName} or {HubName} administrators are 
 
 . The *Edit* user page is displayed where you can modify user details such as, *Password*, *Email*, *User type*, and *Organization*.
 +
-[NOTE]
-====
-If the user account was migrated to {PlatformNameShort} 2.5 during the upgrade process and had administrator privileges for an individual service, additional User type checkboxes will be available. You can use these checkboxes to revoke or add individual privileges or designate the user as a platform administrator, system auditor or normal user.
-====
+// [NOTE]
+// ====
+// If the user account was migrated to {PlatformNameShort} 2.5 during the upgrade process and had administrator privileges for an individual service, additional User type checkboxes will be available. You can use these checkboxes to revoke or add individual privileges or designate the user as a platform administrator, system auditor or normal user.
+// ====
 +
 . After your changes are complete, click *Save user*.

--- a/downstream/modules/platform/proc-gw-roles.adoc
+++ b/downstream/modules/platform/proc-gw-roles.adoc
@@ -9,9 +9,9 @@ You can display the roles assigned for component resources from the menu:Access 
 .Procedure
 
 . From the navigation panel, select {MenuAMRoles}.
-. Select a tab for the component resource for which you want to create custom roles.
+// [[hherbly]This may need to be replaced with updated steps for 2.6.] Select a tab for the component resource for which you want to create custom roles.
 +
-include::snippets/snip-gw-roles-note-multiple-components.adoc[]
+// include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 +
-. From the table header, you can sort the list of roles by using the arrows for *Name*, *Description*, *Created* and *Editable* or by making sort selections in the *Sort* list.
+. From the table header, you can sort the list of roles by using the arrows for *Name*, *Description*, *Component*, *Resource Type*, and *Role Creation*, or by making sort selections in the *Sort* list.
 . You can filter the list of roles by selecting *Name* or *Editable* from the filter list and clicking the arrow.

--- a/downstream/modules/platform/proc-gw-team-add-user.adoc
+++ b/downstream/modules/platform/proc-gw-team-add-user.adoc
@@ -5,13 +5,13 @@
 = Adding users to a team
 To add a user to a team, the user must already have been created. For more information, see xref:proc-controller-creating-a-user[Creating a user]. Adding a user to a team adds them as a member only. Use the *Roles* tab to assign a role for different resources to the selected team.
 
-The following tab selections are available when adding users to a team. When user accounts from {ControllerName} or {HubName} organizations have been migrated to {PlatformNameShort} 2.5 during the upgrade process, the *Automation Execution* and *Automation Content* tabs show content based on whether the users were added to those organizations prior to migration.  
+// [[hherbly]This may need to be replaced with updated steps for 2.6.] The following tab selections are available when adding users to a team. When user accounts from {ControllerName} or {HubName} organizations have been migrated to {PlatformNameShort} 2.5 during the upgrade process, the *Automation Execution* and *Automation Content* tabs show content based on whether the users were added to those organizations prior to migration.  
 
-{PlatformNameShort}:: Reflects all users added to the organization at the platform level. From this tab, you can add users as organization members and, optionally provide specific organization level roles.
+// {PlatformNameShort}:: Reflects all users added to the organization at the platform level. From this tab, you can add users as organization members and, optionally provide specific organization level roles.
 
-Automation Execution:: Reflects users that were added directly to the {ControllerName} organization prior to an upgrade and migration. From this tab, you can only view existing memberships in {ControllerName} and remove those memberships but you can not add new memberships. New organization memberships must be added through the platform.
+// Automation Execution:: Reflects users that were added directly to the {ControllerName} organization prior to an upgrade and migration. From this tab, you can only view existing memberships in {ControllerName} and remove those memberships but you can not add new memberships. New organization memberships must be added through the platform.
 
-Automation Content:: Reflects users that were added directly to the {HubName} organization prior to an upgrade and migration. From this tab, you can only view existing memberships in {HubName} and remove those memberships but you can not add new memberships. 
+// Automation Content:: Reflects users that were added directly to the {HubName} organization prior to an upgrade and migration. From this tab, you can only view existing memberships in {HubName} and remove those memberships but you can not add new memberships. 
 
 New user memberships to a team must be added at the platform level.
 
@@ -21,7 +21,7 @@ New user memberships to a team must be added at the platform level.
 . From the navigation panel, select {MenuAMTeams}.
 . Select the team to which you want to add users.
 . Select the *Users* tab.
-. Select the *{PlatformNameShort}* tab and click btn:[Add users] to add user access to the team, or select the *Automation Execution* or *Automation Content* tab to view or remove user access from the team.
+// . Select the *{PlatformNameShort}* tab and click btn:[Add users] to add user access to the team, or select the *Automation Execution* or *Automation Content* tab to view or remove user access from the team.
 . Select one or more users from the list by clicking the checkbox next to the name to add them as members of this team.
 . Click btn:[Add users].
  


### PR DESCRIPTION
This work is being tracked in[ AAP-45594](https://issues.redhat.com/browse/AAP-45594)