### PR TITLE
Backport-2.6-3875 to AAP-49612: DITA Pre-migration prep work - Using automation decisions guide

### DIFF
--- a/downstream/archive/archived-modules/eda/proc-eda-set-up-token.adoc
+++ b/downstream/archive/archived-modules/eda/proc-eda-set-up-token.adoc
@@ -28,4 +28,5 @@ The token must be in write-scope.
 ====
 . Select btn:[Create controller token].
 
+.Results
 After saving the new token, you are brought to the *Controller Tokens* tab where you can delete the token.

--- a/downstream/assemblies/eda/assembly-eda-credential-types.adoc
+++ b/downstream/assemblies/eda/assembly-eda-credential-types.adoc
@@ -7,8 +7,7 @@
 
 These built-in credential types are not editable. So if you want credential types that support authentication with other systems, you can create your own credential types that can be used in your source plugins. Each credential type contains an input configuration and an injector configuration that can be passed to an Ansible rulebook to configure your sources.
 
-For more information, see xref:eda-custom-credential-types[Custom credential types].
-//[J. Self] Will add the cross-reference/link later. 
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credential-types#eda-custom-credential-types[Custom credential types].
 
 
 include::eda/con-custom-credential-types.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-decision-environments.adoc
+++ b/downstream/assemblies/eda/assembly-eda-decision-environments.adoc
@@ -6,7 +6,7 @@ Decision environments are container images that run Ansible rulebooks.
 They create a common language for communicating automation dependencies, and give a standard way to build and distribute the automation environment.
 You can find the default decision environment in the link:https://quay.io/repository/ansible/ansible-rulebook[Ansible-Rulebook]. 
 
-To create your own decision environment, see xref:eda-controller-install-builder[Installing ansible-builder] and xref:eda-build-a-custom-decision-environment[Building a custom decision environment for Event-Driven Ansible within Ansible Automation Platform].
+To create your own decision environment, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-decision-environments#eda-controller-install-builder[Installing ansible-builder] and link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-decision-environments#eda-build-a-custom-decision-environment[Building a custom decision environment for Event-Driven Ansible within Ansible Automation Platform].
 
 include::eda/ref-eda-controller-install-builder.adoc[leveloffset=+1]
 include::eda/proc-eda-build-a-custom-decision-environment.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-event-filter-plugins.adoc
+++ b/downstream/assemblies/eda/assembly-eda-event-filter-plugins.adoc
@@ -22,7 +22,8 @@ You can chain event filters one after the other, and the updated data is sent fr
 Event filters are defined in the rulebook after a source is defined.
 When the rulebook starts the source plugin it associates the correct filters and transforms the data before putting it into the queue.
 
-.Example
+[Example]
+====
 
 ----
 sources:
@@ -45,5 +46,6 @@ Since every event should record the origin of the event the filter `eda.builtin.
 The `received_at` stores a date time in UTC ISO8601 format and includes the microseconds.
 The `uuid` stores the unique id for the event.
 The `meta key` is used to store metadata about the event and its needed to correctly report about the events in the aap-server.
+====
 
 include::eda/con-eda-author-event-filters.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
+++ b/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
@@ -25,7 +25,7 @@ The following actions are currently supported:
 
 To view further details, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/actions.html[Actions]. 
 
-A rulebook activation is a process running in the background defined by a decision environment executing a specific rulebook. You can set up your rulebook activation by following xref:eda-set-up-rulebook-activation[Setting up a rulebook activation].
+A rulebook activation is a process running in the background defined by a decision environment executing a specific rulebook. You can set up your rulebook activation by following link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rulebook-activations#eda-set-up-rulebook-activation[Setting up a rulebook activation].
 
 [WARNING]
 ====

--- a/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
+++ b/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
@@ -6,7 +6,7 @@ When {EDAcontroller} is deployed on {PlatformNameShort} {PlatformVers}, you can 
 
 [NOTE]
 ====
-If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. To delete deprecated controller tokens and the rulebook activations associated with them, complete the following procedures starting with xref:replacing-controller-tokens[Replacing controller tokens in {PlatformNameShort} {PlatformVers}] before proceeding with xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
+If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used controller tokens to connect {ControllerName} and {EDAcontroller}. These controller tokens have been deprecated in {PlatformNameShort} {PlatformVers}. To delete deprecated controller tokens and the rulebook activations associated with them, complete the following procedures starting with link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-set-up-rhaap-credential-type#replacing-controller-tokens[Replacing controller tokens in {PlatformNameShort} {PlatformVers}] before proceeding with link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-set-up-rhaap-credential-type#eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
 ====
 
 include::eda/con-replacing-controller-tokens.adoc[leveloffset=+1]

--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -8,18 +8,18 @@ These tools monitor IT solutions and identify events and automatically implement
 
 The following procedures form the user configuration:
 
-* xref:eda-credentials[Credentials]
-* xref:eda-credential-types[Credential types]
-* xref:eda-projects[Projects]
-* xref:eda-decision-environments[Decision environments]
-* xref:eda-set-up-rhaap-credential-type[Red Hat Ansible Automation Platform credential]
-* xref:eda-rulebook-activations[Rulebook activations]
-* xref:eda-rulebook-troubleshooting[Rulebook activations troubleshooting]
-* xref:eda-rule-audit[Rule audit]
-* xref:simplified-event-routing[Simplified event routing]
-* xref:eda-performance-tuning[Performance tuning for {EDAcontroller}]
-* xref:eda-event-filter-plugins[Event filter plugins]
-* xref:eda-logging-strategy[Event-Driven Ansible logging strategy]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credentials[Credentials]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credential-types[Credential types]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-projects[Projects]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-decision-environments[Decision environments]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-set-up-rhaap-credential-type[Red Hat Ansible Automation Platform credential]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rulebook-activations[Rulebook activations]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rulebook-troubleshooting[Rulebook activations troubleshooting]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rule-audit[Rule audit]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/simplified-event-routing[Simplified event routing]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-performance-tuning[Performance tuning for {EDAcontroller}]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-event-filter-plugins[Event filter plugins]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-logging-strategy[Event-Driven Ansible logging strategy]
 
 
 [NOTE]
@@ -31,9 +31,7 @@ The following procedures form the user configuration:
 
 [role="_additional-resources"]
 .Additional resources
-* For information on how to set user permissions for {EDAcontroller}, see the following in the link:{URLCentralAuth}/index[Access management and authentication guide]: 
-
-. link:{URLCentralAuth}/gw-managing-access#ref-controller-user-roles[Adding roles for a user]
-. link:{URLCentralAuth}/assembly-gw-roles[Roles]
-
-* If you plan to use {EDAName} 2.5 with a 2.4 {PlatformNameShort}, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/using_event-driven_ansible_2.5_with_ansible_automation_platform_2.4/index[Using Event-Driven Ansible 2.5 with Ansible Automation Platform 2.4].
+* link:{URLCentralAuth}/index[Access management and authentication guide]: 
+** link:{URLCentralAuth}/gw-managing-access#ref-controller-user-roles[Adding roles for a user]
+** link:{URLCentralAuth}/assembly-gw-roles[Roles]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/using_event-driven_ansible_2.5_with_ansible_automation_platform_2.4/index[Using Event-Driven Ansible 2.5 with Ansible Automation Platform 2.4].

--- a/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
+++ b/downstream/modules/eda/con-modifying-simultaneous-activations.adoc
@@ -1,8 +1,8 @@
+:_mod-docs-content-type: CONCEPT
 [id="modifying-simultaneous-activations"]
 
 = Modifying the number of simultaneous rulebook activations 
 
-[role="_abstract"]
 By default, {EDAcontroller} allows 12 rulebook activations per node. For example, with two worker or hybrid nodes, it results in a limit of 24 activations in total to run simultaneously.
 If more than 24 rulebook activations are created, the expected behavior is that subsequent rulebook activations wait until there is an available rulebook activation worker.
 In this case, the rulebook activation status is displayed as *Pending* even if there is enough free memory and CPU on your {EDAcontroller} instance.
@@ -17,6 +17,6 @@ To change this behavior, you must change the default maximum number of running r
 include::proc-modifying-activations-during-install.adoc[leveloffset=+1]
 include::proc-modifying-activations-after-install.adoc[leveloffset=+1]
 
-.Additional Resources 
-* For more information about rulebook activations, see the link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/event-driven_ansible_controller_user_guide/index#eda-rulebook-activations[Rulebook activations].
-* For more information about modifying simultaneous rulebook activations during or after {EDAName} on {OCPShort}, see the example in link:{URLOperatorInstallation}/appendix-operator-crs_appendix-operator-crs#eda_max_running_activations_yml[eda_max_running_activations_yml].
+.Additional references
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/event-driven_ansible_controller_user_guide/index#eda-rulebook-activations[Rulebook activations]
+* link:{URLOperatorInstallation}/appendix-operator-crs_appendix-operator-crs#eda_max_running_activations_yml[eda_max_running_activations_yml]

--- a/downstream/modules/eda/proc-eda-build-a-custom-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-build-a-custom-decision-environment.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-build-a-custom-decision-environment"]
 
 = Building a custom decision environment for {EDAName}
@@ -14,12 +15,6 @@ You can create a custom decision environment for {EDAName} that provides a custo
 * {EDAName}
 * {Builder} > = 3.0
 
-.Procedure
-
-* Use `de-minimal` as the base image with {Builder} to build your custom decision environments. 
-This image is built from a base image provided by Red Hat at link:https://catalog.redhat.com/software/containers/ansible-automation-platform-25/de-minimal-rhel9/650a5672a370728c710acaab[{PlatformNameShort} minimal decision environment].  
-
-+
 [IMPORTANT]
 ====
 * Use the correct {EDAcontroller} decision environment in {PlatformNameShort} to prevent rulebook activation failure.
@@ -27,6 +22,13 @@ This image is built from a base image provided by Red Hat at link:https://catalo
 ** If you want to connect {EDAcontroller} to {PlatformNameShort} 2.4, you must use `registry.redhat.io/ansible-automation-platform-24/de-minimal-rhel9:latest`
 ** If you want to connect {EDAcontroller} to {PlatformNameShort} {PlatformVers}, you must use `registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel9:latest`
 ====
+
+.Procedure
+
+* Use `de-minimal` as the base image with {Builder} to build your custom decision environments. 
+This image is built from a base image provided by Red Hat at link:https://catalog.redhat.com/software/containers/ansible-automation-platform-25/de-minimal-rhel9/650a5672a370728c710acaab[{PlatformNameShort} minimal decision environment].  
+
+.Example
 
 The following is an example of the {Builder} definition file that uses `de-minimal` as a base image to build a custom decision environment with the ansible.eda collection:
 -----

--- a/downstream/modules/eda/proc-eda-config-remote-sys-to-events.adoc
+++ b/downstream/modules/eda/proc-eda-config-remote-sys-to-events.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-config-remote-sys-to-events"] 
 
 = Configuring your remote system to send events
@@ -15,7 +16,7 @@ The following example demonstrates how to configure webhooks in a remote system 
 
 . Log in to your GitHub repository.
 . Click *Your profile name → Your repositories*.
-
++
 [NOTE]
 ====
 If you do not have a repository, click *New* to create a new one, select an owner, add a *Repository name*, and click *Create repository*.
@@ -29,4 +30,5 @@ If you do not have a repository, click *New* to create a new one, select an owne
 . Enter your *Secret*.
 . Click *Add webhook*.
 
-After the webhook has been added, it attempts to send a test payload to ensure there is connectivity between the two systems (GitHub and {EDAcontroller}). If it can successfully send the data you will see a green check mark next to the *Webhook URL* with the message, *Last delivery was successful*.
+.Results
+After the webhook has been added, it attempts to send a test payload to ensure there is connectivity between the two systems (GitHub and {EDAcontroller}). If it can successfully send the data, you will see a green check mark next to the *Webhook URL* with the message, *Last delivery was successful*.

--- a/downstream/modules/eda/proc-eda-create-event-stream-credential.adoc
+++ b/downstream/modules/eda/proc-eda-create-event-stream-credential.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-create-event-stream-credential"] 
 
 = Creating an event stream credential
@@ -29,4 +30,5 @@ Type Details:: Add the requested information for the credential type you selecte
 
 . Click btn:[Create credential].
 
+.Results
 The Details page is displayed. From there or the *Credentials* list view, you can edit or delete it.

--- a/downstream/modules/eda/proc-eda-create-event-stream.adoc
+++ b/downstream/modules/eda/proc-eda-create-event-stream.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-create-event-stream"] 
 
 = Creating an event stream
@@ -7,7 +8,7 @@ You can create event streams that will be attached to a rulebook activation.
 .Prerequisites
 
 * If you will be attaching your event stream to a rulebook activation, ensure that your activation has a decision environment and project already set up.
-* If you plan to connect to {ControllerName} to run your rulebook activation, ensure that you have created a {PlatformName} credential type in addition to the decision environment and project. For more information, see xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
+* If you plan to connect to {ControllerName} to run your rulebook activation, ensure that you have created a {PlatformName} credential type in addition to the decision environment and project. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-set-up-rhaap-credential-type#eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
 
 .Procedure
 
@@ -36,13 +37,17 @@ The event stream's event forwarding can be disabled for testing purposes while d
 
 . Click btn:[Create event stream].
 
+.Results
 After creating your event stream, the following outputs occur:
 
 * The Details page is displayed. From there or the Event Streams list view, you can edit or delete it. Also, the Event Streams page shows all of the event streams you have created and the following columns for each event: *Events received*, *Last event received*, and *Event stream type*. As the first two columns receive external data through the event stream, they are continuously updated to let you know they are receiving events from remote systems.
 * If you disabled the event stream, the Details page is displayed with a warning message, *This event stream is disabled*. 
-* Your new event stream generates a URL that is necessary when you configure the webhook on the remote system that sends events.
-
++
 [NOTE]
 ====
 After an event stream is created, the associated credential cannot be deleted until the event stream it is attached to is deleted.
 ====
+
+* Your new event stream generates a URL that is necessary when you configure the webhook on the remote system that sends events.
+
+

--- a/downstream/modules/eda/proc-eda-delete-controller-token.adoc
+++ b/downstream/modules/eda/proc-eda-delete-controller-token.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: <PROCEDURE>
 [id="eda-delete-controller-token"]
 
 = Deleting controller tokens
@@ -15,4 +16,5 @@ Before you can set up {PlatformName} credentials, you must delete any existing c
 . Select the *Tokens* tab.
 . Delete all of your previous controller tokens. 
 
-After deleting the controller tokens and rulebook activations, proceed with xref:eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].
+.Next steps
+After deleting the controller tokens and rulebook activations, proceed with link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-set-up-rhaap-credential-type#eda-set-up-rhaap-credential[Setting up a {PlatformName} credential].

--- a/downstream/modules/eda/proc-eda-set-up-credential-types.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-credential-types.adoc
@@ -97,4 +97,4 @@ Your newly created credential type is displayed in the list of credential types.
 
 .Additional resources
 
-For information about how to create a new credential, see xref:eda-set-up-credential[Setting up credentials].
+link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credentials#eda-set-up-credential[Setting up credentials].

--- a/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-set-up-new-decision-environment"]
 
 = Setting up a new decision environment
@@ -7,7 +8,7 @@ You can import a decision environment into your {EDAcontroller} using a default 
 .Prerequisites
 
 * You have set up a credential, if necessary.
-For more information, see the xref:eda-set-up-credential[Setting up credentials] section.
+For more information, see the link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credentials#eda-set-up-credential[Setting up credentials] section.
 * You have pushed a decision environment image to an image repository or you chose to use the `de-minimal` image located in link:http://registry.redhat.io/[registry.redhat.io].
 
 .Procedure
@@ -24,6 +25,7 @@ Image:: This is the full image location, including the container registry, image
 Credential:: This field is optional. This is the credential needed to use the decision environment image.
 . Select btn:[Create decision environment].
 
+.Results
 Your decision environment is now created and can be managed on the *Decision Environments* page.
 
 After saving the new decision environment, the decision environment's details page is displayed.

--- a/downstream/modules/eda/proc-eda-set-up-new-project.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-new-project.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-set-up-new-project"]
 
 = Setting up a new project
@@ -8,7 +9,7 @@ You can set up projects to manage and store your rulebooks in {EDAcontroller}.
 // [ddacosta] I'm not sure whether there will be an EDA specific dashboard in the gateway. Step 1 might need to change to something like "Log in to AAP".
 * You are logged in to the {PlatformNameShort} Dashboard as a Content Consumer.
 * You have set up a credential, if necessary.
-For more information, see the xref:eda-set-up-credential[Setting up credentials] section.
+For more information, see the link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credentials#eda-set-up-credential[Setting up credentials][Setting up credentials] section.
 * You have an existing repository containing rulebooks that are integrated with playbooks contained in a repository to be used by {ControllerName}.
 
 .Procedure
@@ -41,6 +42,7 @@ You can disable this option if you have a local repository that uses self-signed
 ====
 . Select btn:[Create project].
 
+.Results
 Your project is now created and can be managed in the *Projects* page.
 
 After saving the new project, the project's details page is displayed.

--- a/downstream/modules/eda/proc-eda-set-up-rhaap-credential.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rhaap-credential.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-set-up-rhaap-credential"]
 
 = Setting up a {PlatformName} credential
@@ -37,4 +38,5 @@ For {PlatformNameShort} {PlatformVers}, use the following example: \https://<you
 . Enter a valid *Username* and *Password*, or *Oauth Token*. 
 . Click btn:[Create credential].
 
+.Next step
 After you create this credential, you can use it for configuring your rulebook activations.

--- a/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-rulebook-activation.adoc
@@ -1,6 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-set-up-rulebook-activation"]
 
 = Setting up a rulebook activation
+
+You can create and configure a rulebook activation within the {PlatformNameShort} Dashboard. This process ensures effective management and deployment of your event-driven automation.
 
 .Prerequisites
 // [ddacosta] I'm not sure whether there will be an EDA specific dashboard in the gateway. Step 1 might need to change to something like "Log in to AAP".
@@ -24,7 +27,7 @@ Credential:: Select 0 or more credentials for this rulebook activation. This fie
 +
 [NOTE]
 ====
-* The credentials that display in this field are customized based on your rulebook activation and only include the following credential types: Vault, {PlatformName}, or any custom credential types that you have created. For more information about credentials, see xref:eda-credentials[Credentials].
+* The credentials that display in this field are customized based on your rulebook activation and only include the following credential types: Vault, {PlatformName}, or any custom credential types that you have created. For more information about credentials, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credentials[Credentials].
 * If you plan to use a {PlatformName} credential, you can _only_ select 1 {PlatformName} credential type for a rulebook activation.
 ====
 
@@ -60,6 +63,7 @@ Options:: Check the *Skip audit events* option if you do not want to see your ev
 
 . Click btn:[Create rulebook activation].
 
+.Results
 Your rulebook activation is now created and can be managed on the *Rulebook Activations* page.
 
 After saving the new rulebook activation, the rulebook activation's details page is displayed, with either a *Pending*, *Running*, or *Failed* status.

--- a/downstream/modules/eda/proc-eda-view-activation-output.adoc
+++ b/downstream/modules/eda/proc-eda-view-activation-output.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-view-activations-output"]
 
 = Viewing activation output
@@ -12,4 +13,5 @@ An activation instance represents a single execution of the activation.
 //[JMSelf] Remove this screenshot due to outdated view.
 //image::eda-rulebook-activation-history.png[Rulebook activation history]
 
-To view events that came in and triggered an action, you can use the xref:eda-rule-audit[Rule Audit] section in the {EDAcontroller} Dashboard.
+.Next steps
+To view events that came in and triggered an action, navigate to {MenuADRuleAudit} and follow instructions in the link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rule-audit[Rule Audit] section. 

--- a/downstream/modules/eda/proc-eda-view-rule-audit-actions.adoc
+++ b/downstream/modules/eda/proc-eda-view-rule-audit-actions.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-view-rule-audit-actions"]
 
 = Viewing rule audit actions
@@ -7,5 +8,6 @@
 . From the navigation panel select *{MenuADRuleAudit}*.
 . Select the desired rule, then select the *Actions* tab.
 
-From here you can view executed actions that were taken.
+.Results
+From here, you can view executed actions that were taken.
 Some actions are linked out to {MenuTopAE} where you can view the output.

--- a/downstream/modules/eda/proc-eda-view-rule-audit-details.adoc
+++ b/downstream/modules/eda/proc-eda-view-rule-audit-details.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-view-rule-audit-details"]
 
 = Viewing rule audit details
@@ -11,4 +12,5 @@ From the *Rule Audit* list view you can check the event that triggered specific 
 . From the navigation panel select *{MenuADRuleAudit}*.
 . Select the desired rule, this brings you to the *Details* tab.
 
+.Results
 From here you can view when it was created, when it was last fired, and the rulebook activation that it corresponds to.

--- a/downstream/modules/eda/proc-modifying-activations-during-install.adoc
+++ b/downstream/modules/eda/proc-modifying-activations-during-install.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="modifying-activations-during-install"]
 
 = Modifying the number of simultaneous rulebook activations during {EDAcontroller} installation 
@@ -6,9 +7,8 @@
 By default, {EDAcontroller} allows 12 rulebook activations per node. For example, with two worker or hybrid nodes, it results in a limit of 24 activations in total to run simultaneously. You can modify this default value during installation by using the following procedure:
 
 .Procedure
-Provide a variable to the VM installer:
-
-. Navigate to the setup inventory file. 
-. Add `automationedacontroller_max_running_activations` in the [all:vars] section.
+. Provide a variable to the VM installer: 
+.. Navigate to the setup inventory file. 
+.. Add `automationedacontroller_max_running_activations` in the [all:vars] section.
 For example, `automationedacontroller_max_running_activations=16`.
-. Run the setup.
+.. Run the setup.

--- a/downstream/modules/eda/ref-eda-logging-samples.adoc
+++ b/downstream/modules/eda/ref-eda-logging-samples.adoc
@@ -1,11 +1,11 @@
+:_mod-docs-content-type: REFERENCE
 [id="eda-logging-samples"]
 
 = Logging samples
 
 When the following APIs are called for each operation, you see the following audit logs:
 
-.Rulebook activation
-
+Rulebook activation::
 ----
 1. Create
     1. 2024-08-15 14:13:20,384 aap_eda.api.views.activation INFO   Action: Create / ResourceType: RulebookActivation / ResourceName: quick_start_project / ResourceID: 53 / Organization: Default
@@ -21,7 +21,7 @@ When the following APIs are called for each operation, you see the following aud
     2024-08-15 14:24:34,169 aap_eda.api.views.activation INFO      Action: Restart / ResourceType: RulebookActivation / ResourceName: quick_start_activation / ResourceID: 1 / Organization: Default
 ----
 
-.EventStream Logs
+EventStream Logs::
 ----
 1. Create
     1. 2024-08-15 13:46:26,903 aap_eda.api.views.webhook INFO     Action: Create / ResourceType: EventStream / ResourceName: ZackTest / ResourceID: 1 / Organization: Default
@@ -35,7 +35,7 @@ When the following APIs are called for each operation, you see the following aud
     1. 2024-08-15 13:57:13,124 aap_eda.api.views.webhook INFO     Action: Delete / ResourceType: EventStream / ResourceName: ZackTest / ResourceID: None / Organization: Default
 ----
 
-.Decision Environment
+Decision Environment::
 ----
 1. Create
     1. 2024-08-15 14:10:53,311 aap_eda.api.views.decision_environment INFO     Action: Create / ResourceType: DecisionEnvironment / ResourceName: quick_start_de / ResourceID: 86 / Organization: Default
@@ -47,7 +47,7 @@ When the following APIs are called for each operation, you see the following aud
 2024-08-15 14:11:42,369 aap_eda.api.views.decision_environment INFO     Action: Delete / ResourceType: DecisionEnvironment / ResourceName: quick_start_de / ResourceID: None / Organization: Default
 ----
 
-.Project
+Project::
 ----
 1. Create
     1. 2024-08-15 14:05:26,874 aap_eda.api.views.project INFO     Action: Create / ResourceType: Project / ResourceName: quick_start_project / ResourceID: 86 / Organization: Default
@@ -61,7 +61,7 @@ When the following APIs are called for each operation, you see the following aud
     1. 2024-08-15 14:06:49,481 aap_eda.api.views.project INFO     Action: Delete / ResourceType: Project / ResourceName: quick_start_project / ResourceID: 86 / Organization: Default
 ----
 
-.Activation Start/Stop
+Activation Start/Stop::
 ----
 1. Start
     1. 2024-08-15 14:21:29,076 aap_eda.services.activation.activation_manager INFO     Requested to start activation 1, starting.


### PR DESCRIPTION
Pre-migration updates on multiple files in the Using automation decisions guide to pass Vale validation test before migrating content to DITA/AEM. Includes updates from PR https://github.com/ansible/aap-docs/pull/3875.