### PR TITLE
2.6 Update nginx_tls_protocols default value (#3990)

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -115,7 +115,7 @@ Set this variable to `true` to disable HTTPS.
 | `controller_nginx_https_protocols` 
 | Protocols that {ControllerName} supports when handling HTTPS traffic.
 | Optional
-| RPM = `[TLSv1.2]`. Container = `[TLSv1.2, TLSv1.3]`
+| `[TLSv1.2, TLSv1.3]`
 
 | `nginx_user_headers` 
 | `controller_nginx_user_headers` 

--- a/downstream/modules/platform/ref-eda-controller-variables.adoc
+++ b/downstream/modules/platform/ref-eda-controller-variables.adoc
@@ -305,7 +305,7 @@ eda_extra_settings:
 | `eda_nginx_https_protocols` 
 | Protocols that {EDAName} supports when handling HTTPS traffic.
 | Optional
-| RPM = `[TLSv1.2]`. Container = `[TLSv1.2, TLSv1.3]`.
+| `[TLSv1.2, TLSv1.3]`
 
 | 
 | `eda_pg_socket` 

--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -267,7 +267,7 @@ Inventory file variables for {Gateway}.
 | `gateway_nginx_https_protocols` 
 | Protocols that {Gateway} will support when handling HTTPS traffic.
 | Optional
-| RPM = `[TLSv1.2]`. Container = `[TLSv1.2, TLSv1.3]`.
+| `[TLSv1.2, TLSv1.3]`
 
 | `redis_disable_tls`
 | `gateway_redis_disable_tls` 

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -373,7 +373,7 @@ For more information about the list of parameters, see link:https://django-stora
 | `hub_nginx_https_protocols` 
 | Protocols that {HubName} will support when handling HTTPS traffic.
 | Optional
-| RPM = `[TLSv1.2]`. Container = `[TLSv1.2, TLSv1.3]`.
+| `[TLSv1.2, TLSv1.3]`
 
 |  
 | `hub_pg_socket` 


### PR DESCRIPTION
Backports #3990 from main to 2.6

RPM installer - update nginx_tls_protocols default value in documentation

https://issues.redhat.com/browse/AAP-48089