### PR TITLE
AAP-50383: Updated docs for onpremise deployment changes and anonymization

### DIFF
--- a/lightspeed/assemblies/assembly_configuring-lightspeed-onpremise.adoc
+++ b/lightspeed/assemblies/assembly_configuring-lightspeed-onpremise.adoc
@@ -19,11 +19,8 @@ As an {PlatformName} administrator, you can set up a {LightspeedShortName} on-pr
 
 include::modules/con_overview-lightspeed-onpremise.adoc[leveloffset=+1]
 include::modules/proc_install-aap-lightspeed-operator.adoc[leveloffset=+1]
-include::modules/proc_create-oauth-app.adoc[leveloffset=+1]
 include::modules/proc_create-connection-secrets.adoc[leveloffset=+1]
-include::modules/proc_create-bundle-secret.adoc[leveloffset=+2]
-include::modules/proc_create-lightspeed-instance.adoc[leveloffset=+1]
-include::modules/proc_update-redirect-uri.adoc[leveloffset=+1]
+include::modules/proc_update-yaml-file.adoc[leveloffset=+1]
 include::modules/proc_configure-vscode-extension-onpremise-deployment.adoc[leveloffset=+1]
 include::modules/proc_update-connection-secrets.adoc[leveloffset=+1]
 include::modules/proc_monitor-onpremise-deployment.adoc[leveloffset=+1]

--- a/lightspeed/assemblies/assembly_troubleshooting-lightspeed.adoc
+++ b/lightspeed/assemblies/assembly_troubleshooting-lightspeed.adoc
@@ -12,7 +12,6 @@ ifdef::context[:parent-context: {context}]
 This section contains information to help you diagnose and resolve issues with using {LightspeedFullName}.
 
 include::modules/ref_troubleshooting-lightspeed-config.adoc[leveloffset=+1]
-include::modules/ref_troubleshooting-lightspeed-onpremise-config.adoc[leveloffset=+1]
 include::modules/ref_troubleshooting-vscode.adoc[leveloffset=+1]
 include::modules/ref_troubleshooting-code-bot.adoc[leveloffset=+1]
 

--- a/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
+++ b/lightspeed/modules/con_overview-lightspeed-onpremise.adoc
@@ -68,24 +68,3 @@ For information about obtaining an API key and model ID from {ibmwatsonxcodeassi
 
 * You have an existing external PostgreSQL database configured for the {PlatformName}, or have a database created for you when configuring the {LightspeedshortName} on-premise deployment. 
 
-== Process for configuring a {LightspeedshortName} on-premise deployment
-
-Perform the following tasks to install and configure a {LightspeedshortName} on-premise deployment:
-
-. xref:install-aap-lightspeed-operator_configuring-lightspeed-onpremise[Install the {PlatformName} operator]
-
-. xref:create-oauth-app_configuring-lightspeed-onpremise[Create an OAuth application]
-
-. xref:create-connection-secrets_configuring-lightspeed-onpremise[Create connections secrets for {PlatformName} and {ibmwatsonxcodeassistant} both]
-
-. xref:create-lightspeed-instance_configuring-lightspeed-onpremise[Create and deploy a {LightspeedshortName} instance]
-
-. xref:update-redirect-uri_configuring-lightspeed-onpremise[Update the Redirect URI to connect to your {LightspeedshortName} on-premise deployment]
-
-. xref:configure-vscode-extension-onpremise-deployment_configuring-lightspeed-onpremise[Install and configure Ansible Visual Studio Code extension to connect to {LightspeedShortName} on-premise deployment]
-
-. Optional: If you want to connect to a different {ibmwatsonxcodeassistant}, xref:update-connection-secrets_configuring-lightspeed-onpremise[update the connection secrets on an existing {PlatformName} operator]
-
-. Optional: xref:monitor-lightspeed-onpremise-deployment_configuring-lightspeed-onpremise[Monitor your {LightspeedShortName} on-premise deployment]
-
-. Optional: xref:use-rest-api_configuring-lightspeed-onpremise[Use the Ansible Lightspeed REST API to build custom automation development and tooling workflow outside of VS Code]

--- a/lightspeed/modules/proc_configure-vscode-extension-onpremise-deployment.adoc
+++ b/lightspeed/modules/proc_configure-vscode-extension-onpremise-deployment.adoc
@@ -12,6 +12,13 @@ To access the on-premise deployment of {LightspeedShortName}, all Ansible users 
 
 .Procedure
 
+. Obtain the URL of your Ansible Lightspeed instance:
+.. In {OCP}, select menu:Networking[Routes] and locate the {LightspeedShortName} instance that was created. 
+.. From the *Location* column, copy the URL of your Ansible Lightspeed instance.
++
+The URL will be in the following format:
+`\https://<lightspeed_route>/complete/aap/`
+
 . Open the VS Code application.
 . From the *Activity* bar, click the *Extensions* icon.
 . From the *Installed Extensions* list, select *Ansible*.
@@ -26,10 +33,4 @@ After configuring Ansible VS Code extension to connect to {LightspeedShortName} 
 ====
 If your organization recently subscribed to the {PlatformName}, it might take a few hours for {LightspeedShortName} to detect the new subscription. In VS Code, use the *Refresh* button in the Ansible extension from the Activity bar to check again.
 ====
-
-[role="_additional-resources"]
-.Additional resources
-* xref:ref-troubleshooting-lightspeed-onpremise-config_troubleshooting-lightspeed[Troubleshooting {LightspeedShortName} on-premise deployment errors]
-
-
 

--- a/lightspeed/modules/proc_create-connection-secrets.adoc
+++ b/lightspeed/modules/proc_create-connection-secrets.adoc
@@ -2,9 +2,9 @@
 
 [id="create-connection-secrets_{context}"]
 
-= Creating connection secrets
+= Creating a model configuration secret
 
-You must create an authorization secret to connect to {PlatformName}, and a model secret to connect to {ibmwatsonxcodeassistant}. If you need to trust a custom Certificate Authority, you must create a bundle secret.
+You must create a configuration secret to connect to an {ibmwatsonxcodeassistant} model, which can be either an on-premise deployment or a cloud deployment.
 
 .Prerequisites
 * You have installed the {PlatformNameShort} operator on the {OCP}. 
@@ -18,65 +18,25 @@ For information about obtaining an API key and model ID from {ibmwatsonxcodeassi
 . Select menu:Workloads[Secrets].
 . Click menu:Create[Key/value secret].
 . From the *Projects* list, select the namespace that you created when you installed the {PlatformName} operator.
-. Create an *authorization secret* to connect to the {PlatformName}:
-.. Click menu:Create[Key/value secret].
-.. In *Secret name*, enter a unique name for the secret. For example, `auth-aiconnect`.
-.. Add the following keys and their associated values individually:
-+
-[cols="30%,70%",options="header"]
-|===
-|Key |Value
-
-|`auth_api_url`
-a|
-Enter the API URL of the {ControllerName} in the following format based on the {PlatformNameShort} version you are using:
-
-* For {PlatformNameShort} 2.4: `\https://<CONTROLLER_SERVER_NAME>/api`
-* For {PlatformNameShort} 2.5: `\https://<GATEWAY_SERVER_NAME>`
-
-|`auth_api_key`
-|Enter the client ID of the OAuth application that you recorded earlier.
-
-|`auth_api_secret`
-|Enter the client secret of the OAuth application that you recorded earlier.
-
-|`auth_allowed_hosts`
-|Enter the list of strings representing the host/domain names used by the underlying Django framework to restrict which hosts can access the service. This is a security measure to prevent HTTP Host header attacks. For more information, see link:https://docs.djangoproject.com/en/5.0/ref/settings/#allowed-hosts[Allowed hosts in django documentation]. 
-
-|`auth_verify_ssl`
-|Enter the value as `true`.
-|===
-+
-[IMPORTANT]
-====
-Ensure that you do not accidentally add any whitespace characters (extra line, space, and so on) to the value fields. If there are any extra or erroneous characters in the secret, the connection to {PlatformName} fails.
-====
-
-.. Click *Create*. 
-+
-The following image is an example of an authorization secret:
-+
-[.thumb]
-image::aiconnect-auth-secret.png[{Example of an authorization secret]
-
-. Similarly, create a *model secret* to connect to an {ibmwatsonxcodeassistant} model:
-.. Click menu:Create[Key/value secret].
-.. In *Secret name*, enter a unique name for the secret. For example, `model-aiconnect`.
-.. Add the following keys and their associated values individually:
+. Click menu:Create[Key/value secret].
+. In *Secret name*, enter a unique name for the secret. For example, `model-aiconnect`.
+. Add the following keys and their associated values individually:
 +
 [cols="30%,70%",options="header"]
 |===
 |Key |Value
 
 |`username`
-|Enter the username you use to connect to your {ibmwatsonxcodeassistant} model.
+d|_For on-premise deployment only_
+
+Enter the username you use to connect to an IBM Cloud Pak for Data deployment.
 
 |`model_type`
 a|Enter one of the following values per your {ibmwatsonxcodeassistant} model:
 
-* For on-premise deployment of {ibmwatsonxcodeassistant} model (IBM Cloud Pak for Data): `wca-onprem`
+* For on-premise deployment (IBM Cloud Pak for Data): `wca-onprem`
 
-* For cloud deployment of {ibmwatsonxcodeassistant} model (IBM Cloud): `wca`
+* For cloud deployment (IBM Cloud): `wca`
 
 |`model_url`
 |Enter the URL of the {ibmwatsonxcodeassistant} model.
@@ -88,10 +48,19 @@ a|Enter one of the following values per your {ibmwatsonxcodeassistant} model:
 |Enter the ID of your {ibmwatsonxcodeassistant} model.
 
 |`model_verify_ssl`
-d|_Optional, and supported on {PlatformName} {PlatformVers} only_
+d|_Optional, and supported on {PlatformNameShort} {PlatformVers} only_
 
 This key controls whether the SSL certificate of the {ibmwatsonxcodeassistant} model is verified. 
  
+Default = `true`
+
+|`model_enable_anonymization`
+d|_Optional and supported on Ansible Automation Platform 2.5.250730 and later_ 
+
+This key controls whether the anonymization of Personally Identifiable Information (PII) is enabled. PII information includes passwords, IP addresses, email addresses, and other sensitive data. When PII anonymization is enabled, users' personal information is modified to some generic values to protect their data and reduce the risk of data leaks. 
+
+You can turn off the anonymization by specifying the value as false if you want to retain all original information as entered by users and improve the quality of the answers. If you set the value to `false` and the Ansible administrator is using Ansible Lightspeed in hybrid mode (where the model is in {ibmwatsonxcodeassistant} in IBM Cloud) then their users' PII is sent to IBM Cloud.
+
 Default = `true`
 |===
 +
@@ -100,6 +69,6 @@ Default = `true`
 Ensure that you do not accidentally add any whitespace characters (extra line, space, and so on) to the value fields. If there are any extra or erroneous characters in the secret, the connection to {ibmwatsonxcodeassistant} fails.
 ====
 
-.. Click *Create*. 
+. Click *Create*. 
 
-After you create the authorization and model secrets, you must select the secrets when you  xref:create-lightspeed-instance_configuring-lightspeed-onpremise[create and deploy a {LightspeedShortName} instance].
+After you create the model configuration secret, you must update the YAML file of the {PlatformNameShort} operator.

--- a/lightspeed/modules/proc_update-connection-secrets.adoc
+++ b/lightspeed/modules/proc_update-connection-secrets.adoc
@@ -1,35 +1,33 @@
 :_content-type: PROCEDURE
 
-[id="update-connection-secrets_{context}"]
+[id="connect-to-different-ibm-wca-model_{context}"]
 
-= Updating connection secrets on an existing {PlatformName} operator
+= Connecting to a different {ibmwatsonxcodeassistant} model
 
-After you have set up the {LightspeedShortName} on-premise deployment successfully, you can modify the deployment if you want to connect to another {ibmwatsonxcodeassistant} model. For example, you connected to the default {ibmwatsonxcodeassistant} model but now want to connect to a custom model instead. To connect to another {ibmwatsonxcodeassistant} model, you must create new connection secrets, and then update the connection secrets and parameters on an existing {PlatformName} operator.
+After you have set up the {LightspeedShortName} on-premise deployment successfully, you can modify the deployment if you want to connect to another {ibmwatsonxcodeassistant} model. For example, you connected to the default {ibmwatsonxcodeassistant} model but now want to connect to a custom model instead. To connect to another {ibmwatsonxcodeassistant} model, you must create new connection secrets, and then update the connection secrets and parameters on an existing {PlatformNameShort} operator.
 
 .Prerequisites
 * You have set up a {LightspeedShortName} on-premise deployment. 
 * You have obtained an API key and a model ID of the {ibmwatsonxcodeassistant} model you want to connect to. 
-* You have created new authorization and model connection secrets for the {ibmwatsonxcodeassistant} model that you want to connect to. For information about creating authorization and model connection secrets, see xref:create-connection-secrets_configuring-lightspeed-onpremise[Creating connection secrets].
+* You have created a new model configuration secret for the {ibmwatsonxcodeassistant} model that you want to connect to. For information about creating a model configuration secrets, see xref:create-connection-secrets_configuring-lightspeed-onpremise[Creating a model configuration secret].
 
 .Procedure
 . Go to the {OCP}. 
 . Select menu:Operators[Installed Operators].
-. From the *Projects* list, select the namespace where you installed the {LightspeedShortName} instance.
-. Locate and select the *Ansible Automation Platform (provided by Red Hat)* operator that you installed earlier.
-. Select the *Ansible Lightspeed* tab.
-. Find and select the instance you want to update.
-. Click menu:Actions[Edit AnsibleLightspeed]. The editor switches to a text or YAML view.
-. Scroll the text to find the `spec:` section.
+. From the list of installed operators, select the *{PlatformNameShort}* operator.
+. Locate and select the *{PlatformNameShort}* custom resource, and then click the required app.
+. Select the *YAML* tab.
+. Scroll the text to find the `spec` section under `Lightspeed` category. For example:
 +
-image:update-connection-secrets.png[Setting to update the connection secrets])
-. Find the entry for the secret you have changed and saved under a new name.
-. Change the name of the secrets to the new secrets. 
+----
+spec:
+  lightspeed:
+    disabled: false
+    model_config_secret_name: <Name of the model configuration secret that you recently created.>
+----
+. Replace the `model_config_secret_name` value with the name of the {ibmwatsonxcodeassistant} that you want to connect to.
 . Click *Save*. 
 +
-The new AnsibleLightspeed Pods are created. After the new pods are running successfully, the old AnsibleLightspeed Pods are terminated.
-
-[role="_additional-resources"]
-.Additional resources
-* xref:ref-troubleshooting-lightspeed-onpremise-config_troubleshooting-lightspeed[Troubleshooting {LightspeedShortName} on-premise deployment errors]
+The new Ansible Lightspeed pods are created. After the new pods are running successfully, the old Ansible Lightspeed pods are terminated.
 
 

--- a/lightspeed/modules/proc_update-yaml-file.adoc
+++ b/lightspeed/modules/proc_update-yaml-file.adoc
@@ -1,0 +1,24 @@
+:_content-type: PROCEDURE
+
+[id="update-yaml-file_{context}"]
+
+= Updating the YAML file of the {PlatformNameShort} operator 
+
+After you create the model configuration secret, you must update the YAML file of the {PlatformNameShort} operator to use the secret.
+
+.Procedure
+. Go to the {OCP}.
+. Select menu:Operators[Installed Operators].
+. From the list of installed operators, select the *{PlatformNameShort}* operator.
+. Locate and select the *{PlatformNameShort}* custom resource, and then click the required app.
+. Select the *YAML* tab.
+. Scroll the text to find the `Lightspeed` category, and add the following details under the `spec:` section:
++
+----
+spec:
+  lightspeed:
+    disabled: false
+    model_config_secret_name: <Name of the model configuration secret that you recently created.>
+----
+. Click *Save*. The Ansible Lightspeed service takes a few minutes to set up. 
+

--- a/lightspeed/modules/ref_troubleshooting-lightspeed-onpremise-config.adoc
+++ b/lightspeed/modules/ref_troubleshooting-lightspeed-onpremise-config.adoc
@@ -15,8 +15,6 @@ After you configure a {LightspeedShortName} on-premise deployment and try to log
 This error indicates an incorrect configuration of the login redirect URI. The redirect URI parameter must contain the URL of the {LightspeedShortName} instance along with `/complete/aap/` suffix. The following is an example of the login redirect URI:
 +
 `https://lightspeed-on-prem-web-service.com/complete/aap/`
-+
-For more information, see xref:update-redirect-uri_configuring-lightspeed-onpremise[Updating the Redirect URIs].
 
 * The log-in attempt fails with the following error message:
 +
@@ -64,7 +62,7 @@ To resolve this error, check the `auth_allowed_hosts` parameter in the authoriza
 
 After you log out from the Ansible Lightspeed portal, you are redirected to the automation controller API page instead of Ansible Lightspeed.
 
-This error indicates that the logout redirect URI was not configured while setting up your {LightspeedShortName} on-premise deployment. You must configure the logout redirect URI by adding the *LOGOUT_ALLOWED_HOSTS* entry to the YAML file. For more information, see xref:update-redirect-uri_configuring-lightspeed-onpremise[Updating the Redirect URIs].
+This error indicates that the logout redirect URI was not configured while setting up your {LightspeedShortName} on-premise deployment. You must configure the logout redirect URI by adding the *LOGOUT_ALLOWED_HOSTS* entry to the YAML file.
 
 == Cannot connect to the Ansible Lightspeed service from the Ansible VS Code extension
 The following scenarios are possible:

--- a/lightspeed/titles/lightspeed-release-notes/modules/ref-release-notes.adoc
+++ b/lightspeed/titles/lightspeed-release-notes/modules/ref-release-notes.adoc
@@ -6,6 +6,15 @@
 [role="_abstract"]
 The release notes for {LightspeedFullName} summarize all new features, enhancements, and any known bugs. 
 
+== 30 July 2025
+This release features the following enhancement:
+
+*Ability to enable or disable PII anonymization on Red Hat Ansible Lightspeed on-premise deployments*
+
+Organization administrators can now enable or disable Personally Identifiable Information (PII) anonymization on {LightspeedShortName} on-premise deployments by using the `model_enable_anonymization key`. PII includes passwords, IP addresses, email addresses, and other sensitive data. When PII anonymization is enabled, users' personal information is modified to some generic values to protect their data and reduce the risk of data leaks. 
+
+For information about enabling or disabling PII anonymization, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant/2.x_latest/html/red_hat_ansible_lightspeed_with_ibm_watsonx_code_assistant_user_guide/set-up-lightspeed_lightspeed-user-guide#create-connection-secrets_configuring-lightspeed-onpremise[Creating connection secrets].
+
 == 29 May 2025
 This release features the following enhancement: 
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-50383 .

Changes made:

- Updated docs with latest Lightspeed on-premise deployment changes
- Added release notes + procedural info. for disabling PII anonymization feature (that was previously removed from an earlier release, JIRA is https://issues.redhat.com/browse/AAP-34014. The functionality is now included as part of AAP 2.5 async release on 30 July 2025. 
- Tech. review is complete. 