### PR TITLE
2.6 AAP-44556 Add registry check in devtools doc (#4000)

### DIFF
--- a/downstream/modules/devtools/proc-devtools-setup-registry-redhat-io.adoc
+++ b/downstream/modules/devtools/proc-devtools-setup-registry-redhat-io.adoc
@@ -8,9 +8,6 @@ All container images available through the Red Hat container catalog are hosted 
 `registry.redhat.io`.
 The registry requires authentication for access to images.
 
-To use the `registry.redhat.io` registry, you must have a Red Hat login.
-This is the same account that you use to log in to the Red Hat Customer Portal (access.redhat.com) and manage your Red Hat subscriptions.
-
 [NOTE]
 ====
 If you are planning to install the {ToolsName} on a container inside {VSCode},
@@ -22,20 +19,26 @@ or the `devcontainer` to use as an execution environment,
 you must log in from a terminal prompt within the `devcontainer` from a terminal inside {VSCode}.
 ====
 
-You can use the `podman login` or `docker login` commands with your credentials to access content on the registry.
+.Prerequisites
 
-Podman::
+* To use the `registry.redhat.io` registry, you must have a Red Hat login.
++
+This is the same account that you use to log in to the Red Hat Customer Portal (access.redhat.com) and manage your Red Hat subscriptions.
+
+.Procedure
+
+. Check whether you are already logged in to the `registry.redhat.io` registry:
++
+----
+$ podman login --get-login registry.redhat.io
+----
++
+The command output displays your Red Hat login if you are logged in to `registry.redhat.io`.
+. If you are not logged in to `registry.redhat.io`, use the `podman login` command with your credentials to access content on the registry.
 +
 ----
 $ podman login registry.redhat.io
-Username: my__redhat_username
-Password: ***********
-----
-Docker::
-+
-----
-$ docker login registry.redhat.io
-Username: my__redhat_username
+Username: my_redhat_username
 Password: ***********
 ----
 
@@ -43,8 +46,4 @@ For more information about Red Hat container registry authentication, see
 link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication]
 on the Red Hat customer portal.
 
-// * If you are an organization administrator, you can create profiles for users in your organization and configure Red Hat customer portal access permissions for them.
-// Refer to link:https://access.redhat.com/start/learn:get-set-red-hat/resource/resources:create-and-manage-other-users[Create and manage other users] on the Red Hat customer portal for information.
-// * If you are a member of an organization, ask your administrator to create a Red Hat customer portal account for you.
-//Troubleshooting link:https://access.redhat.com/articles/3560571[Troubleshooting Authentication Issues with `registry.redhat.io`]
 


### PR DESCRIPTION
AAP-44556 Add registry check in devtools doc
Per the Jira issue, and after consultation with the Devtools team, removed references to Docker, because the rest of the doc refers to Podman only.