### PR TITLE
2.6 AAP-44558 Devtools: Add info about VSCode workspaces (#4007)

### DIFF
--- a/downstream/modules/devtools/proc-devtools-extension-settings.adoc
+++ b/downstream/modules/devtools/proc-devtools-extension-settings.adoc
@@ -9,6 +9,7 @@ The Ansible extension supports multiple configuration options.
 
 You can configure the settings for the extension on a user level, on a workspace level, or for a particular directory.
 User-based settings are applied globally for any instance of VS Code that is opened.
+A {VSCode} workspace is a collection of one or more folders that you can open in a single {VSCode} window.
 Workspace settings are stored within your workspace and only apply when the current workspace is opened.
 
 It is useful to configure settings for your workspace for the following reasons:
@@ -18,15 +19,21 @@ you can customize your Ansible development environment for individual projects w
 You can have different settings for a Python project, an Ansible project, and a C++ project, each optimized for the respective stack without the need to manually reconfigure settings each time you switch projects.
 * If you include workspace settings when setting up version control for a project you want to share with your team, everyone uses the same configuration for that project.
 
+.Prerequisites
+
+* Open a workspace or folder, or create a new folder, in {VSCode} using the menu:File[Open Folder] menu. 
+This is necessary because the file that stores settings preferences for workspaces is specific to a folder or workspace.
+
 .Procedure
 
 . Open the Ansible extension settings:
-.. Click the 'Extensions' icon in the activity bar.
+.. Click the image:vscode-extensions-icon.png[Extensions,15,15] *Extensions* icon in the activity bar.
 .. Select the Ansible extension, and click the 'gear' icon and then *Extension Settings* to display the extension settings.
 +
 Alternatively, click menu:Code[Settings>Settings] to open the *Settings* page.
 .. Enter `Ansible` in the search bar to display the settings for the extension.
 . Select the *Workspace* tab to configure your settings for the current {VSCode} workspace.
+** If the *Workspace* tab is not displayed, open a folder or create a new folder using the menu:File[Open Folder] menu.
 . The Ansible extension settings are pre-populated.
 Modify the settings to suit your requirements:
 ** Check the menu:Ansible[Validation > Lint: Enabled] box to enable ansible-lint.
@@ -34,5 +41,8 @@ Modify the settings to suit your requirements:
 ** Specify the {ExecEnvShort} image you want to use in the *Ansible > Execution Environment: image* field.
 ** To use {LightspeedShortName}, check the *Ansible > Lightspeed: Enabled* box, and enter the URL for Lightspeed.
 
-The settings are documented on the link:https://marketplace.visualstudio.com/items?itemName=redhat.ansible[Ansible {VSCode} Extension by Red Hat page] in the VisualStudio marketplace documentation.  
+[role="_additional-resources"]
+.Additional resources
+* For information about Ansible {VSCode} extension settings, see the link:https://marketplace.visualstudio.com/items?itemName=redhat.ansible[Ansible {VSCode} Extension by Red Hat page] in the VisualStudio marketplace documentation.  
+* For information about {VSCode} workspaces, see link:https://code.visualstudio.com/docs/editing/workspaces/workspaces[What is a {VSCode} workspace?] in the  Visual Studio Code documentation.
 


### PR DESCRIPTION
AAP-44558 Devtools: Add info about VSCode workspaces
Affects `titles/develop-automation-content`
Explain how to make the workspace configuration accessible or available with a fresh installation of VS Code.