### PR TITLE
2.6 Add External Redis support statement (#4013)

### DIFF
--- a/downstream/modules/topologies/ref-rpm-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-rpm-b-env-a.adoc
@@ -31,7 +31,8 @@ include::snippets/rpm-tested-vm-config.adoc[]
 
 [NOTE]
 ====
-6 VMs are required for a Redis high availability (HA) compatible deployment. Redis can be colocated on each {PlatformNameShort} component VM except for {ControllerName}, execution nodes, or the PostgreSQL database.
+* 6 VMs are required for a Redis high availability (HA) compatible deployment. Redis can be colocated on each {PlatformNameShort} component VM except for {ControllerName}, execution nodes, or the PostgreSQL database.
+* External Redis is not supported for RPM-based deployments of {PlatformNameShort}.
 ====
 
 == Tested system configurations

--- a/downstream/snippets/redis-colocation-containerized.adoc
+++ b/downstream/snippets/redis-colocation-containerized.adoc
@@ -1,2 +1,3 @@
 //This snippet details the colocation configuration for a containerized install of AAP - note that it can be colocated with controller.
 * 6 VMs are required for a Redis high availability (HA) compatible deployment. When installing {PlatformNameShort} with the containerized installer, Redis can be colocated on any {PlatformNameShort} component VMs of your choice except for execution nodes or the PostgreSQL database. They might also be assigned VMs specifically for Redis use.
+* External Redis is not supported for containerized {PlatformNameShort}.


### PR DESCRIPTION
Backports #4013 from main to 2.6

External Redis is currently not supported for CONT and RPM topologies.

Clarify external Redis support for CONT and RPM topologies

Affects: `titles/topologies`

https://issues.redhat.com/browse/AAP-50975