### PR TITLE
Backport-2.5-4035 to AAP-51371 - Corrected statement about horizontal scaling for EDA

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25.adoc
+++ b/downstream/titles/release-notes/topics/aap-25.adoc
@@ -67,7 +67,7 @@ With {PlatformNameShort} 2.5, {EDAName} functionality has been enhanced with the
 
 * Simplified event routing capabilities introduce event streams. Event streams are an easy way to connect your sources to your rulebooks. This new capability lets you create a single endpoint to receive alerts from an event source and then use the events in multiple rulebooks. This simplifies rulebook activation setup, reduces maintenance demands, and helps lower risk by eliminating the need for additional ports to be open to external traffic. 
 
-* {EDAName} in the {PlatformNameShort} 2.5 now supports horizontal scalability and enables high-availability deployments of the {EDAController}. These capabilities allow for the installation of multiple {EDAName} nodes and thus enable you to create highly available deployments. 
+* {EDAName} in the {PlatformNameShort} 2.5 now supports horizontal scaling, allowing you to install multiple {EDAName} nodes to handle increased event volume. 
 
 * Migration to the new platform-wide {PlatformName} credential type replaces the legacy controller token for enabling rulebook activations to call jobs in the {ControllerName}.
 


### PR DESCRIPTION
Removed "high availability" from new feature description for EDA horizontal scaling.