### PR TITLE
2.5 Add disconnected install to Containerized installation (#4058)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-containerized-disconnected-installation.adoc
+++ b/downstream/assemblies/platform/assembly-aap-containerized-disconnected-installation.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: ASSEMBLY
+
+[id="aap-containerized-disconnected-installation"]
+
+= Disconnected installation
+
+[role="_abstract"]
+You can install containerized {PlatformNameShort} in an environment that does not have an active internet connection. To do this you need to obtain and configure the RPM source dependencies before performing the disconnected installation.
+
+include::platform/proc-obtaining-configuring-rpm-dependencies.adoc[leveloffset=+1]
+
+include::platform/proc-configure-local-repo-reposync.adoc[leveloffset=+2]
+
+include::platform/proc-configure-local-repo-iso.adoc[leveloffset=+2]
+
+include::platform/proc-perform-containerized-disconnected-installation.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-configure-local-repo-iso.adoc
+++ b/downstream/modules/platform/proc-configure-local-repo-iso.adoc
@@ -1,0 +1,55 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="configure-local-repo-iso"]
+
+= Configuring a local repository from a mounted ISO
+
+[role="_abstract"]
+You can use a {RHEL} Binary DVD image to access the necessary RPM source dependencies in a disconnected environment.
+
+.Prerequisites
+* You have downloaded the {RHEL} Binary DVD image from the link:https://access.redhat.com/downloads/content/rhel[{RHEL} downloads page] and moved it to your disconnected environment.
+
+.Procedure
+. In your disconnected environment, create a mount point directory to serve as the location for the ISO file:
++
+----
+$ sudo mkdir /media/rhel
+----
+
+. Mount the ISO image to the mount point. Replace `<version_number>` and `<arch_name>` with suitable values:
++
+----
+$ sudo mount -o loop rhel-<version_number>-<arch_name>-dvd.iso /media/rhel
+----
+** Note: The ISO is mounted in a read-only state.
+
+. Create a Yum repository file at `/etc/yum.repos.d/rhel.repo` with the following content:
++
+----
+[RHEL-BaseOS]
+name=Red Hat Enterprise Linux BaseOS
+baseurl=file:///media/rhel/BaseOS
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+
+[RHEL-AppStream]
+name=Red Hat Enterprise Linux AppStream
+baseurl=file:///media/rhel/AppStream
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+----
+
+. Import the gpg key to allow the system to verify the packages:
++
+----
+$ sudo rpm --import /media/rhel/RPM-GPG-KEY-redhat-release
+----
+
+. Verify the repository configuration:
++
+----
+$ sudo yum repolist
+----

--- a/downstream/modules/platform/proc-configure-local-repo-reposync.adoc
+++ b/downstream/modules/platform/proc-configure-local-repo-reposync.adoc
@@ -1,0 +1,91 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="configure-local-repo-reposync"]
+
+= Configuring a local repository using reposync
+
+[role="_abstract"]
+With the `reposync` command you can to synchronize the BaseOS and AppStream repositories to a local directory on a {RHEL} host with an active internet connection. You can then transfer the repositories to your disconnected environment.
+
+.Prerequisites
+* A {RHEL} host with an active internet connection.
+
+.Procedure
+. Attach the BaseOS and AppStream repositories using `subscription-manager`:
++
+----
+$ sudo subscription-manager repos \
+    --enable rhel-9-baseos-rhui-rpms \
+    --enable rhel-9-appstream-rhui-rpms
+----
+
+. Install the `yum-utils` package:
++
+----
+$ sudo dnf install yum-utils
+----
+
+. Synchronize the repositories with the `reposync` command. Replace `<path_to_download>` with a suitable value.
++
+----
+$ sudo reposync -m --download-metadata --gpgcheck \
+    -p <path_to_download>
+----
++
+For example:
++
+----
+$ sudo reposync -m --download-metadata --gpgcheck \
+    -p rhel-repos
+----
++
+** Use reposync with the `--download-metadata` option and without the `--newest-only` option for optimal download time.
+
+. After the `reposync` operation is complete, compress the directory:
++
+----
+$ tar czvf rhel-repos.tar.gz rhel-repos
+----
+
+. Move the compressed archive to your disconnected environment.
+. On the disconnected environment, create a directory to store the repository files:
++
+----
+$ sudo mkdir /opt/rhel-repos
+----
+
+. Extract the archive into the `/opt/rhel-repos` directory. The following command assumes the archive file is in your home directory:
++
+----
+$ sudo tar xzvf ~/rhel-repos.tar.gz -C /opt
+----
+
+. Create a Yum repository file at `/etc/yum.repos.d/rhel.repo` with the following content:
++
+----
+[RHEL-BaseOS]
+name=Red Hat Enterprise Linux BaseOS
+baseurl=file:///opt/rhel-repos/rhel-9-baseos-rhui-rpms
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+
+[RHEL-AppStream]
+name=Red Hat Enterprise Linux AppStream
+baseurl=file:///opt/rhel-repos/rhel-9-appstream-rhui-rpms
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+----
+
+. Import the gpg key to allow the system to verify the packages:
++
+----
+$ sudo rpm --import /opt/rhel-repos/rhel-9-baseos-rhui-rpms/RPM-GPG-KEY-redhat-release
+----
+
+. Verify the repository configuration:
++
+----
+$ sudo yum repolist
+----

--- a/downstream/modules/platform/proc-obtaining-configuring-rpm-dependencies.adoc
+++ b/downstream/modules/platform/proc-obtaining-configuring-rpm-dependencies.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="obtaining-and-configuring-rpm-dependencies"]
+
+= Obtaining and configuring RPM source dependencies
+
+[role="_abstract"]
+The {PlatformNameShort} containerized setup bundle installation program does not include RPM source dependencies from the BaseOS and AppStream repositories. It relies on the host system's package manager to resolve these dependencies.
+
+To access these dependencies in a disconnected environment, you can use one of the following methods:
+
+* Use link:https://docs.redhat.com/en/documentation/red_hat_satellite/6.16/html/installing_satellite_server_in_a_disconnected_network_environment/index[Red Hat Satellite] to synchronize repositories in your disconnected environment.
+* Use a local repository that you create with the `reposync` command on a {RHEL} host that has an active internet connection.
+* Use a local repository that you create from a mounted {RHEL} Binary DVD ISO image.

--- a/downstream/modules/platform/proc-perform-containerized-disconnected-installation.adoc
+++ b/downstream/modules/platform/proc-perform-containerized-disconnected-installation.adoc
@@ -1,0 +1,31 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="perform-disconnected-installation"]
+
+= Performing a disconnected installation
+
+[role="_abstract"]
+Use the following steps to perform a disconnected installation of containerized {PlatformNameShort}.
+
+.Prerequisites
+
+You have done the following:
+
+* link:{URLContainerizedInstall}/aap-containerized-installation#preparing-the-rhel-host-for-containerized-installation[Prepared the {RHEL} host]
+* link:{URLContainerizedInstall}/aap-containerized-disconnected-installation#obtaining-and-configuring-rpm-dependencies[Obtained and configured the RPM source dependencies]. The installation program uses your host system's `dnf` package manager to resolve these dependencies.
+* link:{URLContainerizedInstall}/aap-containerized-installation#preparing-the-managed-nodes-for-containerized-installation[Prepared the managed nodes]
+* Downloaded the containerized {PlatformNameShort} setup bundle from the link:{PlatformDownloadUrl}[{PlatformNameShort} download page].
+
+.Procedure
+
+. Log in to the {RHEL} host as your non-root user.
+. Update the inventory file by following the steps in link:{URLContainerizedInstall}/aap-containerized-installation#configuring-inventory-file[Configuring the inventory file].
+. Ensure the following variables are included in your inventory file under the `[all:vars]` group:
++
+----
+bundle_install=true
+# The bundle directory must include /bundle in the path
+bundle_dir='{{ lookup("ansible.builtin.env", "PWD") }}/bundle'
+----
+
+. Follow the steps in link:{URLContainerizedInstall}/aap-containerized-installation#installing-containerized-aap[Installing containerized {PlatformNameShort}] to install containerized {PlatformNameShort} and verify your installation.

--- a/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-rhel-host-for-containerized-installation.adoc
@@ -26,13 +26,13 @@ aap.example.org
 .. If the hostname is not a FQDN, you can set it with the following command:
 +
 ----
-sudo hostnamectl set-hostname <your_hostname>
+$ sudo hostnamectl set-hostname <your_hostname>
 ----
 +
 . Register your {RHEL} host with `subscription-manager`:
 +
 ----
-sudo subscription-manager register
+$ sudo subscription-manager register
 ----
 +
 
@@ -50,19 +50,20 @@ repo id                                                    repo name
 rhel-9-for-x86_64-appstream-rpms                           Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)
 rhel-9-for-x86_64-baseos-rpms                              Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)
 ----
-+
+** For disconnected installations follow the steps in link:{URLContainerizedInstall}/aap-containerized-disconnected-installation#obtaining-and-configuring-rpm-dependencies[Obtaining and configuring RPM source dependencies] to access these repositories.
+
 . Ensure the host can resolve host names and IP addresses using DNS. This is essential to ensure services can talk to one another.
 
 . Install `ansible-core`:
 +
 ----
-sudo dnf install -y ansible-core
+$ sudo dnf install -y ansible-core
 ----
 +
 . Optional: You can install additional utilities that can be useful for troubleshooting purposes, for example `wget`, `git-core`, `rsync`, and `vim`:
 +
 ----
-sudo dnf install -y wget git-core rsync vim
+$ sudo dnf install -y wget git-core rsync vim
 ----
 
 . Optional: To have the installation program automatically pick up and apply your {PlatformNameShort} subscription manifest license, follow the steps in link:{URLCentralAuth}/assembly-gateway-licensing#assembly-aap-obtain-manifest-files[Obtaining a manifest file].

--- a/downstream/modules/platform/ref-configuring-inventory-file.adoc
+++ b/downstream/modules/platform/ref-configuring-inventory-file.adoc
@@ -42,14 +42,3 @@ include::snippets/inventory-cont-b-env-a.adoc[]
 .Additional resources
 * link:{URLTopologies}/container-topologies#infrastructure_topology_6[Container {EnterpriseTopology}]
 * link:{URLPlanningGuide}/ha-redis_planning[Caching and queueing system]
-
-
-== Performing an offline or bundled installation
-
-To perform an offline installation, add the following under the `[all:vars]` group:
-
-----
-bundle_install=true
-# The bundle directory must include /bundle in the path
-bundle_dir=<full_path_to_the_bundle_directory>
-----

--- a/downstream/titles/aap-containerized-install/master.adoc
+++ b/downstream/titles/aap-containerized-install/master.adoc
@@ -14,6 +14,8 @@ include::platform/assembly-gateway-licensing.adoc[leveloffset=+1]
 
 include::platform/assembly-aap-containerized-installation.adoc[leveloffset=+1]
 
+include::platform/assembly-aap-containerized-disconnected-installation.adoc[leveloffset=+1]
+
 include::platform/assembly-horizontal-scaling.adoc[leveloffset=+1]
 
 [appendix]


### PR DESCRIPTION
Backports #4058 from main to 2.5

Adds the new disconnected install assembly to Containerized installation

Containerized installation for Ansible Automation Platform doesn't have any info related to the preparation of the disconnected base operating system

https://issues.redhat.com/browse/AAP-49731