### PR TITLE
Add controller logs for containerized AAP

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-log-files.adoc
+++ b/downstream/assemblies/platform/assembly-controller-log-files.adoc
@@ -2,13 +2,11 @@
 
 [id="assembly-controller-log-files"]
 
-= {ControllerNameStart} logfiles
+= {ControllerNameStart} logs
 
-{ControllerNameStart} logfiles can be accessed from two centralized locations:
+[role="_abstract"]
+{ControllerNameStart} logs are accessed in different ways depending on whether you have an RPM-based or containerized installation of {PlatformNameShort}.
 
-* `/var/log/tower/`
-* `/var/log/supervisor/`
+include::platform/ref-controller-log-files-containerized.adoc[leveloffset=+1]
 
 include::platform/ref-controller-log-files.adoc[leveloffset=+1]
-
-

--- a/downstream/modules/platform/ref-controller-log-files-containerized.adoc
+++ b/downstream/modules/platform/ref-controller-log-files-containerized.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-controller-log-files-containerized"]
+
+= Accessing {ControllerName} logs for containerized {PlatformNameShort} 
+
+Logs for containerized {PlatformNameShort} are not saved to specific files. The application logs are sent to the container `stdout` and handled by Podman with `journald`.
+
+The three containers associated with {ControllerName} are:
+
+* `automation-controller-rsyslog`
+* `automation-controller-task`
+* `automation-controller-web`
+
+For more information about the purpose of each of these containers and how to inspect the logs, see link:{URLContainerizedInstall}/troubleshooting-containerized-ansible-automation-platform#diagnosing-the-problem_troubleshooting-containerized-aap[Diagnosing the problem] in _{TitleContainerizedInstall}_.

--- a/downstream/modules/platform/ref-controller-log-files.adoc
+++ b/downstream/modules/platform/ref-controller-log-files.adoc
@@ -2,7 +2,12 @@
 
 [id="ref-controller-log-files"]
 
-= Access {ControllerName} logfiles
+= Accessing {ControllerName} logs for RPM-based {PlatformNameShort}
+
+{ControllerNameStart} logfiles can be accessed from two centralized locations:
+
+* `/var/log/tower/`
+* `/var/log/supervisor/`
 
 In the `/var/log/tower/` directory, you can view logfiles captured by:
 


### PR DESCRIPTION
Affects title: `titles/controller/controller-admin-guide`

[Docs] Improve documentation regarding logs in containerized AAP installation

https://issues.redhat.com/browse/AAP-48586