### PR TITLE
AAP-51442: broken link correction and module relocation

### DIFF
--- a/downstream/assemblies/platform/assembly-gs-key-functionality.adoc
+++ b/downstream/assemblies/platform/assembly-gs-key-functionality.adoc
@@ -31,6 +31,8 @@ include::platform/con-gs-automation-mesh.adoc[leveloffset=+1]
 
 include::platform/con-gs-ansible-lightspeed.adoc[leveloffset=+1]
 
+include::platform/con-aap-notifications-feed.adoc[leveloffset=+1]
+
 include::platform/con-gs-developer-tools.adoc[leveloffset=+1]
 
 include::platform/ref-gs-install-config.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-aap-notifications-feed.adoc
+++ b/downstream/modules/platform/con-aap-notifications-feed.adoc
@@ -9,8 +9,7 @@
 Effective July 2025, the {PlatformNameShort} RSS notification feed will be available.
 This feed serves as a method for communicating various product updates and changes to customers.
 
-Customers can subscribe to the notifications by visiting link:announcements.ansiblecloud.redhat.com/feed.atom[announcements.ansiblecloud.redhat.com/feed.atom].
-Using an RSS feed reader, customers will be updated with events such as {PlatformNameShort} upgrades and system maintenance.
+Customers can subscribe to the notifications by visiting announcements.ansiblecloud.redhat.com/feed.atom through an RSS feed reader. This feed is updated with events such as {PlatformNameShort} upgrades and system maintenance.
 
 All {PlatformNameShort} customers can subscribe to this content. 
 Messages include categorization tags to specify deployment types: managed, self-managed (on-prem), or a combination. 

--- a/downstream/titles/getting-started/master.adoc
+++ b/downstream/titles/getting-started/master.adoc
@@ -27,5 +27,3 @@ include::platform/assembly-gs-platform-admin.adoc[leveloffset=+1]
 include::platform/assembly-gs-auto-dev.adoc[leveloffset=+1]
 
 include::platform/assembly-gs-auto-op.adoc[leveloffset=+1]
-
-include::platform/platform/con-aap-notifications-feed.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR re-formats an rss feed address so it doesn't get flagged as a broken link and re-locates a concept module in the Getting started with AAP guide. This work is being tracked in [AAP-51442](https://issues.redhat.com/browse/AAP-51442).