### PR TITLE
AAP-51877 edits to Hub variables and backup sections

### DIFF
--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -67,3 +67,17 @@ This backs up the important data deployed by the containerized installer such as
 * Data files
 
 . By default, the backup directory is set to `./backups`. You can change this by using the `backup_dir` variable in your `inventory` file.
+
+.Next steps
+
+To customize the backup, use the following variables in your `inventory` file.
+* Change the backup destination directory from the default `./backups` by using the `backup_dir` variable.
+* Exclude paths that contain duplicated data, such as snapshot subdirectories, by using the `hub_data_path_exclude` variable. For instance, to exclude a .snapshots subdirectory, specify hub_data_path_exclude=['*/.snapshots/*'] in your inventory file.
+**  Alternatively, you can use the command-line interface with the `-e` flag to pass this variable at runtime:
++
+----
+$ ansible-playbook -i inventory ansible.containerized_installer.backup -e hub_data_path_exclude="['*/.snapshots/*']"
+----
+
+
+

--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -89,6 +89,12 @@ Valid options include: `true`, `false`, `auto`
 | Optional
 | `false`
 
+|  
+| `hub_data_path_exclude`
+| {HubName} backup path to exclude.
+| Optional
+| `[]`
+
 | `automationhub_disable_hsts` 
 | `hub_nginx_disable_hsts` 
 | Controls whether HTTP Strict Transport Security (HSTS) is enabled or disabled for {HubName}. 


### PR DESCRIPTION
[AAP-51877](https://issues.redhat.com/browse/AAP-51877)
Document the parameter hub_data_path_exclude for the Containerized Backup

- Update the Automation Hub variables with the hub_data_path_exclude details from the table in https://gitlab.cee.redhat.com/ansible/aap-containerized-installer#automation-hub
- Add information on the backup section defining that it is possible to exclude unwanted paths (NFS-specific providers with paths in which the data is duplicated, like .snapshots, etc.)