### PR TITLE
Minor formatting update to fix a heading in Troubleshooting AAP

### DIFF
--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-jobs.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-jobs.adoc
@@ -11,6 +11,7 @@ Troubleshoot issues with jobs.
 // include::troubleshooting-aap/proc-troubleshoot-job-localhost.adoc[leveloffset=+1]
 include::troubleshooting-aap/proc-troubleshoot-job-resolve-module.adoc[leveloffset=+1]
 
+
 include::troubleshooting-aap/proc-troubleshoot-job-timeout.adoc[leveloffset=+1]
 
 include::troubleshooting-aap/proc-troubleshoot-job-pending.adoc[leveloffset=+1]


### PR DESCRIPTION
A heading in the Troubleshooting AAP guide was not rendering correctly, so that it looked like this:
<img width="1135" height="387" alt="Screenshot 2025-08-21 at 1 58 21 PM" src="https://github.com/user-attachments/assets/7b7a3946-4297-41e6-aca4-cf7033d8ed1a" />

For whatever reason, the fix is to add another space before this module's include statement in assembly-troubleshoot-jobs.adoc. Now it is rendering correctly. 