### PR TITLE
backport to 2.6: Minor formatting update to fix a heading in the Troubleshooting AAP guide (#4103)

### DIFF
--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-jobs.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-jobs.adoc
@@ -11,6 +11,7 @@ Troubleshoot issues with jobs.
 // include::troubleshooting-aap/proc-troubleshoot-job-localhost.adoc[leveloffset=+1]
 include::troubleshooting-aap/proc-troubleshoot-job-resolve-module.adoc[leveloffset=+1]
 
+
 include::troubleshooting-aap/proc-troubleshoot-job-timeout.adoc[leveloffset=+1]
 
 include::troubleshooting-aap/proc-troubleshoot-job-pending.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR ports the changes from [PR 4103](https://github.com/ansible/aap-docs/pull/4103) to the 2.6 branch.