### PR TITLE
Backport-2.6-4099 to AAP-46850 Document external credential support in EDA (#4099)

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-credential-types.adoc
+++ b/downstream/assemblies/eda/assembly-eda-credential-types.adoc
@@ -3,12 +3,14 @@
 
 = Credential types
 
-{EDAcontroller} comes with several built-in credental types that you can use for syncing projects, running rulebook activations, executing job templates through {MenuTopAE} ({ControllerName}), fetching images from container registries, and processing data through event streams. 
+{EDAcontroller} comes with several built-in credential types that you can use for syncing projects, running rulebook activations, executing job templates through {MenuTopAE} ({ControllerName}), fetching images from container registries, and processing data through event streams. 
 
-These built-in credential types are not editable. So if you want credential types that support authentication with other systems, you can create your own credential types that can be used in your source plugins. Each credential type contains an input configuration and an injector configuration that can be passed to an Ansible rulebook to configure your sources.
+These built-in credential types are not editable. So if you want credential types that support authentication with other systems, you can create your own credential types that can be used in your source plugins. Each credential type contains an input configuration and an injector configuration that can be passed to an Ansible rulebook to configure your sources. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credential-types#eda-custom-credential-types[Custom credential types].
 
-For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credential-types#eda-custom-credential-types[Custom credential types].
+If you will be executing job templates through {ControllerName}, you can retrieve credential values from external secret management systems listed in link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credential-types#eda-external-credential-types[External secret management credential types].
 
+
+include::eda/con-external-credential-types.adoc[leveloffset=+1]
 
 include::eda/con-custom-credential-types.adoc[leveloffset=+1]
 

--- a/downstream/modules/eda/con-external-credential-types.adoc
+++ b/downstream/modules/eda/con-external-credential-types.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: <CONCEPT>
+[id="eda-external-credential-types"]
+
+= External secret management credential types
+
+In addition to the built-in credential types, {EDAName} supports a variety of external secret management credential types. These credential types allow rulebooks to securely retrieve sensitive information, such as API keys and passwords, directly from your organization's centralized secret vault. 
+
+The following external credential types are available for use in {EDAcontroller}:
+
+* AWS Secrets Manager
+* Azure Key Vault
+* Centrify Vault Credential Provider
+* CyberArk Central Credential Provider
+* CyberArk Conjur Secrets Manager
+* HashiCorp Vault Secret
+* HashiCorp Vault Signed SSH
+* Thycotic DevOps Secrets Vault
+* Thycotic Secret Server
+* GitHub App Installation Access Token
+
+The process for using these credentials in a rulebook activation is consistent with how they are used in {ControllerName}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/configuring_automation_execution/assembly-controller-secret-management[Secret management system]. 
+
+.Additional references
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/configuring_automation_execution/index[Configuring automation execution]


### PR DESCRIPTION
Added content about external credential types to a sub-chapter titled, External secret management credential types, within the larger chapter on [Credential types](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-credential-types).