### PR TITLE
2.5 Refactor Chapter 6 of Operating AAP guide (#4113)

### DIFF
--- a/downstream/assemblies/platform/assembly-changing-ssl-certs-keys.adoc
+++ b/downstream/assemblies/platform/assembly-changing-ssl-certs-keys.adoc
@@ -3,23 +3,26 @@
 ifdef::context[:parent-context: {context}]
 
 [id="changing-ssl-certs-keys"]
-= Renewing and changing the SSL certificate
+= Renewing and changing the SSL/TLS certificates
 
 :context: renewing-changing-ssl-certs-keys
 
-If your current SSL certificate has expired or will expire soon, you can either renew or replace the SSL certificate used by {PlatformNameShort}.
+[role="_abstract"]
+If your current SSL/TLS certificate has expired or will expire soon, you can either renew or replace the SSL/TLS certificate used by {PlatformNameShort}.
 
-You must renew the SSL certificate if you need to regenerate the SSL certificate with new information such as new hosts.
+You must renew the SSL/TLS certificate if you need to regenerate the SSL/TLS certificate with new information such as new hosts.
 
-You must replace the SSL certificate if you want to use an SSL certificate signed by an internal certificate authority.
+You must replace the SSL/TLS certificate if you want to use an SSL/TLS certificate signed by an internal certificate authority.
 
-//  Renewing the self-signed SSL certificate
+== Operator-based installations
 
-include::platform/proc-renew-ssl-cert.adoc[leveloffset=+1]
+include::platform/proc-change-ssl-controller-ocp.adoc[leveloffset=+2]
 
-== Changing SSL certificates
+include::platform/proc-change-ssl-hub-ocp.adoc[leveloffset=+2]
 
-To change the SSL certificate, you can edit the inventory file and run the installation program.
+== RPM-based installations
+
+To renew or change the SSL certificate for RPM-based installations, you can edit the inventory file and run the installation program.
 The installation program verifies that all {PlatformNameShort} components are working. 
 The installation program can take a long time to run.
 
@@ -28,22 +31,15 @@ This is quicker, but there is no automatic verification.
 
 Red Hat recommends that you use the installation program to make changes to your {PlatformNameShort} instance.
 
-=== Prerequisites
-
-* If there is an intermediate certificate authority, you must append it to the server certificate.
-* Both {ControllerName} and {HubName} use NGINX so the server certificate must be in PEM format.
-* Use the correct order for the certificates: The server certificate comes first, followed by the intermediate certificate authority.
-
-For further information, see the link:http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_certificate[ssl certificate section of the NGINX documentation].
+include::platform/proc-renew-ssl-cert.adoc[leveloffset=+2]
 
 include::platform/proc-change-ssl-installer.adoc[leveloffset=+2]
 
-include::platform/proc-change-ssl-controller.adoc[leveloffset=+3]
-include::platform/proc-change-ssl-controller-ocp.adoc[leveloffset=+3]
-include::platform/proc-change-ssl-hub-ocp.adoc[leveloffset=+3]
-include::platform/proc-change-ssl-eda-controller.adoc[leveloffset=+3]
-include::platform/proc-change-ssl-hub.adoc[leveloffset=+3]
+include::platform/proc-change-ssl-controller.adoc[leveloffset=+2]
+
+include::platform/proc-change-ssl-eda-controller.adoc[leveloffset=+2]
+
+include::platform/proc-change-ssl-hub.adoc[leveloffset=+2]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
-

--- a/downstream/modules/platform/proc-change-ssl-installer.adoc
+++ b/downstream/modules/platform/proc-change-ssl-installer.adoc
@@ -7,6 +7,14 @@
 [role="_abstract"]
 The following procedure describes how to change the SSL certificate and key in the inventory file.
 
+.Prerequisites
+
+* If there is an intermediate certificate authority, you must append it to the server certificate.
+* Both {ControllerName} and {HubName} use NGINX so the server certificate must be in PEM format.
+* Use the correct order for the certificates: The server certificate comes first, followed by the intermediate certificate authority.
+
+For further information, see the link:http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_certificate[ssl certificate section of the NGINX documentation].
+
 .Procedure
 
 . Copy the new SSL certificates and keys to a path relative to the {PlatformNameShort} installer.


### PR DESCRIPTION
Backports #4113 from main to 2.5

Refactors the section Renewing and changing the SSL/TLS certificates in "Operating Ansible Automation Platform" guide to ensure clear delineation between deployment types.

Reorganize content in "Renewing and changing the SSL certificate" of the Operating AAP guide

https://issues.redhat.com/browse/AAP-52027