### PR TITLE
2.5 Adds postgres_extra_settings to inventory appendix (#4059)

### DIFF
--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -17,6 +17,24 @@ Inventory file variables for the database used with {PlatformNameShort}.
 | Optional
 | `5432`
 
+| `postgres_extra_settings`
+| `postgresql_extra_settings`	
+a| Defines additional settings for use by PostgreSQL.
+
+Example usage for RPM:
+----
+postgresql_extra_settings:
+   ssl_ciphers: 'HIGH:!aNULL:!MD5'
+----
+Example usage for containerized:
+----
+postgresql_extra_settings:
+  - setting: ssl_ciphers
+    value: 'HIGH:!aNULL:!MD5' 
+----
+| Optional
+|
+
 | `postgres_firewalld_zone` 
 | `postgresql_firewall_zone` 
 | The firewall zone where PostgreSQL related firewall rules are applied. This controls which networks can access PostgreSQL based on the zone's trust level.


### PR DESCRIPTION
Backports #4059 from main to 2.5

Containerized and RPM Installer Docs - Document postgresql_extra_settings inventory variable

https://issues.redhat.com/browse/AAP-50483