### PR TITLE
Fixing format for next steps section

### DIFF
--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -71,6 +71,7 @@ This backs up the important data deployed by the containerized installer such as
 .Next steps
 
 To customize the backup, use the following variables in your `inventory` file.
+
 * Change the backup destination directory from the default `./backups` by using the `backup_dir` variable.
 * Exclude paths that contain duplicated data, such as snapshot subdirectories, by using the `hub_data_path_exclude` variable. For instance, to exclude a .snapshots subdirectory, specify hub_data_path_exclude=['*/.snapshots/*'] in your inventory file.
 **  Alternatively, you can use the command-line interface with the `-e` flag to pass this variable at runtime:


### PR DESCRIPTION
[AAP-51877](https://issues.redhat.com/browse/AAP-51877)
Document the parameter hub_data_path_exclude for the Containerized Backup

Update the Automation Hub variables with the hub_data_path_exclude details from the table in https://gitlab.cee.redhat.com/ansible/aap-containerized-installer#automation-hub
Add information on the backup section defining that it is possible to exclude unwanted paths (NFS-specific providers with paths in which the data is duplicated, like .snapshots, etc.)