### PR TITLE
Adding redirect to automation mesh guide

### DIFF
--- a/stories/topics/ref-saas-egress-model.adoc
+++ b/stories/topics/ref-saas-egress-model.adoc
@@ -8,5 +8,7 @@ The pull model initiates a WebSocket from the remote execution node to the contr
 This model eliminates the need to deploy hop nodes into your demilitarized zone (DMZ) to establish connectivity to private networks if private networks have outbound internet connectivity.
 Proxy servers that terminate TLS are not supported and will disrupt automation mesh connectivity.
 
+For help with configuring your {AutomationMesh} see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_mesh_for_managed_cloud_or_operator_environments/assembly-automation-mesh-operator-aap#proc-define-mesh-node-types[defining automation mesh node types].
+
 *Figure 1 Pull model*
 image:mesh_egress.png[Pull model] 


### PR DESCRIPTION
[AAP-51578](https://issues.redhat.com/browse/AAP-51578)
Missing information in the AAP installation guide for adding execution nodes that uses the mesh ingress option in AWS-Managed AAP documentations.

Adding a sentence and link that redirects to the Automation mesh guide. 