### PR TITLE
Edits for the OCP part of AAP-51783

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-add-execution-nodes.adoc
+++ b/downstream/assemblies/platform/assembly-operator-add-execution-nodes.adoc
@@ -10,6 +10,14 @@ ifdef::context[:parent-context: {context}]
 
 You can enable the {OperatorPlatformNameShort} with execution nodes by downloading and installing the install bundle.  
 
+[NOTE]
+====
+When using a custom certificate for Receptor nodes, the certificate requires the `otherName` field specified in the Subject Alternative Name (SAN) of the certificate with the value `1.3.6.1.4.1.2312.19.1`.
+For more information, see link:https://ansible.readthedocs.io/projects/receptor/en/latest/user_guide/tls.html#above-the-mesh-tls[Above the mesh TLS].
+
+Receptor does not support the usage of wildcard certificates.
+Additionally, each Receptor certificate must have the host FQDN specified in its SAN for TLS hostname validation to be correctly performed.
+====
 
 include::platform/proc-add-operator-execution-nodes.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[AAP-51783](https://issues.redhat.com/browse/AAP-51783)
'Receptor certificate considerations' section missing for operator based installations.