### PR TITLE
2.6 Update RHEL 10 reqs for containerized (#4137)

### DIFF
--- a/downstream/snippets/cont-tested-system-config.adoc
+++ b/downstream/snippets/cont-tested-system-config.adoc
@@ -13,7 +13,7 @@ a|
 
 a| 
 * {RHEL} 9.4 or later minor versions of {RHEL} 9.
-* {RHEL} 10 or later minor versions of {RHEL} 10 for enterprise topologies.
+* {RHEL} 10 or later minor versions of {RHEL} 10.
 | 
 
 | CPU architecture 

--- a/downstream/titles/release-notes/async/aap-25-20250702.adoc
+++ b/downstream/titles/release-notes/async/aap-25-20250702.adoc
@@ -160,7 +160,7 @@ With this update, the following CVEs have been addressed:
 
 * Validate that nodes are configured with at least 16G of RAM.(AAP-47542)
 
-* Containerized {PlatformNameShort} now supports RHEL 10 for enterprise topologies.(AAP-47083)
+* Containerized {PlatformNameShort} now supports RHEL 10.(AAP-47083)
 
 === Bug Fixes
 


### PR DESCRIPTION
Backports #4137 from main to 2.6

Containerized installation - remove "for enterprise" from RHEL 10 reqs

https://issues.redhat.com/browse/AAP-52074