### PR TITLE
2.5 Adds changing certs proc for containerized aap (#4155)

### DIFF
--- a/downstream/assemblies/platform/assembly-changing-ssl-certs-keys.adoc
+++ b/downstream/assemblies/platform/assembly-changing-ssl-certs-keys.adoc
@@ -8,11 +8,17 @@ ifdef::context[:parent-context: {context}]
 :context: renewing-changing-ssl-certs-keys
 
 [role="_abstract"]
-If your current SSL/TLS certificate has expired or will expire soon, you can either renew or replace the SSL/TLS certificate used by {PlatformNameShort}.
+If your current SSL/TLS certificates have expired or will expire soon, you can either renew or replace the SSL/TLS certificates used by {PlatformNameShort}.
 
-You must renew the SSL/TLS certificate if you need to regenerate the SSL/TLS certificate with new information such as new hosts.
+You must renew the SSL/TLS certificates if you need to regenerate them with new information such as new hosts.
 
-You must replace the SSL/TLS certificate if you want to use an SSL/TLS certificate signed by an internal certificate authority.
+You must replace the SSL/TLS certificates if you want to use certificates signed by an internal certificate authority.
+
+== Container-based installations
+
+You can change the TLS certificates and keys for your container-based {PlatformNameShort} installation. This process involves a preparation step, either providing new custom certificates or deleting or moving the old certificates, followed by running the installation program.
+
+include::platform/proc-change-tls-certs-installer.adoc[leveloffset=+2]
 
 == Operator-based installations
 

--- a/downstream/modules/platform/proc-change-tls-certs-installer.adoc
+++ b/downstream/modules/platform/proc-change-tls-certs-installer.adoc
@@ -1,0 +1,113 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="changing-tls-certificates-keys-using-installation-program"]
+
+= Changing TLS certificates and keys using the installation program
+
+[role="_abstract"]
+The following procedure describes how to update the TLS certificates and keys by using the installation program.
+
+.Procedure
+. To prepare the certificates and keys, choose one of the following methods:
+** To provide custom certificates - For each service that requires updated TLS certificates, copy the new certificates and keys to a path relative to the {PlatformNameShort} installer. Then update the inventory file variables with the absolute paths to the new files.
++
+[source,yaml,subs="+attributes"]
+----
+# {GatewayStart}
+gateway_tls_cert=<path_to_tls_certificate>
+gateway_tls_key=<path_to_tls_key>
+gateway_pg_tls_cert=<path_to_tls_certificate>
+gateway_pg_tls_key=<path_to_tls_key>
+gateway_redis_tls_cert=<path_to_tls_certificate>
+gateway_redis_tls_key=<path_to_tls_key>
+
+# {ControllerNameStart}
+controller_tls_cert=<path_to_tls_certificate>
+controller_tls_key=<path_to_tls_key>
+controller_pg_tls_cert=<path_to_tls_certificate>
+controller_pg_tls_key=<path_to_tls_key>
+
+# {HubNameStart}
+hub_tls_cert=<path_to_tls_certificate>
+hub_tls_key=<path_to_tls_key>
+hub_pg_tls_cert=<path_to_tls_certificate>
+hub_pg_tls_key=<path_to_tls_key>
+
+# {EDAName}
+eda_tls_cert=<path_to_tls_certificate>
+eda_tls_key=<path_to_tls_key>
+eda_pg_tls_cert=<path_to_tls_certificate>
+eda_pg_tls_key=<path_to_tls_key>
+eda_redis_tls_cert=<path_to_tls_certificate>
+eda_redis_tls_key=<path_to_tls_key>
+
+# PostgreSQL
+postgresql_tls_cert=<path_to_tls_certificate>
+postgresql_tls_key=<path_to_tls_key>
+
+# Receptor
+receptor_tls_cert=<path_to_tls_certificate>
+receptor_tls_key=<path_to_tls_key>
+----
+
+** To generate new certificates - If you want the installation program to generate a new certificate for a service, delete or move the existing certificates and keys.
++
+.Certificate and key file paths per service
+[cols="1,2,2"]
+|===
+|Service |Certificate file path |Key file path
+
+|{ControllerNameStart}
+|`~/aap/controller/etc/tower.cert`
+|`~/aap/controller/etc/tower.key`
+
+|{EDAName}
+|`~/aap/eda/etc/eda.cert`
+|`~/aap/eda/etc/eda.key`
+
+|{GatewayStart}
+|`~/aap/gateway/etc/gateway.cert`
+|`~/aap/gateway/etc/gateway.key`
+
+|{HubNameStart}
+|`~/aap/hub/etc/pulp.cert`
+|`~/aap/hub/etc/pulp.key`
+
+|PostgreSQL
+|`~/aap/postgresql/server.crt`
+|`~/aap/postgresql/server.key`
+
+|Receptor
+|`~/aap/receptor/etc/receptor.crt`
+|`~/aap/receptor/etc/receptor.key`
+
+|Redis
+|`~/aap/redis/server.crt`
+|`~/aap/redis/server.key`
+|===
+
+. After preparing your certificates, run the `install` playbook from your installation directory:
++
+----
+ansible-playbook -i <inventory_file_name> ansible.containerized_installer.install
+----
+
+.Verification
+
+Verify that the new TLS certificates are in use by checking that the services are running and accessible. To do this, check a specific endpoint by using `curl`:
+
+----
+$ curl -vk https://<hostname_or_ip>:<port_number>/api/v2/
+----
+
+The output of this command gives details about the TLS handshake. Look for the following output to confirm the correct certificate is being used:
+
+----
+*  SSL certificate verify OK
+----
+
+[role="_additional-resources"]
+.Additional resources
+* link:{URLContainerizedInstall}/aap-containerized-installation#using-custom-tls-certificates[Using custom TLS certificates]
+* link:{URLTroubleshootingAAP}/troubleshoot-networking#troubleshooting-ssl-tls-issues[Troubleshooting SSL/TLS issues]
+* link:{URLContainerizedInstall}/troubleshooting-containerized-ansible-automation-platform#diagnosing-the-problem_troubleshooting-containerized-aap[Diagnosing the problem]


### PR DESCRIPTION
Backports #4155 from main to 2.5

* Adds changing certs proc for containerized aap

Affected title: titles/aap-operations-guide

Containerized AAP missing in the "Renewing and changing the SSL certificate" Section

https://issues.redhat.com/browse/AAP-47079

* updates based on peer review feedback