### PR TITLE
Backport-2.5-4182 to AAP-46220 Applied pre-migration updates to content for chapter 6 (#4182)

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
+++ b/downstream/assemblies/eda/assembly-eda-set-up-rhaap-credential.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="eda-set-up-rhaap-credential-type"]
 
 = {PlatformName} credential
@@ -10,6 +11,9 @@ If you deployed {EDAcontroller} with {PlatformNameShort} 2.4, you probably used 
 ====
 
 include::eda/con-replacing-controller-tokens.adoc[leveloffset=+1]
+
 include::eda/proc-eda-delete-rulebook-activations-with-cont-tokens.adoc[leveloffset=+2]
+
 include::eda/proc-eda-delete-controller-token.adoc[leveloffset=+2]
+
 include::eda/proc-eda-set-up-rhaap-credential.adoc[leveloffset=+1]

--- a/downstream/modules/eda/con-replacing-controller-tokens.adoc
+++ b/downstream/modules/eda/con-replacing-controller-tokens.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: CONCEPT
 [id="replacing-controller-tokens"]
 
 = Replacing controller tokens in {PlatformName} {PlatformVers}

--- a/downstream/modules/eda/proc-eda-delete-controller-token.adoc
+++ b/downstream/modules/eda/proc-eda-delete-controller-token.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: <PROCEDURE>
+:_mod-docs-content-type: PROCEDURE
 [id="eda-delete-controller-token"]
 
 = Deleting controller tokens

--- a/downstream/modules/eda/proc-eda-delete-rulebook-activations-with-cont-tokens.adoc
+++ b/downstream/modules/eda/proc-eda-delete-rulebook-activations-with-cont-tokens.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-delete-rulebook-activations-with-cont-tokens"]
 
 = Deleting rulebook activations with controller tokens


### PR DESCRIPTION
Prepped [Chapter 6. Red Hat Ansible Automation Platform credential](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-set-up-rhaap-credential-type) in the Using automation decisions guide for migration compliance.