### PR TITLE
2.4 Update CIDR IP address (#4196)

### DIFF
--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-subnet-conflict.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-subnet-conflict.adoc
@@ -25,11 +25,11 @@ To resolve this issue, update the default classless inter-domain routing (CIDR) 
 . Add the following to the `/etc/tower/conf.d/custom.py` file:
 +
 ----
-DEFAULT_CONTAINER_RUN_OPTIONS = ['--network', 'slirp4netns:enable_ipv6=true,cidr=192.0.2.0/24'] 
+DEFAULT_CONTAINER_RUN_OPTIONS = ['--network', 'slirp4netns:enable_ipv6=true,cidr=192.168.1.0/24'] 
 ----
 +
 
-* `192.0.2.0/24` is the value for the new CIDR in this example.
+* `192.168.1.0/24` is the value for the new CIDR in this example.
 
 . Stop and start the {ControllerName} service in all controller and hybrid nodes:
 +


### PR DESCRIPTION
Backports #4196 from main to 2.4

[Share Feedback] troubleshooting_ansible_automation_platform/troubleshoot-networking#troubleshoot-networking

https://issues.redhat.com/browse/DOCS-2255