### PR TITLE
Updated deprecation notice for installer (#4215)

### DIFF
--- a/downstream/titles/release-notes/topics/aap-25-deprecated-features.adoc
+++ b/downstream/titles/release-notes/topics/aap-25-deprecated-features.adoc
@@ -56,7 +56,7 @@ Import the helpers from the source definition.
 |Execution environment-29 will be deprecated in the next major release after {PlatformNameShort} 2.5.
 
 |Installer
-|The Ansible team is exploring ways to improve the installation of the {PlatformNameShort} on {RHEL}, which may include changes to how components are deployed using RPM directly on the host OS. RPMs will be replaced by packages deployed into containers that are run via Podman; this is similar to how automation currently executes on Podman in containers (execution environments) on the host OS. Changes will be communicated through release notes, but removal will occur in major release versions of the {PlatformNameShort}.
+|The Ansible team is exploring ways to improve the installation of the {PlatformNameShort} on {RHEL}, which may include changes to how components are deployed using RPM directly on the host OS. RPMs will be replaced by packages deployed into containers that are run via Podman; this is similar to how automation currently executes on Podman in containers (execution environments) on the host OS. Changes will be communicated through release notes, but removal will occur in future revisions of the {PlatformNameShort} link:https://access.redhat.com/support/policy/updates/ansible-automation-platform[lifecycle events].
 
 |Automation mesh
 |The Work Python option has been deprecated and will be removed from automation mesh in a future release.


### PR DESCRIPTION
Notice now takes into consideration lifecycle events rather than major releases.