### PR TITLE
Backport 2.6 4214 for AAP-52745 - Change Title and TOC for Getting Started with Terraform and AAP guide

### DIFF
--- a/downstream/assemblies/terraform-aap/assembly-terraform-product.adoc
+++ b/downstream/assemblies/terraform-aap/assembly-terraform-product.adoc
@@ -1,0 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
+[id="terraform-product"]
+
+= {Terraform} integration

--- a/downstream/assemblies/vault-aap/assembly-vault-product.adoc
+++ b/downstream/assemblies/vault-aap/assembly-vault-product.adoc
@@ -1,0 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
+[id="vault-product"]
+
+= {Vault} integration

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -130,12 +130,21 @@
 :Runner: Ansible Runner
 :Role: Role ARG Spec
 
+//HashiCorp
+:HashiCorpFullName: IBM HashiCorp
+:HashiCorpShortName: HashiCorp
+
 // Terraform
 :TerraformEnterpriseFullName: IBM HashiCorp Terraform
 :TerraformEnterpriseShortName: Terraform Enterprise
 :TerraformCloudShortName: HCP Terraform
 :TerraformCommunityName: Terraform Community Edition
 :Terraform: Terraform
+
+// Vault
+:VaultFullName: IBM HashiCorp Vault
+:VaultCommunityName: Vault Community Edition
+:Vault: Vault
 
 // Ansible development tools
 :ToolsName: Ansible development tools

--- a/downstream/titles/terraform-aap/terraform-aap-getting-started/docinfo.xml
+++ b/downstream/titles/terraform-aap/terraform-aap-getting-started/docinfo.xml
@@ -1,9 +1,9 @@
-<title>Getting started with Terraform and Ansible Automation Platform </title>
+<title>Getting started with HashiCorp and Ansible Automation Platform</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.6</productnumber>
-<subtitle>Integrate Terraform with Ansible Automation Platform</subtitle>
+<subtitle>Integrate HashiCorp products with Ansible Automation Platform</subtitle>
 <abstract>
-    <para> Learn how to configure Ansible Automation Platform with Terraform Enterprise or HCP Terraform, and migrate from Terraform Community.</para>
+    <para> Learn how to configure Ansible Automation Platform with Terraform and Vault, and migrate from the community editions.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/terraform-aap/terraform-aap-getting-started/master.adoc
+++ b/downstream/titles/terraform-aap/terraform-aap-getting-started/master.adoc
@@ -6,10 +6,13 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Getting started with Terraform and Ansible Automation Platform
+// This guide was formerly named Getting started with Terraform and Ansible Automation Platform [Jonquil Williams]
+= Getting started with {HashiCorpShortName} and {PlatformNameShort}
 
 include::{Boilerplate}[]
-include::terraform-aap/assembly-terraform-introduction.adoc[leveloffset=+1]
-include::terraform-aap/assembly-terraform-integrating-from-aap.adoc[leveloffset=+1]
-include::terraform-aap/assembly-terraform-migrating-from-community.adoc[leveloffset=+1]
-include::terraform-aap/assembly-terraform-integrating-from-terraform.adoc[leveloffset=+1]
+include::terraform-aap/assembly-terraform-product.adoc[leveloffset=+1]
+include::terraform-aap/assembly-terraform-introduction.adoc[leveloffset=+2]
+include::terraform-aap/assembly-terraform-integrating-from-aap.adoc[leveloffset=+2]
+include::terraform-aap/assembly-terraform-migrating-from-community.adoc[leveloffset=+2]
+include::terraform-aap/assembly-terraform-integrating-from-terraform.adoc[leveloffset=+2]
+include::vault-aap/assembly-vault-product.adoc[leveloffset=+1]

--- a/downstream/titles/terraform-aap/terraform-aap-getting-started/vault-aap
+++ b/downstream/titles/terraform-aap/terraform-aap-getting-started/vault-aap
@@ -1,0 +1,1 @@
+../../../assemblies/vault-aap


### PR DESCRIPTION


https://issues.redhat.com/browse/AAP-52745

Changing title and TOC of guide to accommodate other Hashicorp products. (Future PRs will add the new feature/product content.)

Must be backported later to 2.5, but not now.