### PR TITLE
Updating controller API examples

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-api-access-resources.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-access-resources.adoc
@@ -10,7 +10,7 @@ You can access {ControllerName} resources by using resource-specific, human-read
 The following example shows the named URL path where you can access a resource object without an auxiliary query string:
 
 ----
-/api/v2/hosts/host_name++inv_name++org_name/
+/api/controller/v2/hosts/host_name++inv_name++org_name/
 ----
 
 include::platform/ref-controller-api-config-settings.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-api-auth-methods.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-auth-methods.adoc
@@ -17,9 +17,7 @@ This ensures that the right people can access its resources.
 
 include::platform/proc-controller-api-session-auth.adoc[leveloffset=+1]
 
-
 include::platform/con-controller-api-basic-auth.adoc[leveloffset=+1]
-
 
 include::platform/con-controller-api-oauth2-token.adoc[leveloffset=+1]
 

--- a/downstream/assemblies/platform/assembly-controller-api-auth-methods.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-auth-methods.adoc
@@ -17,8 +17,12 @@ This ensures that the right people can access its resources.
 
 include::platform/proc-controller-api-session-auth.adoc[leveloffset=+1]
 
+
 include::platform/con-controller-api-basic-auth.adoc[leveloffset=+1]
 
+
 include::platform/con-controller-api-oauth2-token.adoc[leveloffset=+1]
+
+include::platform/proc-controller-api-enable-users-oauth.adoc[leveloffset=+2]
 
 include::platform/con-controller-api-sso-auth.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-api-search.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-search.adoc
@@ -4,18 +4,7 @@
 
 = Using the search query string parameter
 
-.Procedure
+The search query string parameter provides a simple yet powerful way to filter and find specific resources within your {PlatformNameShort} API. 
+Use a non-case-sensitive search to locate relevant data across designated text fields in a model and extend your search across related fields to find exactly what you need.
 
-* Use the search query string parameter to perform a non-case-sensitive search within all designated text fields of a model:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-https://<controller server name>/api/v2/model_verbose_name?search=findme
-----
-
-* To search across related fields, use the following:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-https://<controller server name>/api/v2/model_verbose_name?related__search=findme
-----
+include::platform/proc-controller-api-search.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-controller-api-sorting.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-sorting.adoc
@@ -8,7 +8,7 @@ To give you examples that are easy to follow, we use the following URL throughou
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<controller server name>/api/v2/groups/
+https://<gateway server name>/api/controller/v2/groups/
 ----
 
 include::platform/proc-controller-api-sorting.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-controller-api-oauth2-token.adoc
+++ b/downstream/modules/platform/con-controller-api-oauth2-token.adoc
@@ -36,7 +36,7 @@ Token authentication is best used for any programmatic use of the {ControllerNam
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-curl -u user:password -k -X POST https://<gateway-server>/api/controller/v2/tokens/
+curl -u user:password -k -X POST https://<platform-host>/api/gateway/v1/tokens/
 ----
 
 This call returns JSON data with the following:
@@ -50,7 +50,7 @@ You can use the value of the `token` property to perform a `GET` request for an 
 curl -k -X GET \
   -H “Content-Type: application/json”
   -H “Authorization: Bearer <oauth2-token-value>” \
-  https://<gateway server name>/api/controller/v2/hosts/
+  https://<platform-host>/api/controller/v2/hosts/
 ----
 
 You can also run a job by making a `POST` to the job template that you want to start:
@@ -61,7 +61,7 @@ curl -k -X POST \
   -H "Authorization: Bearer <oauth2-token-value>" \
   -H "Content-Type: application/json" \
   --data '{"limit" : "ansible"}' \
-  https://<gateway server name>/api/controller/v2/job_templates/14/launch/
+  https://<platform-host>/api/controller/v2/job_templates/14/launch/
 ----
 
 .Additional resources

--- a/downstream/modules/platform/con-controller-api-oauth2-token.adoc
+++ b/downstream/modules/platform/con-controller-api-oauth2-token.adoc
@@ -32,9 +32,12 @@ For more information, see link:{URLCentralAuth}/gw-token-based-authentication[Co
 
 Token authentication is best used for any programmatic use of the {ControllerName} API, such as Python scripts or tools such as curl.
 
-.Curl example
+*Curl example*
 
-'curl -u user:password -k -X POST https://<platform-host>/api/gateway/v1/tokens/`
+[literal, options="nowrap" subs="+attributes"]
+----
+curl -u user:password -k -X POST https://<gateway-server>/api/controller/v2/tokens/
+----
 
 This call returns JSON data with the following:
 
@@ -47,7 +50,7 @@ You can use the value of the `token` property to perform a `GET` request for an 
 curl -k -X GET \
   -H “Content-Type: application/json”
   -H “Authorization: Bearer <oauth2-token-value>” \
-  https://<platform-host>/api/controller/v2/hosts/ 
+  https://<gateway server name>/api/controller/v2/hosts/
 ----
 
 You can also run a job by making a `POST` to the job template that you want to start:
@@ -58,20 +61,33 @@ curl -k -X POST \
   -H "Authorization: Bearer <oauth2-token-value>" \
   -H "Content-Type: application/json" \
   --data '{"limit" : "ansible"}' \
-  https://<controller-host>/api/v2/job_templates/14/launch/
+  https://<gateway server name>/api/controller/v2/job_templates/14/launch/
+----
+
+*Python example*
+
+link:https://pypi.org/project/awxkit/[awxkit] is an open source tool that makes it easy to use HTTP requests to access the {ControllerName} API.
+You can have awxkit get a PAT on your behalf by using the awxkit login command.
+For more information, see link:https://docs.ansible.com/automation-controller/latest/html/controllercli/index.html[AWX Command Line Interface].
+
+If you need to write custom requests, you can write a Python script by using Python library requests, such as the following example:
+
+[literal, options="nowrap" subs="+attributes"]
+----
+import requests
+oauth2_token_value = 'y1Q8ye4hPvT61aQq63Da6N1C25jiA'   # your token value from controller
+url = 'https://<gateway server name>/api/gateway/v1/users/
+payload = {}
+headers = {'Authorization': 'Bearer ' + oauth2_token_value,}
+
+# makes request to controller user endpoint
+response = requests.request('GET', url, headers=headers, data=payload,
+allow_redirects=False, verify=False)
+
+# prints json returned from controller with formatting
+print(json.dumps(response.json(), indent=4, sort_keys=True))
 ----
 
 .Additional resources
 
-For more information about obtaining OAuth2 access tokens and how to use OAuth 2 in the context of external applications, see link:{URLCentralAuth}/gw-token-based-authentication[Configuring access to external applications with token-based authentication].
-
-[discrete]
-== Enabling external users to create OAuth 2 tokens
-
-By default, external users such as those created by single sign-on are not able to generate OAuth tokens for security purposes.
-
-.Procedure
-
-. From the navigation panel, select {MenuSetGateway}.
-. Select btn:[Edit {Gateway} settings].
-. Enable the option to *Allow external users to create OAuth2 tokens*.
+* link:{URLCentralAuth}/gw-token-based-authentication[Configuring access to external applications with token-based authentication]

--- a/downstream/modules/platform/con-controller-api-oauth2-token.adoc
+++ b/downstream/modules/platform/con-controller-api-oauth2-token.adoc
@@ -64,30 +64,6 @@ curl -k -X POST \
   https://<gateway server name>/api/controller/v2/job_templates/14/launch/
 ----
 
-*Python example*
-
-link:https://pypi.org/project/awxkit/[awxkit] is an open source tool that makes it easy to use HTTP requests to access the {ControllerName} API.
-You can have awxkit get a PAT on your behalf by using the awxkit login command.
-For more information, see link:https://docs.ansible.com/automation-controller/latest/html/controllercli/index.html[AWX Command Line Interface].
-
-If you need to write custom requests, you can write a Python script by using Python library requests, such as the following example:
-
-[literal, options="nowrap" subs="+attributes"]
-----
-import requests
-oauth2_token_value = 'y1Q8ye4hPvT61aQq63Da6N1C25jiA'   # your token value from controller
-url = 'https://<gateway server name>/api/gateway/v1/users/
-payload = {}
-headers = {'Authorization': 'Bearer ' + oauth2_token_value,}
-
-# makes request to controller user endpoint
-response = requests.request('GET', url, headers=headers, data=payload,
-allow_redirects=False, verify=False)
-
-# prints json returned from controller with formatting
-print(json.dumps(response.json(), indent=4, sort_keys=True))
-----
-
 .Additional resources
 
 * link:{URLCentralAuth}/gw-token-based-authentication[Configuring access to external applications with token-based authentication]

--- a/downstream/modules/platform/proc-controller-api-browsing-api.adoc
+++ b/downstream/modules/platform/proc-controller-api-browsing-api.adoc
@@ -13,6 +13,9 @@
 . Perform a `GET` with just the `/api/` endpoint to get the `current_version`, which is the recommended version.
 . Click the image:api-questionmark.png[Copy,15,15] icon on the navigation menu, for documentation on the access methods for that particular API endpoint and what data is returned when using those methods.
 . Use the `PUT` and `POST` verbs on the specific API pages by formatting JSON in the various text fields.
-
-You can also view changed settings from factory defaults at `/api/v2/settings/changed/` endpoint. 
++
+[NOTE]
+====
+You can also view changed settings from factory defaults at `/api/gateway/v1/settings/` endpoint. 
 It reflects changes you made in the API browser, not changed settings that come from static settings files.
+====

--- a/downstream/modules/platform/proc-controller-api-enable-users-oauth.adoc
+++ b/downstream/modules/platform/proc-controller-api-enable-users-oauth.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="api-enable-users-oauth"]
+
+= Enabling external users to create OAuth 2 tokens
+
+By default, external users such as those created by single sign-on are not able to generate OAuth tokens for security purposes.
+
+.Procedure
+
+. From the navigation panel, select {MenuSetGateway}.
+. Select btn:[Edit {Gateway} settings].
+. Enable the option to *Allow external users to create OAuth2 tokens*.

--- a/downstream/modules/platform/proc-controller-api-filtering.adoc
+++ b/downstream/modules/platform/proc-controller-api-filtering.adoc
@@ -8,28 +8,28 @@
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-http://<controller server name>/api/v2/groups/?name__contains=foo
+http://<gateway server name>/api/controller/v2/groups/?name__contains=foo
 ----
 +
 * To find an exact match, use the following:
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-http://<controller server name>/api/v2/groups/?name=foo
+http://<gateway server name>/api/controller/v2/groups/?name=foo
 ----
 +
 * If a resource is of an integer type, you must add `\_\_int` to the end to cast your string input value to an integer, such as the following:
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-http://<controller server name>/api/v2/arbitrary_resource/?x__int=5
+http://<gateway server name>/api/controller/v2/arbitrary_resource/?x__int=5
 ----
 +
 * You can query related resources with the following:
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-http://<controller server name>/api/v2/users/?first_name__icontains=kim
+http://<gateway server name>/api/gateway/v1/users/?first_name__icontains=kim
 ----
 +
 This returns all users with names that include the string "Kim" in them.
@@ -38,15 +38,15 @@ This returns all users with names that include the string "Kim" in them.
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-http://<controller server name>/api/v2/groups/?name__icontains=test&has_active_failures=false
+http://<gateway server name>/api/controller/v2/groups/?name__icontains=test&has_active_failures=false
 ----
 This finds all groups containing the name "test" that have no active failures.
-
-.Additional resources
-
-For more information about what types of operators are available, see link:https://docs.djangoproject.com/en/dev/ref/models/querysets/[QuerySet API reference].
-
++
 [NOTE]
 ====
 You can also watch the API as the UI is being used to see how it is filtering on various criteria.
 ====
+
+.Additional resources
+
+* link:https://docs.djangoproject.com/en/dev/ref/models/querysets/[QuerySet API reference]

--- a/downstream/modules/platform/proc-controller-api-search.adoc
+++ b/downstream/modules/platform/proc-controller-api-search.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-controller-api-search"]
+
+.Procedure
+
+* Use the search query string parameter to perform a non-case-sensitive search within all designated text fields of a model:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+https://<gateway server name>/api/controller/v2/model_verbose_name?search=findme
+----
++
+* To search across related fields, use the following:
++
+[literal, options="nowrap" subs="+attributes"]
+----
+https://<gateway server name>/api/controller/v2/model_verbose_name?related__search=findme
+----

--- a/downstream/modules/platform/proc-controller-api-sorting.adoc
+++ b/downstream/modules/platform/proc-controller-api-sorting.adoc
@@ -8,20 +8,19 @@
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<controller server name>/api/v2/model_verbose_name_plural?order_by={{ order_field }}
+https://<gateway server name>/api/controller/v2/model_verbose_name_plural?order_by={{ order_field }}
 ----
 +
 ** Prefix the field name with a dash (`-`) to sort in reverse:
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<controller server name>/api/v2/model_verbose_name_plural?order_by=-{{ order_field }}
+https://<gateway server name>/api/controller/v2/model_verbose_name_plural?order_by=-{{ order_field }}
 ----
 +
 ** You can specify the sorting fields by separating the field names with a comma (`,`):
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-https://<controller server name>/api/v2/model_verbose_name_plural?order_by={{ order_field }},some_other_field
+https://<gateway server name>/api/controller/v2/model_verbose_name_plural?order_by={{ order_field }},some_other_field
 ----
-

--- a/downstream/modules/platform/proc-controller-api-using-pagination.adoc
+++ b/downstream/modules/platform/proc-controller-api-using-pagination.adoc
@@ -6,7 +6,7 @@ When you receive the result for a collection, something similar to the following
 
 [literal, options="nowrap" subs="+attributes"]
 ----
-{'count': 25, 'next': 'http://testserver/api/v2/some_resource?page=2', 'previous': None, 'results': [ ... ] }
+{'count': 25, 'next': 'http://testserver/api/controller/v2/some_resource?page=2', 'previous': None, 'results': [ ... ] }
 ----
 
 .Procedure
@@ -19,11 +19,14 @@ However, you can change this limit by setting the value in `/etc/tower/conf.d/<s
 +
 [literal, options="nowrap" subs="+attributes"]
 ----
-http://<controller server name>/api/v2/model_verbose_name?page_size=100&page=2
+http://<gateway server name>/api/controller/v2/model_verbose_name?page_size=100&page=2
 ----
-
++
+[NOTE]
+====
 The preceding and following links returned with the results set these query string parameters automatically.
 
 Do not request page sizes greater than 200.
 
 The user interface uses smaller values to avoid scrolling.
+====

--- a/downstream/modules/platform/ref-controller-api-config-settings.adoc
+++ b/downstream/modules/platform/ref-controller-api-config-settings.adoc
@@ -4,7 +4,7 @@
 
 = Configuration settings
 
-There are two named-URL-related configuration settings available under `/api/v2/settings/named-url/: NAMED_URL_FORMATS` and `NAMED_URL_GRAPH_NODES`.
+There are two named-URL-related configuration settings available under `/api/controller/v2/settings/named-url/: NAMED_URL_FORMATS` and `NAMED_URL_GRAPH_NODES`.
 
 `NAMED_URL_FORMATS` is a read only key-value pair list of all available named URL identifier formats. 
 The following shows an example `NAMED_URL_FORMATS`:
@@ -41,7 +41,7 @@ If a resource can have named URL, its objects must have a `named_url` field that
 That field is only visible under detail view, not list view. 
 You can access specified resource objects by using accurately generated named URL. 
 This the object and its related URLs. 
-For example, if `/api/v2/res_name/obj_slug/` is valid, `/api/v2/res_name/obj_slug/related_res_name/` is also valid.
+For example, if `/api/controller/v2/res_name/obj_slug/` is valid, `/api/controller/v2/res_name/obj_slug/related_res_name/` is also valid.
 
 `NAMED_URL_FORMATS` are instructive enough to compose human-readable unique identifiers and named URLs themselves. 
 For ease-of-use, every object of a resource that can have named URL has a related field `named_url` that displays that object's named URL. 
@@ -51,7 +51,7 @@ For more information, see the help text of the API browser if a resource object 
 You can manually decide the named URL label, for example with ID 5.
 To compose a named URL for this specific resource object by using `NAMED_URL_FORMATS`, first look up the labels field of `NAMED_URL_FORMATS` to get the identifier format `<name>++<organization.name>`:
 
-* The first part of the URL format is `<name>`, which indicates that you can find the label resource detail in `/api/v2/labels/5/`, and look for `name` field in returned JSON. 
+* The first part of the URL format is `<name>`, which indicates that you can find the label resource detail in `/api/controller/v2/labels/5/`, and look for `name` field in returned JSON. 
 If you have the `name` field with value `Foo`, then the first part of the unique identifier is `Foo`.
 * The second part of the format is double plus sign {plus}{plus}. 
 That is the delimiter that separates different parts of a unique identifier. 
@@ -59,11 +59,11 @@ Append them to the unique identifier to get `Foo++`.
 * The third part of the format is `<organization.name>`, which indicates that the field is not in the current label object under investigation, but in an organization that the label object points to. 
 As the format indicates, look up the organization in the related field of the current returned JSON. 
 That field might not exist. 
-If it exists, follow the URL given in that field, for example, `/api/v2/organizations/3/`, to get the details of the specific organization, extract its name field, for example, "Default", and append it to the current unique identifier. Since `<organizations.name>` is the last part of the format, it generates the following named URL: `/api/v2/labels/Foo++Default/`.
+If it exists, follow the URL given in that field, for example, `/api/gateway/v1/organizations/3/`, to get the details of the specific organization, extract its name field, for example, "Default", and append it to the current unique identifier. Since `<organizations.name>` is the last part of the format, it generates the following named URL: `/api/controller/v2/labels/Foo++Default/`.
 +
 In the case where an organization does not exist in the related field of the label object detail, append an empty string instead. 
 This does not alter the current identifier. 
-Therefore, `Foo++` becomes the final unique identifier and the resulting generated named URL becomes `/api/v2/labels/Foo{plus}{plus}/`.
+Therefore, `Foo++` becomes the final unique identifier and the resulting generated named URL becomes `/api/controller/v2/labels/Foo{plus}{plus}/`.
 
 An important aspect of generating a unique identifier for named URL has to do with reserved characters. 
 As the identifier is part of a URL, the following reserved characters by URL standard are encoded by percentage symbols: `;/?:@=&[]`. 

--- a/downstream/modules/platform/ref-controller-api-field-lookups.adoc
+++ b/downstream/modules/platform/ref-controller-api-field-lookups.adoc
@@ -44,7 +44,7 @@ Filtering based on the requesting user's level of access by query string paramet
 ====
 Earlier releases of {PlatformNameShort} returned queries with *_exact* results by default. 
 As a workaround, set the `limit` to `?limit_exact` for the default filter. 
-For example, `/api/v2/jobs/?limit_exact=example.domain.com` results in:
+For example, `/api/controller/v2/jobs/?limit_exact=example.domain.com` results in:
 
 ----
 {


### PR DESCRIPTION
Docs - 2.5 API Examples Outdated

https://issues.redhat.com/browse/AAP-45587

Affects `titles/controller-api-guide`