### PR TITLE
AAP-53064 Corrected link to Pushing an EE to PAH, per link report

### DIFF
--- a/downstream/modules/platform/con-RPM-install-eda-post-steps.adoc
+++ b/downstream/modules/platform/con-RPM-install-eda-post-steps.adoc
@@ -7,7 +7,7 @@ The installation program does not handle the creation of decision environments a
 See the following steps to complete the installation:
 
 . Upload the 2.5 link:https://catalog.redhat.com/software/containers/ansible-automation-platform-25/de-supported-rhel8/644963e6a123f7fc40a1ba17?container-tabs=overview[de-supported decision environment] to {HubName}. 
-For more information, see link:{BaseURL}/red_hat_ansible_automation_platform/2.5/html/creating_and_using_execution_environments/populate-container-registry#push-containers[Pushing a container image to {PrivateHubName}].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/creating_and_consuming_execution_environments/populate-container-registry#push-containers[Pushing a container image to {PrivateHubName}].
 +
 [NOTE]
 ====


### PR DESCRIPTION
Fixed broken link in [Using Event-Driven Ansible 2.5 with Ansible Automation Platform 2.4](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/using_event-driven_ansible_2.5_with_ansible_automation_platform_2.4/index) that should link to [Pushing a container image to private automation hub](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/creating_and_using_execution_environments/populate-container-registry#push-containers) topic.