### PR TITLE
Adding troubleshooting section to generic OIDC

### DIFF
--- a/downstream/assemblies/platform/assembly-gw-config-authentication-type.adoc
+++ b/downstream/assemblies/platform/assembly-gw-config-authentication-type.adoc
@@ -40,6 +40,14 @@ include::platform/proc-controller-google-oauth2-settings.adoc[leveloffset=+1]
 
 include::platform/proc-controller-set-up-generic-oidc.adoc[leveloffset=+1]
 
+include::platform/con-gw-troubleshoot-generic-oidc.adoc[leveloffset=+2]
+
+include::platform/proc-gw-config-jwt-algorithms.adoc[leveloffset=+3]
+
+include::platform/proc-gw-enable-debugging.adoc[leveloffset=+3]
+
+include::platform/proc-gw-troubleshoot-oidc-scope-mismatch.adoc[leveloffset=+3]
+
 include::platform/proc-gw-config-keycloak-settings.adoc[leveloffset=+1]
 
 include::platform/proc-controller-github-settings.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-gw-troubleshoot-generic-oidc.adoc
+++ b/downstream/modules/platform/con-gw-troubleshoot-generic-oidc.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="troubleshoot-generic-oidc"]
+
+= Troubleshoot Generic OIDC Single Sign-On authentication failures
+
+Authentication fails if the `OIDC JWT Algorithm` setting is not explicitly defined. 
+The authentication code requires a list of acceptable algorithms, which it does not retrieve automatically from the OpenID Connect (OIDC) configuration endpoint.

--- a/downstream/modules/platform/proc-gw-config-jwt-algorithms.adoc
+++ b/downstream/modules/platform/proc-gw-config-jwt-algorithms.adoc
@@ -1,0 +1,37 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="config-jwt-algorithms"]
+
+= Configuring JWT_Algorthims manually
+
+To resolve the authentication failure, manually provide the list of supported algorithms in the platform gateway configuration.
+
+.Procedure
+
+. From the navigation panel, select {MenuAMAuthentication}.
+. Select your OIDC authenticator from the list.
+. Click btn:[Edit authentication] and locate the *OIDC JWT Algorithm(s)* field.
+. Enter the list of supported algorithms as a YAML list or a JSON array. 
+These algorithms are typically available from your IdP's OpenID Connect (OIDC) discovery endpoint.
++
+*Example*
++
+----
+[
+    "PS384",
+    "ES384",
+    "RS384",
+    "HS256",
+    "HS512",
+    "ES256",
+    "RS256",
+    "HS384",
+    "ES512",
+    "PS256",
+    "PS512",
+    "RS512"
+]
+----
++
+. Save your changes. 
+The system uses these specified algorithms for token verification, resolving any authentication failures related to their absence.

--- a/downstream/modules/platform/proc-gw-enable-debugging.adoc
+++ b/downstream/modules/platform/proc-gw-enable-debugging.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="enable-debugging"]
+
+= Enabling debugging for enterprise authentication
+
+To further diagnose authentication issues, enable debug logging in platform gateway. 
+
+.Procedure
+
+. Change the logging configuration in the platform gateway's `settings.py` file.
+. Set the logging level for the `ansible_base` logger to `DEBUG`:
++
+----
+LOGGING['loggers']['ansible_base']['level'] = 'DEBUG'
+----
++
+After this change, detailed `AuthTokenError` messages are displayed in the logs, providing specific information about the cause of the failure.

--- a/downstream/modules/platform/proc-gw-troubleshoot-oidc-scope-mismatch.adoc
+++ b/downstream/modules/platform/proc-gw-troubleshoot-oidc-scope-mismatch.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="troubleshoot-oidc-scope-mismatch"]
+
+= Troubleshooting Generic OIDC scope mismatches
+
+Authentication fails when the Identity Provider (IdP) does not support the default scopes automatically appended by the system.
+
+To prevent the system from appending this default scope, you must add a setting to your authenticator configuration.
+
+.Procedure
+
+. From the navigation panel, select {MenuAMAuthentication}.
+. Select your OIDC authenticator from the list.
+. Click btn:[Edit authentication]. 
+. In the *Additional Authenticator Fields* section, add the following attribute and value. 
+This input box supports either YAML or JSON. 
+Ensure you add this key-value pair on a new line if there are other fields present: 
++
+[source,yaml]
+----
+IGNORE_DEFAULT_SCOPE: True
+----
+. Save your changes. 
+The authenticator now only uses the scopes you explicitly defined, resolving any authentication failures related to unsupported scopes.


### PR DESCRIPTION
[DOCS] Document "IGNORE_DEFAULT_SCOPE" for OIDC auth

https://issues.redhat.com/browse/AAP-52259

Affects `titles/central-auth`