### PR TITLE
Remove tech preview snippet from 2.6 AAP migration guide

### DIFF
--- a/downstream/titles/aap-migration/master.adoc
+++ b/downstream/titles/aap-migration/master.adoc
@@ -10,11 +10,6 @@ include::attributes/attributes.adoc[]
 
 include::{Boilerplate}[]
 
-[IMPORTANT]
-====
-include::snippets/technology-preview.adoc[]
-====
-
 include::aap-migration/aap-migration/con-introduction-and-objectives.adoc[leveloffset=+1]
 
 include::aap-migration/aap-migration/con-out-of-scope.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-53343