### PR TITLE
2.6 Remove tech preview snippet from 2.6 AAP migration guide (#4262)

### DIFF
--- a/downstream/titles/aap-migration/master.adoc
+++ b/downstream/titles/aap-migration/master.adoc
@@ -10,11 +10,6 @@ include::attributes/attributes.adoc[]
 
 include::{Boilerplate}[]
 
-[IMPORTANT]
-====
-include::snippets/technology-preview.adoc[]
-====
-
 include::aap-migration/aap-migration/con-introduction-and-objectives.adoc[leveloffset=+1]
 
 include::aap-migration/aap-migration/con-out-of-scope.adoc[leveloffset=+1]


### PR DESCRIPTION
Backports #4262 from main to 2.6

https://issues.redhat.com/browse/AAP-53343