### PR TITLE
Backport-2.5-4270 to AAP-44348 Created new section on supported event sources for EDA controller

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
+++ b/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
@@ -44,6 +44,7 @@ To meet high availability demands, {EDAcontroller} shares centralized link:https
 * Restarting an activation
 ====
 
+include::eda/con-eda-rulebook-supported-event-sources.adoc[leveloffset=+1]
 include::eda/proc-eda-set-up-rulebook-activation.adoc[leveloffset=+1]
 include::eda/con-eda-rulebook-activation-list-view.adoc[leveloffset=+1]
 include::eda/proc-eda-view-activation-output.adoc[leveloffset=+2]

--- a/downstream/modules/eda/con-eda-rulebook-supported-event-sources.adoc
+++ b/downstream/modules/eda/con-eda-rulebook-supported-event-sources.adoc
@@ -1,0 +1,16 @@
+
+[id="eda-rulebook-supported-event-sources"]
+
+= Supported event sources
+
+Event sources are a fundamental component of {EDAName} because they determine where a rulebook can receive events from. The effectiveness of a rulebook activation depends on selecting an event source that is compatible with your automation environment. Certain event sources are designed for use with the web-based {EDAcontroller}, while others, due to their reliance on local host functionality, are exclusive to the `ansible-rulebook` command-line interface (CLI). Understanding this distinction is crucial for successful rulebook activations.
+
+The following list includes currently supported event sources for use with the web-based {EDAcontroller}. You can decide which event sources provide the desired outcome for your rulebook activations.
+
+* `alertmanager`
+* `aws_cloudtrail`
+* `aws_sqs_queue` 
+* `azure_service_bus`
+* `kafka`
+* `pg_listener` 
+* `webhook`


### PR DESCRIPTION
Created a new section, 7.1 Supported event resources, in [Chapter 7. Rulebook activations](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-rulebook-activations) in the Using automation decisions guide.