### PR TITLE
bp to 2.6: AAP-49875: Removes subscription/licensing info from authentication guide

### DIFF
--- a/downstream/titles/central-auth/master.adoc
+++ b/downstream/titles/central-auth/master.adoc
@@ -13,7 +13,7 @@ include::{Boilerplate}[]
 
 include::platform/platform/con-gw-overview-access-auth.adoc[leveloffset=+1]
 
-include::platform/assembly-gateway-licensing.adoc[leveloffset=+1]
+// [removed per AAP-49875 -hherbly]include::platform/assembly-gateway-licensing.adoc[leveloffset=+1]
 
 include::platform/assembly-gw-configure-authentication.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR ports the changes from [PR 3944](https://github.com/ansible/aap-docs/pull/3944) to the 2.6 branch. This work is being tracked in [AAP-49875](https://issues.redhat.com/browse/AAP-49875).