### PR TITLE
AAP-50802 Create admonition stating state gateway is the preferred path for AAP 2.6

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -32,7 +32,7 @@ The following procedures form the user configuration:
 [IMPORTANT]
 
 ====
-In new installations of {PlatformNameShort} 2.6, using {EDAcontroller}'s API to manage organizations, teams, or users requires an automated sync of up to 15 minutes to propagate changes to the rest of the {PlatformNameShort} components. To avoid potential errors and ensure immediate access, use the {Gateway} API instead, or the unified UI.
+In new installations of {PlatformNameShort} {PlatformVers}, using {EDAcontroller}'s API to manage organizations, teams, or users requires an automated sync of up to 15 minutes to propagate changes to the rest of the {PlatformNameShort} components. To avoid potential errors and ensure immediate access, use the {Gateway} API instead, or the unified UI.
 ====
 
 [role="_additional-resources"]


### PR DESCRIPTION
Added admonition per requirement in AAP-50802. Focused strictly on Using automation decisions guide in the [overview chapter](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-user-guide-overview). 

**Note:** 
Other instances of this note are placed in other guides (**Access management and authentication** and **RPM upgrade and migration**) by the owners of those docs in separate PRs.