### PR TITLE
2.5 backport: AAP-29944: adds content signing for hub on OCP procedure (#4253)

### DIFF
--- a/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
+++ b/downstream/assemblies/platform/assembly-installing-hub-operator.adoc
@@ -64,6 +64,9 @@ include::platform/ref-ocp-additional-configs.adoc[leveloffset=+1]
 
 include::platform/proc-aap-add-allowed-registries.adoc[leveloffset=+1]
 
+include::platform/proc-content-signing-hub-on-ocp.adoc[leveloffset=+1]
+
+
 [role="_additional-resources"]
 == Additional resources
 

--- a/downstream/modules/platform/proc-content-signing-hub-on-ocp.adoc
+++ b/downstream/modules/platform/proc-content-signing-hub-on-ocp.adoc
@@ -1,0 +1,123 @@
+:_newdoc-version: 2.18.5
+:_template-generated: 2025-09-10
+:_mod-docs-content-type: PROCEDURE
+
+[id="content-signing-hub-on-ocp_{context}"]
+= Configuring content signing for {OperatorHub}
+
+As an automation administrator for your organization, you can configure {OperatorHub} for signing and publishing Ansible content collections from different groups within your organization.
+
+For additional security, automation creators can configure Ansible-Galaxy CLI to verify these collections to ensure that they have not been changed after they were uploaded to {HubName}.
+
+To successfully sign and publish {CertifiedName}, you must configure {PrivateHubName} for signing.
+
+.Prerequisites
+
+* A GPG key pair. If you do not have one, you can generate one using the `gpg --full-generate-key` command.
+* Your public-private key pair has proper access for configuring content signing on {OperatorHub}.
+
+.Procedure
+
+. Create a ConfigMap for signing scripts. The ConfigMap you create contains the scripts used by the signing service for collections and container images. 
++
+[NOTE]
+====
+This script is used as part of the signing service and must generate an ascii-armored detached `gpg` signature for that file using the key specified through the `PULP_SIGNING_KEY_FINGERPRINT` environment variable.
+====
++
+The script prints out a JSON structure with the following format.
++
+----
+{"file": "filename", "signature": "filename.asc"}
+----
++
+All the file names are relative paths inside the current working directory. 
+The file name must remain the same for the detached signature.
++
+.Example:
+The following script produces signatures for content:
++
+[source,shell]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: signing-scripts
+data:
+  collection_sign.sh: |-
+      #!/usr/bin/env bash
+
+      FILE_PATH=$1
+      SIGNATURE_PATH=$1.asc
+
+      ADMIN_ID="$PULP_SIGNING_KEY_FINGERPRINT"
+      PASSWORD="password"
+
+      # Create a detached signature
+      gpg --quiet --batch --pinentry-mode loopback --yes --passphrase \
+        $PASSWORD --homedir /var/lib/pulp/.gnupg --detach-sign --default-key $ADMIN_ID \
+        --armor --output $SIGNATURE_PATH $FILE_PATH
+
+      # Check the exit status
+      STATUS=$?
+      if [ $STATUS -eq 0 ]; then
+        echo {\"file\": \"$FILE_PATH\", \"signature\": \"$SIGNATURE_PATH\"}
+      else
+        exit $STATUS
+      fi
+  container_sign.sh: |-
+    #!/usr/bin/env bash
+
+    # galaxy_container SigningService will pass the next 4 variables to the script.
+    MANIFEST_PATH=$1
+    FINGERPRINT="$PULP_SIGNING_KEY_FINGERPRINT"
+    IMAGE_REFERENCE="$REFERENCE"
+    SIGNATURE_PATH="$SIG_PATH"
+
+    # Create container signature using skopeo
+    skopeo standalone-sign \
+      $MANIFEST_PATH \
+      $IMAGE_REFERENCE \
+      $FINGERPRINT \
+      --output $SIGNATURE_PATH
+
+    # Optionally pass the passphrase to the key if password protected.
+    # --passphrase-file /path/to/key_password.txt
+
+    # Check the exit status
+    STATUS=$?
+    if [ $STATUS -eq 0 ]; then
+      echo {\"signature_path\": \"$SIGNATURE_PATH\"}
+    else
+      exit $STATUS
+    fi
+----
+
+. Create a secret for your GnuPG private key. This secret securely stores the GnuPG private key you use for signing.
++
+[source,shell]
+----
+gpg --export --armor <your-gpg-key-id> > signing_service.gpg
+
+oc create secret generic signing-galaxy --from-file=signing_service.gpg
+----
++
+The secret must have a key named `signing_service.gpg`.
+
+. Configure the AnsibleAutomationPlatform CR. 
++
+[source,shell]
+----
+apiVersion: aap.ansible.com/v1alpha1
+kind: AnsibleAutomationPlatform
+metadata:
+  name: aap-hub-signing-sample
+spec:
+  hub:
+    signing_secret: "signing-galaxy"
+    signing_scripts_configmap: "signing-scripts"
+----
++
+[role="_additional-resources"]
+.Next steps
+link:{URLHubManagingContent}/managing-cert-valid-content#proc-using-content-signing-services-in-pah[Using content signing services in {PrivateHubName}]


### PR DESCRIPTION
This PR ports the changes from [PR 4253](https://github.com/ansible/aap-docs/pull/4253) to the 2.5 branch. This work is being tracked in [AAP-29944](https://issues.redhat.com/browse/AAP-29944).