### PR TITLE
Update titles for Self-service automation portal

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -153,9 +153,9 @@
 :RHDH: Red Hat Developer Hub
 :RHDHVers: 1.4
 :RHDHShort: RHDH
-:SelfService: Ansible Automation Platform self-service technology preview
-:SelfServiceShort: self-service technology preview
-:SelfServiceShortStart: Self-service technology preview
+:SelfService: Self-service automation portal
+:SelfServiceShort: Self-service automation portal
+:SelfServiceShortStart: Self-service automation portal
 :Builder: Ansible Builder
 :Navigator: automation content navigator
 :NavigatorStart: Automation content navigator

--- a/downstream/titles/self-service-install/docinfo.xml
+++ b/downstream/titles/self-service-install/docinfo.xml
@@ -1,9 +1,9 @@
-<title>Installing Ansible Automation Platform self-service technology preview</title>
+<title>Installing Self-service automation portal</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.6</productnumber>
-<subtitle>Install and configure Ansible Automation Platform self-service technology preview</subtitle>
+<subtitle>Install and configure Self-service automation portal</subtitle>
 <abstract>
-    <para>This guide describes how to install and configure Ansible Automation Platform self-service technology preview so that users can run automation.</para>
+    <para>This guide describes how to install and configure Self-service automation portal so that users can run automation.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/self-service-install/master.adoc
+++ b/downstream/titles/self-service-install/master.adoc
@@ -7,7 +7,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Installing Ansible Automation Platform self-service technology preview
+= Installing Self-service automation portal
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
@@ -15,17 +15,17 @@ This guide describes how to install {SelfService} and connect it with an instanc
 
 include::{Boilerplate}[]
 
-[IMPORTANT]
-==== 
-{SelfService} is a Technology Preview feature only.
-include::snippets/technology-preview.adoc[]
-==== 
-
 include::devtools/assembly-self-service-about.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-installation-overview.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-preinstall-config.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-helm-install.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-view-deployment.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-accessing-deployment.adoc[leveloffset=+1]
+
 include::devtools/assembly-self-service-telemetry-capture.adoc[leveloffset=+1]
 

--- a/downstream/titles/self-service-using/docinfo.xml
+++ b/downstream/titles/self-service-using/docinfo.xml
@@ -1,9 +1,9 @@
-<title>Using Ansible Automation Platform self-service technology preview</title>
+<title>Using Self-service automation portal</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.6</productnumber>
-<subtitle>Use Ansible Automation Platform self-service technology preview</subtitle>
+<subtitle>Use Self-service automation portal</subtitle>
 <abstract>
-    <para>This guide describes how to use Ansible Automation Platform self-service technology preview to implement role-based access control and run automation.</para>
+    <para>This guide describes how to use Self-service automation portal to implement role-based access control and run automation.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/self-service-using/master.adoc
+++ b/downstream/titles/self-service-using/master.adoc
@@ -7,7 +7,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= Using Ansible Automation Platform self-service technology preview
+= Using Self-service automation portal
 
 Thank you for your interest in {PlatformName}. {PlatformNameShort} is a commercial offering that helps teams manage complex multi-tier deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
@@ -18,14 +18,6 @@ It also describes how to configure role-based access control (RBAC) so that you 
 This document has been updated to include information for the latest release of {PlatformNameShort}.
 
 include::{Boilerplate}[]
-
-[IMPORTANT]
-==== 
-{SelfService} is a Technology Preview feature only.
-
-include::snippets/technology-preview.adoc[]
-
-==== 
 
 include::devtools/assembly-self-service-using-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Update titles for Self-service automation portal for 2.6, and remove tech preview snippet from the docs.