### PR TITLE
Backport PR #4298 from main to AAP 2.6 branch

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
+++ b/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
@@ -12,20 +12,12 @@ ifdef::context[:parent-context: {context}]
 To upgrade your {PlatformName}, start by reviewing {LinkPlanningGuide} to ensure a successful upgrade.
 You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
 
-== Prerequisites
-
-* Upgrades to {PlatformNameShort} 2.5 include the link:{URLPlanningGuide}/ref-aap-components#con-about-platform-gateway_planning[{Gateway}]. Ensure you review the link:{URLPlanningGuide}/ref-network-ports-protocols_planning[2.5 Network ports and protocols] for architectural changes and {LinkTopologies} for information on opinionated deployment models. 
-
-* You have reviewed the link:{URLPlanningGuide}/ha-redis_planning#gw-centralized-redis_planning[centralized Redis] instance offered by {PlatformNameShort} for both standalone and clustered topologies.
-
-* Prior to upgrading your {PlatformName}, ensure you have reviewed {LinkPlanningGuide} for a successful upgrade. You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
-
-* Before upgrading your {PlatformName}, ensure you have upgraded to {ControllerName} 4.5 or later. 
-
-* When upgrading to {PlatformNameShort} {PlatformVers}, you must use RPM installer version 2.5-11 or later. If you use an older installer, the installation might fail. If you encounter a failed installation using an older version of the installer, rerun the installation with RPM installer version 2.5-11 or later.
+[IMPORTANT]
+====
+In {PlatformNameShort} {PlatformVers}, while the automation controller's API remains for backward compatibility, new installations must use the {Gateway} API for managing organizations, teams, and users. Using the legacy API will introduce a delay of up to 15 minutes before changes are synchronized to all components, including {EDAcontroller}.
+====
 
 include::platform/con-aap-upgrade-planning.adoc[leveloffset=+1]
-
 include::platform/proc-choosing-obtaining-installer.adoc[leveloffset=+1]
 include::platform/proc-choosing-obtaining-installer-no-internet.adoc[leveloffset=+2]
 include::platform/proc-editing-inventory-file-for-updates.adoc[leveloffset=+1]
@@ -39,4 +31,3 @@ include::platform/proc-upgrade-controller-hub-eda-unified-services.adoc[leveloff
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
- 

--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -1,44 +1,86 @@
 :_mod-docs-content-type: CONCEPT
 
-
-
 [id="aap-upgrade-planning_{context}"]
 
-= {PlatformNameShort} upgrade planning
+= Upgrade prerequisites
  
 [role="_abstract"]
 Before you begin the upgrade process, review the following considerations to plan and prepare your {PlatformNameShort} deployment:
 
-* See link:{URLPlanningGuide}/platform-system-requirements[System requirements] in the {TitlePlanningGuide} guide to ensure you have the topologies that fit your use case. 
-+
-[NOTE]
-====
-2.4 to 2.5 upgrades now include link:{URLPlanningGuide}/ref-aap-components#con-about-platform-gateway_planning[{GatewayStart}]. Ensure you review the 2.5 link:{URLPlanningGuide}/ref-network-ports-protocols_planning[Network ports and protocols] for architectural changes.
-====
+== {PlatformNameShort} requirements
+* Verify that you have a valid subscription before upgrading from a previous version of {PlatformNameShort}. Existing subscriptions are carried over during the upgrade process. 
+* Review {LinkPlanningGuide} for a successful upgrade. You can only upgrade from {PlatformNameShort} 2.4 or 2.5 to 2.6.
+* Upgrade to {PlatformNameShort} installer version 2.6-11 or later. Do not upgrade to an earlier installer version.
+* Back up your {PlatformNameShort} environment before upgrading in case any issues occur. See link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] and {LinkOperatorBackup} for the specific topology of the environment.
+* Capture your inventory or instance group details before upgrading.
+* Upgrade to the latest version of {PlatformNameShort} 2.4 or 2.5 before upgrading to {PlatformName} 2.6.
 +
 [IMPORTANT]
 ====
-When upgrading from {PlatformNameShort} 2.4 to 2.5, the API endpoints for the {ControllerName}, {HubName}, and {EDAcontroller} are all available for use. These APIs are being deprecated and will be disabled in an upcoming release. This grace period is to allow for migration to the new APIs put in place with the {Gateway}.
+When upgrading from {PlatformNameShort} 2.4 to 2.6, the API endpoints for the {ControllerName}, {HubName}, and {EDAcontroller} are all available for use. These APIs are being deprecated and will be disabled in an upcoming release. This grace period is to allow for migration to the new APIs put in place with the {Gateway}.
 ====
-+
-* Verify that you have a valid subscription before upgrading from a previous version of {PlatformNameShort}. Existing subscriptions are carried over during the upgrade process. 
-* Ensure you have a backup of an {PlatformNameShort} 2.4 environment before upgrading in case any issues occur. See link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] and {LinkOperatorBackup} for the specific topology of the environment.
-* Ensure you capture your inventory or instance group details before upgrading.
-* Ensure you have upgraded to the latest version of {PlatformNameShort} 2.4 before upgrading your {PlatformName}.
-* Upgrades of {EDAName} version 2.4 to 2.5 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.5 are not compatible. For more information, see xref:upgrade-controller-hub-eda-unified-ui_aap-upgrading-platform[{ControllerName} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades].
-+
-If you are currently running {EDAcontroller} 2.5, it is recommended that you disable all {EDAName} activations before upgrading to ensure that only new activations run after the upgrade process is complete.
-* {ControllerNameStart} OAuth applications on the platform UI are not supported for 2.4 to 2.5 migration. See this link:https://access.redhat.com/solutions/7091987[Knowledgebase article] for more information. To learn how to recreate your OAuth applications, see link:{URLCentralAuth}/gw-token-based-authentication#assembly-controller-applications[Applications] in the {TitleCentralAuth} guide.
-* During the upgrade process, user accounts from the individual services are migrated. If there are accounts from multiple services, they must be linked to access the unified platform. See xref:account-linking_aap-post-upgrade[Account linking] for details.
-* {PlatformNameShort} 2.5 offers a centralized Redis instance in both link:{URLPlanningGuide}/ha-redis_planning#gw-single-node-redis_planning[standalone] and link:{URLPlanningGuide}/ha-redis_planning#gw-clustered-redis_planning[clustered] topologies. For information on how to configure Redis, see link:{URLInstallationGuide}/assembly-platform-install-scenario#redis-config-enterprise-topology_platform-install-scenario[Configuring Redis] in the {TitleInstallationGuide} guide.
-* When upgrading from {PlatformNameShort} 2.4 to {PlatformVers}, connections to the {Gateway} URL might fail on the {Gateway} UI if you are using the {ControllerName} behind a load balancer. The following error message is displayed: `Error connecting to Controller API`
-+
-To resolve this issue, for each controller host, add the {Gateway} URL as a trusted source in the `CSRF_TRUSTED_ORIGIN` setting in the *settings.py* file for each controller host. You must then restart each controller host so that the URL changes are implemented. For more information, see _Upgrading_ in {LinkTroubleshootingAAP}. 
 
+* Review the {Gateway} requirements:
+** {PlatformNameShort} 2.4 to 2.6 upgrades include the link:{URLPlanningGuide}/ref-aap-components#con-about-platform-gateway_planning[{Gateway}]. Ensure you review the 2.6 link:{URLPlanningGuide}/ref-network-ports-protocols_planning[Network ports and protocols] for architectural changes.
+** {GatewayStart} has a number of associated inventory file variables, some of which are required. For details of the new and changed variables for 2.6, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/rpm_installation/appendix-inventory-files-vars[Appendix A. Inventory file variables].
+** When upgrading from {PlatformNameShort} 2.4 to 2.6, connections to the {Gateway} URL might fail on the {Gateway} UI if you are using the {ControllerName} behind a load balancer. The following error message is displayed: `Error connecting to Controller API`
++
+To resolve this issue, for each {ControllerName} host, add the {Gateway} URL as a trusted source in the `CSRF_TRUSTED_ORIGIN` setting in the *settings.py* file for each {ControllerName} host. You must then restart each {ControllerName} host so that the URL changes are implemented. For more information, see _Upgrading_ in {LinkTroubleshootingAAP}. 
+
+* Review the link:{URLPlanningGuide}/ha-redis_planning#gw-centralized-redis_planning[centralized Redis] instance offered by {PlatformNameShort} for both standalone and clustered topologies.
++
+** {PlatformNameShort} 2.6 offers a centralized Redis instance in both link:{URLPlanningGuide}/ha-redis_planning#gw-single-node-redis_planning[standalone] and link:{URLPlanningGuide}/ha-redis_planning#gw-clustered-redis_planning[clustered] topologies. For information on how to configure Redis, see link:{URLInstallationGuide}/assembly-platform-install-scenario#redis-config-enterprise-topology_platform-install-scenario[Configuring Redis] in the {TitleInstallationGuide} guide.
+** 6 VMs are required for a Redis high availability (HA) compatible deployment. Redis can be colocated on each {PlatformNameShort} component VM except for {ControllerName}, execution nodes, or the PostgreSQL database. 
+** External Redis is not supported for RPM-based deployments of {PlatformNameShort}.
+
+* Limitation:
+** Upgrades of {EDAName} version 2.4 to 2.6 are not supported. Database migrations between {EDAName} 2.4 and {EDAName} 2.6 are not compatible. For more information, see xref:upgrade-controller-hub-eda-unified-ui_aap-upgrading-platform[{ControllerName} and {HubName} 2.4 and {EDAName} 2.6 with unified UI upgrades].
++
+If you are currently running {EDAcontroller} 2.6, it is recommended that you disable all {EDAName} activations before upgrading to ensure that only new activations run after the upgrade process is complete.
+
+== System requirements
+
+
+[cols="20%,40%,40%", options="header"]
+|====
+| Type | Description | Notes 
+h| Subscription | Valid {PlatformName} subscription |
+h| Operating system  
+| {RHEL} 9.4 or later minor versions of {RHEL} 9 | {PlatformName} are also supported on OpenShift, see {LinkOperatorInstallation} for more information.
+h| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power) |
+h| Ansible-core | Ansible-core version {CoreUseVers} or later | {PlatformNameShort} uses the system-wide ansible-core package to install the platform, but uses ansible-core {CoreUseVers} for both its control plane and built-in execution environments.
+h| Browser | A currently supported version of Mozilla Firefox or Google Chrome. |
+h| Database 
+a| 
+* For {PlatformNameShort} managed databases: {PostgresVers}.
+* For customer provided (external) databases: {PostgresVers}, 16, or 17.
+a| 
+* External (customer supported) databases require ICU support.
+* External databases using PostgreSQL 16 or 17 must rely on external backup and restore processes. Backup and restore functionality is dependent on utilities provided with {PostgresVers}.
+|====
+
+== Database requirements
+* {PlatformNameShort} can work with two varieties of database:
+** Database installed with {PlatformNameShort} - This database consists of a PostgreSQL installation done as part of an {PlatformNameShort} installation using PostgreSQL packages provided by Red Hat.
+** Customer provided or configured database - This is an external database that is provided by the customer, whether on bare metal, virtual machine, container, or cloud hosted service.
+{PlatformNameShort} requires customer provided (external) database to have ICU support.
+* PostgreSQL user passwords are hashed with SCRAM-SHA-256 secure hashing algorithm before storing in the database.
+* Ensure that you back up your {PlatformNameShort} environment before upgrading in case any issues occur. See link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] and {LinkOperatorBackup} for the specific topology of the environment.
+
+== User privileges
+* Ensure a dedicated non-root user is configured on the Red Hat Enterprise Linux host.
+
+** This user requires sudo or other Ansible supported privilege escalation (sudo is recommended) to perform administrative tasks during the installation.
+** This user is responsible for the installation of RPM {PlatformNameShort}.
+** You can obtain root access either through the sudo command, or through privilege escalation. You can de-escalate privileges from root to users such as AWX, PostgreSQL, {EDAName}, or Pulp.
+** An NTP client is configured on each node.
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/access_management_and_authentication/assembly-gateway-licensing#proc-attaching-subscriptions[Attaching a subscription]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/access_management_and_authentication/assembly-gateway-licensing#proc-attaching-subscriptions[Attaching a subscription]
 * xref:con-backup-aap_aap-upgrading-platform[Backup and restore]
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/configuring_automation_execution/controller-clustering[Clustering]
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/planning_your_installation/index[Planning your installation]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/configuring_automation_execution/controller-clustering[Clustering]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/planning_your_upgrade/index[Planning your upgrade]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/planning_your_installation/index[Planning your installation]
+
+

--- a/downstream/modules/platform/con-aap-upgrades.adoc
+++ b/downstream/modules/platform/con-aap-upgrades.adoc
@@ -10,7 +10,7 @@ Currently, it is possible to perform {PlatformNameShort} upgrades using one of t
 
 [IMPORTANT]
 ====
-Upgrading from {EDAName} 2.4 is not supported. If you’re using {EDAName} 2.4 in production, contact Red Hat before you upgrade.
+Upgrading from {EDAName} 2.4 is not supported. If you are using {EDAName} 2.4 in production, contact Red Hat before you upgrade.
 ====
 
 Before beginning your upgrade be sure to review the prerequisites and upgrade planning sections of this guide.
@@ -18,29 +18,34 @@ Before beginning your upgrade be sure to review the prerequisites and upgrade pl
 [cols="a,a"]
 |===
 h|Supported upgrade path h| Steps to upgrade
-|{PlatformNameShort} 2.4 to 2.5 | xref:proc-choosing-obtaining-installer_aap-upgrading-platform[Download the installation package].
+|{PlatformNameShort} 2.4 to {PlatformVers} |     
+. xref:proc-choosing-obtaining-installer_aap-upgrading-platform[Download the installation package].
 
-xref:editing-inventory-file-for-updates_aap-upgrading-platform[Set up your inventory file] to match your installation environment. See {LinkTopologies} for a list of example inventory files.
+. xref:editing-inventory-file-for-updates_aap-upgrading-platform[Set up your inventory file] to match your installation environment. See {LinkTopologies} for a list of example inventory files.
 
-link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index#con-backup-aap_upgrading-to-ees[Back up your {PlatformNameShort} instance].
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html-single/red_hat_ansible_automation_platform_upgrade_and_migration_guide/index#con-backup-aap_upgrading-to-ees[Back up your {PlatformNameShort} 2.4 instance].
 
-xref:proc-running-setup-script-for-updates[Run the 2.5 installation program] over your current {PlatformNameShort} instance.
+. xref:proc-running-setup-script-for-updates[Run the {PlatformVers} installation program] over your current {PlatformNameShort} instance.
 
-xref:account-linking_aap-post-upgrade[Link your existing service level accounts] to a single unified platform account. 
+. xref:account-linking_aap-post-upgrade[Link your existing service level accounts] to a single unified platform account. 
 
-|{PlatformNameShort} 2.5 to 2.5.x | xref:proc-choosing-obtaining-installer_aap-upgrading-platform[Download the installation package].
 
-xref:editing-inventory-file-for-updates_aap-upgrading-platform[Set up your inventory file] to match your installation environment. See {LinkTopologies} for a list of example inventory files.
+|{PlatformNameShort} 2.5 to {PlatformVers} |     
+. xref:proc-choosing-obtaining-installer_aap-upgrading-platform[Download the installation package].
 
-xref:con-backup-aap_aap-upgrading-platform[Back up your {PlatformNameShort} instance].
+. xref:editing-inventory-file-for-updates_aap-upgrading-platform[Set up your inventory file] to match your installation environment. See {LinkTopologies} for a list of example inventory files.
 
-xref:proc-running-setup-script-for-updates[Run the 2.5 installation program] over your current {PlatformNameShort} instance.
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_upgrade_and_migration/aap-upgrading-platform#con-backup-aap_aap-upgrading-platform[Back up your {PlatformNameShort} 2.5 instance].
 
-|xref:upgrade-controller-hub-eda-unified-ui_aap-upgrading-platform[{ControllerNameStart} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades] | Upgrade the 2.4 services (using inventory file to only specify {ControllerName} and {HubName} VMs) to get them to the initial version of AAP 2.5.
+. xref:proc-running-setup-script-for-updates[Run the {PlatformVers} installation program] over your current {PlatformNameShort} instance.
 
-After all the services are at the same version, run a 2.5 upgrade on all the services
+. xref:account-linking_aap-post-upgrade[Link your existing service level accounts] to a single unified platform account. 
+
+|xref:upgrade-controller-hub-eda-unified-ui_aap-upgrading-platform[{ControllerNameStart} and {HubName} 2.4 and {EDAName} 2.5 with unified UI upgrades] | Upgrade the 2.4 services (using inventory file to only specify {ControllerName} and {HubName} VMs) to get them to the initial version of {PlatformNameShort} {PlatformVers}.
+
+After all the services are at the same version, run a {PlatformVers} upgrade on all the services.
 |===
- 
+
 
 // [hherbly]: not sure we need the addt'l resources block? the xref goes to the next section of the document.
 // [ddacosta]: agree, it's not needed.

--- a/downstream/modules/platform/con-upgrade-controller-hub-eda-unified-ui.adoc
+++ b/downstream/modules/platform/con-upgrade-controller-hub-eda-unified-ui.adoc
@@ -1,27 +1,27 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="con-upgrade-controller-hub-eda-unified-ui_{context}"]
-= Automation controller and automation hub 2.4 and Event-Driven Ansible 2.5 with unified UI upgrades
+= Automation controller and automation hub 2.4 and Event-Driven Ansible 2.6 with unified UI upgrades
 
-{PlatformNameShort} 2.5 supports upgrades from {PlatformNameShort} 2.4 environments for all components, with the exception of {EDAName}. You can also configure a mixed environment with {EDAName} from 2.5 connected to a legacy 2.4 cluster. Combining install methods (OCP, RPM, Containerized) within such a topology is not supported by {PlatformNameShort}.
+{PlatformNameShort} {PlatformVers} supports upgrades from {PlatformNameShort} 2.4 environments for all components, with the exception of {EDAName}. You can also configure a mixed environment with {EDAName} from 2.6 connected to a legacy 2.4 cluster. Combining install methods (OCP, RPM, Containerized) within such a topology is not supported by {PlatformNameShort}.
 
 [NOTE]
 ====
-If you are running the 2.4 version of {EDAName} in production, before you upgrade, contact Red Hat support or your account representative for more information on how to move to {PlatformNameShort} 2.5.
+If you are running the 2.4 version of {EDAName} in production, before you upgrade, contact Red Hat support or your account representative for more information on how to move to {PlatformNameShort} {PlatformVers}.
 ====
 
 Supported topologies described in this document assume that:
 
 * 2.4 services will only include {ControllerName} and {HubName}.
-* 2.5 parts will always include {EDAName} and the unified UI ({Gateway}).
+* 2.6 parts will always include {EDAName} and the unified UI ({Gateway}).
 * Combining installation methods for these topologies is not supported.
 
 == Upgrade considerations
 
-* You must maintain two separate inventory files: one for the 2.4 services and one for the 2.5 services.
-* You must maintain two separate installations within this scenario: one for the 2.4 services and one for the 2.5 services. 
+* You must maintain two separate inventory files: one for the 2.4 services and one for the 2.6 services.
+* You must maintain two separate installations within this scenario: one for the 2.4 services and one for the 2.6 services. 
 * You must upgrade the two separate installations separately.
 * To upgrade to a consistent component version topology, consider the following: 
-** You must manually combine the inventory file configuration from the 2.4 inventory into the 2.5 inventory and run upgrade on ONLY the 2.5 inventory file. 
-** You must be using an external database for both the 2.4 inventory as well as the 2.5 inventory. 
-** Customers using managed database instances for either 2.4 or 2.5 inventory must migrate to an external database first, before upgrading.
+** You must manually combine the inventory file configuration from the 2.4 inventory into the 2.6 inventory and run the upgrade on the 2.6 inventory file ONLY. 
+** You must be using an external database for both the 2.4 inventory and 2.6 inventory. 
+** Customers using managed database instances for either 2.4 or 2.6 inventory must migrate to an external database first, before upgrading.

--- a/downstream/modules/platform/proc-choosing-obtaining-installer.adoc
+++ b/downstream/modules/platform/proc-choosing-obtaining-installer.adoc
@@ -33,16 +33,10 @@ $ tar xvzf ansible-automation-platform-setup-<latest-version>.tar.gz
 
 . Install the {PlatformNameShort} Installer Package.
 +
-v.{PlatformVers} for RHEL 8 for x86_64:
-+
-----
-$ sudo dnf install --enablerepo=ansible-automation-platform-2.5-for-rhel-8-x86_64-rpms ansible-automation-platform-installer
-----
-+
 v.{PlatformVers} for RHEL 9 for x86-64:
 +
 ----
-$ sudo dnf install --enablerepo=ansible-automation-platform-2.5-for-rhel-9-x86_64-rpms ansible-automation-platform-installer
+$ sudo dnf install --enablerepo=ansible-automation-platform-2.6-for-rhel-9-x86_64-rpms ansible-automation-platform-installer
 ----
 +
 [NOTE]

--- a/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
+++ b/downstream/modules/platform/proc-editing-inventory-file-for-updates.adoc
@@ -16,14 +16,14 @@ Bundled installer::
 +
 [source,options="nowrap",subs=attributes+]
 -----
-$ cd ansible-automation-platform-setup-bundle-2.5-4-x86_64
+$ cd ansible-automation-platform-setup-bundle-2.6-4-x86_64
 -----
 +
 Online installer::
 +
 [source,options="nowrap",subs=attributes+]
 -----
-$ cd ansible-automation-platform-setup-2.5-4
+$ cd ansible-automation-platform-setup-2.6-4
 -----
 
 . Open the `inventory` file for editing.

--- a/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-services.adoc
+++ b/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-services.adoc
@@ -3,17 +3,17 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="upgrade-controller-hub-eda-unified-ui-services_{context}"]
-= Using Migration path for 2.4 services with 2.5 services
+= Using Migration path for 2.4 services with 2.6 services
 
-If you installed {PlatformNameShort} 2.5 to use {EDAName} in a supported scenario, you can upgrade your {PlatformNameShort} 2.4 {ControllerName} and {HubName} to {PlatformNameShort} 2.5 by following the procedure in this section. 
+If you installed {PlatformNameShort} {PlatformVers} to use {EDAName} in a supported scenario, you can upgrade your {PlatformNameShort} 2.4 {ControllerName} and {HubName} to {PlatformNameShort} {PlatformVers} by following the procedure in this section. 
 
 .Prerequisites
 
-* An inventory from 2.4 for {ControllerName} and {HubName} and a 2.5 inventory for unified UI ({Gateway}) and {EDAName}. You must run upgrades on 2.4 services (using the inventory file to specify only {ControllerName} and {HubName} VMs) to get them to the initial version of {PlatformNameShort} 2.5 first. When all the services are at the same version, run an upgrade (using a complete inventory file) on all the services to go to the latest version of {PlatformNameShort} 2.5.
+* An inventory from 2.4 for {ControllerName} and {HubName} and a 2.6 inventory for unified UI ({Gateway}) and {EDAName}. You must run upgrades on 2.4 services (using the inventory file to specify only {ControllerName} and {HubName} VMs) to get them to the initial version of {PlatformNameShort} {PlatformVers} first. When all the services are at the same version, run an upgrade (using a complete inventory file) on all the services to go to the latest version of {PlatformNameShort} {PlatformVers}.
 
 [IMPORTANT]
 ====
-DO NOT upgrade {EDAName} and the unified UI ({Gateway}) to the latest version of {PlatformNameShort} 2.5 without first upgrading the individual services ({ControllerName} and {HubName}) to the initial version of {PlatformNameShort} 2.5.
+DO NOT upgrade {EDAName} and the unified UI ({Gateway}) to the latest version of {PlatformNameShort} {PlatformVers} without first upgrading the individual services ({ControllerName} and {HubName}) to the initial version of {PlatformNameShort} {PlatformVers}.
 ====
 
 * Ensure you have upgraded to the latest version of {PlatformNameShort} 2.4 before upgrading your {PlatformName}.
@@ -22,7 +22,7 @@ DO NOT upgrade {EDAName} and the unified UI ({Gateway}) to the latest version of
 
 . Merge 2.4 inventory data into the 2.5 inventory. 
 +
-The example below shows the inventory file for {ControllerName} and {HubName} for 2.4 and the inventory file for {EDAName} and the unified UI ({Gateway}) for 2.5, respectively, as the starting point, and what the merged inventory looks like. 
+The example below shows the inventory file for {ControllerName} and {HubName} for 2.4 and the inventory file for {EDAName} and the unified UI ({Gateway}) for 2.6, respectively, as the starting point, and what the merged inventory looks like. 
 +
 *Inventory files from 2.4*
 +
@@ -40,7 +40,7 @@ hub-2
 # Here we have the admin passwd, db credentials, etc.
 ----
 +
-*Inventory files from 2.5*
+*Inventory files from 2.6*
 +
 [source,]
 ----
@@ -82,10 +82,10 @@ gw-2
 
 . Run `setup.sh`
 +
-The installer upgrades {ControllerName} and {HubName} from 2.4 to {PlatformNameShort} 2.5.latest, {EDAName}, and the unified UI ({Gateway}) from the fresh install of 2.5 to the latest version of 2.5, and connects {ControllerName} and {HubName} properly with the unified UI ({Gateway}) node to initialize the unified experience. 
+The installer upgrades {ControllerName} and {HubName} from 2.4 to {PlatformNameShort} {PlatformVers}, latest {EDAName}, and the unified UI ({Gateway}) from the fresh install of 2.6 to the latest version of 2.6, and connects {ControllerName} and {HubName} properly with the unified UI ({Gateway}) node to initialize the unified experience. 
 
 .Verification
 
-* Verify that everything has upgraded to 2.5 and is working properly in one of two ways: 
+* Verify that everything has upgraded to 2.6 and is working properly in one of two ways: 
 ** Perform an SSH to {ControllerName} and {EDAName}.
-** In the unified UI, navigate to *Help > About* to verify the RPM versions are at 2.5.
+** In the unified UI, navigate to menu:Help[About] to verify the RPM versions are at 2.6.

--- a/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
+++ b/downstream/modules/platform/proc-upgrade-controller-hub-eda-unified-ui.adoc
@@ -9,11 +9,11 @@ Use this procedure if you have migration path for 2.4 instances with managed dat
 
 .Prerequisites
 
-* An inventory from 2.4 for {ControllerName} and {HubName} and a 2.5 inventory for unified UI ({Gateway}) and {EDAName}. You must run upgrades on 2.4 services (using the inventory file to specify only {ControllerName} and {HubName} VMs) to get them to the initial version of {PlatformNameShort} 2.5 first. When all the services are at the same version, run an upgrade (using a complete inventory file) on all the services to go to the latest version of {PlatformNameShort} 2.5.
+* An inventory from 2.4 for {ControllerName} and {HubName} and a 2.6 inventory for unified UI ({Gateway}) and {EDAName}. You must run upgrades on 2.4 services (using the inventory file to specify only {ControllerName} and {HubName} VMs) to get them to the initial version of {PlatformNameShort} {PlatformVers} first. When all the services are at the same version, run an upgrade (using a complete inventory file) on all the services to go to the latest version of {PlatformNameShort} {PlatformVers}.
 
 [IMPORTANT]
 ====
-DO NOT upgrade {EDAName} and the unified UI ({Gateway}) to the latest version of {PlatformNameShort} 2.5 without first upgrading the individual services ({ControllerName} and {HubName}) to the initial version of {PlatformNameShort} 2.5.
+DO NOT upgrade {EDAName} and the unified UI ({Gateway}) to the latest version of {PlatformNameShort} {PlatformVers} without first upgrading the individual services ({ControllerName} and {HubName}) to the initial version of {PlatformNameShort} {PlatformVers}.
 ====
 
 * Ensure you have upgraded to the latest version of {PlatformNameShort} 2.4 before upgrading your {PlatformName}.


### PR DESCRIPTION
This PR backports PR #4298 from main to AAP 2.6 branch. 

Changes made:
- Asciidoc conversion for RPM 2.6 upgrade guide updates.
- @jself-sudoku's update (JIRA https://issues.redhat.com/browse/AAP-50802).