### PR TITLE
Backport-2.6-4294 to AAP-50802 Create admonition stating gateway is the preferred path for AAP 2.6

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
+++ b/downstream/assemblies/eda/assembly-eda-user-guide-overview.adoc
@@ -29,6 +29,12 @@ The following procedures form the user configuration:
 * To meet high availability demands, {EDAcontroller} shares centralized link:https://redis.io/[Redis (REmote DIctionary Server)] with the {PlatformNameShort} UI. When Redis is unavailable, you will not be able to create or sync projects, or enable rulebook activations.
 ====
 
+[IMPORTANT]
+
+====
+In new installations of {PlatformNameShort} {PlatformVers}, using {EDAcontroller}'s API to manage organizations, teams, or users requires an automated sync of up to 15 minutes to propagate changes to the rest of the {PlatformNameShort} components. To avoid potential errors and ensure immediate access, use the {Gateway} API instead, or the unified UI.
+====
+
 [role="_additional-resources"]
 .Additional resources
 * link:{URLCentralAuth}/index[Access management and authentication guide]: 


### PR DESCRIPTION
Added admonition per requirement in AAP-50802. Focused strictly on Using automation decisions guide in the [overview chapter](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_decisions/index#eda-user-guide-overview). 

**Note:** 
Other instances of this note are placed in other guides (**Access management and authentication** and **RPM upgrade and migration**) by the owners of those docs in separate PRs.