### PR TITLE
2.6 Update Support matrix for upgrade scenarios (#4315)

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -504,7 +504,7 @@
 // titles/aap-migration
 :TitleMigration: Ansible Automation Platform migration
 :URLMigration: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/ansible_automation_platform_migration
-:LinkSaaSAWSGuide: link:{URLMigration}[{TitleMigration}]
+:LinkMigration: link:{URLMigration}[{TitleMigration}]
 //
 // Lightspeed branch titles/lightspeed-user-guide
 :TitleLightspeedUserGuide: Red Hat Ansible Lightspeed with IBM watsonx Code Assistant User Guide

--- a/downstream/modules/platform/ref-upgrade-scenarios-container.adoc
+++ b/downstream/modules/platform/ref-upgrade-scenarios-container.adoc
@@ -16,19 +16,19 @@ Use the following reference tables to find the supported upgrade paths for conta
 | Container-based {PlatformNameShort} 2.5 on RHEL 9 
 | Container-based {PlatformNameShort} 2.6 on RHEL 9 
 a| 
-. Upgrade your container deployment from 2.5 to 2.6.
+* link:{URLContainerizedInstall}/aap-containerized-installation#updating-containerized-ansible-automation-platform[Upgrade your container deployment] from 2.5 to 2.6.
 
 | Container-based {PlatformNameShort} 2.5 on RHEL 9 
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 a| 
-. Backup your container deployment 2.5 on a RHEL 9 environment, then restore to a RHEL 10 environment running a fresh container installation 2.5.
-. Upgrade your container deployment from 2.5 to 2.6.
+. link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backup your container deployment of 2.5] on a RHEL 9 environment, then restore to a RHEL 10 environment running a fresh container installation 2.5.
+. link:{URLContainerizedInstall}/aap-containerized-installation#updating-containerized-ansible-automation-platform[Upgrade your container deployment] from 2.5 to 2.6.
 
 | Container-based {PlatformNameShort} 2.5 on RHEL 9 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Upgrade your container deployment from 2.5 to 2.6.
-. Migrate your container deployment 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
+. link:{URLContainerizedInstall}/aap-containerized-installation#updating-containerized-ansible-automation-platform[Upgrade your container deployment] from 2.5 to 2.6.
+. link:{URLMigration}[Migrate your container deployment] 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
 |===
 
 == Container-based {PlatformNameShort} 2.5 on RHEL 10
@@ -40,13 +40,13 @@ a|
 | Container-based {PlatformNameShort} 2.5 on RHEL 10 
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 a| 
-. Upgrade your container deployment from 2.5 to 2.6.
+* link:{URLContainerizedInstall}/aap-containerized-installation#updating-containerized-ansible-automation-platform[Upgrade your container deployment] from 2.5 to 2.6.
 
 | Container-based {PlatformNameShort} 2.5 on RHEL 10 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Upgrade your container deployment from 2.5 to 2.6.
-. Migrate your container deployment 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
+. link:{URLContainerizedInstall}/aap-containerized-installation#updating-containerized-ansible-automation-platform[Upgrade your container deployment] from 2.5 to 2.6.
+. link:{URLMigration}[Migrate your container deployment] 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
 |===
 
 == Container-based {PlatformNameShort} 2.6 on RHEL 9
@@ -58,12 +58,12 @@ a|
 | Container-based {PlatformNameShort} 2.6 on RHEL 9 
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 a| 
-. Backup your deployment of container 2.6 on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
+* link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backup your deployment of container 2.6] on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
 
 | Container-based {PlatformNameShort} 2.6 on RHEL 9 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Migrate your container deployment 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
+* link:{URLMigration}[Migrate your container deployment] 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
 |===
 
 == Container-based {PlatformNameShort} 2.6 on RHEL 10
@@ -75,5 +75,5 @@ a|
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Migrate your container deployment 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
+* link:{URLMigration}[Migrate your container deployment] 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
 |===

--- a/downstream/modules/platform/ref-upgrade-scenarios-openshift.adoc
+++ b/downstream/modules/platform/ref-upgrade-scenarios-openshift.adoc
@@ -16,7 +16,7 @@ Use the following reference tables to find the supported upgrade paths for {Plat
 | {PlatformNameShort} on {OCPShort} 2.4 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Upgrade from {PlatformNameShort} on {OCPShort} 2.4 to 2.6.
+* link:{URLOperatorInstallation}/operator-upgrade_licensing-gw[Upgrade from {PlatformNameShort} on {OCPShort}] 2.4 to 2.6.
 |===
 
 == {PlatformNameShort} on {OCPShort} 2.5
@@ -28,7 +28,7 @@ a|
 | {PlatformNameShort} on {OCPShort} 2.5 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Upgrade from {PlatformNameShort} on {OCPShort} 2.5 to 2.6.
+* link:{URLOperatorInstallation}/operator-upgrade_licensing-gw[Upgrade from {PlatformNameShort} on {OCPShort}] 2.5 to 2.6.
 |===
 
 == {PlatformNameShort} on {OCPShort} 2.6
@@ -40,5 +40,5 @@ a|
 | {PlatformNameShort} on {OCPShort} 2.6 
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 a| 
-. Migrate {PlatformNameShort} on {OCPShort} 2.6 to container-based {PlatformNameShort} 2.6.
+* link:{URLMigration}[Migrate {PlatformNameShort} on {OCPShort}] 2.6 to container-based {PlatformNameShort} 2.6.
 |===

--- a/downstream/modules/platform/ref-upgrade-scenarios-rpm.adoc
+++ b/downstream/modules/platform/ref-upgrade-scenarios-rpm.adoc
@@ -16,30 +16,30 @@ Use the following reference tables to find the supported upgrade paths for RPM-b
 | RPM-based {PlatformNameShort} 2.4 on RHEL 8 
 | RPM-based {PlatformNameShort} 2.6 on RHEL 9 
 a| 
-. Backup your deployment of 2.4 RPM on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.4.
-. Upgrade your RPM deployment from 2.4 to 2.6.
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_administration_guide/controller-backup-and-restore[Backup your deployment of 2.4 RPM] on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.4.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.4 to 2.6.
 
 | RPM-based {PlatformNameShort} 2.4 on RHEL 8 
 | Container-based {PlatformNameShort} 2.6 on RHEL 9 
 a| 
-. Backup your deployment of 2.4 RPM on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.4.
-. Upgrade your RPM deployment from 2.4 to 2.6.
-. Migrate your RPM deployment 2.6 to a container deployment 2.6.
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_administration_guide/controller-backup-and-restore[Backup your deployment of 2.4 RPM] on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.4.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.4 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to a container deployment 2.6.
 
 | RPM-based {PlatformNameShort} 2.4 on RHEL 8 
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 a| 
-. Backup your deployment of 2.4 RPM on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.4.
-. Upgrade your RPM deployment from 2.4 to 2.6.
-. Migrate your RPM deployment 2.6 to a container deployment 2.6.
-. Backup your deployment of container 2.6 on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_administration_guide/controller-backup-and-restore[Backup your deployment of 2.4 RPM] on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.4.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.4 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to a container deployment 2.6.
+. link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backup your deployment of container 2.6] on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
 
 | RPM-based {PlatformNameShort} 2.4 on RHEL 8 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Backup your deployment of 2.4 RPM on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.4.
-. Upgrade your RPM deployment from 2.4 to 2.6.
-. Migrate your RPM deployment 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_administration_guide/controller-backup-and-restore[Backup your deployment of 2.4 RPM] on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.4.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.4 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
 |===
 
 == RPM-based {PlatformNameShort} 2.4 on RHEL 9
@@ -51,26 +51,26 @@ a|
 | RPM-based {PlatformNameShort} 2.4 on RHEL 9 
 | RPM-based {PlatformNameShort} 2.6 on RHEL 9 
 a| 
-. Upgrade your RPM deployment from 2.4 to 2.6.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.4 to 2.6.
 
 | RPM-based {PlatformNameShort} 2.4 on RHEL 9 
 | Container-based {PlatformNameShort} 2.6 on RHEL 9 
 a| 
-. Upgrade your RPM deployment from 2.4 to 2.6.
-. Migrate your RPM deployment 2.6 to a container deployment 2.6.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.4 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to a container deployment 2.6.
 
 | RPM-based {PlatformNameShort} 2.4 on RHEL 9 
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 a| 
-. Upgrade your RPM deployment from 2.4 to 2.6.
-. Migrate your RPM deployment 2.6 to a container deployment 2.6.
-. Backup your deployment of container 2.6 on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.4 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to a container deployment 2.6.
+. link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backup your deployment of container 2.6] on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
 
 | RPM-based {PlatformNameShort} 2.4 on RHEL 9 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Upgrade your RPM deployment from 2.4 to 2.6.
-. Migrate your RPM deployment 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.4 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
 |===
 
 == RPM-based {PlatformNameShort} 2.5 on RHEL 8
@@ -82,30 +82,30 @@ a|
 | RPM-based {PlatformNameShort} 2.5 on RHEL 8 
 | RPM-based {PlatformNameShort} 2.6 on RHEL 9 
 a| 
-. Backup your deployment of 2.5 RPM on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.5.
-. Upgrade your RPM deployment from 2.5 to 2.6.
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/assembly-platform-install-scenario#con-backup-aap_platform-install-scenario[Backup your deployment of 2.5 RPM] on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.5.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.5 to 2.6.
 
 | RPM-based {PlatformNameShort} 2.5 on RHEL 8 
 | Container-based {PlatformNameShort} 2.6 on RHEL 9 
 a| 
-. Backup your deployment of 2.5 RPM on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.5.
-. Upgrade your RPM deployment from 2.5 to 2.6.
-. Migrate your RPM deployment 2.6 to a container deployment 2.6.
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/assembly-platform-install-scenario#con-backup-aap_platform-install-scenario[Backup your deployment of 2.5 RPM] on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.5.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.5 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to a container deployment 2.6.
 
 | RPM-based {PlatformNameShort} 2.5 on RHEL 8 
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 a| 
-. Backup your deployment of 2.5 RPM on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.5.
-. Upgrade your RPM deployment from 2.5 to 2.6.
-. Migrate your RPM deployment 2.6 to a container deployment 2.6.
-. Backup your deployment of container 2.6 on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/assembly-platform-install-scenario#con-backup-aap_platform-install-scenario[Backup your deployment of 2.5 RPM] on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.5.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.5 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to a container deployment 2.6.
+. link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backup your deployment of container 2.6] on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
 
 | RPM-based {PlatformNameShort} 2.5 on RHEL 8 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Backup your deployment of 2.5 RPM on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.5.
-. Upgrade your RPM deployment from 2.5 to 2.6.
-. Migrate your RPM deployment 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
+. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_installation/assembly-platform-install-scenario#con-backup-aap_platform-install-scenario[Backup your deployment of 2.5 RPM] on RHEL 8, then restore to a RHEL 9 environment running a fresh installation of RPM 2.5.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.5 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
 |===
 
 == RPM-based {PlatformNameShort} 2.5 on RHEL 9
@@ -117,26 +117,26 @@ a|
 | RPM-based {PlatformNameShort} 2.5 on RHEL 9 
 | RPM-based {PlatformNameShort} 2.6 on RHEL 9 
 a| 
-. Upgrade your RPM deployment from 2.5 to 2.6.
+* link:{URLUpgrade}[Upgrade your RPM deployment] from 2.5 to 2.6.
 
 | RPM-based {PlatformNameShort} 2.5 on RHEL 9 
 | Container-based {PlatformNameShort} 2.6 on RHEL 9 
 a| 
-. Upgrade your RPM deployment from 2.5 to 2.6.
-. Migrate your RPM deployment 2.6 to a container deployment 2.6.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.5 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to a container deployment 2.6.
 
 | RPM-based {PlatformNameShort} 2.5 on RHEL 9 
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 a| 
-. Upgrade your RPM deployment from 2.5 to 2.6.
-. Migrate your RPM deployment 2.6 to a container deployment 2.6.
-. Backup your deployment of container 2.6 on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.5 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to a container deployment 2.6.
+. link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backup your deployment of container 2.6] on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
 
 | RPM-based {PlatformNameShort} 2.5 on RHEL 9 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Upgrade your RPM deployment from 2.5 to 2.6.
-. Migrate your RPM deployment 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
+. link:{URLUpgrade}[Upgrade your RPM deployment] from 2.5 to 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
 |===
 
 == RPM-based {PlatformNameShort} 2.6 on RHEL 9
@@ -148,11 +148,11 @@ a|
 | RPM-based {PlatformNameShort} 2.6 on RHEL 9 
 | Container-based {PlatformNameShort} 2.6 on RHEL 10 
 a| 
-. Migrate your RPM deployment 2.6 to a container deployment 2.6.
-. Backup your deployment of container 2.6 on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
+. link:{URLMigration}[Migrate your RPM deployment] 2.6 to a container deployment 2.6.
+. link:{URLContainerizedInstall}/aap-containerized-installation#backing-up-containerized-ansible-automation-platform[Backup your deployment of container 2.6] on RHEL 9, then restore to a RHEL 10 environment running a fresh container installation 2.6.
 
 | RPM-based {PlatformNameShort} 2.6 on RHEL 9 
 | {PlatformNameShort} on {OCPShort} 2.6 
 a| 
-. Migrate your RPM deployment 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
+* link:{URLMigration}[Migrate your RPM deployment] 2.6 to {PlatformNameShort} on {OCPShort} 2.6.
 |===


### PR DESCRIPTION
Backports #4315 from main to 2.6

* Update Support matrix for upgrade scenarios

Affected title: `planning-your-upgrade`

Update the Support matrix for upgrade scenarios "Process" column to include inline links to the relevant documentation

https://issues.redhat.com/browse/AAP-53516

* Updates based on peer review feedback