### PR TITLE
Backport PR #4313 from main to AAP 2.6 repo 

### DIFF
--- a/downstream/assemblies/platform/assembly-upgrade-api-changes.adoc
+++ b/downstream/assemblies/platform/assembly-upgrade-api-changes.adoc
@@ -2,5 +2,20 @@
 
 [id="upgrade-api-changes"]
 
-= API changes in 2.6
+= API changes in {PlatformNameShort} {PlatformVers}
 
+{PlatformNameShort} 2.5 and {PlatformVers} include changes to API endpoints with the addition of {Gateway}. Versions 2.5 and {PlatformVers} expose API access to individual services ({ControllerName}, {PrivateHubName}, {EDAName}) to maintain compatibility with existing REST API integrations. This access will be removed in a future release.
+
+These changes impact your organization if you have 2.4 API calls implemented directly with {ControllerName} or {PrivateHubName}, or if you are integrating directly with {ControllerName} or {PrivateHubName} hosts. You can use API endpoints exposed through the {Gateway} for all {PlatformNameShort} services starting with {PlatformNameShort} 2.5.  Moving integrations to API endpoints exposed through the {Gateway} that your integrations are not disrupted when direct service API access is removed in a future {PlatformNameShort} release.
+
+This section highlights the changed APIs between 2.4 and 2.5 or {PlatformVers}. For detailed API reference information, see the following sources:
+
+* For {Gateway} APIs, see the browsable API at `\https://<gateway server name>/api/gateway/v1`.
+* For {ControllerName} APIs, see the browsable API at `\https://<gateway server name>/api/controller/v2`.
+* For {HubName} APIs, see link:https://developers.redhat.com/api-catalog/api/automation-hub[Automation Hub API] in _API Catalog and Documentation_ to reference the 2.4 {HubName} API.
+* For {EDAName}, see the browsable API at `\https://<gateway server name>/api/eda/v1`.
+
+
+include::platform/ref-upgrade-api-general-changes.adoc[leveloffset=+1]
+
+include::platform/ref-upgrade-api-specific-changes.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-upgrade-data-movement.adoc
+++ b/downstream/assemblies/platform/assembly-upgrade-data-movement.adoc
@@ -26,6 +26,3 @@ include::platform/ref-upgrade-2.5-2.6-hub.adoc[leveloffset=+2]
 include::platform/ref-upgrade-2.5-2.6-eda.adoc[leveloffset=+2]
 
 include::platform/ref-upgrade-post-upgrade.adoc[leveloffset=+1]
-
-
-

--- a/downstream/modules/platform/ref-upgrade-api-general-changes.adoc
+++ b/downstream/modules/platform/ref-upgrade-api-general-changes.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="upgrade-api-general-changes"]
+
+= General changes
+
+[role="_abstract"]
+
+In {PlatformNameShort} 2.5 and later, API endpoints across components changed with the addition of {Gateway}. 
+
+[cols="1,1,1,1"]
+|===
+| Component | 2.4 and earlier endpoints start with… | 2.5 and later endpoints start with… | Notes
+
+| {ControllerNameStart} | `/api/v2/` | `/api/controller/v2/` |
+| {HubNameStart} | `/api/automation-hub` | `/api/galaxy/v1` | This is the default path, but this path can be changed. For example: `\https://<local_hub_URL>/api/`
+| {GatewayStart} | Not applicable | `/api/gateway/v1/` |
+| {EDAName} | Not applicable | `/api/eda/v1/` |
+|===
+

--- a/downstream/modules/platform/ref-upgrade-api-specific-changes.adoc
+++ b/downstream/modules/platform/ref-upgrade-api-specific-changes.adoc
@@ -1,0 +1,118 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="upgrade-api-specific-changes"]
+
+= Specific API changes
+
+[role="_abstract"]
+
+Specific API mappings for functionality that was centralized through the {Gateway} are listed in the following table.
+
+[cols="1,1,1,1"]
+|===
+| Component | 2.4 and earlier endpoints start with… | 2.5 and 2.6 API endpoints | Action needed and notes
+
+| {ControllerNameStart} | `/api/v2/o` | `/api/gateway/v1/tokens/` | Token authentication has moved to the {Gateway}. 
+
+The 2.4 API endpoint is deprecated; it still works in 2.6, but it will not work in a future release.
+
+| {ControllerNameStart} | `/api/v2/organizations` | `/api/gateway/v1/organizations/` | Moved to the {Gateway}. 
+
+The 2.4 API endpoint is deprecated; it still works in 2.6, but it will not work in a future release.
+
+| {ControllerNameStart} | `/api/v2/teams` | `/api/gateway/v1/teams/` | Moved to the {Gateway}. 
+
+The 2.4 API endpoint is deprecated; it still works in 2.6, but it will not work in a future release.
+
+| {ControllerNameStart} | `/api/v2/users` | `/api/gateway/v1/users/` | Moved to the {Gateway}. 
+
+The 2.4 API endpoint is deprecated; it still works in 2.6, but it will not work in a future release.
+
+| {ControllerNameStart} | `/api/v2/roles` | `/api/gateway/v1/role_definitions/` | Moved to the {Gateway}. This is a list of roles. In {PlatformNameShort} 2.6, this is a list of roles which can apply to all services, and includes custom roles. 
+
+The 2.4 API endpoint is only a listing. It still works in 2.6, but it will not work in a future release. 
+
+| {ControllerNameStart}
+a|
+* `/api/v2/roles/{id}/teams/`
+* `/api/gateway/v1/role_definitions/` 
+
+a|
+* `/api/gateway/v1/role_team_assignments/`
+* `/api/gateway/v1/role_user_assignments/` 
+
+| A POST request gives a user a role to a resource. This is how to give user permissions. 
+
+The 2.4 API endpoint is only a listing. It still works in 2.6, but it will not work in a future release. 
+
+| {ControllerNameStart}
+a|
+The following roles list:
+
+* `/api/v2/teams/{id}/roles/`
+* `/api/v2/users/{id}/roles/` 
+
+a|
+* `/api/gateway/v1/role_team_assignments/?team={id}`
+* `/api/gateway/v1/role_user_assignments/?user={id}` 
+
+| List user and team permissions, and give new permissions. 
+
+The 2.4 API endpoint is only a listing. It still works in 2.6, but it will not work in a future release. 
+
+| {ControllerNameStart}
+a|
+The following object roles list:
+
+`/api/v2/{model_name}/{id}/object_roles/`
+
+Example: 
+`/api/v2/credentials/42/` 
+
+a|
+`/api/gateway/v1/role_user_assignments/?content_type__api_slug={model_api_slug}&object_id={id}`
+
+Example: 
+`/api/gateway/v1/role_user_assignments/?content_type__api_slug=awx.credential&object_id=42` 
+
+| List the roles that apply to a resource. 
+
+| {ControllerNameStart}
+a|
+The following resource access list:
+
+`/api/v2/{model_name}/{id}/access_list/`
+
+Example: 
+`/api/v2/credentials/42/access_list/` 
+
+a|
+
+Replacement in 2.6:
+`/api/gateway/v1/role_user_access/{model_api_slug}/{id}/`
+
+Example: 
+`/api/gateway/v1/role_user_access/awx.credential/42/` 
+
+| List the users who have access to a resource.
+
+| {HubNameStart} | `/api/v3/login/keycloak` | `/api/gateway/social/complete/<UID>/` | Moved to the {Gateway}. 
+
+| {HubNameStart} | `/api/v3/auth/token` | `/api/gateway/v1/tokens/` | Token authentication used for pulling collections will migrate to the {Gateway} tokens. 
+
+| {EDAName} | N/A | `/api/gateway/v1/organizations/` | No action needed, as upgrades from 2.4 are not supported. 
+
+| {EDAName} | `/api/v1/teams` | `/api/gateway/v1/teams/` | No action needed, as upgrades from 2.4 are not supported. 
+
+| {EDAName} | `/api/v1/users` | `/api/gateway/v1/users/` | No action needed, as upgrades from 2.4 are not supported.
+
+| {EDAName} | N/A 
+a| 
+* `/api/gateway/v1/role_definitions/`
+* `/api/gateway/v1/role_team_assignments/`
+* `/api/gateway/v1/role_user_assignments/` 
+
+| New role capabilities included as part of the {Gateway} API.
+
+|===
+

--- a/downstream/modules/platform/ref-upgrade-post-upgrade.adoc
+++ b/downstream/modules/platform/ref-upgrade-post-upgrade.adoc
@@ -34,4 +34,4 @@ Request a password reset from your administrator. When you log in with your new 
 Log in with your {ControllerName} username and password; your previous two accounts will be merged and you are now a gateway normal user.
 | An {HubName} user with SSO (no {ControllerName} account) |
 Log in with your SSO credentials; you are now a gateway normal user. 
-
+|====

--- a/downstream/titles/planning-your-upgrade/master.adoc
+++ b/downstream/titles/planning-your-upgrade/master.adoc
@@ -9,7 +9,7 @@ include::attributes/attributes.adoc[]
 // Book Title
 = Planning your upgrade
 
-Use this guide to upgrade from Ansible Automation Platform 2.4 to 2.6. 
+Use this guide to upgrade from {PlatformNameShort} 2.4 to {PlatformVers}. 
 This documentation covers new infrastructure requirements, details how to handle user and authentication data, and provides guidance on various deployment scenarios to help you successfully plan your upgrade.
 
 include::{Boilerplate}[] 


### PR DESCRIPTION
This PR backports Pr #4313 from main to AAP 2.6 repo.

Changes made:
Asciidoc conversion of 'API changes in AAP 2.6' chapter in the new 'Planning your upgrade' guide.