### PR TITLE
2.6 backport: AAP-45618: creates and populates procedure module for verifying user migration

### DIFF
--- a/downstream/modules/platform/proc-verify-user-migration.adoc
+++ b/downstream/modules/platform/proc-verify-user-migration.adoc
@@ -1,0 +1,27 @@
+:_newdoc-version: 2.18.5
+:_template-generated: 2025-08-06
+:_mod-docs-content-type: PROCEDURE
+
+[id="verify-user-migration_{context}"]
+= Verify user migration
+
+During the upgrade to {PlatformNameShort} {PlatformVers}, controller user accounts are converted into platform user accounts. Controller administrators retain their administrative privileges, but they are converted into platform administrator privileges. 
+
+Other controller accounts become platform users, and their existing permissions are mapped over appropriately after an initial password reset. Users with existing accounts associated with other components (like {PrivateHubName} and {EDAName}) must have their passwords reset by their administrator before they can log in.
+
+Authenticator configurations are automatically migrated. SSO and LDAP accounts do not require any manual migration steps, including password resets, with the exception of accounts that use a certificate from the trust store. See [LINK NEEDED] for more information on migrating authentication configurations that use a custom certificate.
+
+After your upgrade to {PlatformNameShort} {PlatformVers} is complete, verify that you can log in to the upgraded platform.
+
+
+.Procedure
+
+If you have a controller account that has been converted to a {Gateway} account for {PlatformNameShort} {PlatformVers}:
+
+* Log into your upgraded platform instance with your controller credentials.
+
+If you have a component-level account (such as an account associated with {PrivateHubName} or {EDAName}):
+
+* Request a password reset from your adminstrator and log into the upgraded platform with your new password.
+
+


### PR DESCRIPTION
This PR ports the changes from [PR 4009](https://github.com/ansible/aap-docs/pull/4009) to the 2.6 branch. This work is being tracked in [AAP-45618](https://issues.redhat.com/browse/AAP-45618)