### PR TITLE
Removing incorrect verbiage as per AAP-49903

### DIFF
--- a/downstream/modules/platform/con-storage-options-for-operator-installation-on-ocp.adoc
+++ b/downstream/modules/platform/con-storage-options-for-operator-installation-on-ocp.adoc
@@ -3,14 +3,14 @@
 [id="con-storage-options-for-operator-installation-on-ocp_{context}"]
 = Storage options for {OperatorPlatformNameShort} installation on {OCP}
 
-{HubNameStart} requires `ReadWriteMany` file-based storage, Azure Blob storage, or Amazon S3-compliant storage for operation so that multiple pods can access shared content, such as collections.
+{HubNameStart} requires `ReadWriteMany` file-based storage, Azure Blob storage, or Amazon S3 storage for operation so that multiple pods can access shared content, such as collections.
 
 The process for configuring object storage on the `AutomationHub` CR is similar for Amazon S3 and Azure Blob Storage.
 
 If you are using file-based storage and your installation scenario includes {HubName}, ensure that the storage option for {OperatorPlatformNameShort} is set to `ReadWriteMany`.
 `ReadWriteMany` is the default storage option.
 
-In addition, {ODFShort} provides a `ReadWriteMany` or S3-compliant implementation. Also, you can set up NFS storage configuration to support `ReadWriteMany`. This, however, introduces the NFS server as a potential, single point of failure.
+In addition, {ODFShort} provides a `ReadWriteMany` or S3 implementation. Also, you can set up NFS storage configuration to support `ReadWriteMany`. This, however, introduces the NFS server as a potential, single point of failure.
 
 
 [role="_additional-resources"]


### PR DESCRIPTION
[AAP-49903](https://issues.redhat.com/browse/AAP-49903)
Documentation for S3 compatible buckets does not fully document available options

Just updating wording to be more accurate with what is documented in hub docs. 