### PR TITLE
AAP-51597 edits

### DIFF
--- a/downstream/modules/platform/proc-operator-deploy-redis.adoc
+++ b/downstream/modules/platform/proc-operator-deploy-redis.adoc
@@ -2,13 +2,18 @@
 
 [id="operator-deploy-redis"]
 
-= Deploying clustered Redis on {OperatorPlatformName}
+= Deploying Redis on {OperatorPlatformName}
 
 When you create an {PlatformNameShort} instance through the {OperatorPlatformNameShort}, standalone Redis is assigned by default. 
-To deploy clustered Redis, use the following procedure.
+If you would prefer to deploy clustered Redis, you can use the following procedure.
 
-//Add a link to the section when ready
 For more information about Redis, refer to Caching and queueing system in the _Planning your installation_ guide.
+
+[IMPORTANT]
+====
+Switching Redis modes on an existing instance is not supported and can lead to unexpected consequences, including data loss. 
+To change the Redis mode, you must deploy a new instance.
+====
 
 .Prerequisites
 * You have installed an {OperatorPlatformNameShort} deployment.


### PR DESCRIPTION
[AAP-51597](https://issues.redhat.com/browse/AAP-51597)
Section explaining the switch from clustered Redis mode to standalone Redis mode in an operator-based installation