### PR TITLE
2.4.20250924 async release notes

### DIFF
--- a/downstream/titles/release-notes/master.adoc
+++ b/downstream/titles/release-notes/master.adoc
@@ -24,6 +24,9 @@ include::topics/docs-24.adoc[leveloffset=+1]
 // == Asynchronous updates
 include::topics/async-updates.adoc[leveloffset=+1]
 
+//Async 2.4.20250924
+include::topics/async-24-20250924.adoc[leveloffset=+2]
+
 //Async 2.4.20250827
 include::topics/async-24-20250827.adoc[leveloffset=+2]
 

--- a/downstream/titles/release-notes/topics/async-24-20250924.adoc
+++ b/downstream/titles/release-notes/topics/async-24-20250924.adoc
@@ -1,0 +1,30 @@
+[id="async-24-20250924"]
+
+= {PlatformNameShort} patch release September 24, 2025
+
+The following enhancements and bug fixes have been implemented in this release of {PlatformNameShort}.
+
+[cols="1a,3a", options="header"]
+|===
+| Release date | Component versions
+
+| September 24, 2025  | 
+* {ControllerNameStart} 4.5.25
+* {EDAcontroller} 1.0.7
+* {HubNameStart} 4.9.5
+* {LightspeedShortName} 2.4.250225
+* {PlatformNameShort}-collection installer (online) 2.4-13
+* {PlatformNameShort}-collection installer (bundle) 2.4-13.3
+* Receptor 1.5.7
+|===
+
+CSV Versions in this release:
+
+* Namespace-scoped Bundle: aap-operator.v2.4.0-0.1758079821
+* Cluster-scoped Bundle: aap-operator.v2.4.0-0.1758080293
+
+== CVE
+
+With this update, the following CVEs have been addressed:
+
+* link:https://access.redhat.com/security/cve/CVE-2025-57833[CVE-2025-57833] `python3x-django`: Django SQL injection in `FilteredRelation` column aliases.


### PR DESCRIPTION
No backports required - direct to 2.4

AAP 2.4 (20250924) Async Release - Update Async Release Notes

https://issues.redhat.com/browse/AAP-52966