### PR TITLE
Removing legacy auth step from Access Management

### DIFF
--- a/downstream/assemblies/platform/assembly-gw-token-based-authentication.adoc
+++ b/downstream/assemblies/platform/assembly-gw-token-based-authentication.adoc
@@ -54,6 +54,8 @@ include::platform/ref-controller-clear-tokens.adoc[leveloffset=+3]
 
 include::platform/ref-controller-clear-sessions.adoc[leveloffset=+3]
 
+include::platform/con-gw-pat-migration.adoc[leveloffset=+2]
+
 include::platform/con-gw-manage-oauth2-external-users.adoc[leveloffset=+1]
 
 include::platform/proc-gw-enable-oauth2-external-users.adoc[leveloffset=+2]

--- a/downstream/modules/platform/con-gw-pat-migration.adoc
+++ b/downstream/modules/platform/con-gw-pat-migration.adoc
@@ -7,7 +7,7 @@
 After upgrading to {PlatformNameShort} 2.6, Personal Access Tokens (PATs) from a 2.4 {ControllerName} remain functional. 
 They are visible in the {Gateway} UI and you can use them with both {ControllerName} and {Gateway} APIs.
 
-*Managing automation controller tokens*
+*Managing {ControllerName} tokens*
 
 After the upgrade, you can perform the following actions with your {ControllerName} tokens:
 

--- a/downstream/modules/platform/con-gw-pat-migration.adoc
+++ b/downstream/modules/platform/con-gw-pat-migration.adoc
@@ -4,7 +4,7 @@
 
 = Personal Access Token migration
 
-After upgrading to {PlatformNameShort} 2.6, Personal Access Tokens (PATs) from a 2.4 {ControllerName} remain functional. 
+After upgrading to {PlatformNameShort} {PlatformVers}, Personal Access Tokens (PATs) from a 2.4 {ControllerName} remain functional. 
 They are visible in the {Gateway} UI and you can use them with both {ControllerName} and {Gateway} APIs.
 
 *Managing {ControllerName} tokens*
@@ -15,4 +15,4 @@ After the upgrade, you can perform the following actions with your {ControllerNa
 * *{ControllerNameStart}* API: You can create, edit, delete, or refresh the tokens.
 
 Tokens are labeled in the UI to indicate if they are {ControllerName} only or {Gateway}. 
-{GatewayStart} tokens are unaffected by these requirements, other than being rendered in the UI with a "platform" type.
+{GatewayStart} tokens are unaffected by these requirements, other than being rendered in the UI with a *platform* type.

--- a/downstream/modules/platform/con-gw-pat-migration.adoc
+++ b/downstream/modules/platform/con-gw-pat-migration.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="gw-pat-migration"]
+
+= Personal Access Token migration
+
+After upgrading to {PlatformNameShort} 2.6, Personal Access Tokens (PATs) from a 2.4 {ControllerName} remain functional. 
+They are visible in the {Gateway} UI and you can use them with both {ControllerName} and {Gateway} APIs.
+
+*Managing automation controller tokens*
+
+After the upgrade, you can perform the following actions with your {ControllerName} tokens:
+
+* *{GatewayStart} UI*: You can edit or delete the tokens, but you cannot create or refresh them.
+* *{ControllerNameStart}* API: You can create, edit, delete, or refresh the tokens.
+
+Tokens are labeled in the UI to indicate if they are {ControllerName} only or {Gateway}. 
+{GatewayStart} tokens are unaffected by these requirements, other than being rendered in the UI with a "platform" type.

--- a/downstream/modules/platform/proc-controller-github-enterprise-org-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-enterprise-org-settings.adoc
@@ -17,9 +17,9 @@ Each key and secret must belong to a unique application and cannot be shared or 
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *GitHub enterprise organization* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
 .. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 

--- a/downstream/modules/platform/proc-controller-github-enterprise-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-enterprise-settings.adoc
@@ -17,9 +17,9 @@ Each key and secret must belong to a unique application and cannot be shared or 
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *GitHub enterprise* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
 .. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 

--- a/downstream/modules/platform/proc-controller-github-enterprise-team-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-enterprise-team-settings.adoc
@@ -21,9 +21,9 @@ The OAuth2key (Client ID) and secret (Client Secret) are used to supply the requ
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *GitHub enterprise team* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
 .. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 

--- a/downstream/modules/platform/proc-controller-github-organization-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-organization-settings.adoc
@@ -17,9 +17,9 @@ The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the req
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *GitHub organization* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
 .. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 

--- a/downstream/modules/platform/proc-controller-github-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-settings.adoc
@@ -14,9 +14,9 @@ The OAuth2 key (Client ID) and secret (Client Secret) are used to supply the req
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *GitHub* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
 .. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 

--- a/downstream/modules/platform/proc-controller-github-team-settings.adoc
+++ b/downstream/modules/platform/proc-controller-github-team-settings.adoc
@@ -16,9 +16,9 @@ Each key and secret must belong to a unique application and cannot be shared or 
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *GitHub team* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . When the application is registered, GitHub displays the *Client ID* and *Client Secret*:
 +
 .. Copy and paste the GitHub Client ID into the GitHub OAuth2 Key field. 

--- a/downstream/modules/platform/proc-controller-google-oauth2-settings.adoc
+++ b/downstream/modules/platform/proc-controller-google-oauth2-settings.adoc
@@ -16,9 +16,9 @@ If you have already completed the setup process, you can access those credential
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *Google OAuth* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . The *Google OAuth2 Key* and *Google OAuth2 Secret* fields are pre-populated. 
 +
 If not, use the credentials Google supplied during the web application setup process. Save these settings for use in the following steps.
@@ -39,7 +39,7 @@ include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
 +
 include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
 +
-Click btn:[Create Authentication Method].
+. Click btn:[Create Authentication Method].
 
 include::snippets/snip-gw-authentication-verification.adoc[]
 

--- a/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
@@ -35,9 +35,9 @@ If you used a custom certificate in 2.5 for LDAP you need to migrate that as wel
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *LDAP* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
++
 //include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
 . In the *LDAP Server URI* field, enter or modify the list of LDAP servers to which you want to connect. This field supports multiple addresses.
 . In the *LDAP Bind DN text* field, enter the Distinguished Name (DN) to specify the user that the {PlatformNameShort} uses to connect to the LDAP server as shown in the following example:
 +

--- a/downstream/modules/platform/proc-controller-set-up-SAML.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-SAML.adoc
@@ -31,9 +31,9 @@ $ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days
 . Click btn:[Create authentication].
 . Enter a *Name* for this SAML configuration. 
 . Select *SAML* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . Enter the application-defined unique identifier used as the audience of the SAML service provider configuration in the *SAML Service Provider Entity ID* field. This is usually the base URL of your service provider, but the actual value depends on the Entity ID expected by your IdP.
 . Include the certificate content in the *SAML Service Provider Public Certificate* field. This information is contained in the cert.pem you created as a prerequisite and must include the `—–BEGIN CERTIFICATE—–` and `—–END CERTIFICATE—–`.
 . Include the private key content in the *SAML Service Provider Private Key* field. This information is contained in the key.pem you created as a prerequisite and must include the `—–BEGIN PRIVATE KEY—–` and `—–END PRIVATE KEY—–`.
@@ -146,7 +146,7 @@ Make sure you include all relevant values so that everything gets mapped correct
 include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
 +
 . Click btn:[Create Authentication Method].
-
++
 [IMPORTANT]
 ====
 You can configure an HTTPS redirect for SAML in operator-based deployments to simplify login for your users. For the steps to configure this setting, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_on_openshift_container_platform/index#proc-operator-enable-https-redirect[Enabling single sign-on (SSO) for {Gateway} on {OCPShort}].

--- a/downstream/modules/platform/proc-controller-set-up-generic-oidc.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-generic-oidc.adoc
@@ -12,9 +12,9 @@ OpenID Connect (OIDC) uses the OAuth 2.0 framework. It enables third-party appli
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *Generic OIDC* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . Enter the following information:
 +
 * *OIDC Provider URL*: The URL for your OIDC provider.

--- a/downstream/modules/platform/proc-controller-set-up-radius.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-radius.adoc
@@ -12,9 +12,9 @@ You can configure {PlatformNameShort} to centrally use RADIUS as a source for au
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *Radius* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . Enter the host or IP of the RADIUS server in the *RADIUS Server* field. If you leave this field blank, RADIUS authentication is disabled.
 . Enter the *Shared secret for authenticating to RADIUS server*.
 +

--- a/downstream/modules/platform/proc-controller-set-up-tacacs+.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-tacacs+.adoc
@@ -17,9 +17,9 @@ This feature is deprecated and will be removed in a future release.
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *TACACS+* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . Enter the following information:
 +
 * Hostname of TACACS+ Server: Provide the hostname or IP address of the TACACS+ server with which to authenticate. If you leave this field blank, TACACS+ authentication is disabled.

--- a/downstream/modules/platform/proc-controller-set-up-tacacs+.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-tacacs+.adoc
@@ -31,7 +31,7 @@ include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
 +
 include::snippets/snip-gw-authentication-common-checkboxes.adoc[]
 +
-Click btn:[Create Authentication Method].
+. Click btn:[Create Authentication Method].
 
 [role="_additional-resources"]
 .Next steps

--- a/downstream/modules/platform/proc-gw-config-keycloak-settings.adoc
+++ b/downstream/modules/platform/proc-gw-config-keycloak-settings.adoc
@@ -17,9 +17,9 @@ When using this authenticator some specific setup in your Keycloak instance is r
 . Click btn:[Create authentication].
 . Enter a *Name* for this authentication configuration. 
 . Select *Keycloak* from the *Authentication type* list. The *Authentication details* section automatically updates to show the fields relevant to the selected authentication type.
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
-
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
 . Enter the location where the user's token can be retrieved in the *Keycloak Access Token URL* field.
 . Optional: Enter the redirect location the user is taken to during the login flow in the *Keycloak Provider URL* field. 
 . Enter the Client ID from your Keycloak installation in the *Keycloak OIDC Key* field.

--- a/downstream/modules/platform/proc-gw-local-authentication.adoc
+++ b/downstream/modules/platform/proc-gw-local-authentication.adoc
@@ -17,8 +17,8 @@ A local authenticator is automatically created by the {PlatformNameShort} instal
 . Click btn:[Create authentication].
 . Enter a *Name* for this Local configuration. The configuration name is required, must be unique across all authenticators, and must not be longer than 512 characters.
 . Select *Local* from the *Authentication type* list. 
-
-include::snippets/snip-gw-authentication-auto-migrate.adoc[]
++
+//include::snippets/snip-gw-authentication-auto-migrate.adoc[]
 +
 include::snippets/snip-gw-authentication-additional-auth-fields.adoc[]
 +


### PR DESCRIPTION
[DOCS] 2.6 - Remove legacy auth step from auth type procedures

https://issues.redhat.com/browse/AAP-53902

Affects `titles/central-auth`