### PR TITLE
OCP 2.6 edits for 2.4 to 2.5 legacy

### DIFF
--- a/downstream/modules/platform/proc-operator-upgrade.adoc
+++ b/downstream/modules/platform/proc-operator-upgrade.adoc
@@ -9,6 +9,8 @@ To upgrade to the latest version of {OperatorPlatformNameShort} on {OCPShort}, y
 [NOTE]
 ====
 If you are on version 2.4, it is recommended to skip 2.5 and upgrade straight to version {PlatformVers}. 
+
+If you upgraded from 2.4 to 2.5, you must migrate your authentication methods and users before upgrading to 2.6 as that legacy authenticator functionality was removed.
 ====
 
 .Prerequisites 


### PR DESCRIPTION
[AAP-49196](https://issues.redhat.com/browse/AAP-49196)
[2.6] Update OCP upgrade information for AAP 2.6

Adding a last minute edit on legacy upgrades:

"If you upgraded from 2.4 to 2.5, you must migrate your authentication methods and users before upgrading to 2.6 as that legacy authenticator functionality was removed."