### PR TITLE
AAP-54033: Fix broken links

### DIFF
--- a/downstream/modules/terraform-aap/proc-terraform-building-execution-environment.adoc
+++ b/downstream/modules/terraform-aap/proc-terraform-building-execution-environment.adoc
@@ -32,5 +32,5 @@ image::ee-create-new.png[Create a new {ExecEnvShort} page]
 
 * link:https://developer.hashicorp.com/terraform/install[`terraform` CLI binary]
 * link:https://catalog.redhat.com/search?gs&q=execution%20environments&searchType=containers[Red Hat ecosystem catalog]
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_execution/assembly-controller-execution-environments#proc-controller-use-an-exec-envi[Execution environments]
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/creating_and_using_execution_environments/index[Creating and using {ExecEnvShort}s]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution/assembly-controller-execution-environments#proc-controller-use-an-exec-envi[Execution environments]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{PlatformVers}/html-single/creating_and_using_execution_environments/index[Creating and using {ExecEnvShort}s]

--- a/downstream/modules/terraform-aap/proc-terraform-creating-launching-job-template.adoc
+++ b/downstream/modules/terraform-aap/proc-terraform-creating-launching-job-template.adoc
@@ -23,6 +23,6 @@ To see that the job has run successfully from the {Terraform} user interface, se
 
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_execution/assembly-controller-execution-environments#proc-controller-use-an-exec-env[Adding an {ExecEnvShort} to a job template]
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/configuring_automation_execution/index[Configuring automation execution]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_execution/assembly-controller-execution-environments#proc-controller-use-an-exec-env[Adding an {ExecEnvShort} to a job template]
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{PlatformVers}/html/configuring_automation_execution/index[Configuring automation execution]
 * link:https://developer.hashicorp.com/terraform/enterprise[Hashicorp {TerraformEnterpriseShortName} documentation]

--- a/downstream/modules/terraform-aap/proc-terraform-migrating-from-community.adoc
+++ b/downstream/modules/terraform-aap/proc-terraform-migrating-from-community.adoc
@@ -39,9 +39,9 @@ You can add the workspace to your playbook to scale your workspace utilization.
 ====
 +
 . From the {PlatformNameShort} user interface:
-.. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/getting_started_with_terraform_and_ansible_automation_platform/terraform-integrating-from-aap#terraform-creating-credential[Create a credential].
-.. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/getting_started_with_terraform_and_ansible_automation_platform/terraform-integrating-from-aap#terraform-building-execution-environment[Build an {ExecEnvShort}].
-.. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/getting_started_with_terraform_and_ansible_automation_platform/terraform-integrating-from-aap#terraform-creating-launching-job-template[Create and launch a job template].
+.. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_terraform_and_ansible_automation_platform/terraform-integrating-from-aap#terraform-creating-credential[Create a credential].
+.. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_terraform_and_ansible_automation_platform/terraform-integrating-from-aap#terraform-building-execution-environment[Build an {ExecEnvShort}].
+.. link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{PlatformVers}/html/getting_started_with_terraform_and_ansible_automation_platform/terraform-integrating-from-aap#terraform-creating-launching-job-template[Create and launch a job template].
 
 . (Optional) After the migration is completed and verified, you can run the additional modules and plugins from the collection in your {ExecEnvShort}:
 

--- a/downstream/modules/vault-aap/con-vault-intro.adoc
+++ b/downstream/modules/vault-aap/con-vault-intro.adoc
@@ -8,7 +8,8 @@
 
 {Vault} lets you centrally store and manage secrets securely. The {PlatformNameShort} certified `hashicorp.vault` collection provides fully automated Key/Value V2 (KV2) secret lifecycle management for {Vault}. You can create, update, and delete secrets through playbooks.
 
-* **Existing `community.hashi_vault` users:** The `hashicorp.vault` solution is intended to replace unsupported `community.hashi_vault` collection. Use the migration path to keep your existing playbooks. For more information about migrating, see link:{URLHashiGuide}/vault-migrating-from-community-hashi-vault[Migrating from `community.hashi_vault`].
+* **Existing `community.hashi_vault` users:** The `hashicorp.vault` solution is intended to replace unsupported `community.hashi_vault` collection. Use the migration path to keep your existing playbooks. For more information about migrating, see
+link:{URLHashiGuide}/vault-product#vault-migrating-from-community-hashi-vault[Migrating from `community.hashi_vault`].
 
 * **New {Vault} users:** The `hashicorp.vault` collection is included in the supported execution environment from {HubName}.
 

--- a/downstream/modules/vault-aap/proc-vault-configuring-kv2-secret-get-lookup.adoc
+++ b/downstream/modules/vault-aap/proc-vault-configuring-kv2-secret-get-lookup.adoc
@@ -15,7 +15,7 @@ The corresponding `community.hashi_vault` modules are:
 
 .Procedure
 
-. Replicate the `community.hashi_vault` modules to the following `hashicorp.vault.kv2_secret_get` parameters. For examples, see link:{URLHashiGuide}/vault-migrating-from-community-hashi-vault#vault-migration-examples-secret-get-lookup[Migration examples for the `hashicorp.vault.kv2_secret_get` lookup plugin].
+. Replicate the `community.hashi_vault` modules to the following `hashicorp.vault.kv2_secret_get` parameters. For examples, see link:{URLHashiGuide}/vault-product#vault-migration-examples-secret-get-lookup[Migration examples for the `hashicorp.vault.kv2_secret_get` lookup plugin].
 +
 ----
 auth_method:
@@ -69,4 +69,4 @@ version:
 * **`version`:** Maps identically to `version` in the `community.hashi_vault.hashi_vault` modules.
 
 .Next step
-* link:{URLHashiGuide}/vault-authenticating#vault-creating-a-credential-type[Creating a credential type]
+* link:{URLHashiGuide}/vault-product#vault-creating-a-credential-type[Creating a credential type]

--- a/downstream/modules/vault-aap/proc-vault-configuring-kv2-secret.adoc
+++ b/downstream/modules/vault-aap/proc-vault-configuring-kv2-secret.adoc
@@ -19,7 +19,7 @@ The corresponding `community.hashi_vault` modules are:
 
 .Procedure
 
-. Replicate your automation tasks from both of the `community.hashi_vault` modules to the following `hashicorp.vault.kv2_secret` parameters.  The `hashicorp.vault.kv2_secret` parameters are similar to `community.hashi_vault`. For examples, see link:{URLHashiGuide}/vault-migrating-from-community-hashi-vault#vault-migration-examples-secret-module[Migration examples for the `hashicorp.vault.kv2_secret` module].
+. Replicate your automation tasks from both of the `community.hashi_vault` modules to the following `hashicorp.vault.kv2_secret` parameters.  The `hashicorp.vault.kv2_secret` parameters are similar to `community.hashi_vault`. For examples, see link:{URLHashiGuide}/vault-product#vault-migration-examples-secret-module[Migration examples for the `hashicorp.vault.kv2_secret` module].
 +
 ----
 auth_method:
@@ -84,4 +84,4 @@ state:
 
 .Next step
 
-* link:{URLHashiGuide}/vault-migrating-from-community-hashi-vault#vault-configuring-kv2-secret-get-lookup[Configuring the `hashicorp.vault.kv2_secret_get` lookup plugin].
+* link:{URLHashiGuide}/vault-product#vault-configuring-kv2-secret-get-lookup[Configuring the `hashicorp.vault.kv2_secret_get` lookup plugin].

--- a/downstream/modules/vault-aap/proc-vault-creating-credential-type.adoc
+++ b/downstream/modules/vault-aap/proc-vault-creating-credential-type.adoc
@@ -15,7 +15,7 @@ You can configure role-based (appRole) authentication or allow users to directly
 Do _one_ of the following:
 
 * **New users:** Install the {PlatformNameShort} certified `hashicorp.vault` collection from link:https://www.redhat.com/en/technologies/management/ansible/automation-hub[{HubNameStart}].
-* **`community.hashi_vault` collection users:** Migrate from `community.hashi_vault`. For more information, see link:{URLHashiGuide}/vault-migrating-from-community-hashi-vault[Migrating from `community.hashi_vault`].
+* **`community.hashi_vault` collection users:** Migrate from `community.hashi_vault`. For more information, see link:{URLHashiGuide}/vault-product#vault-migrating-from-community-hashi-vault[Migrating from `community.hashi_vault`].
 
 .Procedure
 
@@ -68,7 +68,7 @@ env:
 
 .Next step
 
-* link:{URLHashiGuide}/vault-authenticating#vault-creating-custom-credential[Creating a custom credential]
+* link:{URLHashiGuide}/vault-product#vault-creating-custom-credential[Creating a custom credential]
 
 .Additional resources
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAP-54033

After talking with Aine about how to fix them. The links won't work if you try to publish from main, but this is what's been done:

- For Vault: I needed to add vault-product# in front of the topic ID, so the format is:

 `link:{URLHashiGuide}/vault-product#<topidId>[<topicName>]`

- For Terraform: Replaced hardcoded 2.5 in the link to `{PlatformVers}

Please let me know if you have questions. I'll be able to test the links after I backport these changes to 2.5 and 2.6 branches.