### PR TITLE
2.6 backport: AAP-52315: updates links in RBAC content (#4354)

### DIFF
--- a/downstream/modules/platform/proc-controller-add-organization-user.adoc
+++ b/downstream/modules/platform/proc-controller-add-organization-user.adoc
@@ -15,8 +15,8 @@ When you manage a user's organization roles in the *Users* tab, you can also see
 If a user is assigned a "team member" role, this likely indicates that they have an indirectly-assigned role. To see a user's indirectly-assigned roles, click the pencil icon image:leftpencil.png[Edit page,15,15] to view and manage roles, and then click the link labeled *View indirectly-assigned organization roles* in the page banner.
 ====
 
-To assign a user to an organization, the user must already exist. For more information, see xref:proc-controller-creating-a-user[Creating a user]. 
-To assign roles to a user, the role must already exist. See xref:proc-gw-create-roles[Creating a role] for more information.
+To assign a user to an organization, the user must already exist. For more information, see link:{URLCentralAuth}/gw-managing-access#proc-controller-creating-a-user[Creating a user]. 
+To assign roles to a user, the role must already exist. See link:{URLCentralAuth}/assembly-gw-roles#proc-gw-create-roles[Creating a role] for more information.
 
 // [[hherbly] removed for 2.6] The following tab selections are available when adding users to an organization. When user accounts from the {ControllerName} organization have been migrated to {PlatformNameShort} 2.5 during the upgrade process, the *Automation Execution* tab shows content based on whether the users were added to the organization prior to migration.  
 
@@ -45,14 +45,14 @@ include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 A user with roles associated with an organization loses those roles if they are removed from the organization.
 ====
 +
-. To remove a particular user from the organization, select *Remove user* from the *More actions {MoreActionsIcon}* list next to the user. This launches a confirmation dialog, asking you to confirm the removal. Note that removing a user from an organization will also remove all organization roles that the user is indirectly assigned from that specific organization.
+. To remove a particular user from the organization, select *Remove user* from the btn:[More Actions] *{MoreActionsIcon}* list next to the user. This launches a confirmation dialog, asking you to confirm the removal. Note that removing a user from an organization will also remove all organization roles that the user is indirectly assigned from that specific organization.
 . To manage roles for users in an organization, click the *{SettingsIcon}* icon next to the user and select *Manage roles*. You can manage organization roles that are directly assigned to a user by selecting or clearing the checkboxes. Double-check the component column to ensure you are selecting the desired role in the correct component context.
 
 [TIP]
 
 ====
 
-From this screen, you can view, but not manage, indirectly-assigned roles that a user has inherited from a team assignment. To view indirectly-assigned roles, along with the team assignment they originated from, click *View indirectly-assigned organization roles* link in the banner beneath the page heading. To manage roles indirectly assigned to a user through a team assignment, manage that team's organization role assignments or remove the user from that team [LINK]
+From this screen, you can view, but not manage, indirectly-assigned roles that a user has inherited from a team assignment. To view indirectly-assigned roles, along with the team assignment they originated from, click *View indirectly-assigned organization roles* link in the banner beneath the page heading. To manage roles indirectly assigned to a user through a team assignment, link:{URLCentralAuth}/gw-managing-access#proc-controller-user-permissions[manage that team's role assignments] or link:{URLCentralAuth}/gw-managing-access#proc-gw-team-remove-user[remove the user from that team].
 ====
 
 

--- a/downstream/modules/platform/proc-controller-creating-a-team.adoc
+++ b/downstream/modules/platform/proc-controller-creating-a-team.adoc
@@ -6,7 +6,7 @@
 
 You can create new teams, assign an organization to the team, and manage the users and administrators assigned to each team. 
 Users on a team inherit the permissions and roles assigned to the team.
-To add a user or administrator to a team, the user must have already been created.[LINK]
+To assign a user or administrator to a team, the user must have already been created. See link:{URLCentralAuth}/gw-managing-access#proc-gw-team-add-user[Assigning users to a team] or link:{URLCentralAuth}/gw-managing-access#proc-gw-add-admin-team[Assigning administrators to a team] for more information.
 
 .Procedure
 

--- a/downstream/modules/platform/proc-controller-creating-a-user.adoc
+++ b/downstream/modules/platform/proc-controller-creating-a-user.adoc
@@ -21,7 +21,7 @@ Normal user:: Normal users have read and write access limited to the resources (
 If you are modifying your own password, log out and log back in for the change to take effect.
 ====
 +
-. Select the *Organization* to be assigned for this user. For information about creating a new organization, see xref:proc-controller-create-organization[Creating an organization].
+. Select the *Organization* to be assigned for this user. For information about creating a new organization, see link:{URLCentralAuth}/gw-managing-access#proc-controller-create-organization[Creating an organization].
 . Click btn:[Create user].
 +
 When the user is successfully created, the *User* details screen opens. From here, you can review and change the user's teams, roles, tokens and other membership details.
@@ -32,4 +32,4 @@ If the user is not newly-created, the details screen displays the user's last lo
 ====
 
 .Next steps
-If you log in as yourself, and view the details of your user profile, you can manage tokens from your user profile by selecting the *Tokens* tab. For more information, see xref:proc-controller-apps-create-tokens[Adding a token].
+If you log in as yourself, and view the details of your user profile, you can manage tokens from your user profile by selecting the *Tokens* tab. For more information, see link:{URLCentralAuth}/gw-token-based-authentication#proc-controller-apps-create-tokens[Adding a token].

--- a/downstream/modules/platform/proc-gw-add-admin-organization.adoc
+++ b/downstream/modules/platform/proc-gw-add-admin-organization.adoc
@@ -2,7 +2,7 @@
 
 [id="proc-gw-add-admin-organization"]
 
-= Adding an administrator to an organization
+= Assigning an administrator to an organization
 
 You can add administrators to an organization, which allows them to manage the membership and settings of the organization. For example, they can create new users and teams within the organization, and grant permission to users within the organization.
 To add an administrator to an organization, the user must already exist.

--- a/downstream/modules/platform/proc-gw-add-admin-team.adoc
+++ b/downstream/modules/platform/proc-gw-add-admin-team.adoc
@@ -5,7 +5,7 @@
 = Assigning administrators to a team
 
 You can assign administrators to a team, which allows them to manage the membership and settings of that team. For example, they can create new users and grant permission to users within the team.
-To assign an administrator to a team, the administrator must already have been created. For more information, see xref:proc-controller-creating-a-user[Creating a user].
+To assign an administrator to a team, the administrator must already have been created. For more information, see link:{URLCentralAuth}/gw-managing-access#proc-controller-creating-a-user[Creating a user].
 
 .Procedure
 

--- a/downstream/modules/platform/proc-gw-add-team-organization.adoc
+++ b/downstream/modules/platform/proc-gw-add-team-organization.adoc
@@ -2,11 +2,11 @@
 
 [id="proc-gw-add-team-organization"]
 
-= Adding a team to an organization
+= Assigning a team to an organization
 
 You can provide a team access to an organization, and to the resources within that organization, by assigning roles to the team in the organization's *Teams* tab. All users who are part of a team assigned to the organization will inherit the team's organization role assignments.
-To assign roles to a team, the team must already exist in the organization. For more information, see xref:proc-controller-creating-a-team[Creating a team].
-To assign roles for a team, the role must already exist. See xref:proc-gw-create-roles[Creating a role] for more information.
+To assign roles to a team, the team must already exist in the organization. For more information, see link:{URLCentralAuth}/gw-managing-access#proc-controller-creating-a-team[Creating a team].
+To assign roles for a team, the role must already exist. See link:{URLCentralAuth}/assembly-gw-roles#proc-gw-create-roles[Creating a role] for more information.
 
 .Procedure
 

--- a/downstream/modules/platform/proc-gw-delete-team.adoc
+++ b/downstream/modules/platform/proc-gw-delete-team.adoc
@@ -10,4 +10,4 @@ Before you can delete a team, you must have team permissions. When you delete a 
 
 . From the navigation panel, select {MenuAMTeams}.
 . To remove a single team, click the minus icon *-* next to the team and confirm removal on the dialog that appears.
-. To remove teams in bulk, select the checkbox next to each team that you want to remove, then click the {MoreActionsIcon} icon and select *Delete team*.
+. To remove teams in bulk, select the checkbox next to each team that you want to remove, then click the btn:[More Actions] *{MoreActionsIcon}* icon and select *Delete team*.

--- a/downstream/modules/platform/proc-gw-editing-a-user.adoc
+++ b/downstream/modules/platform/proc-gw-editing-a-user.adoc
@@ -18,7 +18,7 @@ To see whether a user had service level auditor privileges, you must refer to th
 
 [NOTE]
 ====
-After upgrading to 2.6, users previously designated as {ControllerName} administrators are labeled as platform administrators in the *User type* column in the xref:proc-gw-users-list-view[Users list view]. {HubNameStart} administrators are labeled as *Normal* in the *User Type* column.
+After upgrading to 2.6, users previously designated as {ControllerName} administrators are labeled as platform administrators in the *User type* column in the link:{URLCentralAuth}/gw-managing-access#proc-gw-users-list-view[Users list view]. {HubNameStart} administrators are labeled as *Normal* in the *User Type* column.
 ====
 
 .Procedure

--- a/downstream/modules/platform/proc-gw-team-add-user.adoc
+++ b/downstream/modules/platform/proc-gw-team-add-user.adoc
@@ -4,7 +4,7 @@
 
 = Assigning users to a team
 
-To assign a user to a team, the user must already have been created. For more information, see xref:proc-controller-creating-a-user[Creating a user]. 
+To assign a user to a team, the user must already have been created. For more information, see link:{URLCentralAuth}/gw-managing-access#proc-controller-creating-a-user[Creating a user]. 
 Assigning a user to a team adds them as a member only. Use the *Roles* tab to assign a role that gives users on the team resource access.
 
 // [[hherbly]This may need to be replaced with updated steps for 2.6.] The following tab selections are available when adding users to a team. When user accounts from {ControllerName} or {HubName} organizations have been migrated to {PlatformNameShort} 2.5 during the upgrade process, the *Automation Execution* and *Automation Content* tabs show content based on whether the users were added to those organizations prior to migration.  

--- a/downstream/modules/platform/proc-gw-users-list-view.adoc
+++ b/downstream/modules/platform/proc-gw-users-list-view.adoc
@@ -6,7 +6,7 @@
 
 The *Users* page displays the existing users for your installation. From here, you can search for a specific user, filter the list of users, or change the sort order for the list.
 
-When user accounts have been migrated to {PlatformNameShort} 2.6 during the upgrade process, these accounts are also displayed in the *Users* list view. You can see whether these users have administrator privileges by editing the account. See xref:gw-editing-a-user[Editing a user] for instructions.
+When user accounts have been migrated to {PlatformNameShort} 2.6 during the upgrade process, these accounts are also displayed in the *Users* list view. You can see whether these users have administrator privileges by editing the account. See link:{URLCentralAuth}/gw-managing-access#gw-editing-a-user[Editing a user] for instructions.
 
 .Procedure
 


### PR DESCRIPTION
This PR ports the changes from [PR 4354](https://github.com/ansible/aap-docs/pull/4354) to the 2.6 branch. This work is being tracked in [AAP-52315](https://issues.redhat.com/browse/AAP-52315).