### PR TITLE
2.6 backport: AAP-52315: fixes one link (#4357)

### DIFF
--- a/downstream/modules/platform/proc-controller-user-permissions.adoc
+++ b/downstream/modules/platform/proc-controller-user-permissions.adoc
@@ -27,7 +27,7 @@ include::snippets/snip-gw-roles-note-multiple-components.adoc[]
 
 ====
 
-If you are selecting more than one role in this step, consider creating a custom role that includes all the permissions for this resource type to give the team the correct access (LINK)
+If you are selecting more than one role in this step, consider link:{URLCentralAuth}/assembly-gw-roles#proc-gw-create-roles[creating a custom role] that includes all the permissions for this resource type to give the team the correct access.
 ====
 +
 . Review the settings and click btn:[Finish].


### PR DESCRIPTION
This PR ports the change from[ PR 4357](https://github.com/ansible/aap-docs/pull/4357) to the 2.6 branch. This work is being tracked in [AAP-52315](https://issues.redhat.com/browse/AAP-52315).