### PR TITLE
2.6 customized execution-environment.yml file leads to image not of type …

### DIFF
--- a/downstream/modules/builder/proc-customize-ee-image.adoc
+++ b/downstream/modules/builder/proc-customize-ee-image.adoc
@@ -42,7 +42,8 @@ In doing so, your final `execution-environment.yml` file appears similar to the 
 version: 3
 
 images:
-  base_image: 'registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel9:latest'
+  base_image: 
+    name: 'registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel9:latest'
 
 dependencies:
   galaxy:


### PR DESCRIPTION
…object (#4366)

Backports #4366 from main to 2.6

https://issues.redhat.com/browse/AAP-51446