### PR TITLE
Backport-2.6-4359 to AAP-46221 Pre-migration work EDA user guide, Chapter 7

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
+++ b/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="eda-rulebook-activations"]
 
 = Rulebook activations
@@ -45,13 +46,23 @@ To meet high availability demands, {EDAcontroller} shares centralized link:https
 ====
 
 include::eda/con-eda-rulebook-supported-event-sources.adoc[leveloffset=+1]
+
 include::eda/proc-eda-set-up-rulebook-activation.adoc[leveloffset=+1]
+
 include::eda/con-eda-rulebook-activation-list-view.adoc[leveloffset=+1]
+
 include::eda/proc-eda-view-activation-output.adoc[leveloffset=+2]
+
 include::eda/proc-eda-enable-rulebook-activations.adoc[leveloffset=+1]
+
 include::eda/proc-eda-restart-rulebook-activations.adoc[leveloffset=+1]
+
 include::eda/proc-eda-edit-rulebook-activation.adoc[leveloffset=+1]
+
 include::eda/proc-eda-copy-rulebook-activation.adoc[leveloffset=+1]
+
 include::eda/proc-eda-delete-rulebook-activations.adoc[leveloffset=+1]
+
 include::eda/proc-eda-activate-webhook.adoc[leveloffset=+1]
+
 include::eda/proc-eda-test-with-K8s.adoc[leveloffset=+1]

--- a/downstream/modules/eda/con-eda-rulebook-activation-list-view.adoc
+++ b/downstream/modules/eda/con-eda-rulebook-activation-list-view.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: CONCEPT
 [id="eda-rulebook-activation-list-view"]
 
 = Rulebook activation list view

--- a/downstream/modules/eda/con-eda-rulebook-supported-event-sources.adoc
+++ b/downstream/modules/eda/con-eda-rulebook-supported-event-sources.adoc
@@ -1,4 +1,4 @@
-
+:_mod-docs-content-type: CONCEPT
 [id="eda-rulebook-supported-event-sources"]
 
 = Supported event sources

--- a/downstream/modules/eda/proc-eda-activate-webhook.adoc
+++ b/downstream/modules/eda/proc-eda-activate-webhook.adoc
@@ -1,8 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-activate-webhook"]
 
 = Activating webhook rulebooks
 
-In Openshift environments, you can allow webhooks to reach an activation-job-pod over a given port by creating a Route that exposes that rulebook activation's Kubernetes service.
+In Openshift environments, you can allow webhooks to reach an activation-job-pod over a given port by creating a route that exposes that rulebook activation's Kubernetes service.
 
 .Prerequisites
 
@@ -62,13 +63,15 @@ spec:
 +
 . When you create the Route, test it with a *Post to the Route URL*:
 +
+[NOTE]
+====
+You do not need the port as it is specified on the Route (targetPort).
+====
++
 -----
 curl -H "Content-Type: application/json" -X POST 
 test-sync-bug-dynatrace.apps.aap-dt.ocp4.testing.ansible.com -d 
 '{}'
 -----
-+
-[NOTE]
-====
-You do not need the port as it is specified on the Route (targetPort).
-====
+
+

--- a/downstream/modules/eda/proc-eda-copy-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-copy-rulebook-activation.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-copy-rulebook-activation"]
 
 = Duplicating a rulebook activation
@@ -29,5 +30,6 @@ Ensure that you have given your newly duplicated activation a meaningful *Name* 
 ====
 . Toggle the btn:[Enable rulebook activation] button to the on position. 
 . After confirming all of your edits are complete, click btn:[Save rulebook activation].
-+
+
+.Results
 This initiates the rulebook activation, and if it runs successfully, the status changes to *Running* or *Completed*.

--- a/downstream/modules/eda/proc-eda-delete-rulebook-activations.adoc
+++ b/downstream/modules/eda/proc-eda-delete-rulebook-activations.adoc
@@ -1,6 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-delete-rulebook-activations"]
 
 = Deleting rulebook activations
+
+You can delete rulebook activations to permanently remove them when they are no longer needed.
 
 .Procedure
 

--- a/downstream/modules/eda/proc-eda-edit-rulebook-activation.adoc
+++ b/downstream/modules/eda/proc-eda-edit-rulebook-activation.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-edit-rulebook-activation"]
 
 = Editing a rulebook activation
@@ -23,5 +24,6 @@ You can also access the *Edit* feature by clicking the rulebook activation on th
 If you prefer to run your activation immediately, you can toggle the btn:[Rulebook activation enabled] button to the on position, and then save your changes.
 ====
 . Click btn:[Save rulebook activation].
-+
+
+.Results
 This takes you back to the Rulebook Activations page.

--- a/downstream/modules/eda/proc-eda-enable-rulebook-activations.adoc
+++ b/downstream/modules/eda/proc-eda-enable-rulebook-activations.adoc
@@ -1,6 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-enable-rulebook-activations"]
 
 = Enabling and disabling rulebook activations
+
+You can enable or disable rulebook activations to control when they run. Disabling an activation is useful for troubleshooting or to temporarily halt automation without deleting the configuration.
 
 .Procedure
 

--- a/downstream/modules/eda/proc-eda-restart-rulebook-activations.adoc
+++ b/downstream/modules/eda/proc-eda-restart-rulebook-activations.adoc
@@ -1,6 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-restart-rulebook-activations"]
 
 = Restarting rulebook activations
+
+You can restart a rulebook activation to quickly re-engage its automation, which is useful after making updates or to recover from an error.
 
 [NOTE]
 ====

--- a/downstream/modules/eda/proc-eda-test-with-K8s.adoc
+++ b/downstream/modules/eda/proc-eda-test-with-K8s.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-test-with-K8s"]
 
 = Testing with Kubernetes


### PR DESCRIPTION
Prepped [Chapter 7. Rulebook activations](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rulebook-activations) in the Using automation decisions guide for migration compliance.