### PR TITLE
AAP-54229: Asciidoc conversion for recent RPM install guide 2.6

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
+++ b/downstream/assemblies/platform/assembly-aap-upgrading-platform.adoc
@@ -9,8 +9,7 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
-To upgrade your {PlatformName}, start by reviewing {LinkPlanningGuide} to ensure a successful upgrade.
-You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
+To upgrade your {PlatformName}, start by reviewing link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/planning_your_upgrade[Planning your upgrade] to ensure a successful upgrade. You can then download the desired version of the {PlatformNameShort} installer, configure the inventory file in the installation bundle to reflect your environment, and then run the installer.
 
 [IMPORTANT]
 ====
@@ -23,6 +22,7 @@ include::platform/proc-choosing-obtaining-installer-no-internet.adoc[leveloffset
 include::platform/proc-editing-inventory-file-for-updates.adoc[leveloffset=+1]
 include::platform/con-backup-aap.adoc[leveloffset=+1]
 include::platform/proc-running-setup-script-for-updates.adoc[leveloffset=+1]
+include::platform/proc-verify-user-migration.adoc[leveloffset=+1]
 include::platform/con-upgrade-controller-hub-eda-unified-ui.adoc[leveloffset=+1]
 include::platform/proc-upgrade-controller-hub-eda-unified-ui.adoc[leveloffset=+2]
 include::platform/proc-upgrade-controller-hub-eda-unified-services.adoc[leveloffset=+2]

--- a/downstream/modules/platform/con-aap-legacy-user-login.adoc
+++ b/downstream/modules/platform/con-aap-legacy-user-login.adoc
@@ -11,5 +11,3 @@
 Users can log in using their legacy accounts by selecting “I have a <component> account” and entering their credentials (username and password). If the login is successful, they may be prompted to link their account with another component account for example, {HubName} and {ControllerName}. If the login credentials are the same for both {HubName} and {ControllerName}, account linking is automatically done for that user.
 
 After successful account linking, user accounts from both components are merged into a `gateway:legacy external password` authenticator. If user accounts are not automatically merged into the `gateway:legacy external password` authenticator, you must auto migrate directly to LDAP without linking accounts.
-
-For more information about account linking, see link:{URLUpgrade}/aap-post-upgrade#account-linking_aap-post-upgrade[Linking your accounts].

--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -9,15 +9,15 @@ Before you begin the upgrade process, review the following considerations to pla
 
 == {PlatformNameShort} requirements
 * Verify that you have a valid subscription before upgrading from a previous version of {PlatformNameShort}. Existing subscriptions are carried over during the upgrade process. 
-* Review {LinkPlanningGuide} for a successful upgrade. You can only upgrade from {PlatformNameShort} 2.4 or 2.5 to 2.6.
-* Upgrade to {PlatformNameShort} installer version 2.6-11 or later. Do not upgrade to an earlier installer version.
+* Review link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/planning_your_upgrade[Planning your upgrade] for a successful upgrade. You can only upgrade from {PlatformNameShort} 2.4 or 2.5 to 2.6. 
 * Back up your {PlatformNameShort} environment before upgrading in case any issues occur. See link:{URLControllerAdminGuide}/controller-backup-and-restore[Backup and restore] and {LinkOperatorBackup} for the specific topology of the environment.
 * Capture your inventory or instance group details before upgrading.
 * Upgrade to the latest version of {PlatformNameShort} 2.4 or 2.5 before upgrading to {PlatformName} 2.6.
 +
 [IMPORTANT]
 ====
-When upgrading from {PlatformNameShort} 2.4 to 2.6, the API endpoints for the {ControllerName}, {HubName}, and {EDAcontroller} are all available for use. These APIs are being deprecated and will be disabled in an upcoming release. This grace period is to allow for migration to the new APIs put in place with the {Gateway}.
+* When upgrading from {PlatformNameShort} 2.4 to 2.6, the API endpoints for the {ControllerName}, {HubName}, and {EDAcontroller} are all available for use. These APIs are being deprecated and will be disabled in an upcoming release. This grace period is to allow for migration to the new APIs put in place with the {Gateway}.
+* If you upgraded from {PlatformNameShort} 2.4 to 2.5, you must migrate your authentication methods and users before upgrading to 2.6 as that legacy authenticator functionality was removed. For information about migrating users, see link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/rpm_upgrade_and_migration/aap-post-upgrade#con-migrate-SAML-users_aap-post-upgrade[Migrating Single Sign-On (SSO) users] in _RPM Upgrade and Migration guide_ for 2.5. 
 ====
 
 * Review the {Gateway} requirements:

--- a/downstream/modules/platform/proc-verify-user-migration.adoc
+++ b/downstream/modules/platform/proc-verify-user-migration.adoc
@@ -3,7 +3,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="verify-user-migration_{context}"]
-= Verify user migration
+= Verifying user migration
 
 During the upgrade to {PlatformNameShort} {PlatformVers}, controller user accounts are converted into platform user accounts. Controller administrators retain their administrative privileges, but they are converted into platform administrator privileges. 
 
@@ -13,15 +13,14 @@ Authenticator configurations are automatically migrated. SSO and LDAP accounts d
 
 After your upgrade to {PlatformNameShort} {PlatformVers} is complete, verify that you can log in to the upgraded platform.
 
-
 .Procedure
 
-If you have a controller account that has been converted to a {Gateway} account for {PlatformNameShort} {PlatformVers}:
+* If you have a controller account that has been converted to a {Gateway} account for {PlatformNameShort} {PlatformVers}:
 
-* Log into your upgraded platform instance with your controller credentials.
+** Log into your upgraded platform instance with your controller credentials.
 
-If you have a component-level account (such as an account associated with {PrivateHubName} or {EDAName}):
+* If you have a component-level account (such as an account associated with {PrivateHubName} or {EDAName}):
 
-* Request a password reset from your adminstrator and log into the upgraded platform with your new password.
+** Request a password reset from your administrator and log into the upgraded platform with your new password.
 
 

--- a/downstream/titles/upgrade/docinfo.xml
+++ b/downstream/titles/upgrade/docinfo.xml
@@ -1,9 +1,9 @@
-<title>RPM upgrade and migration</title>
+<title>RPM upgrade</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.6</productnumber>
-<subtitle>Upgrade and migrate legacy deployments of Ansible Automation Platform</subtitle>
+<subtitle>Upgrade to the latest version of Ansible Automation Platform</subtitle>
 <abstract>
-<para>This guide shows you how to upgrade to the latest version of Ansible Automation Platform and migrate legacy virtual environments to automation execution environments.</para>
+<para>This guide shows you how to upgrade to the latest version of Ansible Automation Platform.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/downstream/titles/upgrade/master.adoc
+++ b/downstream/titles/upgrade/master.adoc
@@ -6,7 +6,7 @@
 include::attributes/attributes.adoc[]
 
 // Book Title
-= RPM upgrade and migration
+= RPM upgrade
 
 include::{Boilerplate}[]
 


### PR DESCRIPTION
This PR addresses JIRA https://issues.redhat.com/browse/AAP-54229.

Changes made:

- Added note as requested by Ron Reed: "If you upgraded from 2.4 to 2.5, you must migrate your authentication methods and users before upgrading to 2.6 as that legacy authenticator functionality was removed." 
- Add Hala's topic https://github.com/ansible/aap-docs/pull/4324 to upgrade guide and remove existing 'Chapter 3. Ansible Automation Platform post-upgrade steps' 
- Title change from "RPM Upgrade and migration guide' to 'RPM upgrade guide' since we now have an entirely separate AAP migration guide, per recent confirmation from Lynne Maynard. Updated both master.adoc and docinfo.xml files.