### PR TITLE
2.5 Update uninstall containerized aap proc (#4384)

### DIFF
--- a/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-uninstalling-containerized-aap.adoc
@@ -12,7 +12,15 @@ Uninstall your {ContainerBase} of {PlatformNameShort}.
 
 .Procedure
 
-. If you intend to reinstall {PlatformNameShort} and want to use the preserved databases, you must collect the existing secret keys by running the following command:
+. If you intend to reinstall {PlatformNameShort} and want to use the preserved databases, you must collect the existing secret keys:
+
+.. First, list the available secrets:
++
+----
+$ podman secret list
+----
+
+.. Next, collect the secret keys by running the following command:
 +
 ----
 $ podman secret inspect --showsecret <secret_key_variable> | jq -r .[].SecretData


### PR DESCRIPTION
Backports #4384 from main to 2.5

Update the Uninstalling containerized AAP procedure to include the step to list the secrets.

[Share Feedback] [Content]

https://issues.redhat.com/browse/DOCS-3394