### PR TITLE
Add ee_from_hub_only to inventory var appendix

### DIFF
--- a/downstream/modules/platform/ref-hub-variables.adoc
+++ b/downstream/modules/platform/ref-hub-variables.adoc
@@ -282,6 +282,12 @@ For the RPM-based installer, if you only want one type of content, set this vari
 | Optional
 | `[]`
 
+| `ee_from_hub_only`
+| 
+| Controls whether {HubName} is the only registry for {ExecEnvShort} images. If set to `true`, {HubName} is the exclusive registry. If set to `false`, images are also pulled directly from Red Hat. 
+| Optional
+| `true` when using the bundle installer, otherwise `false`.
+
 |`generate_automationhub_token` 
 | 
 | Controls whether or not a token is generated for {HubName} during installation. By default, a token is automatically generated during a fresh installation. 


### PR DESCRIPTION
ee_from_hub_only variable missing from AAP 2.5 RPM documentation

https://issues.redhat.com/browse/AAP-53586