### PR TITLE
AAP-49875: removes subscription info from 2.5 access management guide

### DIFF
--- a/downstream/titles/central-auth/master.adoc
+++ b/downstream/titles/central-auth/master.adoc
@@ -13,7 +13,7 @@ include::{Boilerplate}[]
 
 include::platform/platform/con-gw-overview-access-auth.adoc[leveloffset=+1]
 
-// include::platform/assembly-gateway-licensing.adoc[leveloffset=+1]
+// [hherbly removed per aap-49875] include::platform/assembly-gateway-licensing.adoc[leveloffset=+1]
 
 include::platform/assembly-gw-configure-authentication.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This work is being tracked in [AAP-49875](https://issues.redhat.com/browse/AAP-49875). This PR removes subscription info from the Access Management guide. This change has already been made in the 2.6 branch; see [PR 3944](https://github.com/ansible/aap-docs/pull/3944) (update to main) and [PR 4287](https://github.com/ansible/aap-docs/pull/4287)(update to 2.6).