### PR TITLE
Add proc for updating ee image locations for containerized

### DIFF
--- a/downstream/assemblies/builder/assembly-using-builder.adoc
+++ b/downstream/assemblies/builder/assembly-using-builder.adoc
@@ -47,6 +47,8 @@ include::builder/con-build-ee-with-env-vars-for-galaxy.adoc[leveloffset=+2]
 
 include::platform/proc-update-ee-image-locations.adoc[leveloffset=+1]
 
+include::platform/proc-update-ee-image-locations-containerized.adoc[leveloffset=+1]
+
 include::builder/con-optional-build-command-arguments.adoc[leveloffset=+1]
 
 include::builder/con-container_file.adoc[leveloffset=+1]

--- a/downstream/modules/platform/proc-update-ee-image-locations-containerized.adoc
+++ b/downstream/modules/platform/proc-update-ee-image-locations-containerized.adoc
@@ -1,0 +1,42 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="updating-ee-image-locations-containerized"]
+
+= Updating {ExecEnvShort} image locations for container-based installations
+
+[role="_abstract"]
+If you installed {PrivateHubName} separately from containerized {PlatformNameShort}, you can update your {ExecEnvShort} image locations to point to your {PrivateHubName}.
+
+.Procedure
+
+. Go to the installation directory.
+. Edit your inventory file and include the following variables under the `[all:vars]` section:
++
+----
+# Automation hub registry
+registry_username=your-automation-hub-user
+registry_password=your-automation-hub-password
+registry_url=automationhub.example.org
+registry_tls_verify=false
+
+# Execution environment images
+ee_minimal_image=automationhub.example.org/ee-minimal-rhel9:latest
+ee_supported_image=automationhub.example.org/ee-supported-rhel9:latest
+----
++
+[NOTE]
+====
+For information on obtaining `registry_username` and `registry_password`, see link:{URLContainerizedInstall}/aap-containerized-installation#proc-set-registry-username-password[Setting registry_username and registry_password].
+====
+
+. Run the `install` playbook:
++
+----
+ansible-playbook -i inventory ansible.containerized_installer.install
+----
+
+.Verification
+
+. Log in to {PlatformNameShort} as a user with system administrator access.
+. Go to {MenuInfrastructureExecEnvironments}.
+. In the *Image* column, confirm that the {ExecEnvShort} image location has changed from the default value of `<registry url>/ansible-automation-platform-<version>/<image name>:<tag>` to `<automation hub url>/<image name>:<tag>`.

--- a/downstream/modules/platform/proc-update-ee-image-locations.adoc
+++ b/downstream/modules/platform/proc-update-ee-image-locations.adoc
@@ -5,45 +5,45 @@
 
 [id="updating-ee-image-locations"]
 
-= Updating {ExecEnvShort} image locations
+= Updating {ExecEnvShort} image locations for RPM-based installations
 
 [role="_abstract"]
-If you installed {PrivateHubName} separately from {PlatformNameShort}, you can update your {ExecEnvShort} image locations to point to your {PrivateHubName}.
+If you installed {PrivateHubName} separately from RPM-based {PlatformNameShort}, you can update your {ExecEnvShort} image locations to point to your {PrivateHubName}.
 
 .Procedure
-. Go to the directory that contains `setup.sh`
+
+. Go to the directory that contains `setup.sh`.
 . Create `./group_vars/automationcontroller` by running the following command:
 +
 ----
 touch ./group_vars/automationcontroller
 ----
 +
-. Paste the following content into `./group_vars/automationcontroller`. 
-Adjust the settings to fit your environment:
+. Paste the following content into `./group_vars/automationcontroller`. Adjust the settings to fit your environment:
 +
 ----
-# Automation Hub Registry
+# Automation hub registry
 registry_username: 'your-automation-hub-user'
 registry_password: 'your-automation-hub-password'
 registry_url: 'automationhub.example.org'
 registry_verify_ssl: False
 
-## Execution Environments
-control_plane_execution_environment: 'automationhub.example.org/ee-supported-rhel8:latest'
+## Execution environments
+control_plane_execution_environment: 'automationhub.example.org/ee-supported-rhel9:latest'
 
 global_job_execution_environments:
   - name: "Default execution environment"
-    image: "automationhub.example.org/ee-supported-rhel8:latest"
+    image: "automationhub.example.org/ee-supported-rhel9:latest"
   - name: "Minimal execution environment"
-    image: "automationhub.example.org/ee-minimal-rhel8:latest"
+    image: "automationhub.example.org/ee-minimal-rhel9:latest"
 ----
 +
 [NOTE]
 ====
-For information on obtaining `registry_username` and `registry_password`, see link:{URLInstallationGuide}/index#proc-set-registry-username-password[Setting registry_username and registry_password]
+For information on obtaining `registry_username` and `registry_password`, see link:{URLInstallationGuide}/index#proc-set-registry-username-password[Setting registry_username and registry_password].
 ====
 
-. Run the `./setup.sh` script
+. Run the `./setup.sh` script:
 +
 ----
 $ ./setup.sh

--- a/downstream/modules/platform/ref-controller-run-the-builder.adoc
+++ b/downstream/modules/platform/ref-controller-run-the-builder.adoc
@@ -26,7 +26,7 @@ The content of `requirements.yml`:
 ----
 ---
 collections:
-  - name: awx.awx
+  - name: kubernetes.core
 ----
 
 To build an {ExecEnvShort} using the preceding files and run the following command:
@@ -35,7 +35,7 @@ To build an {ExecEnvShort} using the preceding files and run the following comma
 ----
 ansible-builder build
 ...
-STEP 7: COMMIT my-awx-ee
+STEP 7: COMMIT my-custom-ee
 --> 09c930f5f6a
 09c930f5f6ac329b7ddb321b144a029dbbfcc83bdfc77103968b7f6cdfc7bea2
 Complete! The build context can be found at: context


### PR DESCRIPTION
Adds a procedure based on `proc-update-ee-image-locations.adoc` but for Containerized AAP.

Also updates awx.awx collection reference and replaces with kubernetes.core

Creating and using execution environments - Outdated info doesn't account for containerized deployment

https://issues.redhat.com/browse/AAP-52507