### PR TITLE
2.5 Adds gateway_uwsgi_processes to inventory appendix (#4109)

### DIFF
--- a/downstream/modules/platform/ref-gateway-variables.adoc
+++ b/downstream/modules/platform/ref-gateway-variables.adoc
@@ -221,6 +221,12 @@ Inventory file variables for {Gateway}.
 | Optional
 | `false`
 
+| `automationgateway_uwsgi_processes`
+| `gateway_uwsgi_processes`
+| The number of `uwsgi` processes for the {Gateway} container. The value is calculated based on the number of available vCPUs (virtual CPUs).
+| Optional
+| The number of vCPUs multiplied by two, plus one.
+
 | `automationgateway_use_archive_compression`
 | `gateway_use_archive_compression`
 | Controls whether archive compression is enabled or disabled for {Gateway}. You can control this functionality globally by using `use_archive_compression`.


### PR DESCRIPTION
Backports #4109 from main to 2.5

Adds automationgateway_uwsgi_processes (RPM) and gateway_uwsgi_processes (Cont) to inventory vars appendix

Affects: Containerized installation and RPM installation

Document automationgateway_uwsgi_processes parameter in rpm installer

https://issues.redhat.com/browse/AAP-52025