### PR TITLE
Backport-2.5-4413 to AAP-46222 Pre-migration prep for Chapter 8, Using automation decisions

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-rulebook-troubleshooting.adoc
+++ b/downstream/assemblies/eda/assembly-eda-rulebook-troubleshooting.adoc
@@ -1,9 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="eda-rulebook-troubleshooting"]
 
 = Rulebook activations troubleshooting
 
 [role="_abstract"]
-
 Occasionally, rulebook activations might fail due to a variety of reasons that can be resolved. In many cases, log filtering provides information that could be helpful in determining the cause of activation failure.
 
 For improved log filtering, there are two different tracking IDs available for troubleshooting after an action is performed (for example, when you initiate a rulebook activation). Both tracking IDs are universally unique identifiers (UUIDs): 
@@ -17,7 +17,10 @@ You can use both tracking IDs to locate specific log entries in your backend log
 Review the list of possible issues that can cause activation failures and suggestions on how you can resolve them.
 
 include::eda/proc-eda-activation-stuck-pending.adoc[leveloffset=+1]
+
 include::eda/proc-eda-activation-keeps-restarting.adoc[leveloffset=+1]
+
 include::eda/proc-eda-event-streams-not-sending-events.adoc[leveloffset=+1]
+
 include::eda/proc-eda-cannot-connect-to-controller.adoc[leveloffset=+1]
 

--- a/downstream/modules/eda/proc-eda-activation-keeps-restarting.adoc
+++ b/downstream/modules/eda/proc-eda-activation-keeps-restarting.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-activation-keeps-restarting"]
 
 = Activation keeps restarting
 
+[role="_abstract"]
 Perform the following steps if your rulebook activation keeps restarting.
 
 .Procedure

--- a/downstream/modules/eda/proc-eda-activation-stuck-pending.adoc
+++ b/downstream/modules/eda/proc-eda-activation-stuck-pending.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-activation-stuck-pending"]
 
 = Activation stuck in Pending state
 
+[role="_abstract"]
 Perform the following steps if your rulebook activation is stuck in *Pending* state.
 
 .Procedure

--- a/downstream/modules/eda/proc-eda-cannot-connect-to-controller.adoc
+++ b/downstream/modules/eda/proc-eda-cannot-connect-to-controller.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-cannot-connect-to-controller"]
 
 = Cannot connect to the 2.5 {ControllerName} when running activations
 
+[role="_abstract"]
 You might experience a failed connection to {ControllerName} when you run your activations.
 
 .Procedure

--- a/downstream/modules/eda/proc-eda-event-streams-not-sending-events.adoc
+++ b/downstream/modules/eda/proc-eda-event-streams-not-sending-events.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-event-streams-not-sending-events"]
 
 = Event streams not sending events to activation
 
+[role="_abstract"]
 If you are using event streams to send events to your rulebook activations, occasionally those events might not be successfully routed to your rulebook activation. 
 
 .Procedure


### PR DESCRIPTION
Prepped [Chapter 8. Rulebook activations troubleshooting](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rulebook-troubleshooting) in the Using automation decisions guide for migration compliance.