### PR TITLE
Backport-2.5-4415 for AAP-46223 Pre-migration work EDA user guide, Chapter 9

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-rule-audit.adoc
+++ b/downstream/assemblies/eda/assembly-eda-rule-audit.adoc
@@ -1,12 +1,16 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="eda-rule-audit"]
 
 = Rule Audit
 
+[role="_abstract"]
 Rule audit allows the auditing of rules which have been triggered by all the rules that were activated at some point.
 
 The *Rule Audit* list view shows you a list of every time an event came in that matched a condition within a rulebook and triggered an action.
 The list shows you rules within your rulebook and each heading matches up to a rule that has been executed.
 
 include::eda/proc-eda-view-rule-audit-details.adoc[leveloffset=+1]
+
 include::eda/proc-eda-view-rule-audit-events.adoc[leveloffset=+1]
+
 include::eda/proc-eda-view-rule-audit-actions.adoc[leveloffset=+1]

--- a/downstream/modules/eda/proc-eda-view-rule-audit-actions.adoc
+++ b/downstream/modules/eda/proc-eda-view-rule-audit-actions.adoc
@@ -3,6 +3,9 @@
 
 = Viewing rule audit actions
 
+[role="_abstract"]
+You can select a specific rule to view a list of its corresponding actions and view their output.
+
 .Procedure
 
 . From the navigation panel select *{MenuADRuleAudit}*.

--- a/downstream/modules/eda/proc-eda-view-rule-audit-details.adoc
+++ b/downstream/modules/eda/proc-eda-view-rule-audit-details.adoc
@@ -3,6 +3,7 @@
 
 = Viewing rule audit details
 
+[role="_abstract"]
 From the *Rule Audit* list view you can check the event that triggered specific actions.
 
 //[JMSelf] Remove outdated image.

--- a/downstream/modules/eda/proc-eda-view-rule-audit-events.adoc
+++ b/downstream/modules/eda/proc-eda-view-rule-audit-events.adoc
@@ -1,6 +1,10 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-view-rule-audit-events"]
 
 = Viewing rule audit events
+
+[role="_abstract"]
+You can select a specific rule to view a list of its corresponding events, then inspect each event's log, source type, and timestamp for detailed information.
 
 .Procedure
 


### PR DESCRIPTION
Prepped [Chapter 9. Rule Audit](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rule-audit) in the Using automation decisions guide for migration compliance.