### PR TITLE
2.6 backport: fixes typo (#4452)

### DIFF
--- a/downstream/assemblies/security/assembly-aap-security-use-cases.adoc
+++ b/downstream/assemblies/security/assembly-aap-security-use-cases.adoc
@@ -20,7 +20,7 @@ include::security/con-benefits-of-patch-automation.adoc[leveloffset=+2]
 
 include::security/con-patching-examples.adoc[leveloffset=+2]
 
-include::securiy/ref-keep-up-to-date.adoc[leveloffset=+3]
+include::security/ref-keep-up-to-date.adoc[leveloffset=+3]
 
 include::security/ref-install-security-updates.adoc[leveloffset=+3]
 


### PR DESCRIPTION
This PR ports the changes from [PR 4452](https://github.com/ansible/aap-docs/pull/4452) to the 2.6 branch. 