### PR TITLE
AAP-54229-update: Self review of RPM upgrade guide 2.6

### DIFF
--- a/downstream/assemblies/platform/assembly-gateway-licensing.adoc
+++ b/downstream/assemblies/platform/assembly-gateway-licensing.adoc
@@ -3,7 +3,7 @@
 ifdef::context[:parent-context: {context}]
 
 [id="assembly-gateway-licensing"]
-= Managing {PlatformNameShort} licensing, updates and support
+= Managing {PlatformNameShort} licensing, updates, and support
 
 :context: licensing-gw
 

--- a/downstream/assemblies/platform/assembly-platform-install-overview.adoc
+++ b/downstream/assemblies/platform/assembly-platform-install-overview.adoc
@@ -31,13 +31,12 @@ xref:proc-verify-aap-installation_platform-install-scenario[Verifying your {Plat
 //xref:assembly-platform-whats-next_platform-install-scenario[Post-installation steps]:: After successful installation, you can begin using the features of {PlatformNameShort}.
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * {LinkPlanningGuide}
 * {LinkTopologies}
 
 //[Gmurray] this will work for now, but I'd recommend rejigging this as it appears clunky in the built guide. Perhaps you could merge these additional resources into the prereqs - Something like You have reviewed the planning and tested topology guides or something. 
-== Next steps
 
 include::platform/con-aap-installation-prereqs.adoc[leveloffset=+1]
 

--- a/downstream/modules/platform/proc-remove-EDA-2.4-db.adoc
+++ b/downstream/modules/platform/proc-remove-EDA-2.4-db.adoc
@@ -6,7 +6,7 @@
 
 {PlatformNameShort} 2.6 supports upgrades from {PlatformNameShort} 2.4 environments for all components, except for {EDAName}. Database migrations between {EDAName} 2.4 and {EDAName} 2.6 are not compatible.
 
-If you are upgrading from {PlatformNameShort} 2.4 to 2.6, you must first remove the {EDAName} 2.4 database. A new {EDAName} 2.6 database gets created automatically after the upgrade. After the upgrade is completed, a new {EDAName} 2.6 database is created. You can then reconnect {MenuAD} ({EDAcontroller}) to {MenuTopAE} ({ControllerName}) to run rulebook activations. 
+If you are upgrading from {PlatformNameShort} 2.4 to 2.6, you must first remove the {EDAName} 2.4 database. A new {EDAName} 2.6 database gets created automatically after the upgrade. You can then reconnect {MenuAD} ({EDAcontroller}) to {MenuTopAE} ({ControllerName}) to run rulebook activations. 
 
 [NOTE]
 ====

--- a/downstream/modules/platform/ref-upgrade-api-specific-changes.adoc
+++ b/downstream/modules/platform/ref-upgrade-api-specific-changes.adoc
@@ -102,9 +102,9 @@ Example:
 
 | {EDAName} | N/A | `/api/gateway/v1/organizations/` | No action needed, as upgrades from 2.4 are not supported. 
 
-| {EDAName} | `/api/v1/teams` | `/api/gateway/v1/teams/` | No action needed, as upgrades from 2.4 are not supported. 
+| {EDAName} | N/A | `/api/gateway/v1/teams/` | No action needed, as upgrades from 2.4 are not supported. 
 
-| {EDAName} | `/api/v1/users` | `/api/gateway/v1/users/` | No action needed, as upgrades from 2.4 are not supported.
+| {EDAName} | N/A | `/api/gateway/v1/users/` | No action needed, as upgrades from 2.4 are not supported.
 
 | {EDAName} | N/A 
 a| 


### PR DESCRIPTION
This PR is a follow-up doc update as part of JIRA https://issues.redhat.com/browse/AAP-54229.

Changes made:

- Latest comments from @lynne maynard on PR https://github.com/ansible/aap-docs/pull/4313. 
- Some minor doc placement + formatting + URL updates that I felt needed to be made when performing a self review of the RPM upgrade docs.