### PR TITLE
Backport-2.5-4466 for AAP-46224 Pre-migration work EDA user guide, Chapter 10

### DIFF
--- a/downstream/assemblies/eda/assembly-simplified-event-routing.adoc
+++ b/downstream/assemblies/eda/assembly-simplified-event-routing.adoc
@@ -1,19 +1,27 @@
-
+:_mod-docs-content-type: ASSEMBLY
 [id="simplified-event-routing"]
 
 = Simplified event routing
 
+[role="_abstract"]
 Simplified event routing enables {EDAcontroller} to capture and analyze data from various remote systems using event streams. With event streams, you can send events from a remote system like GitHub or GitLab into {EDAcontroller}. You can attach 1 or more event streams to an activation by swapping out sources in a rulebook. 
 
 Event streams are an easy way to connect your sources to your rulebooks. This capability lets you create a single endpoint to receive alerts from an event source and then use the events in multiple rulebooks.
 
 include::eda/con-event-streams.adoc[leveloffset=+1]
+
 include::eda/proc-eda-create-event-stream-credential.adoc[leveloffset=+1]
+
 include::eda/proc-eda-create-event-stream.adoc[leveloffset=+1]
+
 include::eda/proc-eda-config-remote-sys-to-events.adoc[leveloffset=+1]
+
 include::eda/proc-eda-verify-event-streams-work.adoc[leveloffset=+1]
+
 include::eda/proc-eda-replace-sources-with-event-streams.adoc[leveloffset=+1]
+
 include::eda/proc-eda-resend-webhook-data-event-streams.adoc[leveloffset=+1]
+
 include::eda/proc-eda-check-rule-audit-event-stream.adoc[leveloffset=+1]
 
 

--- a/downstream/modules/eda/con-event-streams.adoc
+++ b/downstream/modules/eda/con-event-streams.adoc
@@ -1,4 +1,5 @@
 
+:_mod-docs-content-type: CONCEPT
 [id="event-streams"]
 
 = Event streams

--- a/downstream/modules/eda/proc-eda-check-rule-audit-event-stream.adoc
+++ b/downstream/modules/eda/proc-eda-check-rule-audit-event-stream.adoc
@@ -1,13 +1,16 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-check-rule-audit-event-stream"]
 
 = Check the Rule Audit for events on your new event stream
 
+[role="_abstract"]
 When events have been sent and received by {EDAcontroller}, you can confirm that actions have been triggered by going to the Rule Audit page and viewing the event stream results.
 
 .Procedure
 . Log in to {PlatformNameShort}.
 . From the navigation panel, select {MenuADRuleAudit}. 
-+
-If your rulebook activation received the event data from the event stream type you selected, the Rule Audit page displays the results for *Status*, *Rulebook activation*, and the *Last fired date* fields. 
+
+.Results
+If your rulebook activation received the event data from the event stream type you selected, the *Rule Audit* page displays the results for *Status*, *Rulebook activation*, and the *Last fired date* fields. 
 //[JMSelf]Remove screen shot for now
 //image:eda-rule-audit-event-streams.png[Rule audit - Event stream]

--- a/downstream/modules/eda/proc-eda-config-remote-sys-to-events.adoc
+++ b/downstream/modules/eda/proc-eda-config-remote-sys-to-events.adoc
@@ -3,6 +3,7 @@
 
 = Configuring your remote system to send events
 
+[role="_abstract"]
 After you have created your event stream, you must configure your remote system to send events to {EDAcontroller}. The method used for this configuration varies, depending on the vendor for the event stream credential type you select.
 
 .Prerequisites

--- a/downstream/modules/eda/proc-eda-create-event-stream-credential.adoc
+++ b/downstream/modules/eda/proc-eda-create-event-stream-credential.adoc
@@ -3,6 +3,7 @@
 
 = Creating an event stream credential
 
+[role="_abstract"]
 You must create an event stream credential first before you can use an event stream. 
 
 .Prerequisites

--- a/downstream/modules/eda/proc-eda-create-event-stream.adoc
+++ b/downstream/modules/eda/proc-eda-create-event-stream.adoc
@@ -3,6 +3,7 @@
 
 = Creating an event stream
 
+[role="_abstract"]
 You can create event streams that will be attached to a rulebook activation. 
 
 .Prerequisites
@@ -47,7 +48,5 @@ After creating your event stream, the following outputs occur:
 ====
 After an event stream is created, the associated credential cannot be deleted until the event stream it is attached to is deleted.
 ====
-
 * Your new event stream generates a URL that is necessary when you configure the webhook on the remote system that sends events.
-
 

--- a/downstream/modules/eda/proc-eda-replace-sources-with-event-streams.adoc
+++ b/downstream/modules/eda/proc-eda-replace-sources-with-event-streams.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-replace-sources-with-event-streams"] 
 
 = Replacing sources and attaching event streams to activations
 
+[role="_abstract"]
 When you create rulebook activations, you can use event streams to swap out source mappings in rulebook activations and simplify routing from external sources to {EDAcontroller}. 
 
 There are several key points to keep in mind regarding source mapping:
@@ -90,7 +92,6 @@ Variables:: The variables for the rulebook are in a JSON or YAML format.
 The content would be equivalent to the file passed through the `--vars` flag of ansible-rulebook command.
 Options:: Check the *Skip audit events* option if you do not want to see your events in the Rule Audit.
 . Click btn:[Create rulebook activation].
-+
-After you create your rulebook activation, the *Details* page is displayed. 
-+
-You can navigate to the Event streams page to confirm your events have been received.  
+
+.Results
+After you create your rulebook activation, the *Details* page is displayed. You can navigate to the *Event streams* page to confirm your events have been received.  

--- a/downstream/modules/eda/proc-eda-resend-webhook-data-event-streams.adoc
+++ b/downstream/modules/eda/proc-eda-resend-webhook-data-event-streams.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-resend-webhook-data-event-streams"]
 
 = Resending webhook data from your event stream type
 
+[role="_abstract"]
 After you have replaced your sources with the event stream you created, you can now resend data from the event stream to ensure that it is attached to your rulebook activation. In the example shared earlier, the GitHub event stream was used. The following example demonstrates how to resend webhook data if you were using a GitHub event stream.
 
 .Procedure

--- a/downstream/modules/eda/proc-eda-verify-event-streams-work.adoc
+++ b/downstream/modules/eda/proc-eda-verify-event-streams-work.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: PROCEDURE
 [id="eda-verify-event-streams"] 
 
 = Verifying your event streams work
 
+[role="_abstract"]
 Verify that you can use your event stream to connect to a remote system and receive data.
 
 . Log in to {PlatformNameShort}.
@@ -22,6 +24,6 @@ The *Header* and *Body* sections for the event stream are displayed on the Detai
 +
 
 . Toggle the *Forward events to rulebook activation* option to  enable you to push your events to a rulebook activation.
-This moves the event stream to production mode and makes it easy to attach to rulebook activations.
-+
-When this option is toggled off, your ability to forward events to a rulebook activation is disabled and the *This event stream is disabled* message is displayed.
+
+.Results
+This moves the event stream to production mode and makes it easy to attach to rulebook activations. When this option is toggled off, your ability to forward events to a rulebook activation is disabled and the *This event stream is disabled* message is displayed.


### PR DESCRIPTION
Prepped [Chapter 10. Simplified event routing](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/simplified-event-routing) in the Using automation decisions guide for migration compliance.