### PR TITLE
[easy-fix]Align title name in master.adoc and docinfo.xml files

### DIFF
--- a/downstream/titles/configuration-as-code/docinfo.xml
+++ b/downstream/titles/configuration-as-code/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Configuration as Code</title>
+<title>Configuration-as-Code</title>
 <productname>Red Hat Ansible Automation Platform</productname>
 <productnumber>2.6</productnumber>
 <subtitle>

--- a/downstream/titles/configuration-as-code/master.adoc
+++ b/downstream/titles/configuration-as-code/master.adoc
@@ -5,7 +5,7 @@ include::attributes/attributes.adoc[]
 
 // Book Title
 
-= Configuration-as-code
+= Configuration-as-Code
 
 include::{Boilerplate}[]
 


### PR DESCRIPTION
I had to update the name of "Configuration-as-Code" title so that it reads the same in both master.adoc, docinfo.xml files and on Pantheon

<img width="951" height="1179" alt="docinfo-masteradoc-alignment" src="https://github.com/user-attachments/assets/4bd02b6c-050d-4811-8bd9-fe0efe933806" />
