### PR TITLE
Updates the RPM upgrade guide attributes

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -377,8 +377,8 @@
 :LinkEDAUserGuide: link:{URLEDAUserGuide}[{TitleEDAUserGuide}]
 //
 // titles/upgrade
-:TitleUpgrade: RPM upgrade and migration
-:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_upgrade_and_migration
+:TitleUpgrade: RPM upgrade
+:URLUpgrade: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/rpm_upgrade
 :LinkUpgrade: link:{URLUpgrade}[{TitleUpgrade}]
 //
 // titles/aap-operator-installation


### PR DESCRIPTION
2.6 correct links in Planning your upgrade guide

https://issues.redhat.com/browse/AAP-54892