### PR TITLE
Updates broken links in various 2.6 guides

### DIFF
--- a/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-playbooks.adoc
+++ b/downstream/assemblies/troubleshooting-aap/assembly-troubleshoot-playbooks.adoc
@@ -5,7 +5,3 @@
 
 [role="_abstract"]
 You can use {Navigator} to interactively troubleshoot your playbook.
-
-For more information about troubleshooting a playbook with {Navigator}, see
-link:{URLNavigatorGuide}/assembly-troubleshooting-navigator_ansible-navigator[Troubleshooting Ansible content with {Navigator}]
-in the _{TitleNavigatorGuide}_ Guide.

--- a/downstream/modules/platform/proc-aap-generate-manifest-file.adoc
+++ b/downstream/modules/platform/proc-aap-generate-manifest-file.adoc
@@ -14,7 +14,3 @@ After an allocation is created and has the appropriate subscriptions on it, you 
 . Click btn:[Export Manifest] to download the manifest file.
 +
 This downloads a file _manifest_<allocation name>_<date>.zip_ to your default downloads folder.
-
-[role="_additional-resources"]
-.Next steps
-* link:{URLCentralAuth}/assembly-gateway-licensing#proc-aap-activate-with-manifest[Upload the manifest file].

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-aap-packages.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-aap-packages.adoc
@@ -5,4 +5,4 @@
 [role="_abstract"]
 You cannot locate certain packages that come bundled with the {PlatformNameShort} installer, or you are seeing a "Repositories disabled by configuration" message.
 
-To resolve this issue, enable the repository by using the `subscription-manager` command in the command line. For more information about resolving this issue, see the _Troubleshooting_ section of link:{URLCentralAuth}/assembly-gateway-licensing#proc-attaching-subscriptions[Attaching your {PlatformName} subscription] in _{TitleCentralAuth}_.
+To resolve this issue, enable the repository by using the `subscription-manager` command in the command line.


### PR DESCRIPTION
2.6 correct links in Planning your upgrade guide

https://issues.redhat.com/browse/AAP-54892