### PR TITLE
Fixing build issue for acccess management 2.5

### DIFF
--- a/downstream/modules/platform/con-gw-overview-access-auth.adoc
+++ b/downstream/modules/platform/con-gw-overview-access-auth.adoc
@@ -6,7 +6,7 @@
 
 {PlatformNameShort} features a platform interface where you can set up centralized authentication, configure access management, and configure global and system level settings from a single location.
 
-The first time you log in to the {PlatformNameShort}, you must enter your subscription information to activate the platform. For more information about licensing and subscriptions, refer to xref:assembly-gateway-licensing[Managing {PlatformNameShort} licensing, updates and support]. 
+The first time you log in to the {PlatformNameShort}, you must enter your subscription information to activate the platform. For more information about licensing and subscriptions, see link:{URLCentralAuth}/assembly-gateway-licensing[Managing {PlatformNameShort} licensing, updates and support]. 
 
 A system administrator can configure access, permissions and system settings through the following tasks:
 

--- a/downstream/modules/platform/proc-aap-enable-disable-auth.adoc
+++ b/downstream/modules/platform/proc-aap-enable-disable-auth.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="aap-enable-disable-auth_{context}"]
+[id="aap-enable-disable-auth"]
 
 = Enabling and disabling the local authenticator
 


### PR DESCRIPTION
[Docs] Fix 2.5 Access management broken build

https://issues.redhat.com/browse/AAP-54922

Affects `titles/central-auth`