### PR TITLE
Backport-2.5-4510 to AAP-53847 Corrected link to current location of Actions content

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
+++ b/downstream/assemblies/eda/assembly-eda-rulebook-activations.adoc
@@ -24,7 +24,7 @@ The following actions are currently supported:
 * `debug`
 * `none`
 
-To view further details, see link:https://ansible.readthedocs.io/projects/rulebook/en/stable/actions.html[Actions]. 
+To view further details, see link:https://ansible.readthedocs.io/projects/rulebook/en/latest/actions.html[Actions]. 
 
 A rulebook activation is a process running in the background defined by a decision environment executing a specific rulebook. You can set up your rulebook activation by following link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/using_automation_decisions/eda-rulebook-activations#eda-set-up-rulebook-activation[Setting up a rulebook activation].
 


### PR DESCRIPTION
Corrected the link to [Actions](https://ansible.readthedocs.io/projects/rulebook/en/latest/actions.html) in the ansible.readthedocs.io, which changed after publishing in previous version.