### PR TITLE
AAP-44042 edits for custom host name

### DIFF
--- a/downstream/modules/platform/proc-configuring-controller-route-options.adoc
+++ b/downstream/modules/platform/proc-configuring-controller-route-options.adoc
@@ -19,3 +19,8 @@ The {PlatformName} operator installation form allows you to further configure yo
 . Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*. For most instances *Edge* should be selected.
 . Under *Route TLS credential secret*, click the drop-down menu and select a secret from the list.
 . Under *Enable persistence for __/var/lib/projects__ directory* select either true or false by moving the slider.
++
+[NOTE]
+====
+After you have configured your route you can customize your hostname by adding `route_host:` to the YAML for that {ControllerName} instance.
+====

--- a/downstream/modules/platform/proc-hub-route-options.adoc
+++ b/downstream/modules/platform/proc-hub-route-options.adoc
@@ -19,3 +19,8 @@ The {PlatformName} operator installation form allows you to further configure yo
 . Under *Route DNS host*, enter a common host name that the route answers to.
 . Under *Route TLS termination mechanism*, click the drop-down menu and select *Edge* or *Passthrough*.
 . Under *Route TLS credential secret*, click the drop-down menu and select a secret from the list.
++
+[NOTE]
+====
+After you have configured your route you can customize your hostname by adding `route_host:` to the YAML for that {HubName} instance. 
+====


### PR DESCRIPTION
[AAP-44042](https://issues.redhat.com/browse/AAP-44042)
The documentation is missing instructions for adding an additional route with TLS certificates for the AAP operator.

[Draft](https://docs.google.com/document/d/1Ddyj29j-sR6VNWf8Pf-Xp59_CiyljiQx8N9jS2HDuhk/edit?tab=t.0)