### PR TITLE
2.6 Updates Preparing the managed nodes for containerized installation (#4538)

### DIFF
--- a/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
@@ -19,23 +19,26 @@ Complete the following steps for each host:
 . Create a new user. Replace `<username>` with the username you want, for example `aap`.
 +
 ----
-$ adduser <username>
+$ sudo adduser <username>
 ----
 +
 . Set a password for the new user. Replace `<username>` with the username you created.
 +
 ----
-$ passwd <username>
+$ sudo passwd <username>
 ----
 +
-. Configure the user to run sudo commands.
-.. To do this open the sudoers file:
+. Configure the user to run `sudo` commands.
++
+For a secure and maintainable installation, it is a best practice to configure `sudo` privileges for the installation user in a dedicated file within the `/etc/sudoers.d/` directory.
++
+.. Create a dedicated `sudoers` file for the user:
 +
 ----
-$ vi /etc/sudoers
+$ sudo visudo -f /etc/sudoers.d/<username>
 ----
 +
-.. Add the following line to the file (replacing `<username>` with the username you created):
+.. Add the following line to the file, replacing `<username>` with the username you created:
 +
 ----
 <username> ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
Backports #4538 from main to 2.6

Affected title: Containerized installation

Documentation bug, do not edit etc/sudoers

https://issues.redhat.com/browse/AAP-53072