### PR TITLE
Backport-2.6-4526 to AAP-46228 Pre-migration work EDA user guide, Chapter 12

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-event-filter-plugins.adoc
+++ b/downstream/assemblies/eda/assembly-eda-event-filter-plugins.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="eda-event-filter-plugins"]
 
 = Event filter plugins
 
+[role="_abstract"]
 Events sometimes have extra data that is unnecessary and might overwhelm the rule engine. 
 Use event filters to remove that extra data so you can focus on what matters to your rules. 
 Event filters might also change the format of the data so that the rule conditions can better match the data.
@@ -21,9 +23,6 @@ The default link:https://github.com/ansible/event-driven-ansible/tree/main/exten
 You can chain event filters one after the other, and the updated data is sent from one filter to the next.
 Event filters are defined in the rulebook after a source is defined.
 When the rulebook starts the source plugin it associates the correct filters and transforms the data before putting it into the queue.
-
-[Example]
-====
 
 ----
 sources:
@@ -46,6 +45,6 @@ Since every event should record the origin of the event the filter `eda.builtin.
 The `received_at` stores a date time in UTC ISO8601 format and includes the microseconds.
 The `uuid` stores the unique id for the event.
 The `meta key` is used to store metadata about the event and its needed to correctly report about the events in the aap-server.
-====
+
 
 include::eda/con-eda-author-event-filters.adoc[leveloffset=+1]

--- a/downstream/modules/eda/con-eda-author-event-filters.adoc
+++ b/downstream/modules/eda/con-eda-author-event-filters.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: CONCEPT
 [id="eda-author-event-filters"]
 
 = Author event filters
 
+[role="_abstract"]
 Event filters are functions in a python module that perform transformations on the event data. 
 They can remove, add, change, or move any data in the event data structure. 
 Event filters take the event as the first argument and additional keyword arguments are provided by the configuration in the rulebook.
@@ -30,4 +32,4 @@ You can use this filter in a rulebook by adding it to the filters list in an eve
 ----
 
 .Additional resources
-See the event filter plugins in link:https://github.com/ansible/event-driven-ansible/tree/main/extensions/eda/plugins/event_filter[ansible.eda collection] for more examples of how to author them.
+* link:https://github.com/ansible/event-driven-ansible/tree/main/extensions/eda/plugins/event_filter[ansible.eda collection]


### PR DESCRIPTION
Prepped [Chapter 12. Event filter plugins](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/using_automation_decisions/eda-event-filter-plugins) in the Using automation decisions guide for migration compliance.