### PR TITLE
Backport-2.6-4547 to AAP-46230 Pre-migration work EDA user guide, Chapter 13

### DIFF
--- a/downstream/assemblies/eda/assembly-eda-logging-strategy.adoc
+++ b/downstream/assemblies/eda/assembly-eda-logging-strategy.adoc
@@ -1,7 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="eda-logging-strategy"]
 
 = {EDAName} logging strategy
 
+[role="_abstract"]
 {EDAName} offers an audit logging solution over its resources. 
 Each supported create, read, update and delete (CRUD) operation is logged against rulebook activations, event streams, decision environments, projects, and activations. 
 Some of these resources support further operations, such as sync, enable, disable, restart, start, and stop; for these operations, logging is supported as well. 

--- a/downstream/modules/eda/ref-eda-logging-samples.adoc
+++ b/downstream/modules/eda/ref-eda-logging-samples.adoc
@@ -3,6 +3,7 @@
 
 = Logging samples
 
+[role="_abstract"]
 When the following APIs are called for each operation, you see the following audit logs:
 
 Rulebook activation::


### PR DESCRIPTION
Prepped [Chapter 13. Event-Driven Ansible logging strategy](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/using_automation_decisions/eda-logging-strategy) in the Using automation decisions guide for migration compliance.