### PR TITLE
2.5 backport: AAP-54971: Adds note about collection size limit for uploading to hub docs

### DIFF
--- a/downstream/modules/hub/proc-uploading-collections.adoc
+++ b/downstream/modules/hub/proc-uploading-collections.adoc
@@ -14,6 +14,12 @@ Format your collection file name as follows: <my_namespace-my_collection-1.0.0.t
 .Prerequisites
 * You have a namespace to which you can upload the collection.
 
+[IMPORTANT]
+
+====
+Collections are typically no more than 200MB in size. Uploading very large collections will result in an error. In scenarios that require a complete environment with multiple collections and dependencies, use an {ExecEnvShort}. See link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/managing_automation_content/managing-containers-hub#obtain-images[Pulling {ExecEnvShort}s for use in {HubName}] for more information.
+====
+
 .Procedure
 
 . Log in to {PlatformNameShort}.


### PR DESCRIPTION
This PR ports the changes from [PR 4558](https://github.com/ansible/aap-docs/pull/4558) to the 2.5 branch. This work is being tracked in [AAP-54971](https://issues.redhat.com/browse/AAP-54971).