### PR TITLE
2.6 backport: AAP-55095: updates language around subscriptions, removes references to licenses

### DIFF
--- a/downstream/assemblies/platform/assembly-gateway-licensing.adoc
+++ b/downstream/assemblies/platform/assembly-gateway-licensing.adoc
@@ -15,7 +15,7 @@ You must have valid subscriptions attached before installing {PlatformNameShort}
 
 include::platform/ref-controller-trial-evaluation.adoc[leveloffset=+1]
 
-include::platform/ref-controller-licenses.adoc[leveloffset=+1]
+// include::platform/ref-controller-licenses.adoc[leveloffset=+1]
 
 include::platform/ref-controller-node-counting.adoc[leveloffset=+1]
 

--- a/downstream/modules/platform/ref-controller-node-counting.adoc
+++ b/downstream/modules/platform/ref-controller-node-counting.adoc
@@ -6,11 +6,9 @@
 
 [role="_abstract"]
 
-The {PlatformNameShort} license defines the number of Managed Nodes that can be managed as part of your subscription.
+The {PlatformNameShort} subscription defines the number of Managed Nodes that can be managed as part of your subscription.
 
-A typical license says "License Count: 500", which sets the maximum number of Managed Nodes at 500.
-
-For more information about managed node requirements for licensing, see link:https://access.redhat.com/articles/3331481[How are "managed nodes" defined as part of the {PlatformName} offering].
+For more information about managed node requirements for subscriptions, see link:https://access.redhat.com/articles/3331481[How are "managed nodes" defined as part of the {PlatformName} offering].
 
 [NOTE]
 ====

--- a/downstream/modules/platform/ref-controller-trial-evaluation.adoc
+++ b/downstream/modules/platform/ref-controller-trial-evaluation.adoc
@@ -6,8 +6,8 @@
 
 [role="_abstract"]
 
-A license is required to run {PlatformNameShort}. You can start by using a free trial license.
+A subscription is required to run {PlatformNameShort}. You can start by signing up for a free trial subscription.
 
-* Trial licenses for {PlatformNameShort} are available at the link:https://www.redhat.com/en/products/trials?products=ansible[Red Hat product trial center].
+* Trial subscriptions for {PlatformNameShort} are available at the link:https://www.redhat.com/en/products/trials?products=ansible[Red Hat product trial center].
 
-* Support is not included in a trial license or during an evaluation of the {PlatformNameShort}.
+* Support is not included in a trial subscription or during an evaluation of the {PlatformNameShort}.


### PR DESCRIPTION
This PR ports the changes from [PR 4569](https://github.com/ansible/aap-docs/pull/4569) to the 2.6 branch. This work is being tracked in [AAP-55095](https://issues.redhat.com/browse/AAP-55095)