### PR TITLE
2.6 AAP-55133 Update links in plug-ins doc (#4586)

### DIFF
--- a/downstream/modules/devtools/con-rhdh-recommended-preconfig.adoc
+++ b/downstream/modules/devtools/con-rhdh-recommended-preconfig.adoc
@@ -6,8 +6,8 @@
 Red Hat recommends performing the following initial configuration tasks in {RHDHShort}.
 However, you can install the {AAPRHDH} before completing these tasks.
 
-* link:{BaseURL}/red_hat_developer_hub/{RHDHVers}/html/authentication/index[Setting up authentication in {RHDHShort}] 
-* link:{BaseURL}/red_hat_developer_hub/{RHDHVers}/html/authorization/index[Installing and configuring RBAC in {RHDHShort}] 
+* link:{BaseURL}/red_hat_developer_hub/{RHDHVers}/html/authentication_in_red_hat_developer_hub/index[Authentication in {RHDH}] 
+* link:{BaseURL}/red_hat_developer_hub/{RHDHVers}/html-single/authorization_in_red_hat_developer_hub/index[Authorization in {RHDH}]
 
 [NOTE]
 ====

--- a/downstream/modules/devtools/proc-rhdh-configure-rbac.adoc
+++ b/downstream/modules/devtools/proc-rhdh-configure-rbac.adoc
@@ -30,6 +30,6 @@ data:
 
 
 For more information about permission policies and managing RBAC, refer to the
-link:{BaseURL}/red_hat_developer_hub/{RHDHVers}/html-single/authorization/index[_Authorization_]
+link:{BaseURL}/red_hat_developer_hub/{RHDHVers}/html-single/authorization_in_red_hat_developer_hub/index[_Authorization in {RHDH}_]
 guide for Red Hat Developer Hub.
 


### PR DESCRIPTION
Fixes broken links in `titles/aap-plugin-rhdh-install`