### PR TITLE
2.5 backport: AAP-55081: fixes broken link in Operating AAP guide(#4606)

### DIFF
--- a/downstream/assemblies/platform/assembly-aap-activate.adoc
+++ b/downstream/assemblies/platform/assembly-aap-activate.adoc
@@ -32,9 +32,9 @@ include::platform/proc-aap-activate-with-manifest.adoc[leveloffset=+1]
 endif::operationG[]
 
 ifdef::operationG[]
-To activate {PlatformNameShort} using credentials, see link:{URLCentralAuth}/assembly-gateway-licensing#proc-aap-activate-with-credentials[Activate with credentials].
+To activate {PlatformNameShort} using credentials, see link:{URLContainerizedInstall}/assembly-gateway-licensing#proc-aap-activate-with-credentials[Activate with credentials].
 
-To activate {PlatformNameShort} with a manifest file, see link:{URLCentralAuth}/assembly-gateway-licensing#proc-aap-activate-with-manifest[Activate with a manifest file].
+To activate {PlatformNameShort} with a manifest file, see link:{URLContainerizedInstall}/assembly-gateway-licensing#proc-aap-activate-with-manifest[Activate with a manifest file].
 endif::operationG[]
 
 ifdef::parent-context[:context: {parent-context}]


### PR DESCRIPTION
This PR ports the changes from [PR 4606](https://github.com/ansible/aap-docs/pull/4606) to the 2.6 branch. This work is being tracked in [AAP-55081](https://issues.redhat.com/browse/AAP-55081).