### PR TITLE
Updating managing auth chapter (#4624)

### DIFF
--- a/downstream/assemblies/platform/assembly-gw-managing-authentication.adoc
+++ b/downstream/assemblies/platform/assembly-gw-managing-authentication.adoc
@@ -18,5 +18,9 @@ include::platform/proc-gw-edit-authenticator.adoc[leveloffset=+1]
 
 include::platform/proc-gw-delete-authenticator.adoc[leveloffset=+1]
 
+include::platform/con-gw-gcp-network-port-limits.adoc[leveloffset=+1]
+
+include::platform/proc-gw-gcp-increase-port-limits.adoc[leveloffset=+2]
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/con-gw-gcp-network-port-limits.adoc
+++ b/downstream/modules/platform/con-gw-gcp-network-port-limits.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="gw-gcp-network-port-limits"]
+
+= Google Cloud Platform network configuration for increased authentication performance
+
+[role="_abstract"]
+
+In a Google Cloud Platform (GCP) environment, a high volume of traffic can lead to authentication and performance issues because of the low default port limit set on the GCP Cloud NAT gateway. 
+While this configuration affects all GCP deployments, the highest risk for hitting this limit occurs when {PlatformNameShort} is deployed on OpenShift (version 4.17 and above).
+
+The default setting for the Cloud NAT gateway's *Minimum ports per VM instance* in OpenShift installations on GCP (version 4.17 and above) is 64.
+This low port limit can be quickly exhausted when {Gateway} handles concurrent external network connections, such as Single Sign-On (SSO) requests. 
+When the limit is reached, it prevents new outgoing connections, causing authentication failures or severe performance degradation.

--- a/downstream/modules/platform/proc-gw-gcp-increase-port-limits.adoc
+++ b/downstream/modules/platform/proc-gw-gcp-increase-port-limits.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="gw-gcp-increase-port-limits"]
+
+= Increasing the minimum ports
+
+To address this limitation, manually increase the *Minimum ports per VM instance* setting for the Cloud NAT gateway associated with the worker nodes.
+
+Use the Google Cloud Console to apply this workaround.
+
+.Procedure
+
+. Go to the link:https://console.cloud.google.com/net-services/nat/[Cloud NAT service].
+. Locate and select the NAT gateway configured for your OpenShift cluster's worker nodes.
+. Increase the default value of 64 for the *Minimum ports per VM instance* setting to a higher value to accommodate your anticipated traffic volume.
++
+Increasing this limit ensures enough available ports for external communication, reducing the likelihood of performance issues during high-volume authentication and external communication tasks.


### PR DESCRIPTION
* Updating managing auth chapter

Update documentation about openshift minimal ports per VM when running in gcp

https://issues.redhat.com/browse/AAP-53684

Affects `titles/central-auth`

* Peer review edit

---------