### PR TITLE
AAP-69732: removes references to API tokens in hub docs

### DIFF
--- a/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
+++ b/downstream/assemblies/hub/assembly-syncing-to-cloud-repo.adoc
@@ -41,7 +41,7 @@ include::hub/con-token-management-hub.adoc[leveloffset=+1]
 
 include::hub/proc-create-api-token.adoc[leveloffset=+1]
 
-include::hub/proc-create-api-token-pah.adoc[leveloffset=+1]
+// include::hub/proc-create-api-token-pah.adoc[leveloffset=+1]
 
 include::hub/proc-offline-token-active.adoc[leveloffset=+1]
 

--- a/downstream/modules/hub/proc-create-remote.adoc
+++ b/downstream/modules/hub/proc-create-remote.adoc
@@ -23,10 +23,10 @@ To find the remote server URL and repository path, navigate to {MenuACAdminRepos
 . To sync dependencies, check the box labeled *Sync all dependencies*. To turn off dependency syncing, leave this box unchecked.
 . Configure the credentials to the remote server by entering a *Token* or *Username* and *Password* required to access the external collection.
 +
-[NOTE]
-====
-To generate a token from the navigation panel, select {MenuACAPIToken}, click btn:[Load token] and copy the token that is loaded.
-====
+//[NOTE]
+//====
+//To generate a token from the navigation panel, select {MenuACAPIToken}, click btn:[Load token] and copy the token that is loaded.
+//====
 +
 . To access collections from {Console}, enter the *SSO URL* to sign in to the identity provider (IdP).
 . Select or create a *Requirements file* to identify the collections and version ranges to synchronize with your custom repository. For example, to download only the kubernetes and AWS collection versions 5.0.0 or later the requirements file would look like this:


### PR DESCRIPTION
This work is being tracked in [AAP-69732](https://redhat.atlassian.net/browse/AAP-69732)