### PR TITLE
AAP-65661: Additional SME feedback for content discovery and catalog docs

### DIFF
--- a/downstream/assemblies/devtools/assembly-self-service-admin-content-setup.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-admin-content-setup.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 
 :context: self-service-admin-content-setup
 [role="_abstract"]
-Configure content discovery and catalog functionality in {SelfServiceShort} to enable users to sync repositories, discover {ExecEnvShort}s, and browse collections.
+Configure content discovery and catalog functionality in {SelfServiceShort} to enable users to sync repositories, discover Ansible collections, and browse content.
 
 As an administrator, you must set up authentication to your Git repositories and configure catalog locations before users can sync and discover content.
 

--- a/downstream/assemblies/devtools/assembly-self-service-discovering-ee-content.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-discovering-ee-content.adoc
@@ -8,7 +8,7 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 Use the {ExecEnvShort} and collection catalogs in {SelfServiceShort} to discover, browse, and access automation content.
 
-{ExecEnvShort} definitions created through the EE Builder and Ansible collections discovered from synchronized Git repositories are available in dedicated catalog views.
+Ansible collections discovered from configured content sources are available in the collection catalog view, and {ExecEnvShort} definitions created through the EE Builder are available in the {ExecEnvShort} catalog view.
 
 == Execution environment catalog
 

--- a/downstream/assemblies/devtools/assembly-self-service-repository-synchronization.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-repository-synchronization.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 
 :context: self-service-repository-synchronization
 [role="_abstract"]
-Sync Git repositories to discover and catalog content such as {ExecEnvShort} definitions, Ansible collections, and software templates in {SelfServiceShort}.
+Sync Git repositories to discover and catalog Ansible collections in {SelfServiceShort}.
 
 After configuring Git repository integration, you can sync repositories manually or on automatic schedules to keep your catalog content current.
 

--- a/downstream/modules/devtools/con-self-service-collection-catalog-overview.adoc
+++ b/downstream/modules/devtools/con-self-service-collection-catalog-overview.adoc
@@ -4,17 +4,15 @@
 = The collection catalog
 
 [role="_abstract"]
-The collection catalog in {SelfServiceShort} provides a centralized view of all Ansible collections discovered from your synchronized Git repositories and {ExecEnvShort} definitions.
+The collection catalog in {SelfServiceShort} provides a centralized view of all Ansible collections discovered from your configured content sources.
 Use the catalog to browse, search, and learn about available collections for your automation content.
 
 == Catalog content
 
 The collection catalog displays Ansible collections that have been discovered from:
 
-* {ExecEnvShort} definitions that specify collection requirements
-* Synchronized repositories containing collection metadata
-
-Collections are discovered during repository synchronization when {SelfServiceShort} processes catalog entity files and {ExecEnvShort} definitions.
+* Git repositories containing `galaxy.yml` files with valid collection metadata
+* {PrivateHubName} repositories configured as content sources
 
 == Catalog capabilities
 

--- a/downstream/modules/devtools/con-self-service-content-mgmt-prerequisites.adoc
+++ b/downstream/modules/devtools/con-self-service-content-mgmt-prerequisites.adoc
@@ -31,16 +31,23 @@ For GitLab, the PAT must have the following scopes:
 * `read_repository`
 * `api`
 
+== Collection discovery sources
+
+{SelfServiceShort} discovers Ansible collections from content sources configured in the `app-config`.
+You can configure the following source types for collection discovery:
+
+* *Git repositories*: {SelfServiceShort} scans configured Git repositories for `galaxy.yml` files that contain valid collection metadata.
+* *{PrivateHubName} repositories*: {SelfServiceShort} can discover collections from {PrivateHubName} repositories configured as content sources.
+
+Configure Git content sources in the `ansibleGitContents` section of your Helm chart `app-config` to specify which Git organizations and repositories to scan for collections.
+Configure {PrivateHubName} content sources in the `pahCollections` section to specify which {PrivateHubName} repositories to sync collections from.
+
 == Repository format requirements
 
-Repositories eligible for syncing must contain valid catalog entity files in YAML format. These files define:
+For collection discovery, repositories must contain valid `galaxy.yml` files with collection metadata.
+For software templates and other catalog entities, repositories must contain valid catalog entity files in YAML format.
 
-* {ExecEnvShort} definitions
-* Ansible collections metadata
-* Software templates
-* Other discoverable content
-
-Entity files must:
+Catalog entity files must:
 
 * Use `.yaml` or `.yml` file extensions
 * Follow the catalog entity schema

--- a/downstream/modules/devtools/con-self-service-repository-catalog-overview.adoc
+++ b/downstream/modules/devtools/con-self-service-repository-catalog-overview.adoc
@@ -5,10 +5,9 @@
 
 [role="_abstract"]
 The repository catalog in {SelfServiceShort} provides a centralized view of all Git repositories configured for content synchronization.
-The catalog displays repository status, sync history, and discoverable content such as {ExecEnvShort} definitions, collections, and software templates.
+The catalog displays repository status, sync history, and discoverable content such as Ansible collections.
 
-When a repository syncs successfully, {SelfServiceShort} discovers and catalogs entities defined in YAML files within the repository.
-These entities become available in the appropriate catalog views.
+When a repository syncs successfully, discovered content becomes available in the appropriate catalog views.
 
 == Synchronization options
 

--- a/downstream/modules/devtools/proc-self-service-browse-collection-catalog.adoc
+++ b/downstream/modules/devtools/proc-self-service-browse-collection-catalog.adoc
@@ -5,13 +5,13 @@
 
 [role="_abstract"]
 Browse the collection catalog to find and explore Ansible collections in {SelfServiceShort}.
-The catalog displays collections discovered from your synchronized repositories and {ExecEnvShort} definitions, showing collection metadata, dependencies, and documentation links.
+The catalog displays collections discovered from your configured content sources, showing collection metadata, dependencies, and documentation links.
 Use search and filtering to locate specific collections.
 
 .Prerequisites
 
 * You have logged in to {SelfServiceShort}.
-* Repositories or {ExecEnvShort} definitions containing collection metadata have been synced to the portal.
+* Content sources containing Ansible collections have been configured and synced to the portal.
 
 .Procedure
 
@@ -39,7 +39,7 @@ Detail view contents, including metadata, dependencies, and related {ExecEnvShor
 .Verification
 
 . Verify you can locate expected collections in the catalog.
-. If expected collections are missing, verify repositories or EE definitions containing the collection have been synced successfully.
+. If expected collections are missing, verify that the content sources containing those collections have been configured and synced successfully.
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/devtools/proc-self-service-setup-git-integration.adoc
+++ b/downstream/modules/devtools/proc-self-service-setup-git-integration.adoc
@@ -13,7 +13,6 @@ After completing this procedure, your private repositories are configured as cat
 ** A Personal Access Token (PAT) stored in an OpenShift secret named `secrets-scm`. For more information, see xref:self-service-create-gh-pat_{context}[] or xref:self-service-create-gl-pat_{context}[] and xref:self-service-create-scm-secrets_{context}[].
 ** A GitHub App configured for your organization (GitHub only). For more information, see xref:self-service-create-github-app_{context}[] and xref:self-service-configure-github-app_{context}[].
 * You have administrator access to the {SelfServiceShort} Helm chart configuration.
-* Your repositories contain valid catalog entity files in YAML format.
 
 .Procedure
 
@@ -83,7 +82,8 @@ If repositories fail to sync:
 * If you use a GitHub App, verify the app is installed for the target repositories and the credentials are correctly configured
 * Ensure the authentication secret (`secrets-scm` for PATs, or `github-app-credentials` for GitHub Apps) exists in the same namespace as {SelfServiceShort}
 * Confirm the repository URLs are accessible and correctly formatted
-* Check that catalog entity files in the repository are valid YAML and follow the catalog entity schema
+* For collection discovery, check that repositories contain valid `galaxy.yml` files with collection metadata
+* For other catalog entities, check that entity files are valid YAML and follow the catalog entity schema
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/devtools/proc-self-service-sync-repositories.adoc
+++ b/downstream/modules/devtools/proc-self-service-sync-repositories.adoc
@@ -4,16 +4,17 @@
 = Synchronize Git repositories
 
 [role="_abstract"]
-Sync Git repositories to discover and catalog {ExecEnvShort} definitions, collections, and software templates in {SelfServiceShort}.
+Sync Git repositories to discover and catalog Ansible collections in {SelfServiceShort}.
 After syncing, content from your repositories appears in the portal's catalog views where users can find and manage it.
 You can sync repositories manually on demand or configure automatic synchronization schedules.
 
 .Prerequisites
 
 * You have configured Git repository integration in your Helm chart, including catalog locations and authentication.
-* Your repositories contain valid catalog entity files in YAML format.
 * You have the required permissions to trigger repository synchronization.
-* For private repositories, you have configured authentication with personal access tokens stored in the `secrets-scm` secret.
+* For private repositories, you have configured authentication using one of the following methods:
+** Personal access tokens stored in the `secrets-scm` secret.
+** A GitHub App configured for your organization (GitHub only).
 
 .Procedure
 
@@ -47,6 +48,6 @@ Schedule configuration options and workflow will be documented here with screens
 +
 * Authentication failures due to expired or invalid PATs
 * Repository URLs that are inaccessible or incorrectly formatted
-* Invalid YAML syntax in catalog entity files
-* Missing required metadata fields in entity definitions
+* For collection discovery, missing or invalid `galaxy.yml` files in repositories
+* For catalog entities, invalid YAML syntax or missing required metadata fields in entity definitions
 

--- a/downstream/modules/devtools/ref-self-service-components-custom-ee-definitions.adoc
+++ b/downstream/modules/devtools/ref-self-service-components-custom-ee-definitions.adoc
@@ -6,7 +6,7 @@
 
 [role="_abstract"]
 
-When creating a custom EE, you define the core underlying elements that dictate the environment's capabilities, security, and dependencies. These components are used to define the custom EE, and are also utilized internally by the pre-defined presets.
+When creating a custom EE, you define the core underlying elements that dictate the environment's capabilities, security, and dependencies. These components define a custom EE. The predefined templates also use these components.
 
 |===
 | Component or setting | Description | Key considerations and examples
@@ -14,7 +14,7 @@ When creating a custom EE, you define the core underlying elements that dictate 
 | Base images
 a| The foundation layer of your EE, pre-configured with a specific operating system and toolset.
 
-By default, the following base images are available in all 3 pre-defined templates:
+By default, the following base images are available in all 3 predefined templates:
 
 * Red Hat Ansible Minimal EE - Ansible Core 2.18 (RHEL 8)
 * Red Hat Ansible Minimal EE - Ansible Core 2.18 (RHEL 9)
@@ -26,8 +26,8 @@ By default, the following base images are available in all 3 pre-defined templat
 If you are providing a custom image, it must include `ansible-core` and `ansible-runner`.
 
 | Collections
-| Specifies the Ansible Collections and Python libraries required by your automation content.
-a| Ensure all necessary content is included from the documentation's list. You can add collections manually or upload a `requirements.yml` file.
+| Specifies the Ansible Collections required by your automation content.
+a| Select collections from the list of discovered and cataloged collections available in {SelfServiceShort}.
 
 When collections overlap, the system merges the contents. If duplicates occur:
 
@@ -42,9 +42,7 @@ Avoid repeating Python requirements already specified as a dependency by the sel
 
 | System packages
 | Operating system (OS) libraries and packages required by the Python packages or collections.
-| Defines the extra OS libraries and packages required by the Python packages or collections listed in the EE.
-
-Examples: `git`, `gcc`, `python3-devel`. These are necessary for compiling Python packages during the build process.
+| Examples: `git`, `gcc`, `python3-devel`. These are necessary for compiling Python packages during the build process.
 
 This list supplements, and must not repeat, any base OS dependencies already managed by your environment's build system.
 

--- a/downstream/modules/devtools/ref-self-service-predefined-ee-templates.adoc
+++ b/downstream/modules/devtools/ref-self-service-predefined-ee-templates.adoc
@@ -8,6 +8,13 @@
 
 Predefined execution environment (EE) templates are preconfigured templates that accelerate environment setup for common use cases. These templates include specific base images, collections, and dependencies tailored for each domain.
 
+[NOTE]
+====
+The Networking Automation and Cloud Automation templates are opinionated templates that are not loaded in the Helm chart by default.
+These templates include domain-specific collections selected for common use cases.
+To use these templates, the {SelfServiceShort} administrator must ensure that the collections referenced in the templates are discoverable from a configured content source and accessible to the target users.
+====
+
 |===
 | Preset | Description | Key considerations and use cases
 


### PR DESCRIPTION
## Summary
- Implements 10 SME feedback items from Nilashish Chakraborty for the content discovery and catalog documentation
- Adds collection discovery sources section (`ansibleGitContents` and `pahCollections` configuration)
- Fixes collection catalog sources: `galaxy.yml` files + private automation hub (not EE definitions or catalog entity files)
- Removes EE definition discovery from scope (out of scope for ANSTRAT-1534)
- Removes manual collection add/upload from EE components (only discovered collections available)
- Adds NOTE that predefined Networking/Cloud templates are not loaded by default
- Adds GitHub Apps as auth option in sync prerequisites
- Clarifies `galaxy.yml` vs catalog entity files throughout

## Test plan
- [x] Layer 1 review (review-docs): all files pass
- [x] Layer 2 build: both guides (self-service-config, self-service-using) compile clean
- [x] Layer 3 AI review: 4 parallel agents, 6 fixes applied
- [x] Verified changes against engineering source code (ansible-backstage-plugins)
- [x] SME re-review via Google Doc

**SME Review Doc**: https://docs.google.com/document/d/10FrYKFBo0V6bZWzJJVC3dEm_ua6a0TERHHZBYnJWZYg/edit