### PR TITLE
AAP-70258 Add minimum database requirements for OCP deployment models…

### DIFF
--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -64,13 +64,27 @@ a|
 |
 | Ansible-core | Ansible-core version {CoreUseVers} or later |
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome. |
-| Database 
-a| 
+| Database
+a|
 * For {PlatformNameShort} managed databases: {PostgresVers}
 * For customer provided (external) databases: {PostgresVers}, 16, or 17.
-a| 
+a|
 * External (customer supported) databases require International Components for Unicode (ICU) support.
 * External databases using PostgreSQL 16 or 17 must rely on external backup and restore processes. Backup and restore functionality depends on utilities provided with {PostgresVers}.
+
+.Operator-deployed database connection limits
+[WARNING]
+====
+The operator-deployed PostgreSQL database has a default `max_connections` limit of 100.
+
+Do not use the operator-deployed database if any of the following conditions apply:
+
+* You are running more than 1 replica of any component ({Gateway}, {ControllerName}, {HubName}, or {EDAName}).
+* The {ControllerName} capacity exceeds 100 concurrent jobs.
+* Total database connections from all components exceed 100.
+
+If you need more than 100 database connections, use an external database instead of the operator-deployed database.
+====
 | IP version
 | IPv4, IPv6 (single-stack and dual-stack)
 | 

--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -61,9 +61,9 @@ a|
 ** 2 worker nodes in different availability zones (AZs) at t3.xlarge
 | Ansible-core | Ansible-core version {CoreUseVers} or later
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome.
-| AWS RDS PostgreSQL service 
+| AWS RDS PostgreSQL service
 a|
-* engine: "postgres" 
+* engine: "postgres"
 * engine_version: 15"
 * parameter_group_name: "default.postgres15"
 * allocated_storage: 20
@@ -74,6 +74,18 @@ a|
 * multi_az: true
 * backup_retention_period: 5
 * database: must have International Components for Unicode (ICU) support
+
+.Minimum external database requirements
+[IMPORTANT]
+====
+The external database must meet these minimum requirements:
+
+* 4 vCPUs
+* 16 GB RAM
+* `max_connections`: 1024 (minimum). You might need more connections when scaling replicas.
+
+These requirements ensure adequate database performance for the {EnterpriseTopology} workload profile.
+====
 | AWS Memcached Service
 a|
 * engine: "redis"


### PR DESCRIPTION
… (#5891)

Add minimum external database requirements (4 vCPUs, 16 GB RAM, max_connections 1024) to the OCP-B Enterprise Topology. Add a warning about the operator-deployed PostgreSQL 100-connection limit to the OCP-A Growth Topology, with guidance on when to use an external database instead.