### PR TITLE
AAP-70305 updated upgrading procedure for clarity (#5868)

### DIFF
--- a/downstream/modules/automation-dashboard/proc-upgrading-automation-dashboard.adoc
+++ b/downstream/modules/automation-dashboard/proc-upgrading-automation-dashboard.adoc
@@ -7,7 +7,7 @@
 = Upgrading {AutomationDashboardName}
 
 [role="_abstract"]
-Upgrade your {AutomationDashboardName} installation to the latest version. This process involves running the installation program and updating your cluster configuration with new authentication requirements.
+This procedure applies when upgrading from {AutomationDashboardName} versions before 0.1 (which did not include Redis) to the current version. This process involves running the installation program and updating your cluster configuration with new authentication requirements.
 
 [NOTE]
 ====


### PR DESCRIPTION
2.5 backport for https://github.com/ansible/aap-docs/pull/5862