### PR TITLE
AAP-57833: Expand Configuration as Code guide for ansible.platform 2.7

### DIFF
--- a/downstream/assemblies/configuration-as-code/assembly_configure-your-platform-with-configuration-as-code.adoc
+++ b/downstream/assemblies/configuration-as-code/assembly_configure-your-platform-with-configuration-as-code.adoc
@@ -1,0 +1,30 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-04-09
+:_mod-docs-content-type: ASSEMBLY
+
+ifdef::context[:parent-context-of-configure-your-platform-with-configuration-as-code: {context}]
+
+ifndef::context[]
+[id="configure-your-platform-with-configuration-as-code"]
+endif::[]
+ifdef::context[]
+[id="configure-your-platform-with-configuration-as-code_{context}"]
+endif::[]
+= Configure your platform with Configuration as Code
+
+:context: configure-your-platform-with-configuration-as-code
+
+[role="_abstract"]
+You can define and manage {PlatformNameShort} configuration by using version-controlled Ansible playbooks instead of the web UI.
+The `ansible.platform` collection provides modules for creating and managing platform resources such as organizations, users, teams, RBAC roles, authentication providers, and gateway settings.
+
+include::configuration-as-code/con_configuration-as-code-with-the-ansible-platform-collection.adoc[leveloffset=+1]
+
+include::configuration-as-code/proc_setting-up-your-automation-environment-for-configuration-as-code.adoc[leveloffset=+1]
+
+include::configuration-as-code/ref_ansible-platform-collection-modules.adoc[leveloffset=+1]
+
+include::configuration-as-code/ref_configuration-as-code-migration-guide-for-aap-2-7.adoc[leveloffset=+1]
+
+ifdef::parent-context-of-configure-your-platform-with-configuration-as-code[:context: {parent-context-of-configure-your-platform-with-configuration-as-code}]
+ifndef::parent-context-of-configure-your-platform-with-configuration-as-code[:!context:]

--- a/downstream/modules/configuration-as-code/con_configuration-as-code-with-the-ansible-platform-collection.adoc
+++ b/downstream/modules/configuration-as-code/con_configuration-as-code-with-the-ansible-platform-collection.adoc
@@ -1,0 +1,126 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-04-09
+:_mod-docs-content-type: CONCEPT
+
+[id="configuration-as-code-with-the-ansible-platform-collection_{context}"]
+= Configuration as Code with the ansible.platform collection
+
+[role="_abstract"]
+Configuration as Code (CaC) is an approach where you define and manage the configuration of {PlatformNameShort} using version-controlled files, such as YAML, instead of manually configuring resources through the web UI.
+
+The `ansible.platform` collection provides Ansible modules for managing {PlatformNameShort} resources programmatically.
+You can use this collection to automate the creation and management of organizations, users, teams, role-based access control (RBAC), authentication providers, gateway services, and platform-wide settings.
+
+== Benefits of Configuration as Code
+
+* *Repeatability*: Apply the same configuration across development, staging, and production environments.
+* *Change tracking*: Store configuration in Git to maintain a history of changes with diffs and rollback capability.
+* *Disaster recovery*: Rebuild your {PlatformNameShort} configuration quickly after outages or migrations.
+* *Reduced errors*: Route changes through CI/CD pipelines and pull requests for peer review and automated testing.
+* *Scalability*: Configure multiple organizations, teams, and users in bulk without manual intervention.
+
+== The four-state model
+
+Most modules in the `ansible.platform` collection support a four-state model for managing resources:
+
+present:: Create the resource if it does not exist, or update it if it does.
+Only the parameters you specify are set; other fields retain their current values.
+
+absent:: Delete the resource if it exists.
+
+exists:: Check whether the resource exists without creating or modifying it.
+Use this state to verify that prerequisites are in place before running further tasks.
+
+enforced:: Create or update the resource, and reset any parameters you did not specify to their API default values.
+Use this state when you want to ensure the complete desired state of a resource, not just the fields you explicitly define.
+
+The following example uses the `enforced` state to ensure that an organization has only the specified description.
+Any other fields that were previously set on this organization are reset to their default values:
+
+[source,yaml]
+----
+- name: Enforce organization configuration
+  ansible.platform.organization:
+    name: "Production"
+    description: "Production automation resources"
+    state: enforced
+----
+
+[NOTE]
+====
+Not all modules support every state.
+The `settings` module has no `state` parameter and always applies changes.
+The `token` module supports only `present` and `absent` and is not idempotent.
+The `feature_flag` module defaults to `exists` instead of `present`, so you must explicitly set `state: present` to modify a flag.
+For a complete list of supported states per module, see the module reference.
+====
+
+== Resource names instead of IDs
+
+When you reference resources such as organizations, teams, or users in your playbooks, use human-readable names instead of numeric IDs.
+Names are portable across environments, which means you can apply the same playbook to development, staging, and production without modification.
+Using names also simplifies disaster recovery because you can rebuild your configuration without looking up IDs from a previous environment.
+
+== Check mode and idempotency
+
+All resource modules in the `ansible.platform` collection support Ansible check mode (`--check`).
+In check mode, modules report what changes they would make without applying them.
+Use check mode to verify your playbooks before applying changes to a production environment.
+
+Most modules are idempotent: running the same playbook multiple times produces the same result.
+The `token` module is an exception — each run creates a new token.
+
+== Module defaults for connection parameters
+
+The `ansible.platform` collection defines an action group called `gateway` that includes all modules.
+Use `module_defaults` to set connection parameters once instead of repeating them in every task:
+
+[source,yaml,subs="+quotes"]
+----
+- name: Configure {PlatformNameShort} resources
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/ansible.platform.gateway:
+      aap_hostname: "{{ aap_hostname }}"
+      aap_username: "{{ aap_username }}"
+      aap_password: "{{ aap_password }}"
+      aap_validate_certs: "{{ aap_validate_certs }}"
+  tasks:
+    - name: Ensure organization exists
+      ansible.platform.organization:
+        name: "My Organization"
+        state: present
+
+    - name: Ensure team exists
+      ansible.platform.team:
+        name: "My Team"
+        organization: "My Organization"
+        state: present
+----
+
+You can also use environment variables instead of specifying connection parameters in your playbook.
+The recommended naming convention is to use `AAP_` prefixed variable names, but `GATEWAY_` prefixed names are also accepted for backward compatibility:
+
+* `AAP_HOSTNAME` or `GATEWAY_HOSTNAME`
+* `AAP_USERNAME` or `GATEWAY_USERNAME`
+* `AAP_PASSWORD` or `GATEWAY_PASSWORD`
+* `AAP_TOKEN` or `GATEWAY_API_TOKEN`
+* `AAP_VALIDATE_CERTS` or `GATEWAY_VERIFY_SSL`
+* `AAP_REQUEST_TIMEOUT` or `GATEWAY_REQUEST_TIMEOUT`
+
+== Authentication methods
+
+You can authenticate to {PlatformNameShort} by using one of the following methods:
+
+* *Username and password*: Set `aap_username` and `aap_password`.
+* *OAuth2 token*: Set `aap_token` with a token string or a token object returned by the `ansible.platform.token` module.
+
+All authentication parameters accept both `aap_` and `gateway_` prefixed names for backward compatibility.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:ansible-platform-collection-modules_{context}[]
+* xref:setting-up-your-automation-environment-for-configuration-as-code_{context}[]
+* link:https://console.redhat.com/ansible/automation-hub/repo/published/ansible/platform/content/?showing=module[ansible.platform collection on {HubNameStart}]

--- a/downstream/modules/configuration-as-code/con_configuration-as-code-with-the-ansible-platform-collection.adoc
+++ b/downstream/modules/configuration-as-code/con_configuration-as-code-with-the-ansible-platform-collection.adoc
@@ -105,18 +105,18 @@ The recommended naming convention is to use `AAP_` prefixed variable names, but 
 * `AAP_HOSTNAME` or `GATEWAY_HOSTNAME`
 * `AAP_USERNAME` or `GATEWAY_USERNAME`
 * `AAP_PASSWORD` or `GATEWAY_PASSWORD`
-* `AAP_TOKEN` or `GATEWAY_API_TOKEN`
+* `AAP_TOKEN` or `GATEWAY_API_TOKEN` (the naming is asymmetric by design)
 * `AAP_VALIDATE_CERTS` or `GATEWAY_VERIFY_SSL`
 * `AAP_REQUEST_TIMEOUT` or `GATEWAY_REQUEST_TIMEOUT`
 
 == Authentication methods
 
-You can authenticate to {PlatformNameShort} by using one of the following methods:
+You can authenticate to {PlatformNameShort} by using one of the following module parameters:
 
-* *Username and password*: Set `aap_username` and `aap_password`.
-* *OAuth2 token*: Set `aap_token` with a token string or a token object returned by the `ansible.platform.token` module.
+* *Username and password*: Set the `aap_username` and `aap_password` module parameters.
+* *OAuth2 token*: Set the `aap_token` module parameter with a token string or a token object returned by the `ansible.platform.token` module.
 
-All authentication parameters accept both `aap_` and `gateway_` prefixed names for backward compatibility.
+All authentication module parameters accept both `aap_` and `gateway_` prefixed names for backward compatibility.
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/configuration-as-code/proc_setting-up-your-automation-environment-for-configuration-as-code.adoc
+++ b/downstream/modules/configuration-as-code/proc_setting-up-your-automation-environment-for-configuration-as-code.adoc
@@ -3,7 +3,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="setting-up-your-automation-environment-for-configuration-as-code_{context}"]
-= Setting up your automation environment for Configuration as Code
+= Set up your automation environment for Configuration as Code
 
 [role="_abstract"]
 Configuration as Code is a way of working where you define and manage the configuration of the {PlatformNameShort} itself using the version-controlled configuration files (such as YAML, or JSON), instead of clicking through the web UI.

--- a/downstream/modules/configuration-as-code/ref_ansible-platform-collection-modules.adoc
+++ b/downstream/modules/configuration-as-code/ref_ansible-platform-collection-modules.adoc
@@ -109,7 +109,7 @@ The following tables list the available modules grouped by category.
 | N/A (always applies)
 
 | `feature_flag`
-| Query and manage feature flags. Only run-time flags can be modified; install-time flags are read-only.
+| Query and manage feature flags. Only run-time flags can be modified; install-time flags are read-only. This module defaults to `exists` instead of `present`, so you must explicitly set `state: present` to modify a flag.
 | present, absent, exists, enforced
 |===
 

--- a/downstream/modules/configuration-as-code/ref_ansible-platform-collection-modules.adoc
+++ b/downstream/modules/configuration-as-code/ref_ansible-platform-collection-modules.adoc
@@ -1,0 +1,149 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-04-09
+:_mod-docs-content-type: REFERENCE
+
+[id="ansible-platform-collection-modules_{context}"]
+= Modules in the ansible.platform collection
+
+[role="_abstract"]
+The `ansible.platform` collection provides modules for managing {PlatformNameShort} resources.
+The following tables list the available modules grouped by category.
+
+== Identity and access management
+
+[cols="1,2,1",options="header"]
+|===
+| Module | Description | Supported states
+
+| `organization`
+| Create, update, or delete organizations.
+| present, absent, exists, enforced
+
+| `user`
+| Create, update, or delete users. Configure superuser status and authenticator associations.
+| present, absent, exists, enforced
+
+| `team`
+| Create, update, or delete teams within an organization.
+| present, absent, exists, enforced
+
+| `role_definition`
+| Create, update, or delete custom RBAC role definitions with specific permissions.
+| present, absent, exists, enforced
+
+| `role_user_assignment`
+| Assign roles to users for specific resources or organizations.
+| present, absent, exists
+
+| `role_team_assignment`
+| Assign roles to teams for specific resources or organizations. Supports batch operations with `assignment_objects`.
+| present, absent, exists
+|===
+
+== Authentication
+
+[cols="1,2,1",options="header"]
+|===
+| Module | Description | Supported states
+
+| `authenticator`
+| Configure authentication providers such as LDAP, OIDC, SAML, and GitHub.
+| present, absent, exists, enforced
+
+| `authenticator_map`
+| Define authentication mapping rules to map external groups to {PlatformNameShort} roles, teams, and organizations.
+| present, absent, exists, enforced
+
+| `authenticator_user`
+| Associate users with authentication providers for migration between providers. This module does not support deleting associations.
+| present, exists
+|===
+
+== Gateway infrastructure
+
+[cols="1,2,1",options="header"]
+|===
+| Module | Description | Supported states
+
+| `service`
+| Configure API service routes for {ControllerName}, {HubName}, and {EDAcontroller}.
+| present, absent, exists, enforced
+
+| `route`
+| Configure non-API gateway routes.
+| present, absent, exists, enforced
+
+| `service_cluster`
+| Manage service clusters with health check and outlier detection settings.
+| present, absent, exists, enforced
+
+| `service_node`
+| Add or remove individual service nodes within clusters.
+| present, absent, exists, enforced
+
+| `service_type`
+| Define service type definitions with login and logout paths.
+| present, absent, exists, enforced
+
+| `service_key`
+| Manage service authentication keys for inter-service communication.
+| present, absent, exists, enforced
+
+| `http_port`
+| Configure HTTP listener ports for the Envoy proxy.
+| present, absent, exists, enforced
+
+| `ui_plugin_route`
+| Configure UI plugin routes for front-end plugin integration.
+| present, absent, exists, enforced
+|===
+
+== Platform configuration
+
+[cols="1,2,1",options="header"]
+|===
+| Module | Description | Supported states
+
+| `settings`
+| Modify platform-wide settings including token authentication, JWT configuration, password policies, and session settings. This module has no `state` parameter and always applies changes.
+| N/A (always applies)
+
+| `feature_flag`
+| Query and manage feature flags. Only run-time flags can be modified; install-time flags are read-only.
+| present, absent, exists, enforced
+|===
+
+== Application and token management
+
+[cols="1,2,1",options="header"]
+|===
+| Module | Description | Supported states
+
+| `application`
+| Create, update, or delete OAuth2 applications for the {Gateway}. Configure grant types, client types, and redirect URIs.
+| present, absent, exists, enforced
+
+| `token`
+| Create or delete OAuth2 tokens. Each run creates a new token; this module is not idempotent. The token value is only available at creation time.
+| present, absent
+
+| `ca_certificate`
+| Manage CA certificates for mutual TLS (mTLS) authentication.
+| present, absent, exists
+|===
+
+== Lookup plugin
+
+[cols="1,2",options="header"]
+|===
+| Plugin | Description
+
+| `gateway_api`
+| Query any {Gateway} API endpoint. Supports pagination, filtering, and returning objects or IDs. Use for read-only lookups of users, teams, organizations, settings, and other resources.
+|===
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://console.redhat.com/ansible/automation-hub/repo/published/ansible/platform/content/?showing=module[ansible.platform module documentation on {HubNameStart}]
+* link:https://console.redhat.com/ansible/automation-hub/repo/published/ansible/platform/content/?showing=lookup[ansible.platform lookup plugin documentation on {HubNameStart}]

--- a/downstream/modules/configuration-as-code/ref_configuration-as-code-migration-guide-for-aap-2-7.adoc
+++ b/downstream/modules/configuration-as-code/ref_configuration-as-code-migration-guide-for-aap-2-7.adoc
@@ -1,0 +1,124 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-04-09
+:_mod-docs-content-type: REFERENCE
+
+[id="configuration-as-code-migration-guide-for-aap-2-7_{context}"]
+= Configuration as Code migration guide for {PlatformNameShort} 2.7
+
+[role="_abstract"]
+If you are upgrading to {PlatformNameShort} 2.7, review the following changes to the `ansible.controller` and `ansible.hub` collections that can affect your existing Configuration as Code playbooks.
+
+== Deprecated parameters
+
+The following parameters are deprecated and scheduled for removal in a future release of {PlatformNameShort}.
+Update your playbooks to use the replacement parameters.
+
+[cols="1,1,1,2",options="header"]
+|===
+| Module | Deprecated parameter | Replacement | Details
+
+| `user`
+| `organizations`
+| `role_user_assignment` module
+| Use the `role_user_assignment` module to assign organization roles to users instead of the `organizations` parameter.
+
+| `user`
+| `is_platform_auditor`
+| `role_user_assignment` module
+| Assign the Platform Auditor role by using the `role_user_assignment` module.
+
+| `user`
+| `authenticators`
+| `associated_authenticators`
+| The `associated_authenticators` parameter accepts a dictionary keyed by authenticator ID with values containing `uid` and `email`.
+
+| `user`
+| `authenticator_uid`
+| `associated_authenticators`
+| Use the `associated_authenticators` parameter instead.
+
+| `role_user_assignment`
+| `object_id`
+| `object_ids`
+| The `object_ids` parameter accepts a list of resource identifiers, enabling batch role assignments in a single task.
+|===
+
+== Removed modules from the ansible.hub collection
+
+{PlatformNameShort} 2.7 removes the following modules from the `ansible.hub` collection.
+Use the `ansible.platform` replacements instead.
+
+[cols="1,1,2",options="header"]
+|===
+| Removed module | Replacement | Action required
+
+| `ansible.hub.ah_user`
+| `ansible.platform.user`
+| Update all playbooks that use `ansible.hub.ah_user` to use `ansible.platform.user`. The `ansible.platform.user` module manages users through the {Gateway} and supports additional parameters such as `associated_authenticators`.
+
+| `ansible.hub.ah_token`
+| `ansible.platform.token`
+| Update all playbooks that use `ansible.hub.ah_token` to use `ansible.platform.token`. Note that the `ansible.platform.token` module is not idempotent; each run creates a new token.
+|===
+
+== New modules
+
+The following modules are new in `ansible.platform` version 2.7:
+
+`feature_flag`:: Query and manage feature flags. Use this module to enable or disable run-time feature flags for your platform.
+
+`ca_certificate`:: Manage CA certificates for mutual TLS (mTLS) authentication between services.
+
+`role_team_assignment`:: Assign roles to teams for specific resources or organizations. Supports batch operations through the `assignment_objects` parameter.
+
+`role_definition`:: Create custom RBAC role definitions with specific permissions scoped to a content type.
+
+`ui_plugin_route`:: Configure UI plugin routes for front-end plugin integration with the {Gateway}.
+
+== New features in existing modules
+
+The following features are available in existing modules:
+
+* *Mutual TLS support*: The `service` and `route` modules support an `enable_mtls` parameter for mutual TLS authentication. When you enable mTLS, set `enable_gateway_auth` to `false`.
+* *Route timeouts*: The `service`, `route`, and `ui_plugin_route` modules support `request_timeout_seconds` and `idle_timeout_seconds` parameters for per-route timeout configuration.
+* *OIDC User Identity*: The `authenticator` module supports OIDC User Identity configuration for {Gateway}.
+* *Batch role assignments*: The `role_user_assignment` module supports `object_ids` for assigning a role to a user across multiple resources in a single task.
+
+== Example: Update a playbook for 2.7
+
+The following example shows how to update a playbook that uses deprecated parameters.
+
+.Before (2.6)
+[source,yaml]
+----
+- name: Create user with org membership
+  ansible.platform.user:
+    username: "demo-user"
+    organizations:
+      - "Demo-Organization"
+    is_platform_auditor: true
+----
+
+.After (2.7)
+[source,yaml]
+----
+- name: Create user
+  ansible.platform.user:
+    username: "demo-user"
+    state: present
+
+- name: Assign organization role to user
+  ansible.platform.role_user_assignment:
+    user: "demo-user"
+    role_definition: "Organization Member"
+    object_ids:
+      - "Demo-Organization"
+    state: present
+
+- name: Assign Platform Auditor role to user
+  ansible.platform.role_user_assignment:
+    user: "demo-user"
+    role_definition: "Platform Auditor"
+    # object_ids is not required for platform-wide roles
+    state: present
+----

--- a/downstream/modules/configuration-as-code/ref_configuration-as-code-migration-guide-for-aap-2-7.adoc
+++ b/downstream/modules/configuration-as-code/ref_configuration-as-code-migration-guide-for-aap-2-7.adoc
@@ -47,6 +47,7 @@ Update your playbooks to use the replacement parameters.
 
 {PlatformNameShort} 2.7 removes the following modules from the `ansible.hub` collection.
 Use the `ansible.platform` replacements instead.
+Other modules in the `ansible.hub` collection remain available.
 
 [cols="1,1,2",options="header"]
 |===

--- a/downstream/titles/configuration-as-code/master.adoc
+++ b/downstream/titles/configuration-as-code/master.adoc
@@ -10,4 +10,4 @@ include::attributes/attributes.adoc[]
 include::{Boilerplate}[]
 
 
-include::configuration-as-code/configuration-as-code/proc_setting-up-your-automation-environment-for-configuration-as-code.adoc[leveloffset=+1]
+include::configuration-as-code/assembly_configure-your-platform-with-configuration-as-code.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
- Adds concept overview: four-state model (`present`/`absent`/`exists`/`enforced`), module defaults with action group, check mode, resource names best practice
- Adds reference module listing all 22 `ansible.platform` modules grouped by category with supported states
- Adds migration guide: deprecated parameters, removed `ansible.hub` modules (`ah_user`, `ah_token`), new modules and features, before/after playbook example
- Restructures guide with assembly to organize concept → procedure → reference → migration guide
- Fixes procedure title gerund ("Setting up..." → "Set up...")
- Fixes hardcoded version URL in procedure prerequisites

## Test plan
- [x] Layer 1 review (review-docs): all new files pass
- [x] Layer 2 build: configuration-as-code guide compiles clean
- [x] Layer 3 AI review: 4 parallel agents, 8 fixes applied
- [x] Version-agnostic check: no hardcoded versions except migration guide (intentional)
- [x] SME review via Google Doc

**SME Review Doc**: https://docs.google.com/document/d/1n-2ETOb2hKwd3LnjpOo-g7YfA8WZuT_BCTAyuNinq8Q/edit

Resolves: AAP-57833