### PR TITLE
AAP-70258 Add database storage requirements for OCP deployment models…

### DIFF
--- a/downstream/modules/topologies/ref-ocp-a-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-a-env-a.adoc
@@ -72,18 +72,21 @@ a|
 * External (customer supported) databases require International Components for Unicode (ICU) support.
 * External databases using PostgreSQL 16 or 17 must rely on external backup and restore processes. Backup and restore functionality depends on utilities provided with {PostgresVers}.
 
-.Operator-deployed database connection limits
+.Operator-deployed database connection and storage limits
 [WARNING]
 ====
-The operator-deployed PostgreSQL database has a default `max_connections` limit of 100.
+The operator-deployed PostgreSQL database has a default `max_connections` limit of 100 and a maximum database size of 100 GB.
 
 Do not use the operator-deployed database if any of the following conditions apply:
 
 * You are running more than 1 replica of any component ({Gateway}, {ControllerName}, {HubName}, or {EDAName}).
 * The {ControllerName} capacity exceeds 100 concurrent jobs.
 * Total database connections from all components exceed 100.
+* Estimated 30-day database storage exceeds 100 GB.
 
-If you need more than 100 database connections, use an external database instead of the operator-deployed database.
+If your deployment exceeds any of these limits, use an external database instead of the operator-deployed database.
+
+Database storage consumption depends on your workload, including job frequency, playbook task count, output verbosity, and the number of managed hosts per job. Higher verbosity levels can increase storage consumption by 3-5x.
 ====
 | IP version
 | IPv4, IPv6 (single-stack and dual-stack)

--- a/downstream/modules/topologies/ref-ocp-b-env-a.adoc
+++ b/downstream/modules/topologies/ref-ocp-b-env-a.adoc
@@ -83,6 +83,9 @@ The external database must meet these minimum requirements:
 * 4 vCPUs
 * 16 GB RAM
 * `max_connections`: 1024 (minimum). You might need more connections when scaling replicas.
+* 200 GB storage on a volume capable of at least 3000 IOPS
+
+Database storage consumption depends on your workload, including job frequency, playbook task count, output verbosity, and the number of managed hosts per job. Start with a 200 GB baseline and monitor actual usage after deployment. Configure automated cleanup jobs to prevent unbounded database growth.
 
 These requirements ensure adequate database performance for the {EnterpriseTopology} workload profile.
 ====


### PR DESCRIPTION
… (#5915)

Add storage sizing guidance that was missing from the initial PR:
- Operator-deployed DB (OCP-A): 100 GB hard limit with storage condition
- External DB (OCP-B): 200 GB minimum on 3000 IOPS storage