### PR TITLE
Highlight upgrade and migration changes

### DIFF
--- a/downstream/assemblies/aap-migration/assembly-migration-prerequisites.adoc
+++ b/downstream/assemblies/aap-migration/assembly-migration-prerequisites.adoc
@@ -6,6 +6,11 @@
 [role="_abstract"]
 Prerequisites for migrating your {PlatformNameShort} deployment. For your specific migration path, ensure that you meet all necessary conditions before proceeding.
 
+[WARNING]
+====
+To upgrade to {PlatformNameShort} 2.7, you must first migrate from your RPM-based deployment to a containerized or {OCPShort} deployment. RPM-based deployments are not supported as an upgrade path to 2.7.
+====
+
 include::aap-migration/con-rpm-to-containerized-prerequisites.adoc[leveloffset=+1]
 
 include::aap-migration/con-rpm-to-ocp-prerequisites.adoc[leveloffset=+1]

--- a/downstream/assemblies/platform/assembly-upgrade-support-matrix.adoc
+++ b/downstream/assemblies/platform/assembly-upgrade-support-matrix.adoc
@@ -14,6 +14,11 @@ Review {RHEL} version compatibility and step-by-step processes for RPM, containe
 In-place upgrades of major {RHEL} versions are not supported. You must migrate your existing deployment of {PlatformNameShort} to a new {RHEL} environment.
 ====
 
+[WARNING]
+====
+To upgrade to {PlatformNameShort} 2.7, you must be running a containerized or {OCPShort} deployment. RPM-based deployments are not supported as an upgrade path to 2.7. If you are running an RPM-based deployment, migrate to a containerized or {OCPShort} deployment before you upgrade. For step-by-step instructions on how to migrate, see link:{URLMigration}[{TitleMigration}].
+==== 
+
 include::platform/ref-upgrade-rhel-support.adoc[leveloffset=+1]
 
 include::platform/ref-upgrade-scenarios-rpm.adoc[leveloffset=+1]

--- a/downstream/modules/aap-migration/con-introduction-and-objectives.adoc
+++ b/downstream/modules/aap-migration/con-introduction-and-objectives.adoc
@@ -23,6 +23,11 @@ The supported migration paths include:
 
 Migrations outside of those listed are not supported at this time.
 
+[WARNING]
+====
+To upgrade to {PlatformNameShort} 2.7, you must be running a containerized or {OCPShort} deployment. If you are running an RPM-based deployment, complete your migration to a containerized or {OCPShort} deployment before you upgrade.
+====
+
 The {TitleMigration} guide aims to:
 
 * Document all components and configurations that require migration between {PlatformNameShort} platforms

--- a/downstream/modules/aap-migration/con-migration-process-overview.adoc
+++ b/downstream/modules/aap-migration/con-migration-process-overview.adoc
@@ -11,6 +11,11 @@ Understand the complete migration workflow including preparation, export, artifa
 You can only migrate to a different installation type of the same {PlatformNameShort} version. For example, you can migrate from RPM version {PlatformVers} to containerized {PlatformVers}, but not from RPM version 2.4 to containerized {PlatformVers}.
 ====
 
+[WARNING]
+====
+If you are running an RPM-based deployment, complete your migration to a containerized or {OCPShort} deployment before upgrading to {PlatformNameShort} 2.7. RPM-based deployments are not supported as an upgrade path to 2.7.
+====
+
 The migration between {PlatformNameShort} installation types follows this general workflow:
 
 . Prepare and assess the source environment

--- a/downstream/modules/aap-migration/con-rpm-to-containerized-prerequisites.adoc
+++ b/downstream/modules/aap-migration/con-rpm-to-containerized-prerequisites.adoc
@@ -6,6 +6,11 @@
 [role="_abstract"]
 Before migrating from an RPM-based deployment to a container-based deployment, ensure you meet the following prerequisites:
 
+[NOTE]
+====
+Completing this migration is a required step if you plan to upgrade to {PlatformNameShort} 2.7. RPM-based deployments are not supported as an upgrade path to 2.7.
+====
+
 * You have a source RPM-based deployment of {PlatformNameShort}.
 * The source RPM-based deployment is on the latest async release of the version you are on.
 * You have a target environment prepared for a container-based deployment of {PlatformNameShort}.

--- a/downstream/modules/aap-migration/con-rpm-to-ocp-prerequisites.adoc
+++ b/downstream/modules/aap-migration/con-rpm-to-ocp-prerequisites.adoc
@@ -6,6 +6,11 @@
 [role="_abstract"]
 Before migrating from an RPM-based deployment to an {OCPShort} deployment, ensure you meet the following prerequisites:
 
+[NOTE]
+====
+Completing this migration is a required step if you plan to upgrade to {PlatformNameShort} 2.7. RPM-based deployments are not supported as an upgrade path to 2.7.
+====
+
 * You have a source RPM-based deployment of {PlatformNameShort}.
 * The source RPM-based deployment is on the latest async release of the version you are on.
 * You have a target {OCPShort} environment ready.

--- a/downstream/modules/platform/con-aap-upgrade-overview.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-overview.adoc
@@ -16,6 +16,11 @@
 You must be on the latest version of 2.4 or 2.5 before you upgrade to {PlatformVers}.
 ====
 
+[WARNING]
+====
+To upgrade to {PlatformNameShort} 2.7, you must be running a containerized or {OCPShort} deployment. RPM-based deployments are not supported as an upgrade path to 2.7. If you are running an RPM-based deployment, migrate to a containerized or {OCPShort} deployment before you upgrade. For step-by-step instructions on how to migrate, see link:{URLMigration}[{TitleMigration}].
+==== 
+
 [[from-2.5]]
 Upgrading from 2.5 to 2.6::
 

--- a/downstream/modules/platform/con-aap-upgrade-planning.adoc
+++ b/downstream/modules/platform/con-aap-upgrade-planning.adoc
@@ -5,7 +5,12 @@
 = Upgrade prerequisites
  
 [role="_abstract"]
-Before you begin the upgrade process, review the following considerations to plan and prepare your {PlatformNameShort} deployment:
+Before you begin the upgrade process, review the following considerations to plan and prepare your {PlatformNameShort} deployment.
+
+[WARNING]
+====
+To upgrade to {PlatformNameShort} 2.7, you must be running a containerized or {OCPShort} deployment. RPM-based deployments are not supported as an upgrade path to 2.7. If you are running an RPM-based deployment, migrate to a containerized or {OCPShort} deployment before you upgrade. For step-by-step instructions on how to migrate, see link:{URLMigration}[{TitleMigration}].
+==== 
 
 == {PlatformNameShort} requirements
 * Verify that you have a valid subscription before upgrading from a previous version of {PlatformNameShort}. Existing subscriptions are carried over during the upgrade process. 

--- a/downstream/modules/platform/con-aap-upgrades.adoc
+++ b/downstream/modules/platform/con-aap-upgrades.adoc
@@ -12,6 +12,11 @@ You can upgrade your {PlatformNameShort} installation from version 2.4 or 2.5 to
 Upgrade from {EDAName} 2.5 to 2.6 is supported; however, upgrade from {EDAName} 2.4 to 2.6 is not supported. If you are upgrading from {PlatformNameShort} 2.4 to 2.6 and you have deployed {EDAName}, you must first remove the {EDAName} 2.4 database and then upgrade your platform to 2.6. For information about the procedure, see xref:proc-removing-eda-db_aap-upgrading-platform[Removing {EDAName} 2.4 database]. 
 ====
 
+[WARNING]
+====
+To upgrade to {PlatformNameShort} 2.7, you must be running a containerized or {OCPShort} deployment. RPM-based deployments are not supported as an upgrade path to 2.7. If you are running an RPM-based deployment, migrate to a containerized or {OCPShort} deployment before you upgrade. For step-by-step instructions on how to migrate, see link:{URLMigration}[{TitleMigration}].
+==== 
+
 Before beginning your upgrade be sure to review the prerequisites and upgrade planning sections of this guide.
 
 [cols="a,a"]

--- a/downstream/modules/platform/ref-upgrade-scenarios-rpm.adoc
+++ b/downstream/modules/platform/ref-upgrade-scenarios-rpm.adoc
@@ -8,6 +8,11 @@
 Find the supported upgrade paths for your RPM-based {PlatformNameShort} deployment. 
 This helps you plan the necessary steps for a smooth upgrade. 
 
+[WARNING]
+====
+{PlatformNameShort} 2.6 is the last version that supports RPM-based deployments. To upgrade to {PlatformNameShort} 2.7, migrate to a containerized or {OCPShort} deployment first. For step-by-step instructions, see link:{URLMigration}[{TitleMigration}].
+====
+
 == RPM-based {PlatformNameShort} 2.4 on RHEL 8
 
 [cols="1,1,2"]

--- a/downstream/titles/planning-your-upgrade/master.adoc
+++ b/downstream/titles/planning-your-upgrade/master.adoc
@@ -12,6 +12,11 @@ include::attributes/attributes.adoc[]
 Use this guide to upgrade from {PlatformNameShort} 2.4 to {PlatformVers}. 
 This documentation covers new infrastructure requirements, details how to handle user and authentication data, and provides guidance on various deployment scenarios to help you successfully plan your upgrade.
 
+[WARNING]
+====
+To upgrade to {PlatformNameShort} 2.7, you must be running a containerized or {OCPShort} deployment. RPM-based deployments are not supported as an upgrade path to 2.7. If you are running an RPM-based deployment, migrate to a containerized or {OCPShort} deployment before you upgrade. For step-by-step instructions on how to migrate, see link:{URLMigration}[{TitleMigration}].
+==== 
+
 include::{Boilerplate}[]
 
 include::platform/assembly-upgrade-overview.adoc[leveloffset=+1]


### PR DESCRIPTION
Planning your upgrade and migration content highlights that customers need to be on either Containerized or OCP deployment before considering upgrade to 2.7

https://redhat.atlassian.net/browse/AAP-66569