### PR TITLE
AAP-63892 - Add steps to restart Automation Gateway services

### DIFF
--- a/downstream/modules/platform/proc-change-ssl-manual-rpm.adoc
+++ b/downstream/modules/platform/proc-change-ssl-manual-rpm.adoc
@@ -48,7 +48,7 @@ nginx -t
 systemctl reload nginx.service
 ----
 
-. Restart Automation Gateway services on each Automation Gateway server:
+. Restart services on each {Gateway} server:
 +
 ----
 automation-gateway-service restart

--- a/downstream/modules/platform/proc-change-ssl-manual-rpm.adoc
+++ b/downstream/modules/platform/proc-change-ssl-manual-rpm.adoc
@@ -48,6 +48,12 @@ nginx -t
 systemctl reload nginx.service
 ----
 
+. Restart Automation Gateway services on each Automation Gateway server:
++
+----
+automation-gateway-service restart
+----
+
 . Verify that new SSL/TLS certificate and key have been installed:
 +
 ----


### PR DESCRIPTION
In testing, it was found that restarting just NGINX on the component no longer works. Eenvoy (running on gateway) doesn't pick up the new certificate.