### PR TITLE
[2.5 backport] AAP-71891: updates content upload limits for private automation hub and console

### DIFF
--- a/downstream/modules/hub/proc-uploading-collections.adoc
+++ b/downstream/modules/hub/proc-uploading-collections.adoc
@@ -20,8 +20,7 @@ Format your collection file name as follows: <my_namespace-my_collection-1.0.0.t
 ====
 Attempting to upload very large collections will result in an error.
 
-Limit collection size to 20 mb when uploading to {Galaxy} or {Console}.
-For {PrivateHubName} avoid uploading collections sized 200 mb or more.
+Limit collection size to 200 mb when uploading to {Console} or {PrivateHubName}.
 
 In scenarios that require a complete environment with multiple collections and dependencies, use an {ExecEnvShort}. See link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/managing_automation_content/managing-containers-hub#obtain-images[Pulling {ExecEnvShort}s for use in {HubName}] for more information.
 ====


### PR DESCRIPTION
This PR ports the changes from https://github.com/ansible/aap-docs/pull/5926 to the 2.5 branch. This work is being tracked in [AAP-71891](https://redhat.atlassian.net/browse/AAP-71891).