### PR TITLE
[2.5] Fix en-dash in must-gather namespace command

### DIFF
--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
@@ -40,10 +40,10 @@ oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-25/aap
 +
 [subs="+quotes"]
 ----
-oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-25/aap-must-gather-rhel8 --dest-dir _<dest_dir>_ – /usr/bin/ns-gather _<namespace>_
+oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-25/aap-must-gather-rhel8 --dest-dir _<dest_dir>_ -- /usr/bin/ns-gather _<namespace>_
 ----
 +
-** `– /usr/bin/ns-gather` limits the `must-gather` data collection to a specified namespace
+** `-- /usr/bin/ns-gather` limits the `must-gather` data collection to a specified namespace
 
 . To attach the `must-gather` archive to your support case, create a compressed file from the `must-gather` directory created before and attach it to your support case. 
 * For example, on a computer that uses a Linux operating system, run the following command, replacing `_<must-gather-local.5421342344627712289/>_` with the `must-gather` directory name:


### PR DESCRIPTION
## Summary
- Backport of #5806 to the 2.5 branch
- Corrects en-dash (U+2013) to proper ASCII double-hyphen `--` before `/usr/bin/ns-gather` in the namespace-scoped must-gather command
- Copy-pasting from rendered docs produced empty output directories because `oc` doesn't recognize en-dash as an argument separator