### PR TITLE
AAP-61077 Clarify custom certificate options for containerized install

### DIFF
--- a/downstream/modules/platform/con-certs-per-service-considerations.adoc
+++ b/downstream/modules/platform/con-certs-per-service-considerations.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 When providing custom TLS certificates for each individual service, consider the following:
 
-* It is possible to provide unique certificates per host. This requires defining the specific `_tls_cert` and `_tls_key` variables in your inventory file as shown in the earlier inventory file example.
+* Each service has its own `_tls_cert` and `_tls_key` variables. You can provide unique certificates for each service, or use the same certificate across multiple services if they share a fully qualified domain name (FQDN). If you do not define a certificate for a service, the installation program generates a self-signed certificate for that service.
 * For services deployed across many nodes (for example, when following the enterprise topology), the provided certificate for that service must include the FQDN of all associated nodes in its Subject Alternative Name (SAN) field.
 * If an external-facing service (such as {ControllerName} or {Gateway}) is deployed behind a load balancer that performs SSL/TLS offloading, the service's certificate must include the load balancer's FQDN in its SAN field, in addition to the FQDNs of the individual service nodes.
 

--- a/downstream/modules/platform/proc-provide-custom-tls-certs-per-service.adoc
+++ b/downstream/modules/platform/proc-provide-custom-tls-certs-per-service.adoc
@@ -51,3 +51,35 @@ receptor_tls_key=<path_to_tls_key>
 redis_tls_cert=<path_to_tls_certificate>
 redis_tls_key=<path_to_tls_key>
 ----
+
+If all components share the same fully qualified domain name (FQDN), use the same certificate and key for each service:
+
+[source,yaml]
+----
+gateway_tls_cert=/home/user/certs/myhost.example.com.crt
+gateway_tls_key=/home/user/certs/myhost.example.com.key
+controller_tls_cert=/home/user/certs/myhost.example.com.crt
+controller_tls_key=/home/user/certs/myhost.example.com.key
+hub_tls_cert=/home/user/certs/myhost.example.com.crt
+hub_tls_key=/home/user/certs/myhost.example.com.key
+eda_tls_cert=/home/user/certs/myhost.example.com.crt
+eda_tls_key=/home/user/certs/myhost.example.com.key
+postgresql_tls_cert=/home/user/certs/myhost.example.com.crt
+postgresql_tls_key=/home/user/certs/myhost.example.com.key
+----
+
+If components are deployed on separate hosts with different FQDNs, provide a unique certificate for each service:
+
+[source,yaml]
+----
+gateway_tls_cert=/home/user/certs/gateway.example.com.crt
+gateway_tls_key=/home/user/certs/gateway.example.com.key
+controller_tls_cert=/home/user/certs/controller.example.com.crt
+controller_tls_key=/home/user/certs/controller.example.com.key
+hub_tls_cert=/home/user/certs/hub.example.com.crt
+hub_tls_key=/home/user/certs/hub.example.com.key
+eda_tls_cert=/home/user/certs/eda.example.com.crt
+eda_tls_key=/home/user/certs/eda.example.com.key
+postgresql_tls_cert=/home/user/certs/postgresql.example.com.crt
+postgresql_tls_key=/home/user/certs/postgresql.example.com.key
+----


### PR DESCRIPTION
- Replace vague "It is possible to provide unique certificates per host" with clear guidance covering three scenarios: unique certs per service, shared certs across services with the same FQDN, and auto-generated self-signed certs when no cert is defined
- Add inventory file examples for both common certificate configurations: same certificate for all components on a single host, and unique certificates per component

Fixes AAP-61077