### PR TITLE
AAP-72447: Clarify single-org support in self-service portal docs

### DIFF
--- a/downstream/modules/devtools/con-devspaces-aap-sync-overview.adoc
+++ b/downstream/modules/devtools/con-devspaces-aap-sync-overview.adoc
@@ -4,14 +4,14 @@
 = Understanding {PlatformNameShort} synchronization
 
 [role="_abstract"]
-The synchronization feature imports Organizations, Users, Teams, and Job Templates from {PlatformNameShort} into the {SelfService}. 
+The synchronization feature imports your Organization, Users, Teams, and Job Templates from {PlatformNameShort} into the {SelfService}. 
 This process makes the {PlatformNameShort} entities securely discoverable and accessible to portal users.
 
 == Overview
 
 {SelfServiceShortStart} synchronizes two types of data from {PlatformNameShort}:
 
-* Organizations, Users, and Teams: Identity and organizational structure data
+* Organization, Users, and Teams: Identity and organizational structure data
 * Job Templates: Executable automation templates
 
 Both synchronizations run on a scheduled basis and can be manually triggered by {PlatformNameShort} Administrators in the portal UI.

--- a/downstream/modules/devtools/proc-devspaces-aap-sync-manual.adoc
+++ b/downstream/modules/devtools/proc-devspaces-aap-sync-manual.adoc
@@ -11,7 +11,7 @@
 
 . Log in to {SelfService} as an {PlatformNameShort} Administrator.
 . Navigate to the *Synchronization management* page.
-. Click btn:[Manual sync] for Organizations or Job Templates.
+. Click btn:[Manual sync] for Organization or Job Templates.
 . Monitor the sync progress in the UI.
 
 .Verification

--- a/downstream/modules/devtools/ref-devspaces-aap-sync-config-ref.adoc
+++ b/downstream/modules/devtools/ref-devspaces-aap-sync-config-ref.adoc
@@ -25,7 +25,7 @@ These parameters *must* be included in the `catalog.providers.rhaap` section of 
 | `object`
 | *Must* be provided
 | -
-| Defines how often the identity data (Organizations, Users, and Teams) synchronization runs (for example, `{ minutes: 60 }`).
+| Defines how often the identity data (Organization, Users, and Teams) synchronization runs (for example, `{ minutes: 60 }`).
 
 | `sync.orgsUsersTeams.schedule.timeout`
 | `object`

--- a/downstream/modules/devtools/ref-devspaces-aap-sync-examples.adoc
+++ b/downstream/modules/devtools/ref-devspaces-aap-sync-examples.adoc
@@ -9,7 +9,7 @@ Use the examples to quickly implement and validate settings in your Helm values 
 
 == Minimal configuration
 
-Synchronizes all Organizations, Users, Teams, and Job Templates using the using the default 60-minute frequency and 15-minute timeout.
+Synchronizes the Organization, Users, Teams, and Job Templates using the default 60-minute frequency and 15-minute timeout.
 
 [source,yaml]
 ----
@@ -145,7 +145,7 @@ catalog:
 
 This configuration syncs:
 
-* All Users, Teams, and Organizations from the "Default" organization
+* All Users and Teams from the "Default" organization
 * Job Templates that belong to "Default" organization AND have {PlatformNameShort} Surveys enabled *AND* have {PlatformNameShort} Labels "portal" *OR* "self-service"
 
 

--- a/downstream/titles/self-service-config/master.adoc
+++ b/downstream/titles/self-service-config/master.adoc
@@ -10,7 +10,7 @@ include::attributes/attributes.adoc[]
 = Configuring self-service automation portal
 
 Configure synchronization with {PlatformName} to securely expose core resources to the self-service portal. 
-This process imports {PlatformNameShort} Organizations, Users, Teams, and Job Templates, making these resources readily discoverable.
+This process imports your {PlatformNameShort} Organization, Users, Teams, and Job Templates, making these resources readily discoverable.
 
 include::{Boilerplate}[]
 


### PR DESCRIPTION
## Summary

- Change plural "Organizations" to singular across all sync-related descriptions in the self-service portal guides
- Only one AAP Organization is currently supported; multi-org is on the roadmap (ANSTRAT-912)
- Fixes 7 occurrences across 5 files that implied multi-org support, which was misleading customers

## Test plan

- [x] `self-service-config` guide builds clean with ccutil
- [x] Peer review: verify singular form reads naturally in context
- [x] SME review: Craig Brandt confirmed scope

## Jira

[AAP-72447](https://issues.redhat.com/browse/AAP-72447)