### PR TITLE
Updating API guide for 2.6.

### DIFF
--- a/downstream/assemblies/platform/assembly-controller-api-access-resources.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-access-resources.adoc
@@ -5,8 +5,8 @@
 = Access resources
 
 [role="_abstract"]
-{ControllerNameStart} uses a primary key to access individual resource objects. 
-You can access {ControllerName} resources by using resource-specific, human-readable identifiers through the named URL feature. 
+The {Gateway} API uses a primary key to access individual resource objects. 
+You can access resources by using resource-specific, human-readable identifiers through the named URL feature. 
 
 The following example shows the named URL path where you can access a resource object without an auxiliary query string:
 

--- a/downstream/assemblies/platform/assembly-controller-api-auth-methods.adoc
+++ b/downstream/assemblies/platform/assembly-controller-api-auth-methods.adoc
@@ -5,10 +5,10 @@
 = Authenticating in the API
 
 [role="_abstract"]
-{ControllerNameStart} is designed for organizations to control their automation with a visual dashboard for out-of-the box control while providing a REST API to integrate with your other tools on a deeper level. 
+{PlatformNameShort} provides a visual dashboard for out-of-the box control while providing a REST API to integrate with your other tools on a deeper level. 
 
-{ControllerNameStart} supports several authentication methods to make it easy to embed {ControllerName} into existing tools and processes. 
-This ensures that the right people can access its resources.
+The platform supports several authentication methods to integrate automation into existing tools and processes. 
+This ensures that the right people can access platform resources.
 
 You can use the following authentication methods in the API:
 

--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -450,7 +450,7 @@
 :LinkControllerAdminGuide: link:{URLControllerAdminGuide}[{TitleControllerAdminGuide}]
 //
 // titles/controller/controller-api-overview
-:TitleControllerAPIOverview: Automation execution API overview
+:TitleControllerAPIOverview: Platform gateway API overview
 :URLControllerAPIOverview: {BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/automation_execution_api_overview
 :LinkControllerAPIOverview: link:{URLControllerAPIOverview}[{TitleControllerAPIOverview}]
 //

--- a/downstream/modules/platform/con-controller-api-basic-auth.adoc
+++ b/downstream/modules/platform/con-controller-api-basic-auth.adoc
@@ -5,16 +5,17 @@
 = Basic authentication
 
 [role="_abstract"]
-Basic authentication is stateless, therefore, you must send the base64-encoded username and password along with each request through the Authorization header.
-You can use this for API calls from curl requests, python scripts, or individual requests to the API.
+Basic authentication is stateless. 
+You must send the base64-encoded username and password along with each request through the Authorization header.
+You can use this for API calls from curl requests, Python scripts, or individual requests to the API.
 
-We recommend OAuth 2 Token Authentication for accessing the API when at all possible.
+OAuth 2 token authentication through {Gateway} is the recommended method for accessing the API. 
 
 The following is an example of Basic authentication with curl:
 
 ----
 # the --user flag adds this Authorization header for us
-curl -X GET --user 'user:password' https://<controller-host>/api/gateway/v1/tokens/ -k -L
+curl -X GET --user 'user:password' https://<gateway server name>/api/gateway/v1/tokens/ -k -L
 ----
 
 [role="_additional-resources"]

--- a/downstream/modules/platform/con-controller-api-identifier-format-protocol.adoc
+++ b/downstream/modules/platform/con-controller-api-identifier-format-protocol.adoc
@@ -5,7 +5,7 @@
 = Identifier format protocol
 
 [role="_abstract"]
-{ControllerName} uses a consistent protocol to generate human-readable unique identifiers for resources that can be addressed by name in the API and the web interface.
+The API uses a consistent protocol to generate human-readable unique identifiers for resources that can be addressed by name in the API and the web interface.
 
 Resources are identifiable by their unique keys, which are tuples of resource fields. 
 Every resource is guaranteed to have its primary key number alone as a unique key, but there might be many other unique keys. 
@@ -37,8 +37,8 @@ The underlying resource is pointing to using a foreign key (a child of a traceba
 Sort them in lexicographic order of corresponding foreign keys.
 * Combine all components together using `++` to generate the final identifier format.
 
-When generating an identifier format for resource `Foo`, {ControllerName} generates the standalone formats, `<name>+<choice>` for `Foo` and `<fk.name>+<fk.choice>` for `Bar`, then combines them together to be `<name>+<choice>++<fk.name>+<fk.choice>`.
+When generating an identifier format for resource `Foo`, the API generates the standalone formats, `<name>+<choice>` for `Foo` and `<fk.name>+<fk.choice>` for `Bar`, then combines them together to be `<name>+<choice>++<fk.name>+<fk.choice>`.
 
 When generating identifiers according to the given identifier format, there are cases where a foreign key might point to nowhere. 
-In this case, {ControllerName} substitutes the part of the format corresponding to the resource the foreign key should point to with an empty string. 
+In this case, the API substitutes the part of the format corresponding to the resource the foreign key should point to with an empty string. 
 For example, if a `Foo` object has the `name ="alice"`, `choice ="yes",` but `fk field = None`, its resulting identifier is `alice+yes++`.

--- a/downstream/modules/platform/con-controller-api-oauth2-token.adoc
+++ b/downstream/modules/platform/con-controller-api-oauth2-token.adoc
@@ -6,21 +6,21 @@
 
 [role="_abstract"]
 OAuth (Open Authorization) is an open standard for token-based authentication and authorization.
-OAuth 2 authentication is commonly used when interacting with the {ControllerName} API programmatically.
+OAuth 2 authentication is commonly used when interacting with the {Gateway} API programmatically.
 
-Similar to Basic authentication, you are given an OAuth 2 token with each API request through the Authorization header.
+You provide an OAuth 2 token with each API request through the Authorization header.
 Unlike Basic authentication, OAuth 2 tokens have a configurable timeout and are scopable.
-Tokens have a configurable expiration time and can be easily revoked for one user or for the entire {ControllerName} system by an administrator if needed.
+Tokens have a configurable expiration time and can be revoked for one user or for the entire {Gateway} system by an administrator if needed.
 You can do this with the link:{URLCentralAuth}/gw-token-based-authentication#ref-controller-revoke-oauth2-token[revoke_oauth2_tokens] management command, or by using the API as explained in link:{URLCentralAuth}/gw-token-based-authentication#ref-controller-revoke-access-token[Revoke an access token].
 
-The different methods for obtaining OAuth2 access tokens in {ControllerName} include the following:
+The different methods for obtaining OAuth 2 access tokens include the following:
 
 * Personal access tokens (PAT)
 * Application token: Password grant type
 * Application token: Implicit grant type
 * Application token: Authorization Code grant type
 
-A user needs to create an OAuth 2 token in the API or in the {MenuAMAdminOauthApps} tab of the {Gateway} UI.
+You can create an OAuth 2 token in the API or in the {MenuAMAdminOauthApps} tab of the {Gateway} UI.
 For more information about creating tokens through the UI, see link:{URLCentralAuth}/gw-token-based-authentication#proc-controller-apps-create-tokens[Adding tokens].
 
 For the purpose of this example, use the PAT method for creating a token in the API.
@@ -32,20 +32,22 @@ You can configure the expiration time of the token system-wide.
 For more information, see link:{URLCentralAuth}/gw-token-based-authentication[Configuring access to external applications with token-based authentication].
 ====
 
-Token authentication is best used for any programmatic use of the {ControllerName} API, such as Python scripts or tools such as curl.
+Token authentication is the recommended method for any programmatic use of the {Gateway} API, such as Python scripts or tools such as curl.
 
 *Curl example*
 
+Create a token through the {Gateway} tokens endpoint:
+
 [literal, options="nowrap" subs="+attributes"]
 ----
-curl -u user:password -k -X POST https://<platform-host>/api/gateway/v1/tokens/
+curl -u user:password -k -X POST https://<gateway server name>/api/gateway/v1/tokens/
 ----
 
 This call returns JSON data with the following:
 
 image::api_oauth2_json_returned_token_value.png[API OAuth2 JSON]
 
-You can use the value of the `token` property to perform a `GET` request for an {ControllerName} resource, such as Hosts:
+You can use the value of the `token` property to perform a `GET` request for a resource, such as Hosts:
 
 [literal, options="nowrap" subs="+attributes"]
 ----

--- a/downstream/modules/platform/con-controller-api-sso-auth.adoc
+++ b/downstream/modules/platform/con-controller-api-sso-auth.adoc
@@ -5,11 +5,12 @@
 = Single sign-on authentication
 
 [role="_abstract"]
-Single sign-on (SSO) authentication methods are different from other methods because the authentication of the user happens external to {ControllerName}, such as Google SSO, {Azure} SSO, SAML, or GitHub. 
+Single sign-on (SSO) authentication methods are different from other methods because the authentication of the user happens external to {Gateway}, such as Google SSO, {Azure} SSO, SAML, or GitHub. 
 
-You can configure SSO authentication by using {ControllerName} inside a large organization with a central Identity Provider. 
-Once you have configured an SSO method in {ControllerName}, an option for that SSO is available on the login screen. 
-If you click that option, it redirects you to the Identity Provider, in this case GitHub, where you present your credentials. If the Identity Provider verifies you successfully, {ControllerName} makes a user linked to your GitHub user (if this is your first time logging in with this SSO method), and logs you in.
+You can configure SSO authentication through {Gateway} to integrate with a central identity provider in your organization. 
+Once you have configured an SSO method, an option for that SSO is available on the login screen. 
+If you select that option, the platform redirects you to the identity provider, for example GitHub, where you present your credentials. 
+If the identity provider verifies you successfully, {Gateway} creates a user linked to your GitHub user (if this is your first time logging in with this SSO method) and logs you in.
 
 [role="_additional-resources"]
 .Additional resources

--- a/downstream/modules/platform/proc-controller-api-browsing-api.adoc
+++ b/downstream/modules/platform/proc-controller-api-browsing-api.adoc
@@ -15,7 +15,7 @@ You can find the recommended current version (v2), view documentation for endpoi
 \https://<gateway server name>/api/controller/v2
 +
 . Select the **"v2"** link next to **"current versions"** or **"available versions"**.
-The API supports version 2 of the API.
+Version 2 is the supported API version.
 . Perform a `GET` with the `/api/` endpoint to get the `current_version`, which is the recommended version.
 . Select the image:api-questionmark.png[Copy,15,15] icon on the navigation menu, for documentation on the access methods for that particular API endpoint and what data is returned when using those methods.
 . Use the `PUT` and `POST` verbs on the specific API pages by formatting JSON in the various text fields.

--- a/downstream/modules/platform/proc-controller-api-browsing-api.adoc
+++ b/downstream/modules/platform/proc-controller-api-browsing-api.adoc
@@ -2,21 +2,22 @@
 
 [id="controller-api-browsing"]
 
-= {ControllerName} REST API browsing
+= Browse the REST API 
 
 [role="_abstract"]
-Learn how to access and use the {ControllerName} REST API by using a web browser. Learn how to find the recommended current version (v2), view documentation for endpoints, and use GET, PUT, and POST methods with JSON formatting.
+Access and use the {Gateway} REST API by using a web browser. 
+You can find the recommended current version (v2), view documentation for endpoints, and use GET, PUT, and POST methods with JSON formatting.
 
 .Procedure
 
-. Go to the {ControllerName} REST API in a web browser at: 
+. Go to the REST API in a web browser at: 
 +
 \https://<gateway server name>/api/controller/v2
 +
-. Click the **"v2"** link next to **"current versions"** or **"available versions"**.
-{ControllerNameStart} supports version 2 of the API.
-. Perform a `GET` with just the `/api/` endpoint to get the `current_version`, which is the recommended version.
-. Click the image:api-questionmark.png[Copy,15,15] icon on the navigation menu, for documentation on the access methods for that particular API endpoint and what data is returned when using those methods.
+. Select the **"v2"** link next to **"current versions"** or **"available versions"**.
+The API supports version 2 of the API.
+. Perform a `GET` with the `/api/` endpoint to get the `current_version`, which is the recommended version.
+. Select the image:api-questionmark.png[Copy,15,15] icon on the navigation menu, for documentation on the access methods for that particular API endpoint and what data is returned when using those methods.
 . Use the `PUT` and `POST` verbs on the specific API pages by formatting JSON in the various text fields.
 +
 [NOTE]

--- a/downstream/modules/platform/proc-controller-api-session-auth.adoc
+++ b/downstream/modules/platform/proc-controller-api-session-auth.adoc
@@ -5,17 +5,18 @@
 = Using session authentication
 
 [role="_abstract"]
-You can use session authentication when logging in directly to the {ControllerName}'s API or UI to manually create resources, such as inventories, projects, and job templates and start jobs in the browser. 
+You can use session authentication when logging in to the platform through {Gateway} to manually create resources, such as inventories, projects, and job templates, and start jobs in the browser. 
 
 With this method, you can remain logged in for a prolonged period of time, not just for that HTTP request. 
 For example, when browsing the API or UI in a browser such as Chrome or Mozilla Firefox. 
-When you log in, a session cookie is created, this means that you can remain logged in when navigating to different pages within {ControllerName}. 
+When you log in, a session cookie is created. 
+You can remain logged in when navigating to different pages across the platform.
 
 The following image represents the communication that occurs between the client and server in a session:
 
 image::session-auth-architecture.png[Session authentication architecture]
 
-Use the curl tool to see the activity that occurs when you log in to {ControllerName}.
+Use the curl tool to see the activity that occurs when you log in through {Gateway}.
 
 .Procedure
 
@@ -48,8 +49,9 @@ https://<gateway server name>/api/gateway/v1/login/ -k -D - -o /dev/null
 +
 [NOTE]
 ====
-All of this is done by {ControllerName} when you log in to the UI or API in the browser, and you must only use it when authenticating in the browser. 
-For programmatic integration with {ControllerName}, see xref:controller-api-oauth2-token[OAuth2 token authentication].
+{GatewayStart} performs all of these steps when you log in to the UI or API in the browser. 
+You must use this procedure only when authenticating in the browser. 
+For programmatic integration with the platform, see xref:controller-api-oauth2-token[OAuth 2 token authentication].
 ====
 +
 ----

--- a/downstream/titles/controller/controller-api-overview/master.adoc
+++ b/downstream/titles/controller/controller-api-overview/master.adoc
@@ -8,12 +8,13 @@ include::attributes/attributes.adoc[]
 
 
 // Book Title
-= Automation execution API overview
+= Platform gateway API overview
 
 Thank you for your interest in {PlatformName}.
 {PlatformNameShort} helps teams manage complex multitiered deployments by adding control, knowledge, and delegation to Ansible-powered environments.
 
-The {ControllerName} API Overview focuses on helping you understand the {ControllerName} API.
+{GatewayStart} provides the central API entry point for {PlatformNameShort}. 
+You can use the REST API through {Gateway} to manage automation resources, including inventories, projects, job templates, and credentials.
 
 include::{Boilerplate}[]
 


### PR DESCRIPTION
Update "Automation execution API overview" guide to platform gateway-centric language for AAP 2.6

https://redhat.atlassian.net/browse/AAP-73290

Affects `titles/controller-api-overview`