### PR TITLE
AAP-64217: Added ALIA agent configuration extras parameters

### DIFF
--- a/downstream/modules/platform/proc-configure-lightspeed-variables-container-install.adoc
+++ b/downstream/modules/platform/proc-configure-lightspeed-variables-container-install.adoc
@@ -41,6 +41,7 @@ lightspeed_chatbot_model_api_key: <set your own>
 lightspeed_chatbot_model_id: : <set your own>
 lightspeed_chatbot_default_provider: 'rhoai'
 lightspeed_chatbot_model_extra_settings: {} 
+lightspeed_chatbot_agent_extra_settings: {} 
 # If you want to use Microsoft Azure OpenAI as the LLM provider, specify the lightspeed_chatbot_model_extra_settings value as '{"api_type": ""}', and the lightspeed_chatbot_model_url value to 'https://your_inference_api/openai/v1'. 
 
 # This section is to configure Ansible Lightspeed intelligent assistant with MCP server integration

--- a/downstream/modules/platform/proc-create-chatbot-config-secret.adoc
+++ b/downstream/modules/platform/proc-create-chatbot-config-secret.adoc
@@ -59,7 +59,7 @@ For example, you can specify a parameter `api_version` for {AzureOpenAI} in the 
 |`chatbot_agent_config_extras`
 |_Optional_
 
-Use this field to customize agent behavior, such as conversation history management, response handling, and interaction timeouts.
+Use this parameter to customize agent behavior, such as controlling the temperature of the LLM.
 
 For example, '{"chatbot_temperature_override": 1}'. 
 

--- a/downstream/modules/platform/proc-create-chatbot-config-secret.adoc
+++ b/downstream/modules/platform/proc-create-chatbot-config-secret.adoc
@@ -56,6 +56,12 @@ Use this field to pass a JSON dictionary of extra parameters to pass directly to
 
 For example, you can specify a parameter `api_version` for {AzureOpenAI} in the JSON format `'{"api_version": "<your API version>"}'`.
 
+|`chatbot_agent_config_extras`
+|_Optional_
+
+Use this field to customize agent behavior, such as conversation history management, response handling, and interaction timeouts.
+
+For example, '{"max_history_length": 50, "response_timeout": 30}'.
 
 2+| *Additional settings for MCP server configuration*
 

--- a/downstream/modules/platform/proc-create-chatbot-config-secret.adoc
+++ b/downstream/modules/platform/proc-create-chatbot-config-secret.adoc
@@ -61,7 +61,7 @@ For example, you can specify a parameter `api_version` for {AzureOpenAI} in the 
 
 Use this field to customize agent behavior, such as conversation history management, response handling, and interaction timeouts.
 
-For example, '{"max_history_length": 50, "response_timeout": 30}'.
+For example, '{"chatbot_temperature_override": 1}'. 
 
 2+| *Additional settings for MCP server configuration*
 

--- a/downstream/modules/platform/ref-lightspeed-variables.adoc
+++ b/downstream/modules/platform/ref-lightspeed-variables.adoc
@@ -306,6 +306,12 @@ If you want to use {AzureOpenAI} as the LLM provider, specify the value as `'{"a
 | `{}`
 
 | N/A
+| `lightspeed_chatbot_agent_extra_settings`
+a| Use this parameter to customize agent behavior, such as conversation history management, response handling, and interaction timeouts.
+| Optional
+| `{}`
+
+| N/A
 | `lightspeed_chatbot_chatbot_max_tokens`
 | Maximum number of tokens to generate a chat response. 
 | Optional

--- a/downstream/modules/platform/ref-lightspeed-variables.adoc
+++ b/downstream/modules/platform/ref-lightspeed-variables.adoc
@@ -307,7 +307,7 @@ If you want to use {AzureOpenAI} as the LLM provider, specify the value as `'{"a
 
 | N/A
 | `lightspeed_chatbot_agent_extra_settings`
-a| Use this parameter to customize agent behavior, such as conversation history management, response handling, and interaction timeouts.
+a| Use this parameter to customize agent behavior, such as controlling the temperature of the LLM. For example, '{"chatbot_temperature_override": 1}'. 
 | Optional
 | `{}`
 


### PR DESCRIPTION
This PR addresses JIRA https://redhat.atlassian.net/browse/AAP-64217. 

Changes made:
- Added the `lightspeed_chatbot_agent_extra_settings` attribute to both container-install and operator-based install guides for ALIA. 