### PR TITLE
Comment out EE Builder docs - feature not yet public

### DIFF
--- a/downstream/titles/self-service-config/master.adoc
+++ b/downstream/titles/self-service-config/master.adoc
@@ -28,7 +28,8 @@ include::assemblies/devtools/proc-devspaces-aap-sync-manual.adoc[leveloffset=+1]
 
 include::assemblies/assembly-self-service-admin-content-setup.adoc[leveloffset=+1]
 
-include::assemblies/assembly-self-service-repository-synchronization.adoc[leveloffset=+1]
+// EE Builder feature not yet public - commented out per Craig Brandt (2026-04-29)
+// include::assemblies/assembly-self-service-repository-synchronization.adoc[leveloffset=+1]
 
 include::assemblies/devtools/proc-self-service-customize-portal-ui.adoc[leveloffset=+1]
 

--- a/downstream/titles/self-service-using/master.adoc
+++ b/downstream/titles/self-service-using/master.adoc
@@ -29,8 +29,10 @@ include::devtools/assembly-self-service-rbac.adoc[leveloffset=+1]
 
 include::devtools/assembly-backstage-software-templates.adoc[leveloffset=+1]
 
-include::devtools/assembly-self-service-create-ee-definitions.adoc[leveloffset=+1]
+// EE Builder feature not yet public - commented out per Craig Brandt (2026-04-29)
+// include::devtools/assembly-self-service-create-ee-definitions.adoc[leveloffset=+1]
 
-include::devtools/assembly-self-service-discovering-ee-content.adoc[leveloffset=+1]
+// EE Builder feature not yet public - commented out per Craig Brandt (2026-04-29)
+// include::devtools/assembly-self-service-discovering-ee-content.adoc[leveloffset=+1]
 
 include::devtools/assembly-self-service-feedback.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary

- EE Builder feature is not public or ready for customers per Craig Brandt
- Commented out 3 include directives across 2 guides to remove EE Builder content from published docs
- Content remains on main for future re-enablement when the feature is ready

### Changes

**self-service-config guide:**
- Commented out repository synchronization chapter

**self-service-using guide:**
- Commented out creating EE definitions chapter
- Commented out discovering EE content chapter

## Verification
- Both `self-service-config` and `self-service-using` guides build successfully with these changes