### PR TITLE
Comment out EE Builder disconnected import from content setup chapter

### DIFF
--- a/downstream/assemblies/devtools/assembly-self-service-admin-content-setup.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-admin-content-setup.adoc
@@ -26,7 +26,8 @@ include::devtools/proc-self-service-create-scm-secrets.adoc[leveloffset=+1]
 
 include::devtools/proc-self-service-setup-git-integration.adoc[leveloffset=+1]
 
-include::devtools/proc-self-service-import-templates-disconnected.adoc[leveloffset=+1]
+// EE Builder feature not yet public - commented out per Craig Brandt (2026-04-29)
+// include::devtools/proc-self-service-import-templates-disconnected.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
## Summary

- Follow-up to #5962: removes remaining EE Builder reference from the content setup chapter
- The `proc-self-service-import-templates-disconnected.adoc` module ("Import EE Builder templates in disconnected environments") was still included in the content setup assembly
- Commented out the include on the 2.6 branch — main stays untouched for future re-enablement

## Verification
- `self-service-config` guide builds successfully