### PR TITLE
AAP-73348 Fix migration guide SME feedback (2.6 backport)

### DIFF
--- a/downstream/modules/aap-migration/proc-containerized-post-import.adoc
+++ b/downstream/modules/aap-migration/proc-containerized-post-import.adoc
@@ -60,8 +60,8 @@ $ awx-manage list_instances
 .. Remove those nodes with `awx-manage`, leaving only the `aap-controller-task` instance:
 +
 ----
-awx-manage deprovision_instance --host=node1.example.org
-awx-manage deprovision_instance --host=node2.example.org
+awx-manage deprovision_instance --hostname=node1.example.org
+awx-manage deprovision_instance --hostname=node2.example.org
 ----
 
 . Repair orphaned {HubName} content links for Pulp.

--- a/downstream/modules/aap-migration/proc-containerized-source-environment-export.adoc
+++ b/downstream/modules/aap-migration/proc-containerized-source-environment-export.adoc
@@ -7,21 +7,6 @@
 Export databases, secrets, and custom configurations from your source containerized {PlatformNameShort} deployment to create the migration artifact.
 
 .Procedure
-. Verify the PostgreSQL database version is PostgreSQL version 15.
-+
-You can verify your current PostgreSQL version by connecting to your database server and running the following command as the `postgres` user:
-+
-----
-$ podman exec -it postgresql bash -c 'psql -c "SELECT version();"'
-----
-+
-[IMPORTANT]
-====
-PostgreSQL version 15 is a strict requirement for the migration process to succeed. If running PostgreSQL 13 or earlier, upgrade to version 15 before proceeding with the migration.
-
-If using an {PlatformNameShort} managed database, re-run the installation program to upgrade the PostgreSQL version. If using a customer provided (external) database, contact your database administrator or service provider to confirm the version and arrange for an upgrade if required.
-====
-
 . Create a complete backup of the source environment:
 +
 ----

--- a/downstream/modules/aap-migration/proc-ocp-target-import.adoc
+++ b/downstream/modules/aap-migration/proc-ocp-target-import.adoc
@@ -342,7 +342,7 @@ pod/aap-gateway-6c989b846c-47b91 2/2 Running 0 45s
 ----
 +
 ----
-for i in HTTPPort Route ServiceNode; do; oc exec -it deployment.apps/aap-gateway -- aap-gateway-manage shell -c 'from aap_gateway_api.models import '$i';print('$i'.objects.all().delete())'; done
+for i in HTTPPort Route ServiceNode; do oc exec -it deployment.apps/aap-gateway -- aap-gateway-manage shell -c 'from aap_gateway_api.models import '$i';print('$i'.objects.all().delete())'; done
 ----
 +
 Example output:
@@ -395,8 +395,8 @@ bash-4.4$
 .. Remove old nodes with `awx-manage`, leaving only `aap-controller-task`:
 +
 ----
-awx-manage deprovision_instance --host=node1.example.org
-awx-manage deprovision_instance --host=node2.example.org
+awx-manage deprovision_instance --hostname=node1.example.org
+awx-manage deprovision_instance --hostname=node2.example.org
 ----
 
 . Remove the `aap-resource-server` secret and allow the deployments to reconcile. This will recreate the resource service keys and secret for the components:


### PR DESCRIPTION
Backport of #5970 to 2.6.

- Remove unnecessary PostgreSQL 15 verification step from containerized export procedure
- Fix invalid bash syntax in service endpoint cleanup for loop
- Correct deprovision_instance flag from --host to --hostname