### PR TITLE
Comment out content management chapter in self-service config guide

### DIFF
--- a/downstream/titles/self-service-config/master.adoc
+++ b/downstream/titles/self-service-config/master.adoc
@@ -26,7 +26,8 @@ include::assemblies/devtools/ref-devspaces-aap-sync-troubleshooting.adoc[levelof
 
 include::assemblies/devtools/proc-devspaces-aap-sync-manual.adoc[leveloffset=+1]
 
-include::assemblies/assembly-self-service-admin-content-setup.adoc[leveloffset=+1]
+// Content management chapter commented out per Craig's guidance - should not be published
+// include::assemblies/assembly-self-service-admin-content-setup.adoc[leveloffset=+1]
 
 include::assemblies/assembly-self-service-repository-synchronization.adoc[leveloffset=+1]
 


### PR DESCRIPTION
## Summary
- Comments out Chapter 7 "Set up content management in self-service automation portal" from the configuring guide per Craig's guidance — this content should not be published on the customer portal

## Test plan
- [x] self-service-config guide builds successfully