### PR TITLE
AAP-59549: Update plug-in delivery docs for portal install guide

### DIFF
--- a/downstream/assemblies/devtools/assembly-self-service-create-ocp-registry.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-create-ocp-registry.adoc
@@ -24,7 +24,7 @@ endif::[]
 
 [NOTE]
 ====
-If you are installing {SelfServiceShort} in a disconnected or air-gapped {OCP} environment, complete the pre-installation configuration in this chapter and then follow the procedures in xref:self-service-disconnected-install-prepare_self-service-disconnected-install-prepare[Install {SelfServiceShort} in air-gapped {OCP} environments]. The disconnected installation chapter includes additional steps for mirroring container images, configuring registry authentication, and installing the Helm chart in isolated environments.
+If you are installing {SelfServiceShort} in a disconnected or air-gapped {OCP} environment, complete the pre-installation configuration in this chapter and then follow the procedures in xref:self-service-disconnected-install-prepare_self-service-disconnected-install[Install {SelfServiceShort} in air-gapped {OCP} environments]. The disconnected installation chapter includes additional steps for mirroring container images, configuring registry authentication, and installing the Helm chart in isolated environments.
 ====
 
 include::devtools/proc-self-service-oci-container-delivery.adoc[leveloffset=+1]

--- a/downstream/assemblies/devtools/assembly-self-service-create-ocp-registry.adoc
+++ b/downstream/assemblies/devtools/assembly-self-service-create-ocp-registry.adoc
@@ -17,11 +17,15 @@ endif::[]
 :context: self-service-create-ocp-registry
 
 [role="_abstract"]
-{SelfServiceShortStart} supports two plug-in installation methods. Choose the method that fits your environment:
+{SelfServiceShortStart} supports two plug-in delivery methods:
 
-* *OCI container (recommended)*: {SelfService} automatically pulls an Open Container Initiative (OCI) container from `registry.redhat.io`.
-* *HTTP plug-in registry*: Manually create an HTTP plug-in registry that contains the necessary {SelfService} plug-ins.
+* *OCI container delivery (recommended)*: {SelfService} automatically pulls an Open Container Initiative (OCI) container from `registry.redhat.io` that contains the plug-ins. Use this method for new installations.
+* *HTTP plug-in registry (deprecated)*: Manually create an HTTP plug-in registry that hosts plug-in tarball files. This method is deprecated and will be removed in a future release of {PlatformNameShort}. Existing installations that use this method should migrate to OCI container delivery.
 
+[NOTE]
+====
+If you are installing {SelfServiceShort} in a disconnected or air-gapped {OCP} environment, complete the pre-installation configuration in this chapter and then follow the procedures in xref:self-service-disconnected-install-prepare_self-service-disconnected-install-prepare[Install {SelfServiceShort} in air-gapped {OCP} environments]. The disconnected installation chapter includes additional steps for mirroring container images, configuring registry authentication, and installing the Helm chart in isolated environments.
+====
 
 include::devtools/proc-self-service-oci-container-delivery.adoc[leveloffset=+1]
 

--- a/downstream/modules/devtools/con-self-service-http-plug-in-registry.adoc
+++ b/downstream/modules/devtools/con-self-service-http-plug-in-registry.adoc
@@ -6,3 +6,8 @@
 
 [role="_abstract"]
 The HTTP plug-in registry method hosts plug-in tarball files in a local OpenShift registry that the dynamic plug-in installer pulls during startup.
+
+[IMPORTANT]
+====
+The HTTP plug-in registry method is deprecated and will be removed in a future release of {PlatformName}. Use xref:oci-container-delivery_{context}[OCI container delivery] for new installations. The {SelfServiceShort} setup bundle on the link:{PlatformDownloadUrl}[Product Software downloads page] is provided for existing installations that have not yet migrated to OCI delivery.
+====

--- a/downstream/modules/devtools/proc-self-service-create-ocp-auth-secrets.adoc
+++ b/downstream/modules/devtools/proc-self-service-create-ocp-auth-secrets.adoc
@@ -38,7 +38,7 @@ Replace the placeholder values:
 ** `<aap_instance_url>`: The URL of your {PlatformNameShort} instance.
 ** `<oauth_client_id>`: Your {PlatformNameShort} OAuth client ID.
 ** `<oauth_client_secret>`: Your {PlatformNameShort} OAuth client secret value.
-** `<aap_token>`: A token for {PlatformNameShort} user authentication. The token must have `read` access.
+** `<aap_token>`: A token for {PlatformNameShort} user authentication. The token must have `write` access.
 ** `<project_name>`: The OpenShift project where you will install {SelfServiceShort}.
 
 *OpenShift web console*
@@ -51,6 +51,6 @@ Replace the placeholder values:
 ** Key: `aap-host-url`, Value: {PlatformNameShort} instance URL
 ** Key: `oauth-client-id`, Value: {PlatformNameShort} OAuth client ID
 ** Key: `oauth-client-secret`, Value: {PlatformNameShort} OAuth client secret value
-** Key: `aap-token`, Value: Token for {PlatformNameShort} user authentication (must have `read` access)
+** Key: `aap-token`, Value: Token for {PlatformNameShort} user authentication (must have `write` access)
 . Click *Create*.
 

--- a/downstream/modules/devtools/proc-self-service-create-ocp-auth-secrets.adoc
+++ b/downstream/modules/devtools/proc-self-service-create-ocp-auth-secrets.adoc
@@ -6,40 +6,51 @@
 [role="_abstract"]
 You must create a secret in {OCPShort} for {PlatformNameShort} authentication.
 
+.Prerequisites
+
+* You have logged in to your {OCPShort} cluster.
+* You have access to the OpenShift project where you will install {SelfServiceShort}.
+
 .Procedure
 
-. Log in to your {OCPShort} instance.
-. Open your OpenShift project for {SelfServiceShort} in the *Administrator* view.
-. Click *Secrets* in the side pane.
-. Click *Create* to open the form for creating a new secret.
-. Select the *Key/Value* option.
-. Create a secret named `secrets-rhaap-portal`. 
-+
+Create the `secrets-rhaap-portal` secret using the `oc` CLI or the OpenShift web console.
+
 [NOTE]
 ====
-The secret must use this exact name.
+The secret must use the exact name `secrets-rhaap-portal` with the exact key names specified below.
 ====
-. Add the following key-value pairs to the secret.
+
+*CLI*
+
+* Run the following command to create the secret:
 +
-[NOTE]
-====
-The secrets must use the exact key names specified below.
-====
+----
+$ oc create secret generic secrets-rhaap-portal \
+  --from-literal=aap-host-url="<aap_instance_url>" \
+  --from-literal=oauth-client-id="<oauth_client_id>" \
+  --from-literal=oauth-client-secret="<oauth_client_secret>" \
+  --from-literal=aap-token="<aap_token>" \
+  -n <project_name>
+----
 +
-** Key: `aap-host-url`
+Replace the placeholder values:
 +
-Value needed: {PlatformNameShort} instance URL
+** `<aap_instance_url>`: The URL of your {PlatformNameShort} instance.
+** `<oauth_client_id>`: Your {PlatformNameShort} OAuth client ID.
+** `<oauth_client_secret>`: Your {PlatformNameShort} OAuth client secret value.
+** `<aap_token>`: A token for {PlatformNameShort} user authentication. The token must have `read` access.
+** `<project_name>`: The OpenShift project where you will install {SelfServiceShort}.
+
+*OpenShift web console*
+
+. In the *Administrator* view, click *Workloads* -> *Secrets*.
+. Click *Create* -> *Key/value secret*.
+. Set the secret name to `secrets-rhaap-portal`.
+. Add the following key-value pairs:
 +
-** Key: `oauth-client-id`
-+
-Value needed: {PlatformNameShort} OAuth client ID
-+
-** Key: `oauth-client-secret`
-+
-Value needed: {PlatformNameShort} OAuth client secret value
-+
-** Key: `aap-token`
-+
-Value needed: Token for {PlatformNameShort} user authentication (must have `read` access).
-. Click btn:[Create] to create the secret.
+** Key: `aap-host-url`, Value: {PlatformNameShort} instance URL
+** Key: `oauth-client-id`, Value: {PlatformNameShort} OAuth client ID
+** Key: `oauth-client-secret`, Value: {PlatformNameShort} OAuth client secret value
+** Key: `aap-token`, Value: Token for {PlatformNameShort} user authentication (must have `read` access)
+. Click *Create*.
 

--- a/downstream/modules/devtools/proc-self-service-create-scm-secrets.adoc
+++ b/downstream/modules/devtools/proc-self-service-create-scm-secrets.adoc
@@ -8,33 +8,55 @@ Create an OpenShift secret to hold Personal Access Tokens for your external Sour
 
 This procedure establishes the required `secrets-scm` Key/Value secret within your {OCPShort} project to securely store the GitHub and/or GitLab Personal Access Tokens (PATs).
 
+.Prerequisites
+
+* You have logged in to your {OCPShort} cluster.
+* You have access to the OpenShift project where you will install {SelfServiceShort}.
+
 .Procedure
 
-. Log in to your {OCPShort} instance.
-. Open your OpenShift project for {SelfServiceShort}.
-. Click *Secrets* in the side pane.
-. Click *Create* to open the form for creating a new secret.
-. Select the *Key/Value* option.
-. Create a secret named `secrets-scm`. 
-+
+Create the `secrets-scm` secret using the `oc` CLI or the OpenShift web console. If you use only one SCM provider, include only that provider's token.
+
 [NOTE]
 ====
-The secret must use this exact name.
+The secret must use the exact name `secrets-scm` with the exact key names specified below.
 ====
-. Add the following key-value pairs to the secret.
-If you are only using one SCM, just add the key-value pair for that SCM.
+
+*CLI*
+
+* To create the secret with both GitHub and GitLab tokens:
 +
-[NOTE]
-====
-The secrets must use the exact key names specified below.
-====
+----
+$ oc create secret generic secrets-scm \
+  --from-literal=github-token="<github_pat>" \
+  --from-literal=gitlab-token="<gitlab_pat>" \
+  -n <project_name>
+----
+
+* To create the secret with only a GitHub token:
 +
-** Key: `github-token`
+----
+$ oc create secret generic secrets-scm \
+  --from-literal=github-token="<github_pat>" \
+  -n <project_name>
+----
+
+* To create the secret with only a GitLab token:
 +
-Value needed: Github Personal Access Token (PAT)
+----
+$ oc create secret generic secrets-scm \
+  --from-literal=gitlab-token="<gitlab_pat>" \
+  -n <project_name>
+----
+
+*OpenShift web console*
+
+. In the *Administrator* view, click *Workloads* -> *Secrets*.
+. Click *Create* -> *Key/value secret*.
+. Set the secret name to `secrets-scm`.
+. Add key-value pairs for your SCM providers:
 +
-** Key: `gitlab-token`
-+
-Value needed: Gitlab Personal Access Token (PAT)
-. Click *Create* to create the secret.
+** Key: `github-token`, Value: GitHub Personal Access Token (PAT)
+** Key: `gitlab-token`, Value: GitLab Personal Access Token (PAT)
+. Click *Create*.
 

--- a/downstream/modules/devtools/proc-self-service-install-disconnected-define-parameters.adoc
+++ b/downstream/modules/devtools/proc-self-service-install-disconnected-define-parameters.adoc
@@ -4,13 +4,51 @@
 = Configure plug-in delivery for disconnected environments
 
 [role="_abstract"]
-Complete one of the plug-in delivery methods for disconnected environments.
+Create the registry authentication secret so the dynamic plug-in init container can pull OCI artifacts from your disconnected registry.
 
+.Prerequisites
+
+* You have mirrored the required container images and plug-in artifacts to your disconnected registry.
+* You have credentials for your disconnected registry.
 
 .Procedure
 
-* For OCI delivery: Create the `<release-name>-dynamic-plugins-registry-auth` secret with credentials for your disconnected registry that hosts the mirrored Ansible plug-ins OCI artifacts.
+. Create an `auth.json` file with credentials for your disconnected registry:
++
+----
+{
+  "auths": {
+    "<disconnected_registry_url>": {
+      "auth": "<base64-encoded-registry-credentials>"
+    }
+  }
+}
+----
++
+Generate the base64-encoded value:
++
+----
+$ printf '%s' '<registry_username>:<registry_password>' | base64 -w0
+----
+
+. Create the registry authentication secret:
++
+----
+$ oc create secret generic <release-name>-dynamic-plugins-registry-auth \
+  --from-file=auth.json=./auth.json \
+  -n <project_name>
+----
++
+Replace `<release-name>` with your Helm release name. If you use the default release name from the OpenShift catalog, the secret name is `redhat-rhaap-portal-dynamic-plugins-registry-auth`.
+
+.Verification
+
+* Verify that the secret exists in the project:
++
+----
+$ oc get secret <release-name>-dynamic-plugins-registry-auth -n <project_name>
+----
 
 .Additional resources
 
-* link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html-single/installing_self-service_automation_portal/index#self-service-create-ocp-registry_self-service-preinstall-config[Choose a plug-in delivery method]
+* xref:oci-container-delivery_self-service-create-ocp-registry[OCI container delivery]

--- a/downstream/modules/devtools/proc-self-service-oci-container-delivery.adoc
+++ b/downstream/modules/devtools/proc-self-service-oci-container-delivery.adoc
@@ -5,9 +5,7 @@
 = OCI container delivery
 
 [role="_abstract"]
-Use OCI container delivery to automatically pull an OCI container from `registry.redhat.io` that includes the {SelfService} plug-ins. This is the recommended method for production deployments.
-
-This method is the default for the Helm chart and is the recommended method for production deployments.
+Use OCI container delivery to automatically pull an OCI container from `registry.redhat.io` that includes the {SelfService} plug-ins. This is the recommended method for new installations and production deployments.
 
 .Prerequisites
 
@@ -20,7 +18,7 @@ This method is the default for the Helm chart and is the recommended method for 
 .Procedure
 
 . Create an `auth.json` file on your local machine.
-. Add the following structure to the `auth.json` file:
+. Add registry credentials for `registry.redhat.io` to the `auth.json` file:
 +
 ----
 {
@@ -31,14 +29,31 @@ This method is the default for the Helm chart and is the recommended method for 
   }
 }
 ----
++
+If you pull plug-in artifacts from a private or mirror registry, add an entry for that registry in the same `auth.json` file:
++
+----
+{
+  "auths": {
+    "registry.redhat.io": {
+      "auth": "<base64-encoded-username-password>"
+    },
+    "<private_registry_url>": {
+      "auth": "<base64-encoded-registry-credentials>"
+    }
+  }
+}
+----
++
+For full mirror registry configuration including `imageRegistry`, `ociPluginImage`, and image mirroring procedures, see xref:self-service-disconnected-install-prepare_self-service-disconnected-install-prepare[Install {SelfServiceShort} in air-gapped {OCP} environments].
 
-. Generate the base64-encoded authentication value:
+. Generate the base64-encoded authentication value for each registry:
 +
 ----
 printf '%s' '<username>:<password>' | base64 -w0
 ----
 
-. Replace `<base64-encoded-username-password>` in the `auth.json` file with the output from the previous step.
+. Replace the `<base64-encoded-username-password>` and `<base64-encoded-registry-credentials>` placeholders in the `auth.json` file with the output from the previous step.
 . Create the authentication secret in the target OpenShift project. The secret name must match your Helm release name.
 +
 If you install from the OpenShift catalog and you use the default release name `redhat-rhaap-portal`:
@@ -66,6 +81,8 @@ oc get secret <release-name>-dynamic-plugins-registry-auth
 [IMPORTANT]
 ====
 Create this secret in the same OpenShift project as the Helm release, and create it before you install or upgrade the Helm release.
+
+The dynamic plug-in init container uses `skopeo` to pull OCI artifacts directly. It does not use Kubernetes `imagePullSecrets`, cluster-level `ImageDigestMirrorSet` or `ImageTagMirrorSet`, or {OCPShort} global pull secrets. You must provide registry credentials in the `auth.json` secret even if your cluster is configured with image mirrors.
 ====
 
 *OpenShift web console steps*
@@ -86,7 +103,7 @@ When you configure the Helm chart, set `redhat-developer-hub.global.pluginMode` 
 * `oci` -- OCI container delivery (recommended).
 * `tarball` -- HTTP plug-in registry.
 
-Verify that `pluginMode` is set to the correct value. If you omit this setting, the chart uses its built-in default.
+Verify that `pluginMode` is set to the correct value. If you omit this setting, the chart defaults to `tarball`.
 
 ----
 redhat-developer-hub:

--- a/downstream/modules/devtools/proc-self-service-oci-container-delivery.adoc
+++ b/downstream/modules/devtools/proc-self-service-oci-container-delivery.adoc
@@ -45,7 +45,7 @@ If you pull plug-in artifacts from a private or mirror registry, add an entry fo
 }
 ----
 +
-For full mirror registry configuration including `imageRegistry`, `ociPluginImage`, and image mirroring procedures, see xref:self-service-disconnected-install-prepare_self-service-disconnected-install-prepare[Install {SelfServiceShort} in air-gapped {OCP} environments].
+For full mirror registry configuration including `imageRegistry`, `ociPluginImage`, and image mirroring procedures, see xref:self-service-disconnected-install-prepare_self-service-disconnected-install[Install {SelfServiceShort} in air-gapped {OCP} environments].
 
 . Generate the base64-encoded authentication value for each registry:
 +


### PR DESCRIPTION
> **NOTE:** This PR will NOT be merged. It serves as a reference for content to be converted to DITA format for the AEM pipeline. It will be closed after conversion.

## Summary

- Fix inaccurate "default" claim in OCI section — chart defaults to `tarball`, not `oci`
- Add IMPORTANT deprecation admonition to HTTP plug-in registry (section 3.7.2)
- Rewrite section 3.7 intro to present OCI as recommended, tarball as deprecated
- Add NOTE cross-reference directing disconnected/air-gapped users to Chapter 5
- Add `oc` CLI commands for `secrets-rhaap-portal` and `secrets-scm` creation (sections 3.8.1, 3.8.2)
- Add private registry `auth.json` example and `skopeo` architecture note to OCI section (3.7.1)
- Expand disconnected section 5.3.2 with full `oc create secret generic` procedure

## JIRA tickets

- [AAP-73875](https://issues.redhat.com/browse/AAP-73875) — Add `oc` CLI commands for auth + SCM secrets
- [AAP-73876](https://issues.redhat.com/browse/AAP-73876) — Add cross-reference to disconnected installation chapter
- [AAP-73877](https://issues.redhat.com/browse/AAP-73877) — Update OCI section 3.7.1 + expand section 5.3.2
- [AAP-73879](https://issues.redhat.com/browse/AAP-73879) — Make OCI recommended, correct "default" claim
- [AAP-73880](https://issues.redhat.com/browse/AAP-73880) — Add deprecation warning for HTTP tarball method
- [AAP-73878](https://issues.redhat.com/browse/AAP-73878) — Closed as duplicate of AAP-74315

## Verification

- All claims verified against `ansible-portal-chart` Helm chart source (secret names, keys, `pluginMode` default, `skopeo` usage)
- Both Installing and Configuring portal guides build without errors or warnings
- Cross-chapter xrefs use hardcoded context values to avoid broken links

## Test plan

- [x] Verify OCI section 3.7.1 renders correctly with private registry example and skopeo admonition
- [x] Verify HTTP section 3.7.2 renders deprecation IMPORTANT admonition
- [x] Verify section 3.7 intro shows OCI as recommended and HTTP as deprecated
- [x] Verify disconnected cross-reference NOTE renders in section 3.7
- [x] Verify `oc` CLI commands render in sections 3.8.1 and 3.8.2
- [x] Verify disconnected section 5.3.2 renders full procedure with auth.json and oc command
- [x] Verify Configuring guide section 7.7 picks up SCM secrets CLI changes via shared module