### PR TITLE
Replace hardcoded version references with attributes in cloud docs

### DIFF
--- a/aap-clouds/stories/assembly-saas-post-install-config.adoc
+++ b/aap-clouds/stories/assembly-saas-post-install-config.adoc
@@ -12,7 +12,7 @@ ifdef::context[:parent-context: {context}]
 After you subscribe to {SaaSonAWSShort} and gain access to {PlatformNameShort}, you must configure your {AutomationMesh} nodes and set up your automation jobs. 
 
 For help with configuring your {AutomationMesh} see
-link:{BaseURL}/red_hat_ansible_automation_platform/2.6/html/automation_mesh_for_managed_cloud_or_operator_environments/index[Automation mesh for managed cloud or operator environments].
+link:{URLOperatorMesh}/index[{TitleOperatorMesh}].
 
 [WARNING]
 ====

--- a/aap-clouds/topics/con-aap-notification-feed.adoc
+++ b/aap-clouds/topics/con-aap-notification-feed.adoc
@@ -5,10 +5,9 @@
 = Product Notification Feed 
 
 [role="_abstract"]
-Effective July 2025, the {PlatformNameShort} RSS notification feed is available. 
-This feed serves as a method for communicating various product updates and changes to customers. 
+The {PlatformNameShort} RSS notification feed provides product updates and change notifications. 
 
 Customers can subscribe to the notifications by visiting link:https://announcements.ansiblecloud.redhat.com/feed.atom[announcements.ansiblecloud.redhat.com/feed.atom]. 
 Using an RSS feed reader, customers are updated with events such as {PlatformNameShort} upgrades and system maintenance.
 
-All {PlatformNameShort} customers can subscribe to this content. Messages include categorization tags to specify deployment types: managed, self-managed (on-premises), or a combination. Red Hat is developing a future enhancement to integrate this feature directly into the UI.
+All {PlatformNameShort} customers can subscribe to this content. Messages include categorization tags to specify deployment types: managed, self-managed (on-premises), or a combination.

--- a/aap-clouds/topics/con-azure-infrastructure-usage.adoc
+++ b/aap-clouds/topics/con-azure-infrastructure-usage.adoc
@@ -25,7 +25,7 @@ Azure Kubernetes service (AKS):: The Kubernetes cluster used to deploy {Platform
 +
 [IMPORTANT]
 ====
-All deployments will move from the Azure Kubernetes Service (AKS) *Free tier* to the *Standard tier* as part of infrastructure changes when upgrading to {PlatformNameShort} 2.6.  
+All deployments will move from the Azure Kubernetes Service (AKS) *Free tier* to the *Standard tier* as part of infrastructure changes when upgrading to {PlatformNameShort} {PlatformVers}.  
 ====
 +
 **Service Shape for all Ansible Automation Platform plan sizes:**

--- a/aap-clouds/topics/con-azure-pricing.adoc
+++ b/aap-clouds/topics/con-azure-pricing.adoc
@@ -6,8 +6,8 @@
 
 [role="_abstract"]
 
-As of December 16, 2024, Microsoft has adjusted the API, quotas, and limits of Azure Kubernetes Service (AKS) cluster tiers.
+Microsoft has adjusted the API, quotas, and limits of Azure Kubernetes Service (AKS) cluster tiers.
 
-All {AAPonAzureNameShort} deployments will move from the AKS *Free tier* to the *Standard tier* as part of infrastructure changes when upgrading to {PlatformNameShort} 2.6.
+All {AAPonAzureNameShort} deployments will move from the AKS *Free tier* to the *Standard tier* as part of infrastructure changes when upgrading to {PlatformNameShort} {PlatformVers}.
 This transition aligns the management requirements of {AAPonAzureNameShort} deployments to the proper Azure solution. 
 This change increases the Azure infrastructure costs as the new infrastructure is added to the offering.

--- a/aap-clouds/topics/con-saas-automation-mesh.adoc
+++ b/aap-clouds/topics/con-saas-automation-mesh.adoc
@@ -15,4 +15,4 @@ image:automation_mesh.png[Execution node in a private address space ]
 
 You can also configure the automation mesh with outbound connectivity from the control plane to your execution plane, allowing you to specify the ports used by the automation mesh.
 
-You can use the link:{BaseURL}/red_hat_ansible_automation_platform/2.6/html/automation_mesh_for_managed_cloud_or_operator_environments/index[Automation mesh for managed cloud or operator environments] documentation for instructions.
+You can use the link:{URLOperatorMesh}/index[{TitleOperatorMesh}] documentation for instructions.

--- a/aap-clouds/topics/con-saas-shape.adoc
+++ b/aap-clouds/topics/con-saas-shape.adoc
@@ -11,7 +11,7 @@ Your execution plane's size and shape depend on the type of automation and the l
 
 * Hop Nodes: {SaaSonAWS} includes two hop nodes that customers can use to peer with execution nodes. They typically require minimal resources. The shape of a hop node depends on the number of connected execution nodes. A virtual machine (VM) with 2 vCPUs and 2 GB RAM can route traffic for 2-4 execution nodes. 
 ** For help with configuring your automation mesh see
-link:{BaseURL}/red_hat_ansible_automation_platform/2.6/html/automation_mesh_for_managed_cloud_or_operator_environments/index[Automation mesh for managed cloud or operator environments].
+link:{URLOperatorMesh}/index[{TitleOperatorMesh}].
 * For automation in fewer locations (such as specific geographies or clouds), create a mesh with fewer VMs that can be scaled vertically. Most clouds and hypervisors allow shape changes with minimal downtime.
 * For CPU or RAM-intensive automation, use larger machine shapes.
 * For automation spanning multiple locations, create a mesh with nodes that connect to those locations.

--- a/aap-clouds/topics/con-saas-updates-and-maintenance.adoc
+++ b/aap-clouds/topics/con-saas-updates-and-maintenance.adoc
@@ -9,4 +9,4 @@ Automation mesh execution nodes are designed to minimize the need for patching t
 However, future updates to the technology will require customer involvement to update the components in each execution plane node.
 
 When patches are needed, customers should follow the process for updating an automation mesh node.
-For help with updating your receptor see the _Updating Receptors_ section of the link:{BaseURL}/red_hat_ansible_automation_platform/2.6/html/automation_mesh_for_managed_cloud_or_operator_environments/index[Automation mesh for managed cloud or operator environments].
+For help with updating your receptor see the _Updating Receptors_ section of the link:{URLOperatorMesh}/index[{TitleOperatorMesh}].

--- a/aap-clouds/topics/proc-azure-accessing-aap.adoc
+++ b/aap-clouds/topics/proc-azure-accessing-aap.adoc
@@ -16,5 +16,5 @@ Complete the form to provision {PlatformNameShort} infrastructure and resources 
 * If this is your first time accessing your {PlatformNameShort} through the Azure portal, you must select and copy the deploymentEngineUrl under the *output* section to continue setting up your deployment. After you set up your instance through the deploymentEngineUrl, it is removed from the outputs section because it is no longer needed.
 * If you have already set up your {PlatformNameShort} deployment, you can go directly to it by copying the platformUrl output. 
 . Paste the selected URL into your browser search bar and hit enter. This brings you to your {PlatformNameShort} deployment.
-. The first time you log in to {PlatformNameShort} with the URL, you must configure the subscription. For help see the _Logging in for the first time_ section of the link:{BaseURL}/red_hat_ansible_automation_platform/2.6/html/getting_started_with_ansible_automation_platform/index[Getting started with Ansible Automation Platform] guide.
+. The first time you log in to {PlatformNameShort} with the URL, you must configure the subscription. For help see the _Logging in for the first time_ section of the link:{URLGettingStarted}/index[{TitleGettingStarted}] guide.
 

--- a/aap-clouds/topics/proc-azure-configure-ad-sso.adoc
+++ b/aap-clouds/topics/proc-azure-configure-ad-sso.adoc
@@ -9,6 +9,6 @@ Set up your {MSEntraID} SSO configuration.
 
 .Procedure 
 
-* For help with setting up and configuring your enterprise authentication, see the _Chapter 3. Configuring Microsoft Entra ID authentication_ section of the link:{BaseURL}/red_hat_ansible_automation_platform/2.6/html/access_management_and_authentication/index[Access management and authentication] guide. 
+* For help with setting up and configuring your enterprise authentication, see the _Chapter 3. Configuring Microsoft Entra ID authentication_ section of the link:{URLCentralAuth}/index[{TitleCentralAuth}] guide. 
 
 

--- a/aap-clouds/topics/proc-azure-provisioning-aap.adoc
+++ b/aap-clouds/topics/proc-azure-provisioning-aap.adoc
@@ -61,6 +61,6 @@ See link:{BaseURL}/ansible_on_clouds/2.x/html-single/red_hat_ansible_automation_
 It may take 30 minutes or longer for the infrastructure and software to fully provision.
 
 After provisioning is complete, you can access and log in to your new {PlatformNameShort} instance.
-For help with configuring your  {ControllerName} and {HubName} instances see link:{BaseURL}/red_hat_ansible_automation_platform/2.6/html/configuring_automation_execution/index[Configuring automation execution] and link:{BaseURL}/red_hat_ansible_automation_platform/2.6/html/managing_automation_content[Managing automation content] respectively.
+For help with configuring your  {ControllerName} and {HubName} instances see link:{URLControllerAdminGuide}/index[{TitleControllerAdminGuide}] and link:{URLHubManagingContent}[{TitleHubManagingContent}] respectively.
 
 

--- a/aap-clouds/topics/ref-saas-eda-perf.adoc
+++ b/aap-clouds/topics/ref-saas-eda-perf.adoc
@@ -5,7 +5,7 @@
 = Performance guidelines for {EDAName} on {SaaSonAWSShort}
 
 [role="_abstract"]
-Use this information to plan and configure link:{baseUrl}/red_hat_ansible_automation_platform/2.6/html/using_automation_decisions/index[{EDAName}] on {SaaSonAWSShort}.
+Use this information to plan and configure link:{URLEDAUserGuide}/index[{EDAName}] on {SaaSonAWSShort}.
 
 All customer workloads differ, and performance results may vary. 
 Red Hat recommends monitoring *Subscription Watch* for {PlatformNameShort} Service on AWS meters within Hybrid Cloud Console and creating cost alerts in AWS.

--- a/aap-clouds/topics/ref-saas-egress-model.adoc
+++ b/aap-clouds/topics/ref-saas-egress-model.adoc
@@ -10,7 +10,7 @@ The pull model initiates a WebSocket from the remote execution node to the contr
 This model eliminates the need to deploy hop nodes into your demilitarized zone (DMZ) to establish connectivity to private networks if private networks have outbound internet connectivity.
 Proxy servers that terminate TLS are not supported and will disrupt automation mesh connectivity.
 
-For help with configuring your {AutomationMesh} see link:{BaseURL}/red_hat_ansible_automation_platform/2.6/html/automation_mesh_for_managed_cloud_or_operator_environments/assembly-automation-mesh-operator-aap#proc-define-mesh-node-types[defining automation mesh node types].
+For help with configuring your {AutomationMesh} see link:{URLOperatorMesh}/assembly-automation-mesh-operator-aap#proc-define-mesh-node-types[defining automation mesh node types].
 
 *Pull model*
 

--- a/aap-clouds/topics/ref-saas-egress-model.adoc
+++ b/aap-clouds/topics/ref-saas-egress-model.adoc
@@ -10,7 +10,7 @@ The pull model initiates a WebSocket from the remote execution node to the contr
 This model eliminates the need to deploy hop nodes into your demilitarized zone (DMZ) to establish connectivity to private networks if private networks have outbound internet connectivity.
 Proxy servers that terminate TLS are not supported and will disrupt automation mesh connectivity.
 
-For help with configuring your {AutomationMesh} see link:{URLOperatorMesh}/assembly-automation-mesh-operator-aap#proc-define-mesh-node-types[defining automation mesh node types].
+For help with configuring your {AutomationMesh} see link:{URLOperatorMesh}/assembly-automation-mesh-operator-aap#proc-define-mesh-node-types[Defining automation mesh node types].
 
 *Pull model*
 


### PR DESCRIPTION
## Summary

- Replace 9 hardcoded `2.6` URLs across SaaS AWS and Azure topics with existing URL attributes (`{URLOperatorMesh}`, `{URLEDAUserGuide}`, `{URLControllerAdminGuide}`, `{URLHubManagingContent}`, `{URLGettingStarted}`, `{URLCentralAuth}`) so links resolve correctly when `{PlatformVers}` is updated
- Fix `{baseUrl}` case-sensitivity typo in `ref-saas-eda-perf.adoc` (was lowercase, should use attribute)
- Remove temporal language from `con-aap-notification-feed.adoc` ("Effective July 2025" and "future enhancement" references)
- Replace hardcoded `2.6` version in prose with `{PlatformVers}` attribute in Azure pricing and infrastructure usage topics
- Remove specific date reference ("As of December 16, 2024") from Azure pricing topic

## Files changed (12)

**SaaS AWS (6 files):**
- `topics/con-saas-shape.adoc`
- `topics/ref-saas-egress-model.adoc`
- `topics/con-saas-automation-mesh.adoc`
- `topics/con-saas-updates-and-maintenance.adoc`
- `stories/assembly-saas-post-install-config.adoc`
- `topics/ref-saas-eda-perf.adoc`

**Azure (3 files):**
- `topics/proc-azure-provisioning-aap.adoc`
- `topics/proc-azure-accessing-aap.adoc`
- `topics/proc-azure-configure-ad-sso.adoc`

**Shared / Azure-specific (3 files):**
- `topics/con-aap-notification-feed.adoc`
- `topics/con-azure-pricing.adoc`
- `topics/con-azure-infrastructure-usage.adoc`

## Test plan

- [ ] Verify no remaining hardcoded `2.6` references in topics/ or titles/ (grep clean)
- [ ] Verify all replaced links resolve correctly with current `{PlatformVers}` attribute
- [ ] Build SaaS AWS and Azure guides to confirm no broken references