### PR TITLE
[2.6 backport] AAP-63892 - Add steps to restart Automation Gateway services

### DIFF
--- a/downstream/modules/platform/proc-change-ssl-manual-rpm.adoc
+++ b/downstream/modules/platform/proc-change-ssl-manual-rpm.adoc
@@ -48,6 +48,12 @@ nginx -t
 systemctl reload nginx.service
 ----
 
+. Restart services on each {Gateway} server:
++
+----
+automation-gateway-service restart
+----
+
 . Verify that new SSL/TLS certificate and key have been installed:
 +
 ----


### PR DESCRIPTION
## Summary
Backport of #5983 to 2.6.

- Adds a step to restart services on each gateway server after reloading NGINX when changing SSL/TLS certificates manually
- Envoy (running on gateway) does not pick up the new certificate from an NGINX reload alone

Co-authored-by: Max Mitschke <mmitschk@redhat.com>