### PR TITLE
AAP-69209 Clarify install_pg_port vs pg_port distinction in variable descriptions

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -177,9 +177,9 @@ Use of special characters for this variable is limited. The `!`, `#`, `0` and `@
 | Required if not using client certificate authentication.
 |
 
-| `pg_port` 
-| `controller_pg_port` 
-| Port number for the PostgreSQL database used by {ControllerName}.
+| `pg_port`
+| `controller_pg_port`
+| Port number that {ControllerName} uses to connect to its PostgreSQL database. This variable does not configure the PostgreSQL server listening port. To change the port the PostgreSQL server listens on, use `install_pg_port`.
 | Optional
 | `5432`
 

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -12,8 +12,8 @@ Inventory file variables for the database used with {PlatformNameShort}.
 | RPM variable name | Container variable name | Description | Required or optional | Default
 
 | `install_pg_port`
-| `postgresql_port` 
-| Port number for the PostgreSQL database.
+| `postgresql_port`
+| Port number that the PostgreSQL server listens on. This variable configures the server-side listening port in `postgresql.conf`. To configure the port that a specific component uses to connect to PostgreSQL, use the component-specific port variable, for example, `pg_port` for {ControllerName}.
 | Optional
 | `5432`
 


### PR DESCRIPTION
- `install_pg_port` description updated to make clear it configures the PostgreSQL server listening port (`postgresql.conf`), not a component connection port
- `pg_port` description updated to make clear it configures only the port automation controller uses to connect, and directs users to `install_pg_port` to change the server listening port
- Addresses user confusion reported in AAP-69209 where setting `pg_port` did not affect `postgresql.conf` as expected

Fixes AAP-69209