### PR TITLE
AAP-69209 Fix cross-references in install_pg_port and pg_port descriptions

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -179,7 +179,7 @@ Use of special characters for this variable is limited. The `!`, `#`, `0` and `@
 
 | `pg_port`
 | `controller_pg_port`
-| Port number that {ControllerName} uses to connect to its PostgreSQL database. This variable does not configure the PostgreSQL server listening port. To change the port the PostgreSQL server listens on, use `install_pg_port`.
+| Port number that {ControllerName} uses to connect to its PostgreSQL database. This variable does not configure the PostgreSQL server listening port. To change the port the PostgreSQL server listens on, use `install_pg_port` (RPM) or `postgresql_port` (containerized).
 | Optional
 | `5432`
 

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -13,7 +13,7 @@ Inventory file variables for the database used with {PlatformNameShort}.
 
 | `install_pg_port`
 | `postgresql_port`
-| Port number that the PostgreSQL server listens on. This variable configures the server-side listening port in `postgresql.conf`. To configure the port that a specific component uses to connect to PostgreSQL, use the component-specific port variable, for example, `pg_port` for {ControllerName}.
+| Port number that the PostgreSQL server listens on. This variable configures the server-side listening port in `postgresql.conf`. To configure the port that a specific component uses to connect to PostgreSQL, use the component-specific port variable, for example, `pg_port` (RPM) or `controller_pg_port` (containerized) for {ControllerName}.
 | Optional
 | `5432`
 


### PR DESCRIPTION
Corrects cross-references in #5987 that named only RPM variable names in descriptions shared across both RPM and containerized contexts.

- `install_pg_port` / `postgresql_port` description: cross-reference now names both `pg_port` (RPM) and `controller_pg_port` (containerized) for automation controller
- `pg_port` / `controller_pg_port` description: cross-reference now names both `install_pg_port` (RPM) and `postgresql_port` (containerized) for the server listening port

Fixes AAP-69209