### PR TITLE
AAP-69209 Fix cross-references in install_pg_port and pg_port descriptions (2.6 backport)

### DIFF
--- a/downstream/modules/platform/ref-controller-variables.adoc
+++ b/downstream/modules/platform/ref-controller-variables.adoc
@@ -179,7 +179,7 @@ Use of special characters for this variable is limited. The `!`, `#`, `0` and `@
 
 | `pg_port`
 | `controller_pg_port`
-| Port number that {ControllerName} uses to connect to its PostgreSQL database. This variable does not configure the PostgreSQL server listening port. To change the port the PostgreSQL server listens on, use `install_pg_port`.
+| Port number that {ControllerName} uses to connect to its PostgreSQL database. This variable does not configure the PostgreSQL server listening port. To change the port the PostgreSQL server listens on, use `install_pg_port` (RPM) or `postgresql_port` (containerized).
 | Optional
 | `5432`
 

--- a/downstream/modules/platform/ref-database-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-database-inventory-variables.adoc
@@ -13,7 +13,7 @@ Inventory file variables for the database used with {PlatformNameShort}.
 
 | `install_pg_port`
 | `postgresql_port`
-| Port number that the PostgreSQL server listens on. This variable configures the server-side listening port in `postgresql.conf`. To configure the port that a specific component uses to connect to PostgreSQL, use the component-specific port variable, for example, `pg_port` for {ControllerName}.
+| Port number that the PostgreSQL server listens on. This variable configures the server-side listening port in `postgresql.conf`. To configure the port that a specific component uses to connect to PostgreSQL, use the component-specific port variable, for example, `pg_port` (RPM) or `controller_pg_port` (containerized) for {ControllerName}.
 | Optional
 | `5432`
 


### PR DESCRIPTION
Backport of #5990 to 2.6.