### PR TITLE
AAP-67086 Add direct sos command to collect container-level logs

### DIFF
--- a/downstream/modules/platform/proc-containerized-troubleshoot-gathering-logs.adoc
+++ b/downstream/modules/platform/proc-containerized-troubleshoot-gathering-logs.adoc
@@ -18,6 +18,14 @@ You can collect an `sos` report for each host in your containerized {PlatformNam
 $ ansible-playbook -i <path_to_inventory_file> ansible.containerized_installer.log_gathering
 ----
 +
+. To collect container-level logs, run the `sos` report directly on each host with the `aap_containerized` plugin enabled:
++
+----
+$ sudo sos report -e aap_containerized -k aap_containerized.username=<username>
+----
++
+where `<username>` is the service account or user running the containerized installation.
+
 . Optional: To define additional parameters, specify them with the `-e` option. For example:
 +
 ----


### PR DESCRIPTION
- Adds a step to the "Gathering Ansible Automation Platform logs" procedure showing how to run sos directly with the `aap_containerized` plugin explicitly enabled
- The existing `log_gathering` playbook does not pass `-e aap_containerized`, so container-level logs may not be captured without this command

Fixes AAP-67086