### PR TITLE
AAP-70906: adds deprecation notice to ALIA 2.5 docs

### DIFF
--- a/downstream/assemblies/platform/assembly-deploying-chatbot-operator.adoc
+++ b/downstream/assemblies/platform/assembly-deploying-chatbot-operator.adoc
@@ -11,6 +11,15 @@ ifdef::context[:parent-context: {context}]
 
 [role="_abstract"]
 
+[NOTE]
+
+====
+
+{AAPchatbot} (ALIA), included as a Technology Preview in {PlatformName} 2.5, is deprecated. ALIA in AAP 2.5 is no longer receiving new builds or ongoing security remediation.
+If you require supported intelligent assistant functionality, upgrade to link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/upgrade-con_aap_upgrade_overview[Ansible Automation Platform] 2.6 or later.
+For more information about the support scope of Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[Technology preview] in the {PlatformName} documentation.
+====
+
 As a system administrator, you can deploy {AAPchatbot} on {PlatformNameShort} {PlatformVers} on {OCPShort}.
 
 include::platform/con-about-lightspeed-intelligent-assistant.adoc[leveloffset=+1]

--- a/downstream/modules/platform/con-gs-ansible-lightspeed.adoc
+++ b/downstream/modules/platform/con-gs-ansible-lightspeed.adoc
@@ -5,6 +5,16 @@
 = {LightspeedShortName}
 
 [role="_abstract"]
+
+[NOTE]
+
+====
+
+{AAPchatbot} (ALIA), included as a Technology Preview in {PlatformName} 2.5, is deprecated. ALIA in AAP 2.5 is no longer receiving new builds or ongoing security remediation.
+If you require supported intelligent assistant functionality, upgrade to link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/upgrade-con_aap_upgrade_overview[Ansible Automation Platform] 2.6 or later.
+For more information about the support scope of Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[Technology preview] in the {PlatformName} documentation.
+====
+
 {LightspeedFullName} is a generative AI service designed by and for Ansible platform engineers and developers. 
 It accepts natural-language prompts entered by a user and then interacts with IBM watsonx foundation models to produce code recommendations built on Ansible best practices.
 


### PR DESCRIPTION
This work is being tracked in [AAP-70906](https://redhat.atlassian.net/browse/AAP-70906) and applies to the 2.5 docs only. 