### PR TITLE
AAP-75765 Update PostgreSQL docs link to official versioned documentation

### DIFF
--- a/downstream/modules/platform/ref-postgresql-requirements.adoc
+++ b/downstream/modules/platform/ref-postgresql-requirements.adoc
@@ -37,4 +37,4 @@ For more information about the settings you can use to improve database performa
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://wiki.postgresql.org/wiki/Main_Page[PostgreSQL documentation]
+* link:https://www.postgresql.org/docs/15/[PostgreSQL 15 documentation]


### PR DESCRIPTION
- Updates the "Additional resources" link in the PostgreSQL requirements topic from the unofficial PostgreSQL wiki (`wiki.postgresql.org`) to the official versioned documentation (`postgresql.org/docs/15/`)
- The wiki carries a disclaimer that the PostgreSQL project does not endorse its content

Fixes AAP-75765