### PR TITLE
AAP-75765 Update PostgreSQL docs link to official versioned documentation (2.4 backport)

### DIFF
--- a/downstream/modules/platform/ref-postgresql-requirements.adoc
+++ b/downstream/modules/platform/ref-postgresql-requirements.adoc
@@ -54,7 +54,5 @@ Optionally, you can configure the PostgreSQL database as separate nodes that are
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://wiki.postgresql.org/wiki/Main_Page[PostgreSQL documentation]
+* link:https://www.postgresql.org/docs/15/[PostgreSQL 15 documentation]
 * link:https://access.redhat.com/articles/7128116[Ansible Automation Platform 2.4 - Adoption of PostgreSQL 15]
-
-


### PR DESCRIPTION
Backport of #6001 to 2.4.

Conflict resolved: the 2.4 branch has an additional "Adoption of PostgreSQL 15" link that 2.5 does not; both links are preserved with the wiki URL updated.