### PR TITLE
Update container image refs to AAP 2.7 and RHEL 9

### DIFF
--- a/downstream/attributes/attributes.adoc
+++ b/downstream/attributes/attributes.adoc
@@ -8,13 +8,15 @@
 :AAPCentralAuth: Ansible Automation Platform Central Authentication
 :CentralAuthStart: Central authentication
 :CentralAuth: central authentication
-:PlatformVers: 2.6
+:PlatformVers: 2.7
+:AAPRegistryNS: ansible-automation-platform-27
+:AAPRHELVer: rhel9
 :PostgresVers: PostgreSQL 15
 //The ansible-core version used to install AAP
 :CoreInstVers: 2.14
 //The ansible-core version used by the AAP control plane and EEs
 :CoreUseVers: 2.16
-:PlatformDownloadUrl: https://access.redhat.com/downloads/content/480/ver=2.6/rhel---9/2.6/x86_64/product-software
+:PlatformDownloadUrl: https://access.redhat.com/downloads/content/480/ver=2.7/rhel---9/2.7/x86_64/product-software
 :BaseURL: https://docs.redhat.com/en/documentation
 :VMBase: VM-based installation
 :Installer: installation program

--- a/downstream/modules/builder/con-building-definition-file.adoc
+++ b/downstream/modules/builder/con-building-definition-file.adoc
@@ -15,6 +15,7 @@ The default definition filename, if not provided, is `execution-environment.yml`
 
 The following is an example of a version 3 definition file. Each definition file must specify the major version number of the {Builder} feature set it uses. If not specified, {Builder} defaults to version 1, making most new features and definition keywords unavailable.
 
+[subs="+attributes"]
 ----
 version: 3
 
@@ -30,7 +31,7 @@ dependencies:
 
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest
+    name: registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest
 
 # Custom package manager path for the RHEL based images
 options:

--- a/downstream/modules/builder/proc-build-an-EE-with-MCP-servers.adoc
+++ b/downstream/modules/builder/proc-build-an-EE-with-MCP-servers.adoc
@@ -14,12 +14,13 @@ The ansible.mcp_builder collection is designed to run as a step in building an {
 +
 *Example `execution-environment.yml` configuration*:
 +
+[subs="+attributes"]
 ----
 version: 3
 
 images:
   base_image:
-    name: ansible-automation-platform-26/ee-minimal-rhel9:latest
+    name: {AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest
 dependencies:
   galaxy: requirements.yml
 

--- a/downstream/modules/builder/proc-build-ee-with-mcp-server.adoc
+++ b/downstream/modules/builder/proc-build-ee-with-mcp-server.adoc
@@ -47,6 +47,7 @@ collections:
 
 . Create `ee-build/execution-environment.yml` with this content:
 +
+[subs="+attributes"]
 ----
 # execution-environment.yml
 ---
@@ -54,7 +55,7 @@ version: 3
 
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel9:latest
+    name: registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest
 
 dependencies:
   galaxy: requirements.yml
@@ -77,7 +78,7 @@ Where
 
 * `additional_build_files`: Copies your collection tarballs into the container build context so they can be referenced during the build.
 * `additional_build_steps.append_final`: Runs your installation playbook in the final build stage, after collections are installed.
-* `options.package_manager_path`: Set to `/usr/bin/microdnf` for `ee-minimal-rhel9`, or `/usr/bin/dnf` for UBI9-based images.
+* `options.package_manager_path`: Set to `/usr/bin/microdnf` for `ee-minimal-{AAPRHELVer}`, or `/usr/bin/dnf` for UBI9-based images.
 
 . Run ansible-builder to build your {ExecEnvShort} image:
 +

--- a/downstream/modules/builder/proc-customize-ee-image.adoc
+++ b/downstream/modules/builder/proc-customize-ee-image.adoc
@@ -7,7 +7,7 @@
 [role="_abstract"]
 You can customize existing {ControllerNameStart} provided default {ExecEnvName} by adding content specific to your needs. {ControllerNameStart} includes the following default {ExecEnvName}.
 
-* `Minimal` -  `ansible-automation-platform-26` Includes the latest Ansible-core 2.19 release along with Ansible Runner, but does not include collections or other content.
+* `Minimal` -  `{AAPRegistryNS}` Includes the latest Ansible-core 2.19 release along with Ansible Runner, but does not include collections or other content.
 +
 While supported {ExecEnvShort}s cover many automation prerequisites, minimal execution-environments are the recommended basis for your own custom images, to keep full control over dependencies and their versions.
 * `EE Supported` - Minimal, plus all Red Hat-supported collections and dependencies
@@ -22,8 +22,9 @@ $ podman login -u="[username]" -p="[token/hash]" registry.redhat.io
 ----
 . Ensure that you can pull the required {ExecEnvNameSing} base image:
 +
+[subs="+attributes"]
 -----
-podman pull registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel8:latest
+podman pull registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest
 -----
 +
 . Configure your {Builder} files to specify the required base image and any additional content to add to the new {ExecEnvShort} image.
@@ -38,12 +39,13 @@ collections:
 . In the {ExecEnvShort} definition file, specify the original `ee-minimal` container's URL and tag in the `EE_BASE_IMAGE` field. 
 In doing so, your final `execution-environment.yml` file looks similar to the following:
 +
+[subs="+attributes"]
 ----
 version: 3
 
 images:
-  base_image: 
-    name: 'registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel9:latest'
+  base_image:
+    name: 'registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest'
 
 dependencies:
   galaxy:

--- a/downstream/modules/builder/ref-definition-file-images.adoc
+++ b/downstream/modules/builder/ref-definition-file-images.adoc
@@ -21,6 +21,6 @@ A `name` key is required for the container image to use.
 Specify the `signature _original_name` key if the image is mirrored within your repository, but is signed with the image's original signature key. 
 Image names must contain a tag, such as `:latest`.
 
-The default image is `registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel8:latest`.
+The default image is `registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest`.
 
 |===

--- a/downstream/modules/devtools/proc-devtools-testing-playbook.adoc
+++ b/downstream/modules/devtools/proc-devtools-testing-playbook.adoc
@@ -21,8 +21,9 @@ $ ansible-navigator run <playbook_name.yml> -eei <execution_environment_name>
 ----
 For example, to execute a playbook called `site.yml` on the {PlatformNameShort} RHEL 9 minimum execution environment, run the following command from the terminal in VS Code.
 +
+[subs="+attributes"]
 ----
-ansible-navigator run site.yml --eei ee-minimal-rhel8
+ansible-navigator run site.yml --eei ee-minimal-{AAPRHELVer}
 ----
 
 .Verification

--- a/downstream/modules/devtools/proc-devtools-working-with-ee.adoc
+++ b/downstream/modules/devtools/proc-devtools-working-with-ee.adoc
@@ -24,8 +24,9 @@ link:https://catalog.redhat.com/search?searchType=containers&build_categories_li
 +
 For example, to download the minimal RHEL 8 base image, run the following command:
 +
+[subs="+attributes"]
 ----
-$ podman pull registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9
+$ podman pull registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}
 ----
 +
 You can build and create custom execution environments with `ansible-builder`.

--- a/downstream/modules/devtools/proc-rhdh-add-devtools-container.adoc
+++ b/downstream/modules/devtools/proc-rhdh-add-devtools-container.adoc
@@ -14,6 +14,7 @@ You must update the Helm chart configuration to add an extra container.
 +
 Add the following code:
 +
+[subs="+attributes"]
 ----
 upstream:
   backstage:
@@ -23,7 +24,7 @@ upstream:
           - adt
           - server
         image: >-
-          registry.redhat.io/ansible-automation-platform-26/ansible-dev-tools-rhel9:latest
+          registry.redhat.io/{AAPRegistryNS}/ansible-dev-tools-{AAPRHELVer}:latest
         imagePullPolicy: IfNotPresent
         name: ansible-devtools-server
         ports:

--- a/downstream/modules/devtools/proc-rhdh-operator-add-sidecar-container.adoc
+++ b/downstream/modules/devtools/proc-rhdh-operator-add-sidecar-container.adoc
@@ -14,6 +14,7 @@ To do this, you must modify the base ConfigMap for the {RHDH} deployment.
 . Select the *YAML* tab.
 . In the editing pane, add a `containers` block in the `spec.deployment.patch.spec.template.spec` block:
 +
+[subs="+attributes"]
 ----
 apiVersion: rhdh.redhat.com/v1alpha4
 kind: Backstage
@@ -29,7 +30,7 @@ spec:
               - command:
                   - adt
                   - server
-                image: registry.redhat.io/ansible-automation-platform-26/ansible-dev-tools-rhel9:latest
+                image: registry.redhat.io/{AAPRegistryNS}/ansible-dev-tools-{AAPRHELVer}:latest
                 imagePullPolicy: always
                 ports:
                   - containerPort: 8000

--- a/downstream/modules/devtools/proc-rhdh-uninstall-ocp-helm.adoc
+++ b/downstream/modules/devtools/proc-rhdh-uninstall-ocp-helm.adoc
@@ -35,6 +35,7 @@ For HTTP plug-in registry, remove the `http://plugin-registry:8080/\...` entries
 
 . Remove the `extraContainers` section.
 +
+[subs="+attributes"]
 ----
 upstream:
   backstage:
@@ -44,7 +45,7 @@ upstream:
           - adt
           - server
         image: >-
-          registry.redhat.io/ansible-automation-platform-26/ansible-dev-tools-rhel9:latest
+          registry.redhat.io/{AAPRegistryNS}/ansible-dev-tools-{AAPRHELVer}:latest
         imagePullPolicy: IfNotPresent
         name: ansible-devtools-server
         ports:

--- a/downstream/modules/devtools/proc-rhdh-uninstall-ocp-operator-sidecar-container.adoc
+++ b/downstream/modules/devtools/proc-rhdh-uninstall-ocp-operator-sidecar-container.adoc
@@ -20,6 +20,7 @@ you must modify the base ConfigMap for the {RHDH} deployment.
 
 . In the editing pane, remove the `containers` block for the sidecar container from the `spec.deployment.patch.spec.template.spec` block:
 +
+[subs="+attributes"]
 ----
 ...
 spec:
@@ -32,7 +33,7 @@ spec:
               - command:
                   - adt
                   - server
-                image: registry.redhat.io/ansible-automation-platform-26/ansible-dev-tools-rhel9:latest
+                image: registry.redhat.io/{AAPRegistryNS}/ansible-dev-tools-{AAPRHELVer}:latest
                 imagePullPolicy: always
                 ports:
                   - containerPort: 8000

--- a/downstream/modules/devtools/proc-self-service-install-disconnected-mirror-images.adoc
+++ b/downstream/modules/devtools/proc-self-service-install-disconnected-mirror-images.adoc
@@ -54,20 +54,11 @@ $ podman push <disconnected_registry_url>/<your_namespace>/ansible-automation-pl
 ----
 . Mirror the Ansible Dev Tools sidecar image. Use the path that matches your {PlatformNameShort} version:
 +
-*{PlatformNameShort} 2.5:*
-+
+[subs="+attributes"]
 ----
-$ podman pull registry.redhat.io/ansible-automation-platform-25/ansible-dev-tools-rhel9:latest
-$ podman tag registry.redhat.io/ansible-automation-platform-25/ansible-dev-tools-rhel9:latest <disconnected_registry_url>/<your_namespace>/ansible-automation-platform-25/ansible-dev-tools-rhel9:latest
-$ podman push <disconnected_registry_url>/<your_namespace>/ansible-automation-platform-25/ansible-dev-tools-rhel9:latest
-----
-+
-*{PlatformNameShort} 2.6:*
-+
-----
-$ podman pull registry.redhat.io/ansible-automation-platform-26/ansible-dev-tools-rhel9:latest
-$ podman tag registry.redhat.io/ansible-automation-platform-26/ansible-dev-tools-rhel9:latest <disconnected_registry_url>/<your_namespace>/ansible-automation-platform-26/ansible-dev-tools-rhel9:latest
-$ podman push <disconnected_registry_url>/<your_namespace>/ansible-automation-platform-26/ansible-dev-tools-rhel9:latest
+$ podman pull registry.redhat.io/{AAPRegistryNS}/ansible-dev-tools-{AAPRHELVer}:latest
+$ podman tag registry.redhat.io/{AAPRegistryNS}/ansible-dev-tools-{AAPRHELVer}:latest <disconnected_registry_url>/<your_namespace>/{AAPRegistryNS}/ansible-dev-tools-{AAPRHELVer}:latest
+$ podman push <disconnected_registry_url>/<your_namespace>/{AAPRegistryNS}/ansible-dev-tools-{AAPRHELVer}:latest
 ----
 
 

--- a/downstream/modules/devtools/proc_implementing-automation-content-for-ephemeral-mcp-agents.adoc
+++ b/downstream/modules/devtools/proc_implementing-automation-content-for-ephemeral-mcp-agents.adoc
@@ -20,14 +20,14 @@ You can create an Ansible playbook leveraging the Execution Environment (EE) set
 
 . Create the `execution-environment.yml` definition file, which specifies a step to install the MCP server components: 
 +
-[source,yaml,subs="+quotes"]
+[source,yaml,subs="+quotes,+attributes"]
 ....
 ---
 version: 3
 
 images:
   base_image:
-    name: ansible-automation-platform-26/ee-minimal-rhel9:latest
+    name: {AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest
 dependencies:
   galaxy: requirements.yml
 

--- a/downstream/modules/devtools/ref-rhdh-full-helm-chart-ansible-plugins.adoc
+++ b/downstream/modules/devtools/ref-rhdh-full-helm-chart-ansible-plugins.adoc
@@ -6,6 +6,7 @@
 [role="_abstract"]
 This example provides a full YAML configuration for the Helm chart using OCI container delivery.
 
+[subs="+attributes"]
 ----
 global:
   dynamic:
@@ -47,7 +48,7 @@ upstream:
           - adt
           - server
         image: >-
-          registry.redhat.io/ansible-automation-platform-26/ansible-dev-tools-rhel9:latest
+          registry.redhat.io/{AAPRegistryNS}/ansible-dev-tools-{AAPRHELVer}:latest
         imagePullPolicy: IfNotPresent
         name: ansible-devtools-server
         ports:

--- a/downstream/modules/eda/proc-eda-build-a-custom-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-build-a-custom-decision-environment.adoc
@@ -18,13 +18,14 @@ Customize a decision environment container image to ensure your rulebook activat
 
 ** If you want to connect {EDAcontroller} to {PlatformNameShort} 2.4, you must use `registry.redhat.io/ansible-automation-platform-24/de-minimal-rhel9:latest` (recommended) or `registry.redhat.io/ansible-automation-platform-24/de-minimal-rhel8:latest`
 ** If you want to connect {EDAcontroller} to {PlatformNameShort} 2.5, you must use `registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel9:latest` (recommended) or `registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel8:latest`
-** If you want to connect {EDAcontroller} to {PlatformNameShort} {PlatformVers}, you must use `registry.redhat.io/ansible-automation-platform-26/de-minimal-rhel9:latest`
+** If you want to connect {EDAcontroller} to {PlatformNameShort} 2.6, you must use `registry.redhat.io/ansible-automation-platform-26/de-minimal-rhel9:latest`
+** If you want to connect {EDAcontroller} to {PlatformNameShort} {PlatformVers}, you must use `registry.redhat.io/{AAPRegistryNS}/de-minimal-{AAPRHELVer}:latest`
 ====
 
 .Procedure
 
 . Use `de-minimal` as the base image with {Builder} to build your custom decision environments. 
-This image is built from a base image provided by Red Hat at link:https://catalog.redhat.com/software/containers/ansible-automation-platform-26/de-minimal-rhel9/6449633cfb26ed69bfc5d755[{PlatformNameShort} minimal decision environment]. 
+This image is built from a base image provided by Red Hat at link:https://catalog.redhat.com/software/containers/ansible-automation-platform-27/de-minimal-rhel9/6449633cfb26ed69bfc5d755[{PlatformNameShort} minimal decision environment]. 
 +
 [IMPORTANT] 
 ====
@@ -34,12 +35,13 @@ The `ansible.eda` collection is already installed in the `de-minimal` base image
 The following is an example of the {Builder} definition file that uses `de-minimal` as a base image to build a custom decision environment with the `servicenow.itsm` collection:
 +
 
+[subs="+attributes"]
 ----
 version: 3
 
 images:
   base_image:
-    name: 'registry.redhat.io/ansible-automation-platform-26/de-minimal-rhel9:latest'
+    name: 'registry.redhat.io/{AAPRegistryNS}/de-minimal-{AAPRHELVer}:latest'
 
 dependencies:
   galaxy:
@@ -59,12 +61,13 @@ options:
 . Optional: If you need other Python packages or RPMs, add the following to a single definition file:
 +
 
+[subs="+attributes"]
 ----
 version: 3
 
 images:
   base_image:
-    name: 'registry.redhat.io/ansible-automation-platform-26/de-minimal-rhel9:latest'
+    name: 'registry.redhat.io/{AAPRegistryNS}/de-minimal-{AAPRHELVer}:latest'
 
 dependencies:
   galaxy:

--- a/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
+++ b/downstream/modules/eda/proc-eda-set-up-new-decision-environment.adoc
@@ -10,7 +10,7 @@ Set up a new decision environment to define the dedicated, containerized runtime
 
 * You have set up a credential, if necessary.
 For more information, see the link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{PlatformVers}/html/using_automation_decisions/eda-credentials#eda-set-up-credential[Setting up credentials] section.
-* You have pushed a decision environment image to an image repository or you chose to use the `de-minimal` link:https://catalog.redhat.com/en/software/containers/ansible-automation-platform-26/de-minimal-rhel9/66fed7ad6ae4c44aa5de8c72[image] located in link:http://registry.redhat.io/[registry.redhat.io].
+* You have pushed a decision environment image to an image repository or you chose to use the `de-minimal` link:https://catalog.redhat.com/en/software/containers/ansible-automation-platform-27/de-minimal-rhel9/66fed7ad6ae4c44aa5de8c72[image] located in link:http://registry.redhat.io/[registry.redhat.io].
 
 .Procedure
 

--- a/downstream/modules/eda/ref-eda-github-event-stream-prereqs.adoc
+++ b/downstream/modules/eda/ref-eda-github-event-stream-prereqs.adoc
@@ -8,7 +8,7 @@ Before configuring simplified event routing, you must prepare your {PlatformName
 
 To successfully integrate GitHub event streams with rulebook activations, verify that the following components and configurations are in place:
 
-* *Decision environment:* Use the image version that corresponds to your specific {PlatformNameShort} instance (for example, `de-minimal-rhel9`).
+* *Decision environment:* Use the image version that corresponds to your specific {PlatformNameShort} instance (for example, `de-minimal-{AAPRHELVer}`).
 * *Event stream credentials:* Configure credentials specifically for simplified event routing within the controller interface.
 * *Project synchronization:* Ensure your Ansible project is synced to the Git repository containing your rulebook YAML files.
 * *Plugin compatibility:* Verify that your decision environment supports the required event source plugins (for example, `eda.builtin`).

--- a/downstream/modules/platform/con-building-an-execution-environment-in-a-disconnected-environment.adoc
+++ b/downstream/modules/platform/con-building-an-execution-environment-in-a-disconnected-environment.adoc
@@ -22,10 +22,10 @@ For information about importing collections from {Galaxy} or {HubName} into a {P
 
 Mirrored PyPI content once transferred into the disconnected network can be made available by using a web server or an artifact repository such as Nexus. The RHEL and UBI repository content can be exported from an internet-facing Red Hat Satellite Server, copied into the disconnected environment, then imported into a disconnected Satellite so it is available for building custom {ExecEnvShort}s. See link:{BaseURL}/red_hat_satellite/{SatelliteVers}/html-single/installing_satellite_server_in_a_disconnected_network_environment/index#iss_export_sync_in_an_air_gapped_scenario[ISS Export Sync in an Air-Gapped Scenario] for details.
 
-The default base container image, `ee-minimal-rhel8`, is used to create custom {ExecEnvShort} images and is included with the bundled installer. 
+The default base container image, `ee-minimal-{AAPRHELVer}`, is used to create custom {ExecEnvShort} images and is included with the bundled installer. 
 This image is added to the {PrivateHubName} at install time. 
 
-If a different base container image such as `ee-minimal-rhel9` is required, it must be imported to the disconnected network and added to the {PrivateHubName} container registry.
+If a different base container image such as `ee-minimal-{AAPRHELVer}` is required, it must be imported to the disconnected network and added to the {PrivateHubName} container registry.
 
 Once all of the prerequisites are available on the disconnected network, the ansible-builder command can be used to create custom {ExecEnvShort} images.
 

--- a/downstream/modules/platform/proc-controller-scm-ssh-proxy-config.adoc
+++ b/downstream/modules/platform/proc-controller-scm-ssh-proxy-config.adoc
@@ -28,11 +28,12 @@ $ cd builder/newee
 
 . Create an `execution-environment.yml` file with the following content:
 +
+[subs="+attributes"]
 ----
 version: 1
 
 build_arg_defaults:
-  EE_BASE_IMAGE: 'registry.redhat.io/ansible-automation-platform-24/ee-supported-rhel8:latest'
+  EE_BASE_IMAGE: 'registry.redhat.io/{AAPRegistryNS}/ee-supported-{AAPRHELVer}:latest'
 
 additional_build_steps:
   prepend:

--- a/downstream/modules/platform/proc-creating-the-custom-execution-environment-definition.adoc
+++ b/downstream/modules/platform/proc-creating-the-custom-execution-environment-definition.adoc
@@ -31,12 +31,13 @@ Version 3 of the {ExecEnvShort} definition format is required, so ensure the `ex
 .. Define the additional build files needed to point to any disconnected content sources that will be used in the build process.
 Your custom `execution-environment.yml` file should look similar to the following example:
 +
+[subs="+attributes"]
 ----
 version: 3
 
 images:
   base_image:
-    name: private-hub.example.com/ee-minimal-rhel8:latest
+    name: private-hub.example.com/ee-minimal-{AAPRHELVer}:latest
 
 dependencies:
   python: requirements.txt

--- a/downstream/modules/platform/proc-operator-collect-diagnostic-data.adoc
+++ b/downstream/modules/platform/proc-operator-collect-diagnostic-data.adoc
@@ -12,13 +12,14 @@ Use the `oc adm must-gather` command to collect comprehensive diagnostic data ab
 
 . To start the `must-gather` tool, run:
 +
+[subs="+attributes"]
 ----
-oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-26/aap-must-gather-rhel9
+oc adm must-gather --image=registry.redhat.io/{AAPRegistryNS}/aap-must-gather-{AAPRHELVer}
 ----
 +
 [NOTE]
 ====
-For version {PlatformVers}, the base image name changes to `registry.redhat.io/ansible-automation-platform-26/aap-must-gather-rhel9`.
+For version {PlatformVers}, the base image name changes to `registry.redhat.io/{AAPRegistryNS}/aap-must-gather-{AAPRHELVer}`.
 ====
 +
 . View the collected data, use the `omc` tool to query the `must-gather` tarball as if it were a live cluster.

--- a/downstream/modules/platform/proc-update-ee-image-locations.adoc
+++ b/downstream/modules/platform/proc-update-ee-image-locations.adoc
@@ -27,11 +27,11 @@ Update your {ExecEnvShort} image locations to use images hosted on your {Private
 . Update the default {ExecEnvShort}s to use images from your {PrivateHubName}:
 .. From the navigation panel, select {MenuInfrastructureExecEnvironments}.
 .. Locate the *Default {ExecEnvShort}* and click image:leftpencil.png[Edit,15,15] to edit it.
-.. In the *Image* field, update the image path to point to your {PrivateHubName}, such as `automationhub.example.org/ee-supported-rhel9:latest`.
+.. In the *Image* field, update the image path to point to your {PrivateHubName}, such as `automationhub.example.org/ee-supported-{AAPRHELVer}:latest`.
 .. In the *Registry Credential* field, select the container registry credential that you created.
 .. Click btn:[Save {ExecEnvShort}].
 .. Locate the *Minimal {ExecEnvShort}* and click image:leftpencil.png[Edit,15,15] to edit it.
-.. In the *Image* field, update the image path to point to your {PrivateHubName}, such as `automationhub.example.org/ee-minimal-rhel9:latest`.
+.. In the *Image* field, update the image path to point to your {PrivateHubName}, such as `automationhub.example.org/ee-minimal-{AAPRHELVer}:latest`.
 .. In the *Registry Credential* field, select the container registry credential that you created.
 .. Click btn:[Save {ExecEnvShort}].
 .. Repeat these steps for any other {ExecEnvShort}s that you want to update to use images from your {PrivateHubName}.

--- a/downstream/modules/platform/proc-uploading-the-custom-execution-environment-to-the-private-hub.adoc
+++ b/downstream/modules/platform/proc-uploading-the-custom-execution-environment-to-the-private-hub.adoc
@@ -15,11 +15,12 @@ Before the new {ExecEnvShort} image can be used for automation jobs, it must be 
 
 . First, verify that the {ExecEnvShort} image can be seen in the local Podman cache:
 +
+[subs="+attributes"]
 ----
 $ podman images --format "table {{.ID}} {{.Repository}} {{.Tag}}"
 IMAGE ID	    REPOSITORY					              TAG
 b38e3299a65e	private-hub.example.com/custom-ee     	  latest
-8e38be53b486	private-hub.example.com/ee-minimal-rhel8  latest
+8e38be53b486	private-hub.example.com/ee-minimal-{AAPRHELVer}  latest
 ----
 
 . Then log in to the {PrivateHubName}'s container registry and push the image to make it available for use with job templates and workflows:

--- a/downstream/modules/platform/ref-containerized-troubleshoot-diagnosing.adoc
+++ b/downstream/modules/platform/ref-containerized-troubleshoot-diagnosing.adoc
@@ -171,10 +171,11 @@ CONTAINERS_STORAGE_CONF=<user_home_directory>/aap/containers/storage.conf
 
 Example with output:
 
+[subs="+attributes"]
 ----
 $ CONTAINER_HOST=unix://run/user/1000/podman/podman.sock podman images
 
 REPOSITORY                                                            TAG         IMAGE ID      CREATED     SIZE
-registry.redhat.io/ansible-automation-platform-26/ee-supported-rhel9  latest      59d1bc680a7c  6 days ago  2.24 GB
-registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9    latest      a64b9fc48094  6 days ago  338 MB
+registry.redhat.io/{AAPRegistryNS}/ee-supported-{AAPRHELVer}  latest      59d1bc680a7c  6 days ago  2.24 GB
+registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}    latest      a64b9fc48094  6 days ago  338 MB
 ----

--- a/downstream/modules/platform/ref-controller-ee-definition.adoc
+++ b/downstream/modules/platform/ref-controller-ee-definition.adoc
@@ -26,7 +26,7 @@ dependencies:
   system: bindep.txt
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel8:latest
+    name: registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest
 additional_build_files:
     - src: files/ansible.cfg
       dest: configs

--- a/downstream/modules/platform/ref-general-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-general-inventory-variables.adoc
@@ -275,13 +275,13 @@ Set to `false` to prevent pulling newer container images during installation.
 | `registry_ns_aap` 
 | {PlatformNameShort} registry namespace. 
 | Optional 
-| `ansible-automation-platform-26`
+| `ansible-automation-platform-27`
 
 | 
 | `registry_ns_rhel`
 | RHEL registry namespace. 
 | Optional 
-| `rhel8`
+| `rhel9`
 
 | 
 | `setup_monitoring` 

--- a/downstream/modules/platform/ref-images-inventory-variables.adoc
+++ b/downstream/modules/platform/ref-images-inventory-variables.adoc
@@ -15,13 +15,13 @@ Inventory file variables for images.
 |
 | Additional container images to pull from the configured container registry during deployment.
 | Optional
-| `ansible-builder-rhel8`
+| `ansible-builder-{AAPRHELVer}`
 
 | 
 | `controller_image` 
 | Container image for {ControllerName}.
 | Optional
-| `controller-rhel9:latest`
+| `controller-{AAPRHELVer}:latest`
 
 |
 | `de_extra_images` 
@@ -33,19 +33,19 @@ Inventory file variables for images.
 | `de_supported_image` 
 | Supported decision environment container image.
 | Optional
-| `de-supported-rhel9:latest`
+| `de-supported-{AAPRHELVer}:latest`
 
 | 
 | `eda_image` 
 | Backend container image for {EDAName}. 
 | Optional
-| `eda-controller-rhel9:latest`
+| `eda-controller-{AAPRHELVer}:latest`
 
 | 
 | `eda_web_image` 
 | Front-end container image for {EDAName}.
 | Optional
-| `eda-controller-ui-rhel9:latest`
+| `eda-controller-ui-{AAPRHELVer}:latest`
 
 | 
 | `ee_extra_images` 
@@ -57,37 +57,37 @@ Inventory file variables for images.
 | `ee_minimal_image` 
 | Minimal {ExecEnvShort} container image. 
 | Optional
-| `ee-minimal-rhel9:latest`
+| `ee-minimal-{AAPRHELVer}:latest`
 
 | 
 | `ee_supported_image` 
 | Supported {ExecEnvShort} container image.
 | Optional
-| `ee-supported-rhel9:latest`
+| `ee-supported-{AAPRHELVer}:latest`
 
 |
 | `gateway_image`
 | Container image for {Gateway}.
 | Optional
-| `gateway-rhel9:latest`
+| `gateway-{AAPRHELVer}:latest`
 
 |
 | `gateway_proxy_image`
 | Container image for {Gateway} proxy.
 | Optional
-| `gateway-proxy-rhel9:latest`
+| `gateway-proxy-{AAPRHELVer}:latest`
 
 | 
 | `hub_image` 
 | Backend container image for {HubName}.
 | Optional
-| `hub-rhel9:latest`
+| `hub-{AAPRHELVer}:latest`
 
 |
 | `hub_web_image`
 | Front-end container image for {HubName}.
 | Optional
-| `hub-web-rhel9:latest`
+| `hub-web-{AAPRHELVer}:latest`
 
 |
 | `pcp_image`
@@ -105,7 +105,7 @@ Inventory file variables for images.
 | `receptor_image`
 | Container image for receptor.
 | Optional
-| `receptor-rhel9:latest`
+| `receptor-{AAPRHELVer}:latest`
 
 |
 | `redis_image`

--- a/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
+++ b/downstream/modules/troubleshooting-aap/proc-troubleshoot-must-gather.adoc
@@ -28,9 +28,9 @@ oc login _<openshift_url>_
 
 * Run `must-gather` across the entire cluster:
 +
-[subs="+quotes"]
+[subs="+quotes,+attributes"]
 ----
-oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-26/aap-must-gather-rhel9 --dest-dir _<dest_dir>_
+oc adm must-gather --image=registry.redhat.io/{AAPRegistryNS}/aap-must-gather-{AAPRHELVer} --dest-dir _<dest_dir>_
 ----
 +
 ** `--image` specifies the image that gathers data
@@ -38,9 +38,9 @@ oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-26/aap
 
 * Run `must-gather` for a specific namespace in the cluster:
 +
-[subs="+quotes"]
+[subs="+quotes,+attributes"]
 ----
-oc adm must-gather --image=registry.redhat.io/ansible-automation-platform-26/aap-must-gather-rhel9 --dest-dir _<dest_dir>_ -- /usr/bin/ns-gather _<namespace>_
+oc adm must-gather --image=registry.redhat.io/{AAPRegistryNS}/aap-must-gather-{AAPRHELVer} --dest-dir _<dest_dir>_ -- /usr/bin/ns-gather _<namespace>_
 ----
 +
 ** `-- /usr/bin/ns-gather` limits the `must-gather` data collection to a specified namespace

--- a/downstream/test-JTBD/Configure/con-define-create-build-EEs.adoc
+++ b/downstream/test-JTBD/Configure/con-define-create-build-EEs.adoc
@@ -15,6 +15,7 @@ The default definition filename, if not provided, is `execution-environment.yml`
 
 The following is an example of a version 3 definition file. Each definition file must specify the major version number of the {Builder} feature set it uses. If not specified, {Builder} defaults to version 1, making most new features and definition keywords unavailable.
 
+[subs="+attributes"]
 ----
 version: 3
 
@@ -30,7 +31,7 @@ dependencies:
 
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel9:latest
+    name: registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest
 
 # Custom package manager path for the RHEL based images
 options:

--- a/downstream/test-JTBD/Configure/con-disconnected-environment-customizations.adoc
+++ b/downstream/test-JTBD/Configure/con-disconnected-environment-customizations.adoc
@@ -20,9 +20,9 @@ For information about importing collections from {Galaxy} or {HubName} into a {P
 
 Mirrored PyPI content once transferred into the disconnected network can be made available by using a web server or an artifact repository such as Nexus. The RHEL and UBI repository content can be exported from an internet-facing Red Hat Satellite Server, copied into the disconnected environment, then imported into a disconnected Satellite so it is available for building custom {ExecEnvShort}s. See link:{BaseURL}/red_hat_satellite/{SatelliteVers}/html-single/installing_satellite_server_in_a_disconnected_network_environment/index#iss_export_sync_in_an_air_gapped_scenario[ISS Export Sync in an Air-Gapped Scenario] for details.
 
-The default base container image, `ee-minimal-rhel8`, is used to create custom {ExecEnvShort} images and is included with the bundled installer. 
+The default base container image, `ee-minimal-{AAPRHELVer}`, is used to create custom {ExecEnvShort} images and is included with the bundled installer. 
 This image is added to the {PrivateHubName} at install time. 
 
-If a different base container image such as `ee-minimal-rhel9` is required, it must be imported to the disconnected network and added to the {PrivateHubName} container registry.
+If a different base container image such as `ee-minimal-{AAPRHELVer}` is required, it must be imported to the disconnected network and added to the {PrivateHubName} container registry.
 
 Once all of the prerequisites are available on the disconnected network, the ansible-builder command can be used to create custom {ExecEnvShort} images.

--- a/downstream/test-JTBD/Configure/con-using-default-runtime-ee.adoc
+++ b/downstream/test-JTBD/Configure/con-using-default-runtime-ee.adoc
@@ -7,6 +7,6 @@
 
 Ansible Automation Platform includes the following default runtime environments, or execution environments, which you can specify when setting up a job template in the Ansible Automation Platform UI or access them from automation hub. 
 
-* ee-minimal – Includes the latest Ansible-core 2.16 release along with Ansible Runner, but does not include collections or other content. Ansible-automation-platform-24 Includes the Ansible-core 2.15 release along with Ansible Runner, but does not include collections or other content. While supported execution environments cover many automation prerequisites, minimal execution-environments are the recommended basis for your own custom images, to keep full control over dependencies and their versions.
+* ee-minimal – Includes the latest Ansible-core 2.16 release along with Ansible Runner, but does not include collections or other content. {AAPRegistryNS} Includes the Ansible-core 2.15 release along with Ansible Runner, but does not include collections or other content. While supported execution environments cover many automation prerequisites, minimal execution-environments are the recommended basis for your own custom images, to keep full control over dependencies and their versions.
 * ee-supported - Contents of the minimal execution environment, plus all Red Hat-supported collections and dependencies.
 

--- a/downstream/test-JTBD/Configure/proc-creating-custom-ee-def-file.adoc
+++ b/downstream/test-JTBD/Configure/proc-creating-custom-ee-def-file.adoc
@@ -30,12 +30,13 @@ Version 3 of the {ExecEnvShort} definition format is required, so ensure the `ex
 .. Define the additional build files needed to point to any disconnected content sources that will be used in the build process.
 Your custom `execution-environment.yml` file should look similar to the following example:
 +
+[subs="+attributes"]
 ----
 version: 3
 
 images:
   base_image:
-    name: private-hub.example.com/ee-minimal-rhel8:latest
+    name: private-hub.example.com/ee-minimal-{AAPRHELVer}:latest
 
 dependencies:
   python: requirements.txt

--- a/downstream/test-JTBD/Configure/proc-populate-pah-container-registry.adoc
+++ b/downstream/test-JTBD/Configure/proc-populate-pah-container-registry.adoc
@@ -19,11 +19,12 @@ Before the new {ExecEnvShort} image can be used for automation jobs, it must be 
 
 . First, verify that the {ExecEnvShort} image can be seen in the local podman cache:
 +
+[subs="+attributes"]
 ----
 $ podman images --format "table {{.ID}} {{.Repository}} {{.Tag}}"
 IMAGE ID	    REPOSITORY					              TAG
 b38e3299a65e	private-hub.example.com/custom-ee     	  latest
-8e38be53b486	private-hub.example.com/ee-minimal-rhel8  latest
+8e38be53b486	private-hub.example.com/ee-minimal-{AAPRHELVer}  latest
 ----
 
 . Then log in to the {PrivateHubName}'s container registry and push the image to make it available for use with job templates and workflows:

--- a/downstream/test-JTBD/Configure/ref-controller-ee-definition.adoc
+++ b/downstream/test-JTBD/Configure/ref-controller-ee-definition.adoc
@@ -27,7 +27,7 @@ dependencies:
   system: bindep.txt
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel8:latest
+    name: registry.redhat.io/{AAPRegistryNS}/ee-minimal-{AAPRHELVer}:latest
 additional_build_files:
     - src: files/ansible.cfg
       dest: configs


### PR DESCRIPTION
## Summary

- Bump `PlatformVers` from 2.6 to 2.7 in the central attributes file
- Add new `AAPRegistryNS` attribute (`ansible-automation-platform-27`) so future version bumps only require changing one line in `downstream/attributes/attributes.adoc`
- Replace all hardcoded `ansible-automation-platform-{24,25,26}` registry namespaces with `{AAPRegistryNS}`, adding `[subs="+attributes"]` to code listing blocks where needed
- Change all `ee-minimal-rhel8` and `ee-supported-rhel8` references to `rhel9`
- Update `registry_ns_aap` default from `platform-26` to `platform-27`
- Update `registry_ns_rhel` default from `rhel8` to `rhel9`
- Keep historical version entries in EDA docs (2.4, 2.5, 2.6) and add 2.7

### Intentionally skipped

- `ref-pac-inputs-outputs.adoc` — contains a sha256 digest that cannot be generically updated
- `proc-specify-nodes-job-execution.adoc` — historical platform-22 sha256 reference
- `archive/` and `release-notes/` — historical content

## Test plan

- [ ] Grep for `rhel8` and `platform-2[456]` outside archive/release-notes to confirm no stragglers
- [ ] Verify `{AAPRegistryNS}` resolves correctly in prose and in `[subs="+attributes"]` code blocks
- [ ] Build locally with `asciidoctor` to confirm no rendering issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)