### PR TITLE
AAP-69780 Update minimum RHEL 9 version from 9.4 to 9.6

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -19,7 +19,7 @@ h| Subscription | Valid {PlatformName} subscription |
 h| Operating system  
 a|
 * {RHEL} 8.10 or later minor versions of {RHEL} 8
-* {RHEL} 9.4 or later minor versions of {RHEL} 9 | {PlatformName} are also supported on OpenShift, see {LinkOperatorInstallation} for more information.
+* {RHEL} 9.6 or later minor versions of {RHEL} 9 | {PlatformName} are also supported on OpenShift, see {LinkOperatorInstallation} for more information.
 h| CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power) |
 h| Ansible-core | Ansible-core version {CoreUseVers} or later | {PlatformNameShort} uses the system-wide ansible-core package to install the platform, but uses ansible-core {CoreUseVers} for both its control plane and built-in execution environments.
 h| Browser | A currently supported version of Mozilla Firefox or Google Chrome. |

--- a/downstream/snippets/cont-tested-system-config.adoc
+++ b/downstream/snippets/cont-tested-system-config.adoc
@@ -14,7 +14,7 @@ a|
 | Operating system 
 
 a| 
-* {RHEL} 9.4 or later minor versions of {RHEL} 9.
+* {RHEL} 9.6 or later minor versions of {RHEL} 9.
 * {RHEL} 10 or later minor versions of {RHEL} 10.
 | 
 

--- a/downstream/snippets/rpm-env-a-tested-system-config.adoc
+++ b/downstream/snippets/rpm-env-a-tested-system-config.adoc
@@ -7,7 +7,7 @@
 | Operating system 
 a| 
 * {RHEL} 8.10 or later minor versions of {RHEL} 8. 
-* {RHEL} 9.4 or later minor versions of {RHEL} 9. |
+* {RHEL} 9.6 or later minor versions of {RHEL} 9. |
 | CPU architecture | x86_64, AArch64, s390x (IBM Z), ppc64le (IBM Power) |
 | `ansible-core` | `ansible-core` version {CoreUseVers} or later | {PlatformNameShort} uses the system-wide ansible-core package to install the platform, but uses ansible-core 2.16 for both its control plane and built-in execution environments.
 | Browser | A currently supported version of Mozilla Firefox or Google Chrome |


### PR DESCRIPTION
- Updates minimum supported RHEL 9 version from 9.4 to 9.6 across system requirements and tested system configuration content
- Affects: `ref-system-requirements.adoc`, `cont-tested-system-config.adoc`, `rpm-env-a-tested-system-config.adoc`
- RHEL 9.4 reached end of life April 30, 2026

Fixes AAP-69780