### PR TITLE
AAP-69780 Update minimum RHEL 9 version from 9.4 to 9.6 (2.4)

### DIFF
--- a/downstream/modules/platform/ref-system-requirements.adoc
+++ b/downstream/modules/platform/ref-system-requirements.adoc
@@ -14,7 +14,7 @@ Your system must meet the following minimum system requirements to install and r
 
 h| Subscription | Valid {PlatformName} |
 
-h| OS | {RHEL} 8.10 or later 64-bit (x86, ppc64le, s390x, aarch64), or {RHEL} 9.4 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
+h| OS | {RHEL} 8.10 or later 64-bit (x86, ppc64le, s390x, aarch64), or {RHEL} 9.6 or later 64-bit (x86, ppc64le, s390x, aarch64) |{PlatformName} is also supported on OpenShift, see link:{BaseURL}/red_hat_ansible_automation_platform/{PlatformVers}/html/deploying_the_red_hat_ansible_automation_platform_operator_on_openshift_container_platform/index[Deploying the Red Hat Ansible Automation Platform operator on OpenShift Container Platform] for more information.
 
 h| Ansible-core | Ansible-core version {CoreInstVers} or later | {PlatformNameShort} includes execution environments that contain ansible-core {CoreUseVers}.
 


### PR DESCRIPTION
- Updates minimum supported RHEL 9 version from 9.4 to 9.6 in system requirements content
- Affects: `ref-system-requirements.adoc` (RPM installer requirements only; 2.4 containerized was tech preview, unchanged)
- RHEL 9.4 reached end of life April 30, 2026

Fixes AAP-69780