### PR TITLE
AAP-72434 Update cluster external database PostgreSQL version requirement

### DIFF
--- a/downstream/modules/platform/con-cluster-platform-ext-database.adoc
+++ b/downstream/modules/platform/con-cluster-platform-ext-database.adoc
@@ -10,7 +10,7 @@ This scenario includes installation of multiple {ControllerName} nodes and an {H
 
 [NOTE]
 ====
-* Running in a cluster setup requires any database that {ControllerName} uses to be external--PostgreSQL must be installed on a machine that is not one of the primary or secondary tower nodes. When in a redundant setup, the remote PostgreSQL version requirements is *PostgreSQL 13*.
+* Running in a cluster setup requires any database that {ControllerName} uses to be external--PostgreSQL must be installed on a machine that is not one of the primary or secondary tower nodes. When in a redundant setup, the remote PostgreSQL version requirements is *{PostgresVers}*.
 ** See link:https://docs.ansible.com/automation-controller/latest/html/administration/clustering.html[Clustering] for more information on configuring a clustered setup.
 * Provide a reachable IP address for the `[automationhub]` host to ensure users can sync content from Private Automation Hub from a different node.
 ====


### PR DESCRIPTION
- Replaces hardcoded `PostgreSQL 13` with the `{PostgresVers}` attribute (resolves to PostgreSQL 15) in `con-cluster-platform-ext-database.adoc`
- The stale version reference was in a NOTE admonition describing cluster setup requirements

Fixes AAP-72434