### PR TITLE
AAP-72434 Update cluster external database PostgreSQL version requirement (2.4 backport)

### DIFF
--- a/downstream/modules/platform/con-cluster-platform-ext-database.adoc
+++ b/downstream/modules/platform/con-cluster-platform-ext-database.adoc
@@ -8,7 +8,7 @@ This scenario includes installation of multiple {ControllerName} nodes and an {H
 
 [NOTE]
 ====
-* Running in a cluster setup requires any database that {ControllerName} uses to be external--PostgreSQL must be installed on a machine that is not one of the primary or secondary tower nodes. When in a redundant setup, the remote PostgreSQL version requirements is *PostgreSQL 13*.
+* Running in a cluster setup requires any database that {ControllerName} uses to be external--PostgreSQL must be installed on a machine that is not one of the primary or secondary tower nodes. When in a redundant setup, the remote PostgreSQL version requirements is *PostgreSQL 15*.
 ** See link:https://docs.ansible.com/automation-controller/latest/html/administration/clustering.html[Clustering] for more information on configuring a clustered setup.
 * Provide a reachable IP address for the `[automationhub]` host to ensure users can sync content from Private Automation Hub from a different node.
 ====


### PR DESCRIPTION
Backport of #6009 to 2.4.

- Uses hardcoded `PostgreSQL 15` (2.4 branch does not define the `{PostgresVers}` attribute)