### PR TITLE
AAP-73542 Update PostgreSQL external doc links from v13 to v15

### DIFF
--- a/downstream/modules/platform/proc-setup-ext-db-without-admin-creds.adoc
+++ b/downstream/modules/platform/proc-setup-ext-db-without-admin-creds.adoc
@@ -22,7 +22,7 @@ For example:
 # psql -h db.example.com -U superuser -p 5432
 ----
 
-. Create the user with a password and ensure the `CREATEDB` role is assigned to the user. For more information, see link:https://www.postgresql.org/docs/13/user-manag.html[Database Roles].
+. Create the user with a password and ensure the `CREATEDB` role is assigned to the user. For more information, see link:https://www.postgresql.org/docs/15/user-manag.html[Database Roles].
 +
 [source,sql,subs="+attributes"]
 ----

--- a/downstream/modules/platform/proc-setup-postgresql-ext-database.adoc
+++ b/downstream/modules/platform/proc-setup-postgresql-ext-database.adoc
@@ -50,7 +50,7 @@ If so, connection string parameters override any conflicting command line option
 . Connect to the database as the user `username` instead of the default (you must have permission to do so).
 
 . Create the user, database, and password with the `createDB` or `administrator` role assigned to the user. 
-For further information, see link:https://www.postgresql.org/docs/13/user-manag.html[Database Roles].
+For further information, see link:https://www.postgresql.org/docs/15/user-manag.html[Database Roles].
 
 . Run the installation program. If you are using a PostgreSQL database, the database is owned by the connecting user and must have a `createDB` or administrator role assigned to it.
 

--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -59,4 +59,4 @@ Set `maintenance_work_mem` higher than `work_mem` to improve performance for vac
 
 .Additional resources
 
-* link:https://www.postgresql.org/docs/13/runtime-config-autovacuum.html[Automatic Vacuuming]
+* link:https://www.postgresql.org/docs/15/runtime-config-autovacuum.html[Automatic Vacuuming]


### PR DESCRIPTION
- Updates stale `postgresql.org/docs/13/` links to `postgresql.org/docs/15/` in three modules:
  - `proc-setup-ext-db-without-admin-creds.adoc` (Database Roles link)
  - `proc-setup-postgresql-ext-database.adoc` (Database Roles link)
  - `ref-controller-database-settings.adoc` (Automatic Vacuuming link)

Fixes AAP-73542