### PR TITLE
AAP-73542 Update PostgreSQL external doc links from v13 to v15 (2.4 backport)

### DIFF
--- a/downstream/modules/platform/proc-setup-postgresql-ext-database.adoc
+++ b/downstream/modules/platform/proc-setup-postgresql-ext-database.adoc
@@ -44,9 +44,9 @@ If so, connection string parameters override any conflicting command line option
 +
 Connect to the database as the user `username` instead of the default. (You must have permission to do so.)
 
-. Create the user, database, and password with the `createDB` or administrator role assigned to the user. 
-For further information, see link:https://www.postgresql.org/docs/13/user-manag.html[Database Roles].
-. Add the database credentials and host details to the {ControllerName} inventory file as an external database. 
+. Create the user, database, and password with the `createDB` or administrator role assigned to the user.
+For further information, see link:https://www.postgresql.org/docs/15/user-manag.html[Database Roles].
+. Add the database credentials and host details to the {ControllerName} inventory file as an external database.
 +
 The default values are used in the following example.
 +

--- a/downstream/modules/platform/ref-controller-database-settings.adoc
+++ b/downstream/modules/platform/ref-controller-database-settings.adoc
@@ -56,4 +56,4 @@ Total RAM * 0.05
 NOTE: Set `maintenance_work_mem` higher than `work_mem` to improve performance for vacuuming. 
 
 .Additional resources
-For more information on autovacuuming settings, see link:https://www.postgresql.org/docs/13/runtime-config-autovacuum.html[Automatic Vacuuming].
+For more information on autovacuuming settings, see link:https://www.postgresql.org/docs/15/runtime-config-autovacuum.html[Automatic Vacuuming].


### PR DESCRIPTION
Backport of #6011 to 2.4.

- `proc-setup-ext-db-without-admin-creds.adoc` does not exist on 2.4 -- skipped
- `proc-setup-postgresql-ext-database.adoc` -- kept 2.4 content structure, updated link to v15
- `ref-controller-database-settings.adoc` -- kept 2.4 prose format in Additional resources, updated link to v15