### PR TITLE
Add PrivateLink disconnection guidance for SaaS on AWS

### DIFF
--- a/aap-clouds/stories/assembly-saas-private-link.adoc
+++ b/aap-clouds/stories/assembly-saas-private-link.adoc
@@ -24,5 +24,7 @@ include::topics/proc-saas-config-ingress-privatelink.adoc[leveloffset=+2]
 
 include::topics/proc-saas-config-egress-privatelink.adoc[leveloffset=+2]
 
+include::topics/ref-saas-disconnect-aws-privatelink.adoc[leveloffset=+1]
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/aap-clouds/stories/assembly-saas-private-link.adoc
+++ b/aap-clouds/stories/assembly-saas-private-link.adoc
@@ -26,5 +26,9 @@ include::topics/proc-saas-config-egress-privatelink.adoc[leveloffset=+2]
 
 include::topics/ref-saas-disconnect-aws-privatelink.adoc[leveloffset=+1]
 
+include::topics/proc-saas-disconnect-ingress-privatelink.adoc[leveloffset=+2]
+
+include::topics/proc-saas-disconnect-egress-privatelink.adoc[leveloffset=+2]
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/aap-clouds/topics/proc-saas-disconnect-egress-privatelink.adoc
+++ b/aap-clouds/topics/proc-saas-disconnect-egress-privatelink.adoc
@@ -1,0 +1,54 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-saas-disconnect-egress-privatelink"]
+
+= Disconnecting Egress {AWSPrivateLink} connectivity (PUSH model)
+
+[role="_abstract"]
+This procedure removes Egress PrivateLink connectivity used for the PUSH model, including control plane access to private execution nodes, Git, and {PrivateHubName} in your VPC.
+
+.Procedure
+
+. Submit a *separate* {CustomerSupport} case to request Egress PrivateLink disconnection.
+Include the following in your request:
+* *AWS Account ID*
+* *Deployment ID*
+* *Endpoint Service Name*
+* *Service Regions/AZs*
+. Wait for Red Hat to delete the consumer VPC endpoint on the control plane side and confirm that you can proceed.
++
+[IMPORTANT]
+====
+Do not delete your Endpoint Service, NLB, or related components until Red Hat confirms removal on the control plane side.
+Deleting customer-side resources first can leave the connection in a failed or disconnected state and prevent a clean teardown.
+====
+. After Red Hat confirms removal, remove split-horizon DNS configuration for the private resources that were accessed through PrivateLink.
+. Delete the AWS Endpoint Service, NLB, and any other AWS resources that were created solely for this Egress PrivateLink connection.
+. Verify connectivity:
+* Confirm whether PUSH model execution nodes or private resources such as Git and {PrivateHubName} still require access from the control plane.
+* If alternate connectivity is required, configure it before you decommission the Endpoint Service and NLB.
+
+*Egress PrivateLink disconnection request template*
++
+----
+Subject:
+Request to Disconnect Egress PrivateLink: <Instance ID>
+
+Body:
+Hello Red Hat Support,
+
+We would like to disconnect Egress PrivateLink connectivity for our AAP on AWS instance. This PrivateLink connection is used for PUSH model access from the AAP control plane to our private resources (for example, execution nodes, private automation hub, and Git).
+
+Deployment details:
+AAP Deployment Name/ID: <for example, ans-123456>
+
+Configuration details:
+Our AWS Account ID: <Your 12-digit AWS Account ID>
+Our Endpoint Service Name: <for example, com.amazonaws.vpce.us-east-1.vpce-svc-xxxxxxxx>
+Service Regions/AZs: <for example, us-east-1 / us-east-1a, us-east-1b>
+
+Action required:
+Please delete the consumer VPC endpoint on the control plane side and confirm when we can safely delete our Endpoint Service, NLB, and related AWS resources.
+
+Thank you.
+----

--- a/aap-clouds/topics/proc-saas-disconnect-ingress-privatelink.adoc
+++ b/aap-clouds/topics/proc-saas-disconnect-ingress-privatelink.adoc
@@ -1,0 +1,50 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-saas-disconnect-ingress-privatelink"]
+
+= Disconnecting Ingress {AWSPrivateLink} connectivity (PULL model)
+
+[role="_abstract"]
+This procedure removes Ingress PrivateLink connectivity used for the PULL model, including access to the {PlatformNameShort} UI, API, and mesh ingress from your VPC.
+
+.Procedure
+
+. Submit a {CustomerSupport} case to request Ingress PrivateLink disconnection.
+Include the following in your request:
+* *AWS Account ID*
+* *Region*
+* *Deployment URL*
+* *VPC Endpoint ID* (if known)
+. Wait for Red Hat to complete teardown on the control plane side and confirm that you can proceed.
+. After Red Hat confirms removal, delete the AWS VPC Endpoint (Interface) in your VPC that connects to the {PlatformNameShort} control plane.
+. If you configured a custom domain with PrivateLink, remove the Private DNS or split-horizon DNS records for the platform and mesh-ingress hostnames.
+. Update the security group attached to your VPC subnets or endpoints as required by your organization.
+. Verify connectivity:
+* If public internet access to the deployment is still enabled, confirm that users and PULL model execution nodes can reach the UI, API, and mesh ingress over the public route before you decommission PrivateLink-only paths.
+* If PrivateLink is your only access path, plan alternate connectivity before you delete the VPC Endpoint.
+
+*Ingress PrivateLink disconnection request template*
++
+----
+Subject:
+Request to Disconnect Ingress PrivateLink: <Your Company Name> - <Deployment ID>
+
+Body:
+Hello Red Hat Support,
+
+We would like to disconnect Ingress PrivateLink connectivity for our AAP on AWS instance. This PrivateLink connection is used for PULL model access to the AAP Control Plane (UI/API and mesh ingress) from our VPC.
+
+Deployment details:
+AAP Deployment Name/ID: <for example, ans-123456>
+AAP Deployment URL: <for example, https://ans-123456.ansible.redhat.com>
+
+Our Network Information:
+Our AWS Account ID: <Your 12-digit AWS Account ID>
+Target Region: <for example, us-east-1>
+VPC Endpoint ID: <for example, vpce-xxxxxxxxxxxxxxxxx>
+
+Action required:
+Please complete teardown on the control plane side and confirm when we can safely delete the VPC Endpoint in our AWS account.
+
+Thank you.
+----

--- a/aap-clouds/topics/ref-saas-disconnect-aws-privatelink.adoc
+++ b/aap-clouds/topics/ref-saas-disconnect-aws-privatelink.adoc
@@ -14,3 +14,13 @@ Red Hat must delete the consumer VPC endpoint on the control plane side before y
 If customer-side resources are deleted first, the connection may remain in a failed or disconnected state and prevent a clean teardown.
 Once Red Hat confirms removal on the control plane side, you can safely delete your AWS resources.
 ====
+
+[NOTE]
+====
+*PULL* and *PUSH* refer to the automation mesh connectivity models described in link:{BaseURL}/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_service_on_aws/saas-pull-push[{SaaSonAWS} PULL and PUSH models].
+
+* *Ingress PrivateLink (PULL):* Used when users, automation, or execution nodes in your VPC access the {PlatformNameShort} UI, API, or mesh ingress over PrivateLink.
+* *Egress PrivateLink (PUSH):* Used when the {PlatformNameShort} control plane connects to private resources in your VPC, such as execution nodes, Git, or {PrivateHubName}.
+
+If you configured both directions, submit a *separate* {CustomerSupport} case for each direction you want to disconnect.
+====

--- a/aap-clouds/topics/ref-saas-disconnect-aws-privatelink.adoc
+++ b/aap-clouds/topics/ref-saas-disconnect-aws-privatelink.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-disconnect-aws-privatelink"]
+
+= Disconnecting and deleting {AWSPrivateLink} connectivity
+
+[role="_abstract"]
+Before you remove any PrivateLink resources, open a {CustomerSupport} case and wait for Red Hat to complete teardown on the control plane side.
+
+[IMPORTANT]
+====
+Open a {CustomerSupport} case with Red Hat *before* deleting PrivateLink resources.
+Red Hat must delete the consumer VPC endpoint on the control plane side before you remove your Endpoint Service, Network Load Balancer (NLB), or related components.
+If customer-side resources are deleted first, the connection may remain in a failed or disconnected state and prevent a clean teardown.
+Once Red Hat confirms removal on the control plane side, you can safely delete your AWS resources.
+====


### PR DESCRIPTION
## Summary
- Add a new section documenting how to safely disconnect and delete AWS PrivateLink connectivity for Ansible Automation Platform Service on AWS.
- Require customers to open a Red Hat support case before deleting PrivateLink resources so Red Hat can remove the consumer VPC endpoint on the control plane side first.

## Test plan
- [ ] Build the Private Link chapter locally with `asciidoctor assembly-saas-private-link.adoc`
- [ ] Confirm the disconnect section renders after the ingress/egress configuration procedures
- [ ] Verify the IMPORTANT admonition displays correctly


Made with [Cursor](https://cursor.com)