### PR TITLE
AAP-76659 Document managed Postgres PVC cleanup after 13 to 15 upgrade

### DIFF
--- a/downstream/assemblies/platform/assembly-operator-upgrade.adoc
+++ b/downstream/assemblies/platform/assembly-operator-upgrade.adoc
@@ -17,5 +17,7 @@ include::platform/con-operator-upgrade-prereq.adoc[leveloffset=+1]
 
 include::platform/proc-operator-upgrade.adoc[leveloffset=+1]
 
+include::platform/proc-operator-upgrade-managed-postgres-pvc-cleanup.adoc[leveloffset=+1]
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/downstream/modules/platform/proc-operator-upgrade-managed-postgres-pvc-cleanup.adoc
+++ b/downstream/modules/platform/proc-operator-upgrade-managed-postgres-pvc-cleanup.adoc
@@ -1,0 +1,62 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-operator-upgrade-managed-postgres-pvc-cleanup_{context}"]
+
+= Remove the retained Postgres 13 PVC
+
+[role="_abstract"]
+
+After upgrading {PlatformName} from a version that uses Postgres 13 to one that uses Postgres 15, the original Postgres 13 Persistent Volume Claim (PVC) is not automatically removed for {ControllerName} deployments using a managed database. If your deployment uses an external database, no PVC cleanup is required. You must manually delete the retained PVC after confirming that the upgrade completed successfully.
+
+.Prerequisites
+
+* You have upgraded {PlatformNameShort} to a version that uses Postgres 15.
+* Your {ControllerName} deployment uses a managed database. Deployments that use an external database do not require PVC cleanup.
+
+.Procedure
+
+. Confirm that the Postgres 15 pod is running:
++
+[source,terminal]
+----
+$ oc get pods -n <your_namespace> | grep postgres
+----
++
+.Verification
+Verify that a pod with `postgres-15` in its name is in `Running` state.
+
+. List the PVCs in your namespace to identify the retained Postgres 13 PVC:
++
+[source,terminal]
+----
+$ oc get pvc -n <your_namespace>
+----
++
+The retained Postgres 13 PVC follows this naming format:
++
+----
+postgres-13-<deployment_name>-postgres-13-0
+----
++
+The current Postgres 15 PVC follows this naming format:
++
+----
+postgres-15-<deployment_name>-postgres-15-0
+----
+
+. Delete the retained Postgres 13 PVC:
++
+[source,terminal]
+----
+$ oc delete pvc postgres-13-<deployment_name>-postgres-13-0 -n <your_namespace>
+----
+
+[IMPORTANT]
+====
+Do not delete the Postgres 13 PVC before confirming that the upgrade completed successfully. The retained volume can be used for data recovery if the upgrade fails.
+====
+
+[NOTE]
+====
+The `postgres_keep_pvc_after_upgrade` field in the `AutomationController` custom resource definition (CRD) has no effect in {PlatformNameShort} 2.4 and later. Manual PVC cleanup is always required.
+====


### PR DESCRIPTION
[AAP-76659](https://issues.redhat.com/browse/AAP-76659)

After the Postgres 13 to 15 upgrade, the original Postgres 13 PVC is retained and not automatically deleted for managed automation controller deployments. This behavior was undocumented for managed postgres users (AAP-38389 covered external postgres only).

## Changes

- New module: `proc-operator-upgrade-managed-postgres-pvc-cleanup.adoc`
- Added include to `assembly-operator-upgrade.adoc` after `proc-operator-upgrade.adoc`

## Notes

- Scoped to managed database deployments only; external database deployments are excluded in the short description and prerequisites
- Includes IMPORTANT admonition warning users not to delete the PVC before confirming upgrade success (the retained volume is a recovery safety net)
- Includes NOTE that `postgres_keep_pvc_after_upgrade` in the AutomationController CRD is dead code in 2.4 and later
- Commands validated against KCS [solutions/7143048](https://access.redhat.com/solutions/7143048)

Backport of #6020