### PR TITLE
AAP-76659 Remove Verification label from step 1

### DIFF
--- a/downstream/modules/platform/proc-operator-upgrade-managed-postgres-pvc-cleanup.adoc
+++ b/downstream/modules/platform/proc-operator-upgrade-managed-postgres-pvc-cleanup.adoc
@@ -22,7 +22,6 @@ After upgrading {PlatformName} from a version that uses Postgres 13 to one that 
 $ oc get pods -n <your_namespace> | grep postgres
 ----
 +
-.Verification
 Verify that a pod with `postgres-15` in its name is in `Running` state.
 
 . List the PVCs in your namespace to identify the retained Postgres 13 PVC:


### PR DESCRIPTION
Follow-up to #6021. Removes the `.Verification` label from step 1 — the sentence reads clearly without it and the label is better suited to end-of-procedure verification sections.