### PR TITLE
AAP-80005: adds note about not using hub api tokens for pulling EEs

### DIFF
--- a/downstream/modules/hub/proc-create-api-token-pah.adoc
+++ b/downstream/modules/hub/proc-create-api-token-pah.adoc
@@ -29,5 +29,5 @@ The API token is now available for configuring {HubName} as your default collect
 
 ====
 
-The Automation Hub API token is intended only for authenticating with the `ansible-galaxy` CLI for collection operations (sync, install, publish). It is not supported for container registry operations such as `podman login` or `podman pull` of Execution Environment images. For execution environment image operations, use your username and password.
+The Automation Hub API token is intended only for authenticating with the `ansible-galaxy` CLI for collection operations (sync, install, publish). It is not supported for container registry operations such as `podman login` or `podman pull` of execution environment images. For execution environment image operations, use your username and password.
 ====

--- a/downstream/modules/hub/proc-create-api-token-pah.adoc
+++ b/downstream/modules/hub/proc-create-api-token-pah.adoc
@@ -25,3 +25,9 @@ The API token does not expire.
 .Next step
 The API token is now available for configuring {HubName} as your default collections server or uploading collections using the `ansible-galaxy` command line tool.
 
+[IMPORTANT]
+
+====
+
+The Automation Hub API token is intended only for authenticating with the `ansible-galaxy` CLI for collection operations (sync, install, publish). It is not supported for container registry operations such as `podman login` or `podman pull` of Execution Environment images. For execution environment image operations, use your username and password.
+====


### PR DESCRIPTION
This work is tracked in https://redhat.atlassian.net/browse/AAP-80004