### PR TITLE
2.5 backport: AAP-80004: adds note about not using hub api tokens for pulling EEs (…

### DIFF
--- a/downstream/modules/hub/proc-create-api-token-pah.adoc
+++ b/downstream/modules/hub/proc-create-api-token-pah.adoc
@@ -25,3 +25,9 @@ The API token does not expire.
 .Next step
 The API token is now available for configuring {HubName} as your default collections server or uploading collections using the `ansible-galaxy` command line tool.
 
+[IMPORTANT]
+
+====
+
+The Automation Hub API token is intended only for authenticating with the `ansible-galaxy` CLI for collection operations (sync, install, publish). It is not supported for container registry operations such as `podman login` or `podman pull` of execution environment images. For execution environment image operations, use your username and password.
+====


### PR DESCRIPTION
This pr ports the changes from https://github.com/ansible/aap-docs/pull/6024 to 2.5.