### PR TITLE
2.4 backport AAP-80004 adds note about not using the hub api token to pull EEs

### DIFF
--- a/downstream/modules/hub/proc-obtaining-org-collection-url.adoc
+++ b/downstream/modules/hub/proc-obtaining-org-collection-url.adoc
@@ -16,3 +16,9 @@ The API token is a secret token used to protect your content.
 . Click btn:[Copy to clipboard] to copy the API token.
 . Paste the API token into a file and store in a secure location.
 
+[IMPORTANT]
+
+====
+
+The Automation Hub API token is intended only for authenticating with the `ansible-galaxy` CLI for collection operations (sync, install, publish). It is not supported for container registry operations such as `podman login` or `podman pull` of execution environment images. For execution environment image operations, use your username and password.
+====


### PR DESCRIPTION
This pr ports the changes from https://github.com/ansible/aap-docs/pull/6024 to 2.4.