### PR TITLE
AAP-84678 Fix NFS snapshot directory name in backup procedure

### DIFF
--- a/downstream/modules/platform/proc-backup-aap-container.adoc
+++ b/downstream/modules/platform/proc-backup-aap-container.adoc
@@ -75,16 +75,16 @@ To customize the backup process, you can use the following variables in your inv
 * Change the backup destination directory from the default `./backups` by using the `backup_dir` variable.
 * Exclude paths that contain duplicated data, such as snapshot subdirectories, by using the `hub_data_path_exclude` variable.
 +
-For example, to exclude a `.snapshots` subdirectory from the backup, add the following to your inventory file:
+For example, to exclude a `.snapshot` subdirectory from the backup, add the following to your inventory file:
 +
 ----
-hub_data_path_exclude=["*/.snapshots", "*/.snapshots/*"]
+hub_data_path_exclude=["*/.snapshot", "*/.snapshot/*"]
 ----
 +
 Alternatively, you can pass this variable at runtime by using the `-e` flag:
 +
 ----
-$ ansible-playbook -i inventory ansible.containerized_installer.backup -e hub_data_path_exclude="['*/.snapshots', '*/.snapshots/*']"
+$ ansible-playbook -i inventory ansible.containerized_installer.backup -e hub_data_path_exclude="['*/.snapshot', '*/.snapshot/*']"
 ----
 +
 You can also define the exclusion patterns in a YAML extra variables file and pass it at runtime:
@@ -92,8 +92,8 @@ You can also define the exclusion patterns in a YAML extra variables file and pa
 .exclude_vars.yml
 ----
 hub_data_path_exclude:
-  - "*/.snapshots/*"
-  - "*/.snapshots"
+  - "*/.snapshot/*"
+  - "*/.snapshot"
 ----
 +
 ----


### PR DESCRIPTION
- Fix `.snapshots` (plural) to `.snapshot` (singular) in all backup exclusion examples
- NFS servers use `.snapshot` (singular) for the snapshot directory; the plural form causes the exclusion pattern to silently fail
- Customer impact: backup size 900GB vs 15GB when exclusion works correctly

Fixes AAP-84678