### PR TITLE
AAP-82342: Rename misleading 'Prepare the managed nodes' heading

### DIFF
--- a/downstream/modules/platform/proc-installing-containerized-aap.adoc
+++ b/downstream/modules/platform/proc-installing-containerized-aap.adoc
@@ -10,7 +10,7 @@ Run the `install` playbook to install containerized {PlatformNameShort} after pr
 .Prerequisites
 
 * You have link:{URLContainerizedInstall}/preparing-containerized-installation#preparing-the-rhel-host-for-containerized-installation[prepared the {RHEL} host]
-* You have link:{URLContainerizedInstall}/preparing-containerized-installation#preparing-the-managed-nodes-for-containerized-installation[prepared the managed nodes]
+* You have link:{URLContainerizedInstall}/preparing-containerized-installation#preparing-the-managed-nodes-for-containerized-installation[created the installation user]
 * You have link:{URLContainerizedInstall}/preparing-containerized-installation#downloading-ansible-automation-platform[downloaded {PlatformNameShort}]
 * You have link:{URLContainerizedInstall}/preparing-containerized-installation#configuring-inventory-file[configured the inventory file]
 * You are logged in to the {RHEL} host as your non-root user

--- a/downstream/modules/platform/proc-perform-containerized-disconnected-installation.adoc
+++ b/downstream/modules/platform/proc-perform-containerized-disconnected-installation.adoc
@@ -11,7 +11,7 @@ A disconnected installation installs containerized {PlatformNameShort} without r
 
 * You have link:{URLContainerizedInstall}/preparing-containerized-installation#preparing-the-rhel-host-for-containerized-installation[prepared the {RHEL} host]
 * You have link:{URLContainerizedInstall}/aap-containerized-disconnected-installation#obtaining-and-configuring-rpm-dependencies[obtained and configured the RPM source dependencies]. The installation program uses your host system's `dnf` package manager to resolve these dependencies.
-* You have link:{URLContainerizedInstall}/preparing-containerized-installation#preparing-the-managed-nodes-for-containerized-installation[prepared the managed nodes]
+* You have link:{URLContainerizedInstall}/preparing-containerized-installation#preparing-the-managed-nodes-for-containerized-installation[created the installation user]
 * You have downloaded the containerized {PlatformNameShort} setup bundle from the link:{PlatformDownloadUrl}[{PlatformNameShort} download page].
 
 .Procedure

--- a/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
+++ b/downstream/modules/platform/proc-preparing-the-managed-nodes-for-containerized-installation.adoc
@@ -2,11 +2,10 @@
 
 [id="preparing-the-managed-nodes-for-containerized-installation"]
 
-= Preparing the managed nodes for containerized installation
+= Creating the installation user for containerized installation
 
 [role="_abstract"]
-Managed nodes, also referred to as hosts, are the devices that {PlatformNameShort} manages. 
-To ensure a consistent and secure setup of containerized {PlatformNameShort}, create a dedicated user on each managed node. {PlatformNameShort} connects as this user to run tasks on the node.
+To ensure a consistent and secure setup of containerized {PlatformNameShort}, create a dedicated user on each {RHEL} host. The containerized installation program connects as this user to run tasks on the host.
 
 .Procedure
 

--- a/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
+++ b/downstream/modules/platform/ref-cont-aap-system-requirements.adoc
@@ -14,7 +14,7 @@ Use this information when planning your installation of containerized {PlatformN
 ** This user is responsible for the installation of containerized {PlatformNameShort}.
 ** This user is also the service account for the containers running {PlatformNameShort}.
 
-* For managed nodes, configure a dedicated user on each node. {PlatformNameShort} connects as this user to run tasks on the node. For more information about configuring a dedicated user on each node, see link:{URLContainerizedInstall}/preparing-containerized-installation#preparing-the-managed-nodes-for-containerized-installation[Preparing the managed nodes for containerized installation].
+* For each {RHEL} host in your containerized deployment, configure a dedicated user. The containerized installation program connects as this user to run tasks on the host. For more information, see link:{URLContainerizedInstall}/preparing-containerized-installation#preparing-the-managed-nodes-for-containerized-installation[Creating the installation user for containerized installation].
 
 * For remote host installations, configure SSH public key authentication for the non-root user. For guidelines on setting up SSH public key authentication for the non-root user, see link:https://access.redhat.com/solutions/4110681[How to configure SSH public key authentication for passwordless login].
 


### PR DESCRIPTION
## Summary
- Renamed "Preparing the managed nodes for containerized installation" to "Creating the installation user for containerized installation"
- Updated the shortdesc to remove the misleading "managed nodes" definition and clarify these are RHEL hosts for AAP installation
- Updated cross-references in the install procedure, disconnected install procedure, and system requirements topics to match

## Why
The heading "Prepare the managed nodes" was misleading because "managed nodes" in Ansible terminology refers to the target machines that AAP automates. This topic is about creating a dedicated user on the RHEL hosts where AAP itself gets installed. The shortdesc compounded the confusion by defining managed nodes as "devices that AAP manages."

Fixes: https://issues.redhat.com/browse/AAP-82342

## Test plan
- [ ] Verify rendered title and shortdesc are accurate
- [ ] Verify cross-reference link text matches the new heading
- [ ] Confirm the anchor ID is unchanged (no broken links)