### PR TITLE
Add MRBC chapter (aap-clouds files only)

### DIFF
--- a/aap-clouds/stories/assembly-saas-business-continuity.adoc
+++ b/aap-clouds/stories/assembly-saas-business-continuity.adoc
@@ -1,0 +1,56 @@
+:_mod-docs-content-type: ASSEMBLY
+
+ifdef::context[:parent-context: {context}]
+
+:context: saas-business-continuity
+
+[id="assembly-saas-business-continuity"]
+= Multi-Region Active/Passive infrastructure
+
+Ansible Automation Platform Service on AWS provides a multi-region active/passive deployment for enterprise-class mission critical automation. This chapter describes the customer-facing rules of engagement, guidance thresholds, notification protocols, and operational boundaries that govern regional failover and rollback procedures.
+
+include::topics/ref-saas-guidance-parameters.adoc[leveloffset=+1]
+
+include::topics/ref-saas-failure-domains.adoc[leveloffset=+1]
+
+include::topics/ref-saas-regional-outages.adoc[leveloffset=+2]
+
+include::topics/ref-saas-service-outages.adoc[leveloffset=+3]
+
+include::topics/ref-saas-customer-notification-and-confirmation.adoc[leveloffset=+1]
+
+include::topics/ref-saas-notification-timeline.adoc[leveloffset=+2]
+
+include::topics/proc-saas-request-regional-failover.adoc[leveloffset=+2]
+
+include::topics/ref-saas-primary-region-status.adoc[leveloffset=+2]
+
+include::topics/ref-saas-rollback-protocol.adoc[leveloffset=+1]
+
+include::topics/proc-saas-primary-deployment-footprint.adoc[leveloffset=+2]
+
+include::topics/ref-saas-network-dns-routing.adoc[leveloffset=+2]
+
+include::topics/ref-saas-technical-operational-impacts.adoc[leveloffset=+1]
+
+include::topics/ref-saas-mesh-configuration.adoc[leveloffset=+1]
+
+include::topics/proc-saas-ingress-configuration-without.adoc[leveloffset=+2]
+
+include::topics/proc-saas-standard-ingress-configuration.adoc[leveloffset=+2]
+
+include::topics/ref-saas-schedule-business-continuity-tests.adoc[leveloffset=+1]
+
+include::topics/proc-saas-initiate-business-continuity-test.adoc[leveloffset=+2]
+
+include::topics/ref-saas-infrastructure-requirements.adoc[leveloffset=+1]
+
+include::topics/ref-saas-new-customers.adoc[leveloffset=+2]
+
+include::topics/proc-saas-existing-customers.adoc[leveloffset=+2]
+
+include::topics/ref-saas-metering-implications-idle.adoc[leveloffset=+1]
+
+include::topics/ref-saas-what-idle-means.adoc[leveloffset=+2]
+
+include::topics/ref-saas-infrastructure-cost-breakdown.adoc[leveloffset=+2]

--- a/aap-clouds/stories/assembly-saas-service-definition.adoc
+++ b/aap-clouds/stories/assembly-saas-service-definition.adoc
@@ -17,5 +17,9 @@ include::assembly-saas-execution-plane.adoc[leveloffset=+1]
 
 include::assembly-saas-support.adoc[leveloffset=+1]
 
+include::assembly-saas-business-continuity.adoc[leveloffset=+1]
+
+//include::assembly-saas-security.adoc[leveloffset=+1]
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/aap-clouds/topics/proc-saas-existing-customers.adoc
+++ b/aap-clouds/topics/proc-saas-existing-customers.adoc
@@ -1,0 +1,40 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-saas-existing-customers"]
+= Existing customers
+
+[role="_abstract"]
+Existing customers must migrate their current infrastructure layout to the mandatory MRBC topology. 
+
+All customers with environments deployed prior to Aug 4, 2026 are on retired infrastructure that is deprecated as of Aug 4, 2026.  This infrastructure shuts down on Aug 3, 2027.  Existing customers must plan a migration of their current deployment to the new infrastructure on or before Aug 3, 2027 
+
+* You can request a migration at any time prior to Aug 3, 2027 to take advantage of the multi-region infrastructure.
+* 50 node deployments that customers wish to keep on a single-region deployment must also migrate to the new infrastructure.
+* 50 node deployment migrations will allow for selection of single region or multi-region during the migration.
+* All deployments on tiers greater than 50 nodes will all be migrated to multi-region infrastructure.
+* If an environment has not been migrated by Aug 3, 2027, Red Hat will automatically migrate the infrastructure to the mandatory active/passive topology.
+* You must reconfigure custom DNS, AWS PrivateLink, and any other infrastructure-related configuration during the migrations.
+* *Custom Domains*: If the customer has configured a custom (vanity) domain for their Ansible Automation Platform instance, they are required to perform manual DNS updates during a failover event.
+* *The Impact*: Custom domain routing requires specific DNS configurations that do not automatically map to the secondary region infrastructure during a failover event.
+* *Customer Action*: Customers must disclose their use of custom domains in their migration support ticket. During a failover event, customers are strictly responsible for updating their DNS CNAME records to route traffic to the secondary region.
+
+.Procedure
+. Log in to the Red Hat link:https://access.redhat.com/[Customer Portal].
+. Open a support ticket requesting a regional failover to the  secondary deployment footprint.
+. Ensure you have selected *{PlatformName} On Clouds* as the product. 
+. Use the following formatting exactly for the support ticket subject and body to ensure rapid routing and execution by the Red Hat SRE team.
++
+----
+SUBJECT: Request for Migration to MRBC Infrastructure
+
+Severity: 3 
+BODY:
+
+Hello SRE Team,
+
+I am requesting the migration of my existing managed Ansible Automation Platform environment to the MRBC infrastructure topology.
+
+--- TARGET ENVIRONMENT ---
+Instance/Cluster ID: [INSERT ID, e.g., cus-xxxx]
+Instance URL: [URL]
+----

--- a/aap-clouds/topics/proc-saas-ingress-configuration-without.adoc
+++ b/aap-clouds/topics/proc-saas-ingress-configuration-without.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-saas-ingress-configuration-without"]
+
+= Configure ingress without AWS PrivateLink
+
+[role="_abstract"]
+For deployments with automation mesh, configuration relies on persistent, load-balanced ingress endpoints that resolve dynamically during a disaster recovery event.
+
+.Procedure
+. Locate the configuration files or installation playbooks for the remote execution nodes.
+. Configure the remote execution nodes to peer directly with the designated ingress routing addresses matching the custom domain or deployment naming convention:
+.. `mesh-ingress-0.<exampledomain.com>`
+.. `mesh-ingress-1.<exampledomain.com>`
++
+[NOTE]
+====
+When peered with these standard endpoints, remote execution nodes automatically reconnect and self-heal following a failover window. No manual reconfiguration of local mesh nodes or topology files is required.
+====

--- a/aap-clouds/topics/proc-saas-initiate-business-continuity-test.adoc
+++ b/aap-clouds/topics/proc-saas-initiate-business-continuity-test.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-saas-initiate-business-continuity-test"]
+= Initiate a Business Continuity test
+
+[role="_abstract"]
+Use the following procedure to initiate a Business Continuity test for your {PlatformName} service deployment.
+
+.Procedure
+. Open a standard support ticket through the Red Hat Customer Portal to coordinate the failover exercise with Red Hat.
+. Red Hat moves the environment to the secondary region only after receiving a customer's explicit confirmation through the support ticket.
++
+[NOTE]
+====
+During this window, the application and automation in the environment will experience expected outages.
+====
+
+. Red Hat coordinates with you in the support ticket to confirm the failover was successful.
+. You must verify that the secondary environment is active and report back in the ticket when you are ready for the rollback.
+. Red Hat initiates the rollback to the primary region. After verifying with you that the environment is working as intended, Red Hat will close the support case.

--- a/aap-clouds/topics/proc-saas-primary-deployment-footprint.adoc
+++ b/aap-clouds/topics/proc-saas-primary-deployment-footprint.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-saas-primary-deployment-footprint"]
+= Return to the primary deployment footprint
+
+[role="_abstract"]
+The primary deployment footprint is the region where the customer's {PlatformName} service is deployed and where the customer's data is stored.
+
+.Procedure
+. Open a support ticket to request return to the primary region.  Red Hat SRE will verify that the region is in a stable state and the service can be reverted back to the primary region.
+. Schedule an agreed-upon maintenance window to execute the rollback operation to mitigate any potential disruption to active automation workloads.
+. Allow the automated delta reconciliation process to synchronize and restore any platform content changes, job histories, or inventory modifications updated while running in the secondary region back to the primary environment before traffic is shifted.

--- a/aap-clouds/topics/proc-saas-request-regional-failover.adoc
+++ b/aap-clouds/topics/proc-saas-request-regional-failover.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-saas-request-regional-failover"]
+
+= Request a regional failover
+
+[role="_abstract"]
+Although Red Hat attempts to notify the customer after the 15-minute threshold, the failover process does not begin until the customer opens a support case.
+
+.Procedure
+. Log in to the link:https://access.redhat.com/support[Red Hat Customer Portal].
+. Open a support ticket requesting a regional failover to the  secondary deployment footprint.
+. Ensure that you select *{PlatformName} On Clouds* as the product.
+. Use the following exact formatting for the support ticket subject and body to ensure rapid routing and execution by the Red Hat SRE team.
++
+----
+*SUBJECT*: Urgent: Request for Regional Failover Execution - MRBC
+
+*Severity*: 1
+
+*BODY*:
+
+Hello SRE Team,
+
+I am requesting the immediate execution of a regional failover for my managed Ansible Automation Platform environment from the primary deployment region to our designated secondary multi-region business continuity (MRBC) footprint. 
+
+--- TARGET ENVIRONMENT ---
+
+- Company Name: [INSERT COMPANY NAME]
+
+- Instance URL: [URL]
+----

--- a/aap-clouds/topics/proc-saas-standard-ingress-configuration.adoc
+++ b/aap-clouds/topics/proc-saas-standard-ingress-configuration.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="proc-saas-standard-ingress-configuration"]
+
+= Configure ingress with AWS PrivateLink
+
+[role="_abstract"]
+Unlike standard deployments where DNS handles traffic redirection automatically (as described in xref:ref-saas-network-dns-routing[Network and DNS routing]), the automated self-healing behavior of the automation mesh endpoints does not automatically bridge across separate private cloud networks when using AWS PrivateLink.
+
+.Procedure
+. Pre-configure or manually verify corresponding AWS PrivateLink connections, route tables, and security policy rules inside the secondary region's AWS infrastructure.
+. Ensure that link:https://docs.redhat.com/en/documentation/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_service_on_aws/saas-pull-push#con-saas-automation[remote execution nodes] are permitted to establish a network path to the secondary control plane endpoints during a failover scenario.

--- a/aap-clouds/topics/ref-saas-customer-notification-and-confirmation.adoc
+++ b/aap-clouds/topics/ref-saas-customer-notification-and-confirmation.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="customer-notification-and-confirmation"]
+
+= Customer notification and failover confirmation protocol
+
+[role="_abstract"]
+Failover to the secondary region does not occur automatically. To ensure the customer maintains full authority over their environment, the process requires customer approval.

--- a/aap-clouds/topics/ref-saas-failure-domains.adoc
+++ b/aap-clouds/topics/ref-saas-failure-domains.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-failure-domains"]
+= Failure domains and events requiring failover
+
+[role="_abstract"]
+The following are operational issues that indicate when a disruption qualifies for a failover:

--- a/aap-clouds/topics/ref-saas-guidance-parameters.adoc
+++ b/aap-clouds/topics/ref-saas-guidance-parameters.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-guidance-parameters"]
+
+= Guidance parameters and service objectives
+
+[role="_abstract"]
+{SaaSonAWSShort} features an active-passive infrastructure topology designed to withstand long-term AWS regional outages. In the event of a critical disruption in a primary deployment region, traffic can be rerouted to a secondary regional pair to sustain business-critical operations.
+
+* *Failover guidance window*: Regional failover is not automatic. The 15-minute downtime threshold serves solely as operational guidance for when Red Hat begins attempts to proactively communicate a primary region disruption to the impacted customer(s).
+* *SLA*: The managed service SLA terms defined in link:https://www.redhat.com/licenses/Appendix-4-Red-Hat-Online-Services-English-20250805.pdf[Red Hat Terms of Service Appendix 4] do not change with the addition of this capability. No guarantees are made regarding the speed of failover operations.

--- a/aap-clouds/topics/ref-saas-infrastructure-cost-breakdown.adoc
+++ b/aap-clouds/topics/ref-saas-infrastructure-cost-breakdown.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-infrastructure-cost-breakdown"]
+= Metering estimates
+
+[role="_abstract"]
+You can calculate total infrastructure cost. This can be done by multiplying your total metered vCPU hours by the variable infrastructure metering rate of $0.10 per vCPU hour.
+
+[cols="3,3,3,2", options="header"]
+|====
+| Metric | Primary AWS region | Secondary AWS region | Combined 
+| *Hourly vCPU hours* | 16 | 12 | 28
+| *Daily vCPU hours* | 384 | 288 | 672
+| *Annual vCPU hours* | 140,160 | 105,120 | 245,280
+|====
+
+[NOTE]
+====
+To increase security and reduce infrastructure costs, deploy all execution nodes within your infrastructure.
+====
+
+[IMPORTANT]
+====
+If your instance is still using the legacy infrastructure metering unit of 1, migrating to the new multi-region infrastructure shape will convert the customer's metering unit to a variable consumption-based rate of $0.10 per vCPU hour.
+====

--- a/aap-clouds/topics/ref-saas-infrastructure-requirements.adoc
+++ b/aap-clouds/topics/ref-saas-infrastructure-requirements.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-infrastructure-requirements"]
+
+= Infrastructure requirements
+
+[role="_abstract"]
+Multi-region active/passive deployment is a mandatory platform requirement for all customers running Ansible Automation Platform Service on AWS on plans above 50 nodes. It cannot be disabled or opted-out of.

--- a/aap-clouds/topics/ref-saas-mesh-configuration.adoc
+++ b/aap-clouds/topics/ref-saas-mesh-configuration.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-mesh-configuration"]
+= Automation mesh configuration and ingress architecture
+
+[role="_abstract"]
+The {PlatformName} {AutomationMesh} adapts natively to regional failover events, minimizing configuration modifications.

--- a/aap-clouds/topics/ref-saas-metering-implications-idle.adoc
+++ b/aap-clouds/topics/ref-saas-metering-implications-idle.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-metering-implications-idle"]
+= Metering Implications of idle region
+
+[role="_abstract"]
+{SaaSonAWS} uses a consumption-based metering model across the entire service. All active infrastructure components, including primary control planes and execution nodes, are metered at a variable rate based on vCPU utilization.
+
+Maintaining a multi-region business continuity footprint involves an active-passive state layout. Understanding the distinction between active and idle components is necessary for evaluating your baseline infrastructure metering.

--- a/aap-clouds/topics/ref-saas-network-dns-routing.adoc
+++ b/aap-clouds/topics/ref-saas-network-dns-routing.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-network-dns-routing"]
+= Network and DNS Routing
+
+[role="_abstract"]
+The platform uses automated networking mechanics to abstract failover shifts away from external calling systems.
+
+* *Service endpoints and URLs*: The customer-facing {PlatformNameShort} endpoint URL does not change during or after a failover event. For deployments using standard ingress, you do not need to update bookmarks, API integrations, CI/CD pipelines, or automation mesh configurations. The URL used to access the primary region resolves smoothly to the secondary region after the cutover. AWS private link users should see xref:proc-saas-ingress-config-private-link[Ingress configuration with AWS PrivateLink].
+* *DNS-layer routing*: Traffic redirection from the primary region to the secondary region is handled natively at the DNS layer. When a failover is initiated, Red Hat-managed DNS records are updated so that the existing custom domain or auto-generated Red Hat URL resolves to the secondary region's infrastructure footprint. This includes both default services URLs, and customer custom DNS records already configured with the primary region.

--- a/aap-clouds/topics/ref-saas-new-customers.adoc
+++ b/aap-clouds/topics/ref-saas-new-customers.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-new-customers"]
+
+= New customers
+
+[role="_abstract"]
+You must activate Multi-Region Business Continuity during the onboarding process.
+
+* For all new deployments with more than 50 nodes created on or after the feature launch date, active/passive architecture is enabled by default. These environments automatically deploy with the infrastructure required to support regional failover.
+* New deployments starting with exactly 50 nodes will default to a single-region architecture.
+* Customers with a 50-node tier can move to a multi-region active passive architecture by submitting a support ticket.

--- a/aap-clouds/topics/ref-saas-notification-timeline.adoc
+++ b/aap-clouds/topics/ref-saas-notification-timeline.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-notification-timeline"]
+= Notification timeline
+
+[role="_abstract"]
+If a critical failure event persists for at least 15 minutes, Red Hat initiates best-effort attempts to notify your designated deployment contacts by email or through the sales account teams. Ensure that your contact information is kept up to date by working with your account team, particularly if there are personnel changes within your organization.

--- a/aap-clouds/topics/ref-saas-primary-region-status.adoc
+++ b/aap-clouds/topics/ref-saas-primary-region-status.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-primary-region-status"]
+= Primary region retention
+
+[role="_abstract"]
+Until the failover request is received through the support ticket, the environment remains in the degraded primary region.
+
+[IMPORTANT]
+====
+During this retention window, where there is primary region degradation and no failover, the application and automation workloads in the environment will experience ongoing outages. Red Hat will not alter, terminate, or migrate the primary environment without your explicit written authorization.
+====

--- a/aap-clouds/topics/ref-saas-regional-outages.adoc
+++ b/aap-clouds/topics/ref-saas-regional-outages.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-regional-outages"]
+
+= Regional outages
+
+[role="_abstract"]
+A regional outage constitutes a complete AWS infrastructure failure impacting your primary deployment region.
+
+This includes:
+
+* *Data center isolation*: A total loss of external network routing capabilities and API access to the underlying AWS availability zones, rendering the infrastructure entirely unreachable.
+* *Absolute loss of availability zones*: Concurrent physical or logical failures of all hosting zones within the specified AWS region.

--- a/aap-clouds/topics/ref-saas-rollback-protocol.adoc
+++ b/aap-clouds/topics/ref-saas-rollback-protocol.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-rollback-protocol"]
+
+= Rollback protocol
+
+[role="_abstract"]
+To minimize risk, returning to the primary region requires collaboration between the customer and the Red Hat SRE team.

--- a/aap-clouds/topics/ref-saas-schedule-business-continuity-tests.adoc
+++ b/aap-clouds/topics/ref-saas-schedule-business-continuity-tests.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-schedule-business-continuity-tests"]
+= Scheduling failover tests
+
+[role="_abstract"]
+A customer can validate regional failover operations by scheduling a simulation once annually.
+
+[IMPORTANT]
+====
+To ensure platform stability and maintain operational availability, customers are restricted to scheduling a maximum of one failover test per calendar year.
+====

--- a/aap-clouds/topics/ref-saas-service-outages.adoc
+++ b/aap-clouds/topics/ref-saas-service-outages.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-service-outages"]
+= Service outages
+
+[role="_abstract"]
+A service outage is defined as functional degradation to the {PlatformNameShort} service, despite stable cloud hosting infrastructure. 
+
+Indicators include:
+
+* *Total loss of responsiveness*: Complete inability to access or authenticate through user interfaces (UIs) or programmatic endpoints (APIs).

--- a/aap-clouds/topics/ref-saas-technical-operational-impacts.adoc
+++ b/aap-clouds/topics/ref-saas-technical-operational-impacts.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-technical-operational-impacts"]
+= Technical and operational impacts (in-flight jobs)
+
+[role="_abstract"]
+During a failover event, active operations on the primary control plane are impacted as follows:
+
+* *Operations Running on the Control Plane*: The outcome of in-flight jobs depends entirely on the nature of the regional failure.
+** *Ingress Failures*: If external ingress fails but the internal control plane remains operational, jobs currently dispatched to execution nodes may continue to run and complete successfully.
+** *Total Control Plane Failures*: If the primary control plane crashes entirely, running playbook jobs, project synchronizations (e.g., in-progress Git clones), and inventory synchronizations fail immediately. Scheduled jobs triggered during the active failover window are also dropped.
+** *Job Queue*: Jobs that were queued but not yet dispatched to an execution node are not preserved during the transition.
+** *External execution node behavior*: Jobs running directly on customer execution nodes (such as long-running playbooks against targeted managed hosts) can continue to execute uninterrupted, provided the execution nodes themselves remain healthy. However, these nodes cannot report their final results back to the control plane, and the final job status will not be reflected once the environment is restored in the secondary region.
+* *Post-failover remediation*: When the failover process is complete and the secondary environment is fully active, the customer must manually re-launch any failed or queued jobs from the secondary region.

--- a/aap-clouds/topics/ref-saas-what-idle-means.adoc
+++ b/aap-clouds/topics/ref-saas-what-idle-means.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-saas-what-idle-means"]
+= What "idle" means in the secondary region
+
+[role="_abstract"]
+{SaaSonAWSShort} deployments use an active/passive warm standby state.
+
+* 3 VM nodes run 24/7 to keep the {PlatformNameShort} pods healthy and ready to accept traffic instantly.
+* The {PlatformNameShort} control plane operations remain running on the primary region until a failover is triggered, which then moves the workloads onto the infrastructure in the secondary region.


### PR DESCRIPTION
## Summary
- Cherry-picked the 25 `aap-clouds/*` files from PR #6038, excluding `.agent_workspace/`, `.claude/settings.json`, and other non-clouds files.
- Adds the MRBC (Multi-Region Business Continuity) chapter: 2 assemblies and 23 topic modules.

## Context
Extracted from #6038 to separate the aap-clouds content into its own PR.