### PR TITLE
Fix WSL config file path in Windows install procedure

### DIFF
--- a/downstream/modules/devtools/proc-devtools-install-podman-desktop-wsl.adoc
+++ b/downstream/modules/devtools/proc-devtools-install-podman-desktop-wsl.adoc
@@ -18,7 +18,7 @@ $ wsl --install --no-distribution
 ----
 . Use `cgroupsv2` by disabling `cgroupsv1` for WSL2:
 +
-Edit the `%USERPROFILE%/wsl.conf` file and add the following lines to force `cgroupv2` usage:
+Edit the `%USERPROFILE%\.wslconfig` file and add the following lines to force `cgroupv2` usage:
 +
 ----
 [wsl2]


### PR DESCRIPTION
## Summary
- Fixes the WSL2 config file path in the devtools Windows installation procedure
- Changed `%USERPROFILE%/wsl.conf` to `%USERPROFILE%\.wslconfig`
- The previous path had two errors: wrong filename (`wsl.conf` is the per-distro config at `/etc/wsl.conf` inside the Linux filesystem) and wrong path separator (`/` instead of `\` for Windows)
- Reference: [Microsoft WSL configuration docs](https://learn.microsoft.com/en-us/windows/wsl/wsl-config)

Resolves: AAP-44159

## Test plan
- [ ] Verify the rendered docs show the corrected path `%USERPROFILE%\.wslconfig`
- [ ] Confirm the `[wsl2]` section heading in the code block is consistent with `.wslconfig` file format per Microsoft docs