### PR TITLE
AAP-84085: correct ACCESS_TOKEN_EXPIRE_SECONDS gateway default

### DIFF
--- a/downstream/modules/platform/con-gw-manage-oauth2-provider.adoc
+++ b/downstream/modules/platform/con-gw-manage-oauth2-provider.adoc
@@ -15,7 +15,7 @@ This change increases credential security through more frequent token rotation.
 +
 ----
 {
-  "ACCESS_TOKEN_EXPIRE_SECONDS": 31536000000,
+  "ACCESS_TOKEN_EXPIRE_SECONDS": 31536000,
   "REFRESH_TOKEN_EXPIRE_SECONDS": 2628000,
   "AUTHORIZATION_CODE_EXPIRE_SECONDS": 600
 }


### PR DESCRIPTION
## Summary
- Fixes conflicting default in Manage OAUTH2_PROVIDER settings
- Gateway ACCESS_TOKEN_EXPIRE_SECONDS is 31536000 (1 year), not 31536000000
- Matches django-ansible-base settings_logic.py setdefault
- Affects titles/central-auth

Fixes https://issues.redhat.com/browse/AAP-84085

## Test plan
- [ ] JSON block shows 31536000
- [ ] It matches the “updated … to 1 year” sentence
- [ ] Backport to 2.6 after merge (published 2.6 page still has the old value)