### PR TITLE
AAP-88332 Add responsibility matrix to AAP on Azure docs

### DIFF
--- a/aap-clouds/stories/assembly-azure-support.adoc
+++ b/aap-clouds/stories/assembly-azure-support.adoc
@@ -11,6 +11,8 @@ ifdef::context[:parent-context: {context}]
 {AAPonAzureNameShort} is a managed application, supported and maintained by Red Hat.
 Due to the architecture of the application and the deployment strategy in Azure, there are some situations where customizing and changing some aspects of the configuration could lead to a change in the responsibilities of some components.
 
+include::topics/ref-azure-responsibilities.adoc[leveloffset=+1]
+
 == Azure Virtual Appliance routing with {AAPonAzureNameShort}
 
 As an {AAPonAzureNameShort} user, you can configure the {PlatformNameShort} network to peer your own network.

--- a/aap-clouds/topics/ref-azure-responsibilities.adoc
+++ b/aap-clouds/topics/ref-azure-responsibilities.adoc
@@ -1,0 +1,75 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ref-azure-responsibilities"]
+= Overview of responsibilities for {AAPonAzureNameShort}
+
+[role="_abstract"]
+Red Hat is your primary contact for support for {AAPonAzureName}.
+For support issues, contact Red Hat customer support.
+Red Hat engages Microsoft support for infrastructure and platform issues.
+For account questions, contact your Red Hat account executive.
+
+The following table describes who is responsible for support and change management across {AAPonAzureNameShort} resources.
+
+.{AAPonAzureNameShort} responsibility matrix
+[cols="3,1,1",options="header"]
+|===
+| Resource | Support | Change management
+
+| Customer data
+| Customer
+| Customer
+
+| Identity and access management
+| Customer
+| Customer
+
+| Post-deployment network configuration and routing
+| Customer
+| Customer
+
+| Infrastructure monitoring and operations
+| Red Hat and Microsoft
+| Microsoft
+
+| {PlatformNameShort} monitoring
+| Red Hat
+| Red Hat
+
+| Logging
+| Red Hat
+| Red Hat
+
+| Upgrades
+| Red Hat
+| Red Hat
+
+| Capacity management
+| Red Hat
+| Red Hat
+
+| Physical infrastructure security
+| Microsoft
+| Microsoft
+|===
+
+[id="ref-azure-security-compliance"]
+== Security and regulation compliance
+
+{AAPonAzureNameShort} is not currently certified for any compliance standard.
+Red Hat maintains compliance responsibility for the offering where required by law, Red Hat, or Microsoft policies.
+
+[id="ref-azure-customer-responsibilities"]
+== Customer responsibilities
+
+You are responsible for all configuration and use of {PlatformNameShort}.
+This includes the following areas:
+
+* Application settings for {ControllerName} and {PrivateHubName}
+* All customer-facing functions of these applications, such as managing projects, templates, and {ExecEnvName}
+* Single sign-on (SSO) configuration
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:con-azure-lifecycle[{AAPonAzureNameShort} lifecycle]


### PR DESCRIPTION
## Summary
- Adds a new reference topic (`ref-azure-responsibilities.adoc`) containing the responsibility matrix from KB article 6966926, covering support and change management responsibilities across Customer, Red Hat, and Microsoft
- Includes sections on security/compliance posture and customer responsibilities
- Includes the new topic in the existing `assembly-azure-support.adoc` assembly

## Test plan
- [ ] Verify the topic renders correctly in a local preview build
- [ ] Confirm the responsibility table matches the source KB article (https://access.redhat.com/articles/6966926)
- [ ] Check the `con-azure-lifecycle` cross-reference resolves correctly
- [ ] Verify product name attributes render as expected

Resolves: [AAP-88332](https://redhat.atlassian.net/browse/AAP-88332)

🤖 Generated with [Claude Code](https://claude.com/claude-code)