### PR TITLE
AAP-88695: Document authenticator map replacement for removed LDAP group settings (2.5)

### DIFF
--- a/downstream/modules/platform/con-gw-authenticator-map-triggers.adoc
+++ b/downstream/modules/platform/con-gw-authenticator-map-triggers.adoc
@@ -25,9 +25,15 @@ See the *Operation* field to determine the behavior of the trigger if more than 
 +
 [NOTE]
 ====
-You must enter group identifiers in lowercase. 
+You must enter group identifiers in lowercase.
 For example, `cn=johnsmith,dc=example,dc=com` instead of `CN=JohnSmith,DC=Example,DC=COM`.
 ====
++
+If you previously used {ControllerName}-side LDAP group settings, configure the equivalent behavior with authenticator maps:
++
+* `AUTH_LDAP_REQUIRE_GROUP`: Create an *Allow* map with a *Group* trigger, and select *Revoke* so that users who are not in the required group are denied access.
+* `AUTH_LDAP_DENY_GROUP`: Create an *Allow* map with a *Never* trigger for the group whose members you want to deny.
+* `AUTH_LDAP_USER_FLAGS_BY_GROUP`: Create a map for the corresponding flag (for example, an *Is Superuser* map) with a *Group* trigger.
 +
 Attribute:: The map is true or false based on a users attributes coming from the source system. See link:{URLCentralAuth}/gw-configure-authentication#gw-authenticator-map-examples[Authenticator map examples] for information about using *Attribute* triggers.
 +

--- a/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
+++ b/downstream/modules/platform/proc-controller-set-up-LDAP.adoc
@@ -26,8 +26,10 @@ Users created through an LDAP login should not change their username, first name
 
 [IMPORTANT]
 ====
-Migration of LDAP authentication settings are not supported for 2.4 to 2.5 in the platform UI. If you are upgrading from {PlatformNameShort} 2.4 to 2.5, be sure to save your authentication provider data before upgrading. 
+Migration of LDAP authentication settings are not supported for 2.4 to 2.5 in the platform UI. If you are upgrading from {PlatformNameShort} 2.4 to 2.5, be sure to save your authentication provider data before upgrading.
 ====
+
+The `AUTH_LDAP_REQUIRE_GROUP`, `AUTH_LDAP_DENY_GROUP`, and `AUTH_LDAP_USER_FLAGS_BY_GROUP` settings are not configured directly on the {Gateway} LDAP authenticator. When you upgrade, these settings are converted to authenticator maps. To configure equivalent group-based access and user flags for a new LDAP authenticator, use authenticator maps. See link:{URLCentralAuth}/gw-configure-authentication#gw-authenticator-map-triggers[Authenticator map triggers].
 
 .Procedure
 


### PR DESCRIPTION
## Summary

Documents the replacement for the automation controller-side LDAP group-restriction settings that are no longer configured directly on the platform gateway LDAP authenticator in Ansible Automation Platform 2.5:

- `AUTH_LDAP_REQUIRE_GROUP`
- `AUTH_LDAP_DENY_GROUP`
- `AUTH_LDAP_USER_FLAGS_BY_GROUP`

On upgrade these settings are converted to authenticator maps (per engineering story AAP-48484); going forward, users configure the equivalent behavior with an **Allow** map and a **Group** trigger.

## Changes

- **`proc-controller-set-up-LDAP.adoc`**: Adds a paragraph explaining that the three settings are not configured directly on the platform gateway LDAP authenticator and are converted to authenticator maps on upgrade, with an xref to *Authenticator map triggers*.
- **`con-gw-authenticator-map-triggers.adoc`**: Adds per-setting mapping guidance at the end of the **Group** trigger description (require group → *Revoke*; deny group → *Never* trigger; user flags → *Is Superuser* map).

## Jira

Resolves [AAP-88695](https://redhat.atlassian.net/browse/AAP-88695) (linked SFDC case 04520210). Technical framing verified against AAP-48484 and the aap-gateway / ansible.platform sources; UI labels (**Group**, **Revoke**) confirmed against the 2.5 content and reviewer.

## Notes

- Targets the **2.5** branch. Equivalent changes for 2.6/2.7 use the updated UI labels (**Based on groups**, **Block non-matching users**) and will be handled separately.
- AI assistance was used to draft these changes (tool: Claude Code, claude.ai/code).