### PR TITLE
Add 50 node tier exception to backup deprecation notice

### DIFF
--- a/aap-clouds/topics/con-saas-regions.adoc
+++ b/aap-clouds/topics/con-saas-regions.adoc
@@ -9,4 +9,4 @@ Each supported AWS region is paired with a companion region where backup data is
 
 For more information, see link:https://docs.redhat.com/en/documentation/ansible_on_clouds/2.x/html/red_hat_ansible_automation_platform_service_on_aws/saas-service-definition#assembly-saas-business-continuity[Multi-region Active/Passive infrastructure].
 
-With the release of multi-region deployment, the current backup availability model is deprecated from August 3, 2026, and removed by August 3, 2027, for all customers, unless otherwise opted in.
+With the release of multi-region deployment, the current backup availability model is deprecated from August 3, 2026, and removed by August 3, 2027, for all customers, unless otherwise opted in or on the 50 node tier.


### PR DESCRIPTION
## Summary
- Adds "or on the 50 node tier" exception to the backup availability model deprecation notice in `con-saas-regions.adoc`
- Addresses post-merge feedback from @rraafffaa on #6052 (https://github.com/ansible/aap-docs/pull/6052/files#r3857438000)

## Test plan
- [ ] Verify the deprecation sentence reads correctly with the added exception
- [ ] Confirm no other files need the same update